### PR TITLE
fix: crawl HTTP polling bug + SDK test suite + docs

### DIFF
--- a/docs/docs/agent-onboarding.md
+++ b/docs/docs/agent-onboarding.md
@@ -32,7 +32,7 @@ For most agent workflows, start with this sequence:
 1. **Discover** what pages exist on a target domain:
 
 ```bash
-curl -X POST http://localhost:3002/v1/map \
+curl -X POST http://localhost:3000/v1/map \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
@@ -41,7 +41,7 @@ curl -X POST http://localhost:3002/v1/map \
 2. **Extract** content from specific pages:
 
 ```bash
-curl -X POST http://localhost:3002/v1/scrape \
+curl -X POST http://localhost:3000/v1/scrape \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com/page", "formats": ["markdown"]}'
@@ -50,7 +50,7 @@ curl -X POST http://localhost:3002/v1/scrape \
 3. **Search** when you need to find relevant pages across the web:
 
 ```bash
-curl -X POST http://localhost:3002/v1/search \
+curl -X POST http://localhost:3000/v1/search \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"query": "your search query", "limit": 5}'

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### New: Search Endpoint
 
-- `POST /api/v1/search` -- search the web with optional content scraping
+- `POST /api/v1/search` (cloud) / `POST /v1/search` (self-hosted) -- search the web with optional content scraping
 - Supports web, news, and image results via `sources` parameter
 - Time-based filtering with `tbs` parameter (`qdr:h`, `qdr:d`, `qdr:w`, `qdr:m`, `qdr:y`)
 - Category filtering: `github`, `research`, `pdf`

--- a/docs/docs/credit-costs.md
+++ b/docs/docs/credit-costs.md
@@ -42,7 +42,7 @@ The safest way to confirm actual consumption is still the balance endpoint befor
 
 ## Balance check
 
-Use `GET /api/v1/account/balance` with your API key to inspect included credits, purchased balance, and total available credits.
+Use `GET /api/v1/account/balance` (cloud only — fastcrw.com) with your API key to inspect included credits, purchased balance, and total available credits.
 
 ## Example Monitoring Pattern
 

--- a/docs/docs/extract.md
+++ b/docs/docs/extract.md
@@ -45,7 +45,7 @@ If your next step is retrieval, summarization, or semantic search, markdown is o
 ## End-to-End Request Example
 
 ```bash
-curl -X POST http://localhost:3002/api/v1/scrape \
+curl -X POST http://localhost:3000/v1/scrape \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -10,11 +10,16 @@ Published PyPI package: [`crewai-crw`](https://pypi.org/project/crewai-crw/)
 pip install crewai crewai-crw
 ```
 
-Three ready-to-use tools — no custom `BaseTool` subclasses needed:
+Four ready-to-use tools — no custom `BaseTool` subclasses needed:
 
 ```python
 from crewai import Agent, Task, Crew
-from crewai_crw import CrwScrapeWebsiteTool, CrwCrawlWebsiteTool, CrwMapWebsiteTool
+from crewai_crw import (
+    CrwScrapeWebsiteTool,
+    CrwCrawlWebsiteTool,
+    CrwMapWebsiteTool,
+    CrwSearchWebTool,
+)
 
 # Self-hosted (default: localhost:3000)
 scrape_tool = CrwScrapeWebsiteTool()
@@ -69,6 +74,15 @@ loader = CrwLoader(
     api_key="crw_live_...",
     mode="crawl",
     params={"max_depth": 3, "max_pages": 50},
+)
+docs = loader.load()
+
+# Search the web (cloud only)
+loader = CrwLoader(
+    mode="search",
+    query="web scraping tools",
+    api_url="https://fastcrw.com/api",
+    api_key="crw_live_...",
 )
 docs = loader.load()
 ```
@@ -203,7 +217,7 @@ console.log(data.markdown);
 The API is straightforward enough that most integrations are a thin wrapper:
 
 1. Set the `Authorization` header with your API key.
-2. POST JSON to the endpoint you need (`/v1/scrape`, `/v1/crawl`, `/v1/map`).
+2. POST JSON to the endpoint you need (`/v1/scrape`, `/v1/crawl`, `/v1/map`, `/v1/search`).
 3. Parse the JSON response.
 
 No SDK is required — the consistent API design means any HTTP client works.
@@ -219,6 +233,25 @@ No SDK is required — the consistent API design means any HTTP client works.
 | Rate limits | Per plan | Unlimited |
 
 Both options expose the same API, so your integration code works with either.
+
+## Endpoint Support Matrix
+
+Not every integration supports every endpoint. Search is a cloud-only feature that requires the fastcrw.com API backend.
+
+| Integration | Scrape | Crawl | Map | Search | Extract |
+|-------------|--------|-------|-----|--------|---------|
+| [CrewAI](https://pypi.org/project/crewai-crw/) | Yes | Yes | Yes | Yes (cloud) | -- |
+| [LangChain](https://pypi.org/project/langchain-crw/) | Yes | Yes | Yes | Yes (cloud) | -- |
+| [OpenClaw](https://www.npmjs.com/package/openclaw-plugin-crw) | Yes | Yes | Yes | Yes (cloud) | -- |
+| [n8n](https://www.npmjs.com/package/n8n-nodes-crw) | Yes | Yes | Yes | Yes (cloud) | -- |
+| [Dify](https://github.com/us/dify-plugin-crw) | Yes | Yes | Yes | Yes (cloud) | -- |
+| MCP Server | Yes | Yes | Yes | -- | -- |
+| Firecrawl SDK (drop-in) | Yes | Yes | Yes | -- | Yes |
+| Direct HTTP | Yes | Yes | Yes | Yes (cloud) | Yes |
+
+:::note
+The MCP server is designed for self-hosted use and does not expose the search endpoint. Use the Python SDK, a framework integration, or direct HTTP calls for search.
+:::
 
 ## All Integrations
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -54,7 +54,7 @@ CRW covers 15% more URLs than Firecrawl (92% vs 77.2%), runs 5.5x faster, and us
 :::tabs
 ::tab{title="cURL"}
 ```bash
-curl -X POST http://localhost:3002/v1/scrape \
+curl -X POST http://localhost:3000/v1/scrape \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{"url": "https://example.com", "formats": ["markdown"]}'
@@ -63,7 +63,7 @@ curl -X POST http://localhost:3002/v1/scrape \
 ```python
 import requests
 
-resp = requests.post("http://localhost:3002/v1/scrape", json={
+resp = requests.post("http://localhost:3000/v1/scrape", json={
     "url": "https://example.com",
     "formats": ["markdown"]
 }, headers={"Authorization": "Bearer YOUR_API_KEY"})
@@ -72,7 +72,7 @@ print(resp.json()["data"]["markdown"])
 ```
 ::tab{title="Node.js"}
 ```javascript
-const resp = await fetch("http://localhost:3002/v1/scrape", {
+const resp = await fetch("http://localhost:3000/v1/scrape", {
   method: "POST",
   headers: {
     "Content-Type": "application/json",

--- a/docs/docs/map.md
+++ b/docs/docs/map.md
@@ -9,7 +9,7 @@
 - and whether a full crawl is justified at all.
 
 ```bash
-curl -X POST http://localhost:3002/api/v1/map \
+curl -X POST http://localhost:3000/v1/map \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{"url":"https://example.com"}'

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -415,7 +415,7 @@ Expected:
   "result": {
     "protocolVersion": "2024-11-05",
     "capabilities": {"tools": {}},
-    "serverInfo": {"name": "crw-mcp", "version": "0.0.12"}
+    "serverInfo": {"name": "crw-mcp", "version": "0.3.0"}
   }
 }
 ```

--- a/docs/docs/sdk-examples.md
+++ b/docs/docs/sdk-examples.md
@@ -3,7 +3,7 @@
 ## TypeScript
 
 ```ts
-const res = await fetch("http://localhost:3002/api/v1/scrape", {
+const res = await fetch("http://localhost:3000/v1/scrape", {
   method: "POST",
   headers: {
     Authorization: "Bearer YOUR_API_KEY",
@@ -28,7 +28,7 @@ This is enough for most Node.js backends, server actions, and edge handlers.
 import requests
 
 res = requests.post(
-    "http://localhost:3002/api/v1/scrape",
+    "http://localhost:3000/v1/scrape",
     headers={
         "Authorization": "Bearer YOUR_API_KEY",
         "Content-Type": "application/json",
@@ -55,7 +55,7 @@ import (
 
 func main() {
   body := []byte(`{"url":"https://example.com","formats":["markdown"]}`)
-  req, _ := http.NewRequest("POST", "http://localhost:3002/api/v1/scrape", bytes.NewBuffer(body))
+  req, _ := http.NewRequest("POST", "http://localhost:3000/v1/scrape", bytes.NewBuffer(body))
   req.Header.Set("Authorization", "Bearer YOUR_API_KEY")
   req.Header.Set("Content-Type", "application/json")
 
@@ -75,7 +75,7 @@ func main() {
 ### TypeScript
 
 ```ts
-const res = await fetch("http://localhost:3002/api/v1/search", {
+const res = await fetch("http://localhost:3000/v1/search", {
   method: "POST",
   headers: {
     Authorization: "Bearer YOUR_API_KEY",
@@ -95,7 +95,7 @@ const { data } = await res.json();
 
 ```python
 resp = requests.post(
-    "http://localhost:3002/api/v1/search",
+    "http://localhost:3000/v1/search",
     headers={"Authorization": "Bearer YOUR_API_KEY"},
     json={"query": "web scraping tools 2026", "limit": 5},
 )
@@ -108,7 +108,7 @@ data = resp.json()["data"]
 
 ```go
 body := `{"query":"web scraping tools 2026","limit":5}`
-req, _ := http.NewRequest("POST", "http://localhost:3002/api/v1/search",
+req, _ := http.NewRequest("POST", "http://localhost:3000/v1/search",
     strings.NewReader(body))
 req.Header.Set("Authorization", "Bearer YOUR_API_KEY")
 req.Header.Set("Content-Type", "application/json")
@@ -125,7 +125,7 @@ defer resp.Body.Close()
 Add `scrapeOptions` to fetch page content for each result in one call:
 
 ```ts
-const res = await fetch("http://localhost:3002/api/v1/search", {
+const res = await fetch("http://localhost:3000/v1/search", {
   method: "POST",
   headers: {
     Authorization: "Bearer YOUR_API_KEY",
@@ -164,7 +164,7 @@ That includes server actions, background jobs, serverless functions, and interna
 The same shape works in every language:
 
 ```ts
-const start = await fetch("http://localhost:3002/api/v1/crawl", {
+const start = await fetch("http://localhost:3000/v1/crawl", {
   method: "POST",
   headers: {
     Authorization: "Bearer YOUR_API_KEY",
@@ -175,7 +175,7 @@ const start = await fetch("http://localhost:3002/api/v1/crawl", {
 
 const { id } = await start.json();
 
-const status = await fetch(`http://localhost:3002/api/v1/crawl/${id}`, {
+const status = await fetch(`http://localhost:3000/v1/crawl/${id}`, {
   headers: { Authorization: "Bearer YOUR_API_KEY" },
 });
 ```

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -10,7 +10,7 @@ Use `search` when you need to find content across the web without knowing specif
 - and competitive analysis across multiple sources.
 
 ```bash
-curl -X POST http://localhost:3002/api/v1/search \
+curl -X POST http://localhost:3000/v1/search \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{"query":"web scraping tools","limit":5}'
@@ -93,7 +93,7 @@ When `sources` is set, results are grouped by type. The `limit` applies per sour
 The real power of the search endpoint is combining search with content scraping in a single call. Add `scrapeOptions` to fetch the full page content for each result:
 
 ```bash
-curl -X POST http://localhost:3002/api/v1/search \
+curl -X POST http://localhost:3000/v1/search \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{
@@ -129,7 +129,7 @@ When `scrapeOptions` is combined with `sources`, only `web` results are scraped.
 Search specifically for recent news articles:
 
 ```bash
-curl -X POST http://localhost:3002/api/v1/search \
+curl -X POST http://localhost:3000/v1/search \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{"query":"artificial intelligence","sources":["news"],"limit":5}'
@@ -142,7 +142,7 @@ News results include a `publishedDate` field with the article publication timest
 Search for images across the web:
 
 ```bash
-curl -X POST http://localhost:3002/api/v1/search \
+curl -X POST http://localhost:3000/v1/search \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{"query":"neural network diagram","sources":["images"],"limit":5}'

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -218,3 +218,4 @@ If you search with `limit: 5` and `scrapeOptions`, and all 5 results scrape succ
 - [Extract endpoint](/docs/extract) -- for structured JSON extraction from pages.
 - [Credit costs](/docs/credit-costs) -- full billing breakdown across all endpoints.
 - [SDK examples](/docs/sdk-examples) -- search examples in TypeScript, Python, and Go.
+- [Integrations](/docs/integrations) -- search support across CrewAI, LangChain, n8n, Dify, and more.

--- a/npm/crw-mcp/package.json
+++ b/npm/crw-mcp/package.json
@@ -22,14 +22,16 @@
     "crw-mcp": "bin/crw-mcp.js"
   },
   "files": [
-    "bin/crw-mcp.js"
+    "bin/crw-mcp.js",
+    "bin/init.js",
+    "skills/SKILL.md"
   ],
   "optionalDependencies": {
-    "crw-mcp-darwin-x64": "0.2.0",
-    "crw-mcp-darwin-arm64": "0.2.0",
-    "crw-mcp-linux-x64": "0.2.0",
-    "crw-mcp-linux-arm64": "0.2.0",
-    "crw-mcp-win32-x64": "0.2.0",
-    "crw-mcp-win32-arm64": "0.2.0"
+    "crw-mcp-darwin-x64": "0.3.0",
+    "crw-mcp-darwin-arm64": "0.3.0",
+    "crw-mcp-linux-x64": "0.3.0",
+    "crw-mcp-linux-arm64": "0.3.0",
+    "crw-mcp-win32-x64": "0.3.0",
+    "crw-mcp-win32-arm64": "0.3.0"
   }
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
 ]
 dependencies = ["platformdirs>=3.0"]
 
+[project.optional-dependencies]
+test = ["pytest>=7.0", "pytest-timeout>=2.0"]
+
 [project.urls]
 Homepage = "https://github.com/us/crw"
 Documentation = "https://us.github.io/crw"
@@ -27,6 +30,13 @@ Repository = "https://github.com/us/crw"
 
 [project.scripts]
 crw-mcp = "crw.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "integration: tests that hit real APIs (need CRW_API_KEY env var)",
+]
+timeout = 120
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/crw"]

--- a/python/src/crw/client.py
+++ b/python/src/crw/client.py
@@ -253,7 +253,7 @@ class CrwClient:
 
     # --- HTTP mode ---
 
-    def _http_request(self, method: str, path: str, body: dict | None = None) -> dict:
+    def _http_request(self, method: str, path: str, body: dict | None = None, *, raw: bool = False) -> dict:
         import urllib.request
 
         url = f"{self._api_url.rstrip('/')}{path}"
@@ -269,6 +269,8 @@ class CrwClient:
 
         if not result.get("success"):
             raise CrwApiError(result.get("error", "API error"))
+        if raw:
+            return result
         return result.get("data", result)
 
     def _http_post(self, path: str, body: dict) -> dict:
@@ -288,7 +290,7 @@ class CrwClient:
             if time.monotonic() - start > timeout:
                 raise CrwTimeoutError(f"Crawl {job_id} timed out after {timeout}s")
 
-            status_result = self._http_get(f"/v1/crawl/{job_id}")
+            status_result = self._http_request("GET", f"/v1/crawl/{job_id}", raw=True)
             status = status_result.get("status")
 
             if status == "completed":

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures and markers for CRW SDK tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from crw import CrwClient
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "unit: pure unit tests (no network)")
+    config.addinivalue_line(
+        "markers", "integration: tests that hit real APIs (need CRW_API_KEY env var)"
+    )
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-skip integration tests when CRW_API_KEY is not set."""
+    skip_integration = pytest.mark.skip(reason="CRW_API_KEY env var not set")
+    for item in items:
+        if "integration" in item.keywords and not os.environ.get("CRW_API_KEY"):
+            item.add_marker(skip_integration)
+
+
+@pytest.fixture
+def api_key() -> str:
+    """Return CRW_API_KEY from the environment."""
+    key = os.environ.get("CRW_API_KEY", "")
+    return key
+
+
+@pytest.fixture
+def cloud_client(api_key: str) -> CrwClient:
+    """Create a CrwClient pointing at the cloud API."""
+    return CrwClient(api_url="https://fastcrw.com/api", api_key=api_key)

--- a/python/tests/test_binary.py
+++ b/python/tests/test_binary.py
@@ -1,0 +1,60 @@
+"""Unit tests for binary resolution and platform detection."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from crw._binary import ensure_binary
+from crw._platform import PLATFORM_MAP, get_asset_name
+from crw.exceptions import CrwBinaryNotFoundError
+
+
+@pytest.mark.unit
+class TestEnsureBinaryEnv:
+    def test_ensure_binary_env_override(self, tmp_path: Path) -> None:
+        """CRW_BINARY pointing to a real file should be returned directly."""
+        fake_binary = tmp_path / "crw-mcp"
+        fake_binary.write_text("#!/bin/sh\necho hi")
+        fake_binary.chmod(0o755)
+
+        with patch.dict(os.environ, {"CRW_BINARY": str(fake_binary)}):
+            result = ensure_binary()
+            assert result == fake_binary
+
+    def test_ensure_binary_env_override_missing(self) -> None:
+        """CRW_BINARY pointing to a nonexistent path should raise."""
+        with patch.dict(os.environ, {"CRW_BINARY": "/no/such/binary"}):
+            with pytest.raises(CrwBinaryNotFoundError, match="does not exist"):
+                ensure_binary()
+
+
+@pytest.mark.unit
+class TestGetAssetName:
+    def test_get_asset_name_returns_string(self) -> None:
+        result = get_asset_name()
+        # On a supported platform this is a string; on unsupported it's None
+        if result is not None:
+            assert isinstance(result, str)
+            assert "crw-mcp" in result
+
+
+@pytest.mark.unit
+class TestPlatformMap:
+    def test_platform_map_coverage(self) -> None:
+        """All six expected platform entries must exist."""
+        expected_keys = [
+            ("Darwin", "arm64"),
+            ("Darwin", "x86_64"),
+            ("Linux", "x86_64"),
+            ("Linux", "aarch64"),
+            ("Windows", "AMD64"),
+            ("Windows", "ARM64"),
+        ]
+        assert len(PLATFORM_MAP) == 6
+        for key in expected_keys:
+            assert key in PLATFORM_MAP, f"Missing platform entry: {key}"
+            assert isinstance(PLATFORM_MAP[key], str)

--- a/python/tests/test_client_integration.py
+++ b/python/tests/test_client_integration.py
@@ -1,0 +1,96 @@
+"""Integration tests for CrwClient — hit real fastcrw.com API.
+
+These tests require CRW_API_KEY to be set in the environment.
+They are automatically skipped when the key is not available.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from crw import CrwClient
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(30)
+class TestScrapeIntegration:
+    def test_scrape_real_url(self, cloud_client: CrwClient) -> None:
+        result = cloud_client.scrape("https://example.com")
+        assert "markdown" in result
+        assert len(result["markdown"]) > 0
+        assert "metadata" in result
+        assert result["metadata"].get("title")
+
+    def test_scrape_with_formats(self, cloud_client: CrwClient) -> None:
+        result = cloud_client.scrape(
+            "https://example.com", formats=["markdown", "html"]
+        )
+        assert "markdown" in result
+        assert "html" in result
+
+    def test_scrape_invalid_url(self, cloud_client: CrwClient) -> None:
+        """Scraping a non-URL should raise an error or return empty content."""
+        with pytest.raises(Exception):
+            cloud_client.scrape("not-a-url")
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(60)
+class TestCrawlIntegration:
+    def test_crawl_real_site(self, cloud_client: CrwClient) -> None:
+        results = cloud_client.crawl(
+            "https://example.com", max_pages=2, timeout=60
+        )
+        assert isinstance(results, list)
+        assert len(results) >= 1
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(30)
+class TestMapIntegration:
+    def test_map_real_site(self, cloud_client: CrwClient) -> None:
+        links = cloud_client.map("https://example.com")
+        assert isinstance(links, list)
+        assert len(links) >= 1
+        assert all(isinstance(link, str) for link in links)
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(30)
+class TestSearchIntegration:
+    def test_search_web(self, cloud_client: CrwClient) -> None:
+        results = cloud_client.search("python web scraping")
+        assert isinstance(results, (list, dict))
+        if isinstance(results, list):
+            assert len(results) > 0
+            first = results[0]
+            assert "url" in first
+            assert "title" in first
+
+    def test_search_with_limit(self, cloud_client: CrwClient) -> None:
+        results = cloud_client.search("python web scraping", limit=3)
+        if isinstance(results, list):
+            assert len(results) <= 3
+
+    def test_search_with_scrape_options(self, cloud_client: CrwClient) -> None:
+        results = cloud_client.search(
+            "python web scraping",
+            limit=2,
+            scrape_options={"formats": ["markdown"]},
+        )
+        if isinstance(results, list) and len(results) > 0:
+            # At least one result should have markdown content
+            has_markdown = any(r.get("markdown") for r in results)
+            assert has_markdown
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(30)
+class TestContextManagerIntegration:
+    def test_client_context_manager(self, api_key: str) -> None:
+        with CrwClient(
+            api_url="https://fastcrw.com/api", api_key=api_key
+        ) as client:
+            result = client.scrape("https://example.com")
+            assert "markdown" in result
+            assert len(result["markdown"]) > 0

--- a/python/tests/test_client_unit.py
+++ b/python/tests/test_client_unit.py
@@ -1,0 +1,233 @@
+"""Unit tests for CrwClient — all network/subprocess calls are mocked."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crw.client import CrwClient
+from crw.exceptions import CrwApiError, CrwError, CrwTimeoutError
+
+
+# ---------------------------------------------------------------------------
+# Init mode detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInit:
+    def test_init_subprocess_mode(self) -> None:
+        client = CrwClient()
+        assert client._api_url is None
+        assert client._api_key is None
+
+    def test_init_http_mode(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+        assert client._api_url == "https://fastcrw.com/api"
+        assert client._api_key == "fc-test"
+
+
+# ---------------------------------------------------------------------------
+# Scrape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScrape:
+    def test_scrape_http_builds_correct_request(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+        mock_response = {"markdown": "# Hello", "metadata": {"title": "Hello"}}
+
+        with patch.object(client, "_http_post", return_value=mock_response) as mock_post:
+            result = client.scrape("https://example.com", formats=["markdown", "html"])
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "/v1/scrape"
+        body = call_args[0][1]
+        assert body["url"] == "https://example.com"
+        assert body["formats"] == ["markdown", "html"]
+        assert result == mock_response
+
+    def test_scrape_subprocess_calls_tool(self) -> None:
+        client = CrwClient()
+        mock_response = {"markdown": "# Hello"}
+
+        with patch.object(client, "_tool_call", return_value=mock_response) as mock_tool:
+            result = client.scrape("https://example.com")
+
+        mock_tool.assert_called_once()
+        call_args = mock_tool.call_args
+        assert call_args[0][0] == "crw_scrape"
+        assert call_args[0][1]["url"] == "https://example.com"
+        assert result == mock_response
+
+
+# ---------------------------------------------------------------------------
+# Crawl
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCrawl:
+    def test_crawl_http_polls_until_complete(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+
+        crawl_start_response = {"id": "job-123"}
+        poll_in_progress = {"success": True, "status": "scraping", "data": []}
+        poll_completed = {
+            "success": True,
+            "status": "completed",
+            "data": [{"url": "https://example.com", "markdown": "# Hello"}],
+        }
+
+        with (
+            patch.object(client, "_http_post", return_value=crawl_start_response) as mock_post,
+            patch.object(
+                client, "_http_request", side_effect=[poll_in_progress, poll_completed]
+            ) as mock_req,
+            patch("crw.client.time.sleep"),
+        ):
+            result = client.crawl("https://example.com", poll_interval=0.01, timeout=10)
+
+        assert mock_req.call_count == 2
+        assert len(result) == 1
+        assert result[0]["url"] == "https://example.com"
+
+    def test_crawl_raises_timeout(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+
+        crawl_start_response = {"id": "job-timeout"}
+        poll_in_progress = {"success": True, "status": "scraping", "data": []}
+
+        with (
+            patch.object(client, "_http_post", return_value=crawl_start_response),
+            patch.object(client, "_http_request", return_value=poll_in_progress),
+            patch("crw.client.time.sleep"),
+            patch("crw.client.time.monotonic", side_effect=[0.0, 0.0, 100.0]),
+        ):
+            with pytest.raises(CrwTimeoutError, match="timed out"):
+                client.crawl("https://example.com", poll_interval=0.01, timeout=5)
+
+    def test_crawl_raises_on_failure(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+
+        crawl_start_response = {"id": "job-fail"}
+        poll_failed = {"success": True, "status": "failed", "error": "Something went wrong"}
+
+        with (
+            patch.object(client, "_http_post", return_value=crawl_start_response),
+            patch.object(client, "_http_request", return_value=poll_failed),
+            patch("crw.client.time.sleep"),
+        ):
+            with pytest.raises(CrwError, match="Crawl failed"):
+                client.crawl("https://example.com", poll_interval=0.01, timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMap:
+    def test_map_http_returns_links(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+        mock_response = {"links": ["https://example.com/a", "https://example.com/b"]}
+
+        with patch.object(client, "_http_post", return_value=mock_response):
+            result = client.map("https://example.com")
+
+        assert result == ["https://example.com/a", "https://example.com/b"]
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSearch:
+    def test_search_requires_api_url(self) -> None:
+        client = CrwClient()
+        with pytest.raises(CrwError, match="requires api_url"):
+            client.search("python web scraping")
+
+    def test_search_http_sends_query(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+        mock_response = [{"url": "https://example.com", "title": "Example"}]
+
+        with patch.object(client, "_http_post", return_value=mock_response) as mock_post:
+            result = client.search("python web scraping", limit=5)
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "/v1/search"
+        body = call_args[0][1]
+        assert body["query"] == "python web scraping"
+        assert body["limit"] == 5
+        assert result == mock_response
+
+
+# ---------------------------------------------------------------------------
+# Close / context manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLifecycle:
+    def test_close_terminates_process(self) -> None:
+        client = CrwClient()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # process is alive
+        mock_proc.wait.return_value = 0
+        client._process = mock_proc
+
+        client.close()
+
+        mock_proc.stdin.close.assert_called_once()
+        assert client._process is None
+
+    def test_context_manager(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api")
+        with patch.object(client, "close") as mock_close:
+            with client as c:
+                assert c is client
+            mock_close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestErrors:
+    def test_api_error_raised_on_failure(self) -> None:
+        client = CrwClient(api_url="https://fastcrw.com/api", api_key="fc-test")
+
+        with patch.object(
+            client,
+            "_http_request",
+            side_effect=CrwApiError("Bad request", status_code=400),
+        ):
+            with pytest.raises(CrwApiError) as exc_info:
+                client.scrape("https://example.com")
+            assert exc_info.value.status_code == 400
+
+    def test_jsonrpc_error_handling(self) -> None:
+        client = CrwClient()
+        mock_proc = MagicMock()
+        error_response = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32600, "message": "Invalid request"},
+        })
+        mock_proc.stdout.readline.return_value = error_response + "\n"
+        mock_proc.poll.return_value = None
+        client._process = mock_proc
+
+        with pytest.raises(CrwApiError, match="Invalid request"):
+            client._jsonrpc("tools/call", {"name": "crw_scrape", "arguments": {}})


### PR DESCRIPTION
## Summary
- **Bug fix**: `_http_crawl` polling was broken — `_http_request` returned `result.get("data")` (a list) instead of the full response envelope, so `status` field was never found. Added `raw=True` parameter to return full response.
- **Tests**: Added 27 Python SDK tests (14 unit, 9 integration via fastcrw.com, 4 binary)
- **Docs**: Added endpoint support matrix to integrations.md, fixed n8n Extract column, added cloud-only notes to changelog/credit-costs

## Test plan
- [x] All 27 SDK tests passing locally
- [x] Integration tests verified against fastcrw.com