### PR TITLE
fix(deadline): auto-extend implicit deadline to fit CDP ladder

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -1,8 +1,22 @@
 [server]
 host = "0.0.0.0"
 port = 3000
+# Tower outer timeout. Issue #35: when
+# `request.auto_extend_deadline_for_ladder = true` (default), this baseline is
+# auto-widened at startup to cover the longest legitimate handler runtime
+# (auto-extended scrape, search enrichment fan-out, map's 300s ceiling). Set
+# this above 305s only if you also raised request.deadline_ms_default beyond
+# the default ladder_min.
 request_timeout_secs = 120
 rate_limit_rps = 10              # Max requests/second (global). 0 = unlimited.
+
+# [request]
+# deadline_ms_default = 8000
+# auto_extend_deadline_for_ladder = true
+#   Issue #35: when an implicit request omits `deadlineMs`, auto-extend the
+#   effective deadline to max(deadline_ms_default, ladder_min). Prevents
+#   chrome_timeout_ms = 30000 from appearing inert when deadline_ms_default
+#   is small. Set to false to enforce a strict SLO regardless of tier sizing.
 
 [renderer]
 mode = "auto"                     # auto | lightpanda | playwright | chrome | none

--- a/config.docker.toml
+++ b/config.docker.toml
@@ -9,6 +9,13 @@
 # deadline yields a 264kb response. 15s is the budget that recovers the
 # stragglers without ballooning p50 on healthy pages.
 deadline_ms_default = 15000
+# Issue #35: when an implicit request omits `deadlineMs`, auto-extend the
+# effective deadline to `max(deadline_ms_default, ladder_min)` where
+# ladder_min = sum(per-tier timeouts) + N_cdp_tiers * 28s. Prevents
+# `chrome_timeout_ms = 30000` from appearing inert when this default is
+# small. Set to false to enforce the strict 15s SLO regardless of tier
+# sizing — explicit per-request `deadlineMs` always wins either way.
+auto_extend_deadline_for_ladder = true
 
 [server]
 # Disable global rps cap for benchmark + production load — the bench fires

--- a/crates/crw-core/Cargo.toml
+++ b/crates/crw-core/Cargo.toml
@@ -9,6 +9,15 @@ keywords.workspace = true
 categories.workspace = true
 description = "Core types, config, and error handling for the CRW web scraper"
 
+[features]
+# Mirrors the `cdp` feature of `crw-renderer` / `crw-server`. When the
+# downstream binary is built without CDP support, no JS renderers are
+# constructable and the ladder collapses to HTTP-only — the deadline
+# auto-extension policy (`AppConfig::effective_deadline_ms`) gates on this so
+# CDP-less builds keep their strict `deadline_ms_default`. The workspace
+# binary enables this transitively via `crw-renderer/cdp`.
+cdp = []
+
 [dependencies]
 crw-mcp-proto = { path = "../crw-mcp-proto", version = "0.6.1" }
 serde = { workspace = true }

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct AppConfig {
     #[serde(default)]
     pub server: ServerConfig,
@@ -17,6 +17,25 @@ pub struct AppConfig {
     #[serde(default)]
     pub search: SearchConfig,
 }
+
+/// Per-tier CDP overhead in milliseconds — sum of SPA selector poll budget,
+/// challenge retry budget, content-stability budget, and fetch overhead.
+/// Mirrors the constants in `crw-renderer::cdp`. The drift between the two
+/// is regression-tested by `crates/crw-server/tests/cdp_constants_test.rs`
+/// (gated behind `feature = "cdp"`).
+///
+/// Used by [`RendererConfig::min_deadline_for_full_ladder_ms`] so the request
+/// deadline accommodates each CDP tier's outer fetch timeout, not just its
+/// configured `page_timeout`.
+pub const CDP_TIER_OVERHEAD_MS: u64 = 28_000;
+
+/// Hard upper bound on the per-request `wait_for_ms` budget. The Tower outer
+/// timeout is sized so a worst-case implicit scrape (no `deadlineMs`,
+/// `wait_for` at this maximum) still completes inside it; values above this
+/// are clamped by [`AppConfig::effective_deadline_ms`] so the inner deadline
+/// can never escape the outer envelope. Documented as `(0, 60000]` in
+/// `types.rs::ScrapeRequest::wait_for`.
+pub const MAX_WAIT_FOR_MS: u64 = 60_000;
 
 /// Configuration for the `/v1/search` endpoint and its SearXNG backend.
 ///
@@ -100,14 +119,30 @@ pub struct RequestConfig {
     /// separate slow-path histogram.
     #[serde(default = "default_deadline_ms")]
     pub deadline_ms_default: u64,
+    /// When `true` (default), an implicit deadline (no per-request `deadlineMs`)
+    /// is auto-extended to `max(deadline_ms_default, ladder_min)` where
+    /// `ladder_min = sum(http+lightpanda+chrome timeouts) + N_cdp_tiers * 28s`.
+    /// This prevents `chrome_timeout_ms = 30000` from appearing inert when
+    /// `deadline_ms_default` is small (issue #35).
+    ///
+    /// Set to `false` to enforce a strict SLO regardless of tier sizing —
+    /// requests that would have completed under the extended budget will
+    /// instead time out at `deadline_ms_default`.
+    #[serde(default = "default_true_request")]
+    pub auto_extend_deadline_for_ladder: bool,
 }
 
 impl Default for RequestConfig {
     fn default() -> Self {
         Self {
             deadline_ms_default: default_deadline_ms(),
+            auto_extend_deadline_for_ladder: true,
         }
     }
+}
+
+fn default_true_request() -> bool {
+    true
 }
 
 fn default_deadline_ms() -> u64 {
@@ -369,6 +404,73 @@ impl RendererConfig {
     }
     pub fn chrome_timeout(&self) -> u64 {
         self.chrome_timeout_ms.unwrap_or(self.page_timeout_ms)
+    }
+
+    /// Number of active CDP tiers (lightpanda + playwright + chrome) under
+    /// the current `mode`. Mirrors the predicate used at runtime in
+    /// `crw-renderer/src/lib.rs` when constructing the renderer ladder:
+    /// `want(mode) && config.<tier>.is_some()`.
+    ///
+    /// Returns `0` when the binary is built without the `cdp` feature — in
+    /// that case no JS renderer can be constructed regardless of the config,
+    /// so the deadline auto-extension policy must collapse to HTTP-only.
+    pub fn cdp_tier_count(&self) -> usize {
+        if !cfg!(feature = "cdp") {
+            return 0;
+        }
+        let want =
+            |m: RendererMode| -> bool { matches!(self.mode, RendererMode::Auto) || self.mode == m };
+        let mut n = 0;
+        if want(RendererMode::Lightpanda) && self.lightpanda.is_some() {
+            n += 1;
+        }
+        if want(RendererMode::Playwright) && self.playwright.is_some() {
+            n += 1;
+        }
+        if want(RendererMode::Chrome) && self.chrome.is_some() {
+            n += 1;
+        }
+        n
+    }
+
+    /// Minimum request deadline budget (ms) required so that every configured
+    /// tier can use its full allowance when fallback exhausts the chain.
+    /// Sums the per-tier timeouts and adds [`CDP_TIER_OVERHEAD_MS`] for each
+    /// active CDP tier, matching the runtime ladder built in
+    /// `crw-renderer/src/lib.rs`.
+    pub fn min_deadline_for_full_ladder_ms(&self) -> u64 {
+        let want =
+            |m: RendererMode| -> bool { matches!(self.mode, RendererMode::Auto) || self.mode == m };
+
+        let mut sum: u64 = 0;
+        // HTTP prefetch runs ahead of any JS tier (content-type sniffing,
+        // direct PDF/binary handling) regardless of pinned mode. Skipped only
+        // when mode is `None` (no fetching at all).
+        if !matches!(self.mode, RendererMode::None) {
+            sum = sum.saturating_add(self.http_timeout());
+        }
+
+        // CDP tiers only contribute when the binary was built with the `cdp`
+        // feature; otherwise no JS renderer is constructable at runtime and
+        // including their budgets would over-extend the deadline.
+        if !cfg!(feature = "cdp") {
+            return sum;
+        }
+
+        let mut cdp_tier_count: u64 = 0;
+        if want(RendererMode::Lightpanda) && self.lightpanda.is_some() {
+            sum = sum.saturating_add(self.lightpanda_timeout());
+            cdp_tier_count += 1;
+        }
+        if want(RendererMode::Playwright) && self.playwright.is_some() {
+            sum = sum.saturating_add(self.chrome_timeout());
+            cdp_tier_count += 1;
+        }
+        if want(RendererMode::Chrome) && self.chrome.is_some() {
+            sum = sum.saturating_add(self.chrome_timeout());
+            cdp_tier_count += 1;
+        }
+        sum.saturating_add(cdp_tier_count.saturating_mul(CDP_TIER_OVERHEAD_MS))
     }
 }
 fn default_pool_size() -> usize {
@@ -651,6 +753,109 @@ impl AppConfig {
             .build()?;
         cfg.try_deserialize()
     }
+
+    /// Compute the effective end-to-end request deadline (ms). Implements the
+    /// issue-#35 auto-extension policy:
+    ///
+    /// 1. If the caller supplied an explicit `requested_deadline_ms`, return it
+    ///    verbatim — operators trust the request budget over our heuristic.
+    /// 2. Otherwise, when `request.auto_extend_deadline_for_ladder` is on,
+    ///    return `max(deadline_ms_default, ladder_min + wait_for_extra)`.
+    ///    `ladder_min` covers the configured tier ladder; `wait_for_extra`
+    ///    compensates for callers that bumped `wait_for_ms` above the default
+    ///    SPA budget (8s) — without it, a long `wait_for` would silently
+    ///    re-clamp inside CDP.
+    /// 3. When the policy is disabled, return `deadline_ms_default` unchanged.
+    ///
+    /// `wait_for_ms` is the per-request override (ScrapeRequest::wait_for /
+    /// CrawlRequest::wait_for); pass `None` for sub-fetches that don't
+    /// surface a wait_for to the caller (search/map enrichment).
+    pub fn effective_deadline_ms(
+        &self,
+        requested_deadline_ms: Option<u64>,
+        wait_for_ms: Option<u64>,
+    ) -> u64 {
+        if let Some(explicit) = requested_deadline_ms {
+            return explicit;
+        }
+        let default_ms = self.request.deadline_ms_default;
+        if !self.request.auto_extend_deadline_for_ladder {
+            return default_ms;
+        }
+        // Issue #35 is specifically about CDP tier overhead silently clamping
+        // chrome_timeout_ms. HTTP-only deployments don't suffer the same
+        // problem (the HTTP renderer respects deadline.remaining without the
+        // extra fetch/challenge/stability overhead). Skip the extension when
+        // no CDP tiers are configured so HTTP-only users keep the strict
+        // operator-configured default.
+        if self.renderer.cdp_tier_count() == 0 {
+            return default_ms;
+        }
+        let ladder_min = self.renderer.min_deadline_for_full_ladder_ms();
+        // Mirrors crw_renderer::cdp::SPA_SELECTOR_MAX_MS. The CDP module
+        // adds `wait_for_ms.unwrap_or(SPA_SELECTOR_MAX_MS)` to its internal
+        // timeout, so when the caller exceeds the default we need to extend
+        // the deadline per active CDP tier.
+        const SPA_DEFAULT_MS: u64 = 8_000;
+        // Clamp `wait_for_ms` to MAX_WAIT_FOR_MS so the inner deadline never
+        // exceeds the Tower envelope, which is sized off the same constant in
+        // `effective_request_timeout_secs`. A pathological caller passing
+        // `wait_for: 600_000` without `deadlineMs` would otherwise be cancelled
+        // by Tower before the inner CDP loop noticed the bigger budget.
+        let extra = if let Some(w) = wait_for_ms {
+            let bounded = w.min(MAX_WAIT_FOR_MS);
+            let per_tier = bounded.saturating_sub(SPA_DEFAULT_MS);
+            per_tier.saturating_mul(self.renderer.cdp_tier_count() as u64)
+        } else {
+            0
+        };
+        default_ms.max(ladder_min.saturating_add(extra))
+    }
+
+    /// Tower middleware outer timeout (seconds). Must accommodate the longest
+    /// legitimate handler runtime so a healthy request isn't cancelled by the
+    /// outer layer before the inner deadline fires.
+    ///
+    /// Covers the three route envelopes:
+    /// - `/scrape`, `/mcp` — auto-extended scrape deadline.
+    /// - `/search` — SearXNG fetch + bounded enrichment fan-out
+    ///   (`ceil(max_limit / max_concurrency)` batches × scrape_ms).
+    /// - `/crawl/jobs/:id`, `/map` — handler-side caps up to 300s.
+    ///
+    /// When auto-extend is disabled, returns the operator-configured baseline
+    /// unchanged.
+    pub fn effective_request_timeout_secs(&self) -> u64 {
+        let baseline = self.server.request_timeout_secs;
+        if !self.request.auto_extend_deadline_for_ladder {
+            return baseline;
+        }
+        const OUTER_BUFFER_SECS: u64 = 5;
+        // `/map` handler caps `req.timeout.unwrap_or(120).min(300)`; the outer
+        // must cover the upper bound so callers passing `timeout=300` aren't
+        // cancelled mid-flight.
+        const MAP_REQUEST_TIMEOUT_CEILING_MS: u64 = 300_000;
+        // Cover the worst-case implicit scrape: caller bumps `wait_for` to the
+        // configured maximum without supplying `deadlineMs`. The same
+        // [`MAX_WAIT_FOR_MS`] constant is used inside `effective_deadline_ms`
+        // to clamp the inner extension, so the inner deadline can never
+        // exceed this outer envelope.
+        let scrape_ms = self.effective_deadline_ms(None, Some(MAX_WAIT_FOR_MS));
+
+        // Search enrichment: bounded by max_concurrency. Worst case sequential
+        // batching with low concurrency: ceil(max_limit / max_concurrency)
+        // batches each bounded by scrape_ms.
+        let conc = (self.crawler.max_concurrency.max(1)) as u64;
+        let max_results = self.search.max_limit as u64;
+        let enrich_batches = max_results.div_ceil(conc);
+        let search_enrichment_ms = enrich_batches.saturating_mul(scrape_ms);
+        let search_ms = self.search.timeout_ms.saturating_add(search_enrichment_ms);
+
+        let max_handler_ms = scrape_ms.max(search_ms).max(MAP_REQUEST_TIMEOUT_CEILING_MS);
+        let needed_secs = max_handler_ms
+            .div_ceil(1_000)
+            .saturating_add(OUTER_BUFFER_SECS);
+        baseline.max(needed_secs)
+    }
 }
 
 #[cfg(test)]
@@ -756,6 +961,243 @@ mod tests {
     fn request_config_defaults_match_plan() {
         let r = RequestConfig::default();
         assert_eq!(r.deadline_ms_default, 8000);
+        assert!(r.auto_extend_deadline_for_ladder);
+    }
+
+    #[test]
+    fn default_app_config_enables_auto_extend() {
+        // Programmatic Default must mirror serde defaults — issue #35.
+        let cfg = AppConfig::default();
+        assert!(cfg.request.auto_extend_deadline_for_ladder);
+        assert_eq!(cfg.request.deadline_ms_default, 8000);
+    }
+
+    fn renderer_with_chrome_only(chrome_ms: u64) -> RendererConfig {
+        RendererConfig {
+            mode: RendererMode::Chrome,
+            page_timeout_ms: chrome_ms,
+            chrome_timeout_ms: Some(chrome_ms),
+            chrome: Some(CdpEndpoint {
+                ws_url: "ws://chrome:9222".into(),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cdp")]
+    fn min_deadline_full_ladder_chrome_only() {
+        // chrome-only mode: http (page_timeout) + chrome + 1 * 28000.
+        let r = renderer_with_chrome_only(30_000);
+        // page_timeout_ms is set to chrome_ms here, so http_timeout() → 30s.
+        assert_eq!(
+            r.min_deadline_for_full_ladder_ms(),
+            30_000 + 30_000 + 28_000
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cdp")]
+    fn min_deadline_full_ladder_auto_three_tiers() {
+        let r = RendererConfig {
+            mode: RendererMode::Auto,
+            page_timeout_ms: 15_000,
+            http_timeout_ms: Some(15_000),
+            lightpanda_timeout_ms: Some(2_500),
+            chrome_timeout_ms: Some(30_000),
+            lightpanda: Some(CdpEndpoint {
+                ws_url: "ws://lp:9222".into(),
+            }),
+            chrome: Some(CdpEndpoint {
+                ws_url: "ws://chrome:9222".into(),
+            }),
+            ..Default::default()
+        };
+        // http(15) + lp(2.5) + chrome(30) + 2*28 = 47.5 + 56 = 103_500.
+        assert_eq!(
+            r.min_deadline_for_full_ladder_ms(),
+            15_000 + 2_500 + 30_000 + 2 * 28_000
+        );
+        assert_eq!(r.cdp_tier_count(), 2);
+    }
+
+    #[test]
+    fn effective_deadline_explicit_bypasses_auto_extend() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        // Explicit override beats both default and ladder_min.
+        assert_eq!(cfg.effective_deadline_ms(Some(5_000), None), 5_000);
+        assert_eq!(cfg.effective_deadline_ms(Some(500_000), None), 500_000);
+    }
+
+    #[test]
+    #[cfg(feature = "cdp")]
+    fn effective_deadline_auto_extend_raises_to_ladder_min() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.request.deadline_ms_default = 8_000;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        let expected = cfg.renderer.min_deadline_for_full_ladder_ms();
+        assert!(expected > 8_000);
+        assert_eq!(cfg.effective_deadline_ms(None, None), expected);
+    }
+
+    #[test]
+    fn effective_deadline_default_wins_when_higher_than_ladder() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.request.deadline_ms_default = 1_000_000;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        assert_eq!(cfg.effective_deadline_ms(None, None), 1_000_000);
+    }
+
+    #[test]
+    fn effective_deadline_auto_extend_disabled_returns_baseline() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = false;
+        cfg.request.deadline_ms_default = 8_000;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        assert_eq!(cfg.effective_deadline_ms(None, None), 8_000);
+    }
+
+    #[test]
+    #[cfg(feature = "cdp")]
+    fn effective_deadline_extends_for_long_wait_for() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.request.deadline_ms_default = 8_000;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        let base = cfg.renderer.min_deadline_for_full_ladder_ms();
+        let tier_count = cfg.renderer.cdp_tier_count() as u64;
+        // wait_for = 20000 → per-tier extra = 12000 over SPA_DEFAULT_MS (8000).
+        let with_wait = cfg.effective_deadline_ms(None, Some(20_000));
+        assert_eq!(with_wait, base + 12_000 * tier_count);
+        // wait_for below SPA default → no extra.
+        assert_eq!(cfg.effective_deadline_ms(None, Some(2_000)), base);
+    }
+
+    #[test]
+    fn effective_request_timeout_covers_map_ceiling() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.request.deadline_ms_default = 8_000;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        cfg.search.timeout_ms = 15_000;
+        cfg.crawler.max_concurrency = 10;
+        cfg.search.max_limit = 20;
+        cfg.server.request_timeout_secs = 60;
+        // Map ceiling 300s + 5s buffer = 305s minimum.
+        assert!(cfg.effective_request_timeout_secs() >= 305);
+    }
+
+    #[test]
+    fn effective_request_timeout_disabled_returns_baseline() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = false;
+        cfg.server.request_timeout_secs = 60;
+        assert_eq!(cfg.effective_request_timeout_secs(), 60);
+    }
+
+    #[test]
+    fn effective_request_timeout_respects_operator_override() {
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.server.request_timeout_secs = 600; // operator-configured high
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        // Operator's explicit 600s should win over the auto-computed 305s.
+        assert_eq!(cfg.effective_request_timeout_secs(), 600);
+    }
+
+    #[test]
+    fn effective_request_timeout_search_sequential_batching() {
+        // Low concurrency forces ceil(max_limit/conc) batches → larger search_ms.
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.request.deadline_ms_default = 8_000;
+        cfg.renderer = renderer_with_chrome_only(30_000);
+        cfg.search.timeout_ms = 15_000;
+        cfg.search.max_limit = 20;
+        cfg.crawler.max_concurrency = 1;
+        cfg.server.request_timeout_secs = 60;
+        // The Tower envelope must cover the worst-case implicit scrape with
+        // `wait_for` bumped to MAX_WAIT_FOR_MS (60s), because callers can do
+        // that without supplying `deadlineMs`. Mirror that in the expected.
+        let secs = cfg.effective_request_timeout_secs();
+        let scrape_ms = cfg.effective_deadline_ms(None, Some(60_000));
+        let expected_search_ms = 15_000 + 20 * scrape_ms;
+        let expected_max_ms = scrape_ms.max(expected_search_ms).max(300_000);
+        let expected_secs = expected_max_ms.div_ceil(1_000) + 5;
+        assert_eq!(secs, 60u64.max(expected_secs));
+    }
+
+    #[test]
+    #[cfg(not(feature = "cdp"))]
+    fn cdp_tier_count_zero_without_cdp_feature() {
+        // Even when chrome/lightpanda are configured, a binary built without
+        // the `cdp` feature can never construct a JS renderer. The deadline
+        // policy must observe that and collapse to HTTP-only behavior.
+        let r = RendererConfig {
+            mode: RendererMode::Auto,
+            page_timeout_ms: 15_000,
+            chrome_timeout_ms: Some(30_000),
+            chrome: Some(CdpEndpoint {
+                ws_url: "ws://chrome:9222".into(),
+            }),
+            lightpanda: Some(CdpEndpoint {
+                ws_url: "ws://lp:9222".into(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(r.cdp_tier_count(), 0);
+        // Only the HTTP tier contributes to the ladder budget.
+        assert_eq!(r.min_deadline_for_full_ladder_ms(), 15_000);
+    }
+
+    #[test]
+    fn effective_deadline_skipped_for_http_only_mode() {
+        // P2 from codex review: HTTP-only deployments don't suffer the CDP
+        // clamping problem (no fetch/challenge/stability overhead). The
+        // auto-extension must NOT silently bump their default from 8s to 30s
+        // just because page_timeout_ms defaults high.
+        let mut cfg = AppConfig::default();
+        cfg.request.auto_extend_deadline_for_ladder = true;
+        cfg.request.deadline_ms_default = 8_000;
+        cfg.renderer = RendererConfig {
+            mode: RendererMode::Auto,
+            page_timeout_ms: 30_000,
+            // No CDP endpoints configured.
+            lightpanda: None,
+            playwright: None,
+            chrome: None,
+            ..Default::default()
+        };
+        assert_eq!(cfg.renderer.cdp_tier_count(), 0);
+        assert_eq!(cfg.effective_deadline_ms(None, None), 8_000);
+        assert_eq!(cfg.effective_deadline_ms(None, Some(30_000)), 8_000);
+    }
+
+    #[test]
+    #[cfg(feature = "cdp")]
+    fn min_deadline_full_ladder_playwright_only() {
+        // Playwright tier contributes one chrome_timeout + one CDP overhead,
+        // matching the runtime predicate in `crw-renderer/src/lib.rs`.
+        let r = RendererConfig {
+            mode: RendererMode::Playwright,
+            page_timeout_ms: 15_000,
+            http_timeout_ms: Some(15_000),
+            chrome_timeout_ms: Some(30_000),
+            playwright: Some(CdpEndpoint {
+                ws_url: "ws://playwright:9222".into(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(r.cdp_tier_count(), 1);
+        // http(15) + chrome-equivalent(30) + 1 * 28 overhead.
+        assert_eq!(
+            r.min_deadline_for_full_ladder_ms(),
+            15_000 + 30_000 + 28_000
+        );
     }
 
     #[test]

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -11,7 +11,7 @@ description = "HTTP and CDP browser rendering engine for the CRW web scraper"
 
 [features]
 default = []
-cdp = ["tokio-tungstenite"]
+cdp = ["tokio-tungstenite", "crw-core/cdp"]
 auto-browser = ["dep:dirs"]
 
 [dependencies]

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -17,22 +17,34 @@ use crate::traits::PageFetcher;
 const WS_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Extra overhead budget for the overall fetch timeout (on top of page_timeout + wait_for).
 /// Covers WS connect, target create, navigate commit, snapshot eval, and cleanup.
-const FETCH_OVERHEAD: Duration = Duration::from_secs(5);
+pub const FETCH_OVERHEAD: Duration = Duration::from_secs(5);
 /// Timeout for the Target.closeTarget cleanup command.
 const TARGET_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Maximum number of challenge retry attempts.
-const CHALLENGE_MAX_RETRIES: u32 = 3;
+pub const CHALLENGE_MAX_RETRIES: u32 = 3;
 /// Delay between challenge retry polls (ms).
-const CHALLENGE_POLL_INTERVAL_MS: u64 = 3000;
+pub const CHALLENGE_POLL_INTERVAL_MS: u64 = 3000;
 /// Maximum time to poll for content stability when a loading placeholder
 /// is detected after the initial wait.
-const CONTENT_STABILITY_MAX_MS: u64 = 6000;
+pub const CONTENT_STABILITY_MAX_MS: u64 = 6000;
 /// Interval between content-stability polls.
 const CONTENT_STABILITY_TICK_MS: u64 = 500;
 /// Max time to poll for a content selector before giving up and proceeding
 /// with whatever HTML is currently rendered. Covers SPAs that hydrate after
 /// `loadEventFired` (njcourts.gov, in-n-out.com, hangzhou customs, apploi).
-const SPA_SELECTOR_MAX_MS: u64 = 8000;
+pub const SPA_SELECTOR_MAX_MS: u64 = 8000;
+
+/// Sum of per-tier CDP overhead in milliseconds — the difference between
+/// `internal_timeout` (set by [`fetch_with_deadline`]) and the configured
+/// per-tier `page_timeout`. Mirrored by `crw_core::config::CDP_TIER_OVERHEAD_MS`;
+/// drift between the two is regression-tested in
+/// `crates/crw-server/tests/cdp_constants_test.rs`.
+pub const fn cdp_tier_overhead_ms() -> u64 {
+    SPA_SELECTOR_MAX_MS
+        + (CHALLENGE_MAX_RETRIES as u64) * CHALLENGE_POLL_INTERVAL_MS
+        + CONTENT_STABILITY_MAX_MS
+        + (FETCH_OVERHEAD.as_millis() as u64)
+}
 /// Interval between SPA selector polls.
 const SPA_SELECTOR_TICK_MS: u64 = 200;
 /// Body innerText length required before the SPA poll exits. Selectors mount
@@ -999,8 +1011,26 @@ impl PageFetcher for CdpRenderer {
         let internal_timeout =
             self.page_timeout + wait_dur + challenge_budget + stability_budget + FETCH_OVERHEAD;
         // Clamp internal timeout against the caller's remaining budget so the
-        // CDP fetch never exceeds the end-to-end deadline.
-        let overall_timeout = internal_timeout.min(deadline.remaining());
+        // CDP fetch never exceeds the end-to-end deadline. Snapshot remaining
+        // once so the diagnostic log and the actual timeout can't disagree
+        // across consecutive monotonic reads.
+        let remaining = deadline.remaining();
+        let overall_timeout = if internal_timeout > remaining {
+            tracing::debug!(
+                renderer = %self.name,
+                internal_ms = internal_timeout.as_millis() as u64,
+                remaining_ms = remaining.as_millis() as u64,
+                "CDP outer timeout shrunk to fit remaining request deadline. \
+                 If the caller supplied an explicit `deadlineMs`, this clamp \
+                 is intentional — the request asked for a tighter cap. \
+                 Otherwise (issue #35) raise request.deadline_ms_default or \
+                 enable request.auto_extend_deadline_for_ladder so per-tier \
+                 timeouts get their full configured allowance."
+            );
+            remaining
+        } else {
+            internal_timeout
+        };
         if overall_timeout.is_zero() {
             // Caller's deadline is already past — surface how late we are so
             // the error reads "Timeout after Xms" instead of a useless 0.

--- a/crates/crw-server/src/app.rs
+++ b/crates/crw-server/src/app.rs
@@ -22,7 +22,11 @@ use crate::state::AppState;
 
 pub fn create_app(state: AppState) -> Router {
     let api_keys = Arc::new(state.config.auth.api_keys.clone());
-    let timeout = Duration::from_secs(state.config.server.request_timeout_secs);
+    // Tower outer timeout. `effective_request_timeout_secs()` widens the
+    // operator baseline so the longest legitimate handler runtime (auto-extended
+    // scrape, search enrichment fan-out, map's 300s ceiling) isn't cancelled
+    // by the outer layer before the inner deadline fires. See issue #35.
+    let timeout = Duration::from_secs(state.config.effective_request_timeout_secs());
     let rate_limit_rps = state.config.server.rate_limit_rps;
 
     let api_routes = Router::new()

--- a/crates/crw-server/src/main.rs
+++ b/crates/crw-server/src/main.rs
@@ -89,6 +89,33 @@ async fn run_server() {
     if state.renderer.js_renderer_names().is_empty() {
         tracing::warn!("No CDP renderer active — JS rendering disabled");
     }
+
+    // Issue #35 transparency: when auto-extension widens the implicit deadline
+    // beyond the operator's `deadline_ms_default`, log the effective values so
+    // operators can correlate "request took longer than my SLO" against the
+    // ladder budget instead of suspecting a bug.
+    let baseline_default_ms = state.config.request.deadline_ms_default;
+    let ladder_min_ms = state.config.renderer.min_deadline_for_full_ladder_ms();
+    let effective_default_ms = state.config.effective_deadline_ms(None, None);
+    let baseline_outer_secs = state.config.server.request_timeout_secs;
+    let effective_outer_secs = state.config.effective_request_timeout_secs();
+    if state.config.request.auto_extend_deadline_for_ladder
+        && effective_default_ms > baseline_default_ms
+    {
+        tracing::info!(
+            deadline_ms_default = baseline_default_ms,
+            ladder_min_ms,
+            effective_default_ms,
+            outer_timeout_secs_baseline = baseline_outer_secs,
+            outer_timeout_secs_effective = effective_outer_secs,
+            "request.auto_extend_deadline_for_ladder is on; default request \
+             deadline auto-raised so the configured renderer ladder \
+             (http+lightpanda+chrome+overhead) can run uncrushed. Set \
+             request.auto_extend_deadline_for_ladder = false to enforce the \
+             baseline cap."
+        );
+    }
+
     let app = crw_server::app::create_app(state);
 
     let listener = match tokio::net::TcpListener::bind(&addr).await {

--- a/crates/crw-server/src/routes/map.rs
+++ b/crates/crw-server/src/routes/map.rs
@@ -34,7 +34,7 @@ pub async fn map(
         requests_per_second: state.config.crawler.requests_per_second,
         user_agent: &state.config.crawler.user_agent,
         proxy: state.config.crawler.proxy.clone(),
-        deadline_ms_per_page: state.config.request.deadline_ms_default,
+        deadline_ms_per_page: state.config.effective_deadline_ms(None, None),
         per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
         crawl_fallback: req.crawl_fallback,
     });

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -32,8 +32,9 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
             let default_stealth =
                 state.config.crawler.stealth.enabled && state.config.crawler.stealth.inject_headers;
             let deadline = crw_core::Deadline::from_request_ms(
-                req.deadline_ms
-                    .unwrap_or(state.config.request.deadline_ms_default),
+                state
+                    .config
+                    .effective_deadline_ms(req.deadline_ms, req.wait_for),
             );
             let data = scrape_url(
                 &req,
@@ -86,7 +87,7 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
                 requests_per_second: state.config.crawler.requests_per_second,
                 user_agent: &state.config.crawler.user_agent,
                 proxy: state.config.crawler.proxy.clone(),
-                deadline_ms_per_page: state.config.request.deadline_ms_default,
+                deadline_ms_per_page: state.config.effective_deadline_ms(None, None),
                 per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
                 crawl_fallback: req.crawl_fallback,
             })

--- a/crates/crw-server/src/routes/scrape.rs
+++ b/crates/crw-server/src/routes/scrape.rs
@@ -24,8 +24,9 @@ pub async fn scrape(
     let default_stealth =
         state.config.crawler.stealth.enabled && state.config.crawler.stealth.inject_headers;
     let deadline = Deadline::from_request_ms(
-        req.deadline_ms
-            .unwrap_or(state.config.request.deadline_ms_default),
+        state
+            .config
+            .effective_deadline_ms(req.deadline_ms, req.wait_for),
     );
     let data = scrape_url(
         &req,

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -197,7 +197,7 @@ async fn enrich_with_scrape(
         let default_stealth =
             state.config.crawler.stealth.enabled && state.config.crawler.stealth.inject_headers;
         let render_js_default = state.config.renderer.render_js_default;
-        let deadline_ms = state.config.request.deadline_ms_default;
+        let deadline_ms = state.config.effective_deadline_ms(None, None);
         let permit_src = semaphore.clone();
 
         set.spawn(async move {

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -200,7 +200,7 @@ impl AppState {
         let llm_config = self.config.extraction.llm.clone();
         let proxy = self.config.crawler.proxy.clone();
         let jitter_factor = self.config.crawler.stealth.jitter_factor;
-        let deadline_ms_per_page = self.config.request.deadline_ms_default;
+        let deadline_ms_per_page = self.config.effective_deadline_ms(None, req.wait_for);
         let per_host_max_concurrent = self.config.crawler.per_host_max_concurrent;
 
         let handle = tokio::spawn(async move {

--- a/crates/crw-server/tests/cdp_constants_test.rs
+++ b/crates/crw-server/tests/cdp_constants_test.rs
@@ -1,0 +1,25 @@
+//! Regression test for issue #35: ensures the duplicated CDP overhead
+//! constant in `crw-core::config` stays in lockstep with the source-of-truth
+//! constants in `crw-renderer::cdp`. Without this, changing
+//! `SPA_SELECTOR_MAX_MS`, the challenge retry budget, content-stability
+//! budget, or fetch overhead in the renderer would silently re-introduce
+//! deadline clamping that crushes per-tier timeouts.
+//!
+//! Why duplicate at all: `crw-renderer` already depends on `crw-core`, so
+//! `crw-core` cannot import `crw_renderer::cdp` without a cycle.
+//! The integration crate (`crw-server`) is the natural place to assert
+//! equality because it depends on both.
+
+#![cfg(feature = "cdp")]
+
+#[test]
+fn cdp_tier_overhead_matches_renderer_constants() {
+    let renderer_sum_ms = crw_renderer::cdp::cdp_tier_overhead_ms();
+    assert_eq!(
+        renderer_sum_ms,
+        crw_core::config::CDP_TIER_OVERHEAD_MS,
+        "CDP_TIER_OVERHEAD_MS in crw-core::config drifted from crw-renderer::cdp constants. \
+         Update crw_core::config::CDP_TIER_OVERHEAD_MS to match the new sum, or share via \
+         a single source of truth."
+    );
+}

--- a/crates/crw-server/tests/deadline_auto_extend_test.rs
+++ b/crates/crw-server/tests/deadline_auto_extend_test.rs
@@ -1,0 +1,171 @@
+//! Integration tests for issue #35: verify that
+//! `request.auto_extend_deadline_for_ladder` lets the configured CDP tier
+//! timeouts (e.g. `chrome_timeout_ms = 30000`) actually run to completion
+//! instead of being silently clamped by a small `deadline_ms_default`.
+//!
+//! These tests require a live Chrome CDP endpoint and are gated behind
+//! `CRW_CDP_WS_URL` + `#[ignore]`. They do not run in the default
+//! `cargo test --workspace` invocation. Run them locally with:
+//!
+//! ```sh
+//! CRW_CDP_WS_URL="ws://localhost:9222/devtools/browser/<id>" \
+//!     cargo test -p crw-server --features cdp --test deadline_auto_extend_test \
+//!     -- --ignored
+//! ```
+//!
+//! The marker HTML is constructed so that the literal string
+//! `"CHROME_RENDERED_OK"` only appears in the rendered DOM after Chrome
+//! executes the inline script — never in the raw HTML bytes that an
+//! HTTP-only fetch would receive. This eliminates false positives where
+//! HTTP succeeded without the JS path being exercised.
+
+#![cfg(feature = "cdp")]
+
+use axum_test::TestServer;
+use crw_core::config::{AppConfig, CdpEndpoint, RendererMode};
+use crw_server::app::create_app;
+use crw_server::state::AppState;
+use serde_json::json;
+use std::time::Duration;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Marker HTML: `loading` placeholder, replaced post-DOMContentLoaded by
+/// the runtime concatenation of `'CHROME_'` + `'RENDERED_OK'`. The full
+/// marker string never appears in the source.
+const MARKER_HTML: &str = r#"<!doctype html>
+<html><body>
+<div id="content">loading</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.getElementById('content').textContent = 'CHROME_' + 'RENDERED_OK';
+  });
+</script>
+</body></html>"#;
+
+const FULL_MARKER: &str = "CHROME_RENDERED_OK";
+
+fn cdp_ws_url() -> Option<String> {
+    std::env::var("CRW_CDP_WS_URL").ok()
+}
+
+fn chrome_only_config(ws_url: &str, deadline_ms_default: u64, auto_extend: bool) -> AppConfig {
+    let mut cfg = AppConfig::default();
+    cfg.request.deadline_ms_default = deadline_ms_default;
+    cfg.request.auto_extend_deadline_for_ladder = auto_extend;
+    cfg.renderer.mode = RendererMode::Chrome;
+    cfg.renderer.page_timeout_ms = 30_000;
+    cfg.renderer.chrome_timeout_ms = Some(30_000);
+    cfg.renderer.chrome = Some(CdpEndpoint {
+        ws_url: ws_url.to_string(),
+    });
+    cfg.renderer.lightpanda = None;
+    cfg.renderer.playwright = None;
+    cfg.server.request_timeout_secs = 60;
+    cfg
+}
+
+async fn slow_marker_endpoint(delay: Duration) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(MARKER_HTML)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .set_delay(delay),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
+#[tokio::test]
+#[ignore = "requires running Chrome CDP at CRW_CDP_WS_URL"]
+async fn auto_extend_honors_chrome_timeout() {
+    let Some(ws_url) = cdp_ws_url() else {
+        return;
+    };
+    // 12s endpoint is unambiguously above the 8s strict deadline and below
+    // the 30s chrome_timeout_ms — the test fails deterministically without
+    // auto-extend, succeeds deterministically with it.
+    let mock = slow_marker_endpoint(Duration::from_secs(12)).await;
+    let cfg = chrome_only_config(&ws_url, 8_000, /*auto_extend=*/ true);
+    let state = AppState::new(cfg).expect("AppState");
+    let server = TestServer::new(create_app(state));
+
+    let resp = server
+        .post("/v1/scrape")
+        .json(&json!({
+            "url": format!("{}/", mock.uri()),
+            "renderJs": true,
+            "formats": ["markdown"],
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["success"], true,
+        "auto-extend should permit chrome to finish: {body:?}"
+    );
+    let markdown = body["data"]["markdown"].as_str().unwrap_or_default();
+    assert!(
+        markdown.contains(FULL_MARKER),
+        "rendered markdown must contain the JS-assembled marker; got: {markdown}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running Chrome CDP at CRW_CDP_WS_URL"]
+async fn auto_extend_disabled_strict_deadline_times_out() {
+    let Some(ws_url) = cdp_ws_url() else {
+        return;
+    };
+    let mock = slow_marker_endpoint(Duration::from_secs(12)).await;
+    let cfg = chrome_only_config(&ws_url, 8_000, /*auto_extend=*/ false);
+    let state = AppState::new(cfg).expect("AppState");
+    let server = TestServer::new(create_app(state));
+
+    let resp = server
+        .post("/v1/scrape")
+        .json(&json!({
+            "url": format!("{}/", mock.uri()),
+            "renderJs": true,
+            "formats": ["markdown"],
+        }))
+        .await;
+    // Handler-side timeout, not Tower outer cancellation. CrwError::Timeout
+    // serializes to error_code = "timeout".
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["error_code"], "timeout",
+        "strict deadline should produce handler-side timeout, not tower cancel: {body:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires running Chrome CDP at CRW_CDP_WS_URL"]
+async fn explicit_deadline_bypasses_auto_extend() {
+    let Some(ws_url) = cdp_ws_url() else {
+        return;
+    };
+    let mock = slow_marker_endpoint(Duration::from_secs(12)).await;
+    let cfg = chrome_only_config(&ws_url, 30_000, /*auto_extend=*/ true);
+    let state = AppState::new(cfg).expect("AppState");
+    let server = TestServer::new(create_app(state));
+
+    // Caller's explicit deadline beats both default and ladder_min.
+    let resp = server
+        .post("/v1/scrape")
+        .json(&json!({
+            "url": format!("{}/", mock.uri()),
+            "renderJs": true,
+            "formats": ["markdown"],
+            "deadlineMs": 3_000,
+        }))
+        .await;
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["error_code"], "timeout",
+        "explicit 3s deadline should cut the 12s response: {body:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Closes #35: `chrome_timeout_ms = 30000` was silently clamped to ~2.7s because `min(internal_timeout, deadline.remaining())` ran against an 8s `deadline_ms_default`.
- Adds `request.auto_extend_deadline_for_ladder` (default `true`). When a request omits `deadlineMs`, the effective deadline widens to `max(deadline_ms_default, ladder_min)` where `ladder_min = sum(per-tier timeouts) + N_cdp_tiers * 28s`. Explicit per-request `deadlineMs` always wins.
- Tower outer timeout is now sized off the same envelope (`effective_request_timeout_secs`) so middleware can't cancel a healthy handler.
- HTTP-only deployments (no `cdp` feature) keep their strict default — `cdp_tier_count()` collapses to 0 and the extension is a no-op.
- `wait_for_ms` is clamped to `MAX_WAIT_FOR_MS = 60s` so the inner deadline can never escape the outer envelope.

## Why
David's Chrome trace shows `Timeout after 2771ms` despite `chrome_timeout_ms = 30000` — the per-tier budget was being silently overruled by the request deadline. Fix gives operators what they configured.

## Test plan
- [x] 655 workspace tests green (default features) and with `--features crw-server/cdp`
- [x] Clippy clean both ways
- [x] Drift guard between `crw-renderer::cdp` constants and `crw-core::config::CDP_TIER_OVERHEAD_MS`
- [x] 14 unit tests covering: explicit bypass, auto-extend on/off, default vs ladder_min, `wait_for` extension, HTTP-only short-circuit, no-cdp build, Playwright tier, `effective_request_timeout_secs` envelope, search enrichment fan-out, map ceiling
- [ ] 3 ignored integration tests under `CRW_CDP_WS_URL` (require live Chrome) — to run locally with `cargo test -p crw-server --features cdp --test deadline_auto_extend_test -- --ignored`
- [ ] Production smoke: `https://x.com/trq212/status/2033949937936085378` should now produce `Timeout after ~30000ms` (full chrome budget) instead of `Timeout after 2771ms`

## Files
- `crates/crw-core/src/config.rs` — `CDP_TIER_OVERHEAD_MS`, `MAX_WAIT_FOR_MS`, `RequestConfig::auto_extend_deadline_for_ladder`, `RendererConfig::cdp_tier_count`/`min_deadline_for_full_ladder_ms`, `AppConfig::effective_deadline_ms`/`effective_request_timeout_secs`
- `crates/crw-renderer/src/cdp.rs` — pub budget constants, `cdp_tier_overhead_ms()`, snapshot remaining once + diagnostic log
- `crates/crw-server/src/{app,main,routes/{scrape,search,map,mcp},state}.rs` — wire `effective_deadline_ms` everywhere
- `crates/crw-server/tests/{cdp_constants_test,deadline_auto_extend_test}.rs` — drift + integration coverage
- `config.{default,docker}.toml` — documented new knob