### PR TITLE
fix(crawl): drop redundant .into_iter() for clippy 1.95

### DIFF
--- a/crates/crw-crawl/src/sitemap.rs
+++ b/crates/crw-crawl/src/sitemap.rs
@@ -286,7 +286,7 @@ pub async fn fetch_sitemap_tree(
         }
         total_fetched += batch.len();
 
-        let results: Vec<(String, SitemapResult)> = stream::iter(batch.into_iter())
+        let results: Vec<(String, SitemapResult)> = stream::iter(batch)
             .map(|u| {
                 let client = client.clone();
                 async move {


### PR DESCRIPTION
Fixes red CI on main. `stream::iter` accepts any `IntoIterator`, so the explicit `.into_iter()` on `batch` triggers `clippy::useless_conversion` under Rust 1.95.0 (CI's toolchain). Local Rust 1.94.1 didn't flag it, which is how it slipped through #33's merge.

Trivial one-line fix; tests still green.