### PR TITLE
feat(map): drop action URLs and strip tracking params (closes #40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "crw-core",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crw-core",
  "crw-extract",
@@ -737,6 +737,9 @@ dependencies = [
  "dashmap",
  "flate2",
  "futures",
+ "phf 0.11.3",
+ "proptest",
+ "publicsuffix",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "scraper",
@@ -749,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -774,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "crw-core",
@@ -789,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -798,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -822,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crw-core",
  "futures",
@@ -838,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "axum-test",
@@ -2398,6 +2401,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -2407,7 +2411,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -2450,6 +2454,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2573,6 +2590,25 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2722,6 +2758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3087,6 +3132,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4017,6 +4074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,6 +4180,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,10 +89,15 @@ url = { version = "2", features = ["serde"] }
 sha2 = "0.10"
 hex = "0.4"
 
+# Compile-time perfect-hash sets (url_filter deny-lists)
+phf = { version = "0.11", features = ["macros"] }
+
 # Test dependencies
 tokio-test = "0.4"
 wiremock = "0.6"
 axum-test = "19"
+proptest = "1"
+insta = { version = "1", features = ["json"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -269,6 +269,31 @@ curl -X POST http://localhost:3000/v1/map \
 ```
 </details>
 
+#### URL Filtering (default-on)
+
+`/v1/map` filters its output by default to keep content URLs and drop
+transactional action URLs (e.g. WooCommerce `?add-to-cart=…`,
+`?add_to_wishlist=…&_wpnonce=…`). Tracking parameters (`utm_*`, `gclid`,
+`fbclid`, …) are stripped from the URLs that remain. Counts come back in
+`droppedActionCount` and `strippedTrackingCount`.
+
+Per-request fields (all optional):
+
+| Field | Effect |
+|---|---|
+| `ignoreQueryParameters: true` | Coarse Firecrawl-compatible: strip ALL params from kept URLs (action drop still runs). |
+| `ignoreQueryParameters: false` | Disable both filters — raw URLs. |
+| `stripTrackingParams: bool` | Toggle Tier B only. |
+| `dropActionUrls: bool` | Toggle Tier A only. |
+| `extraTrackingParams: [string]` | Additive (≤64 keys). |
+| `extraActionParams: [string]` | Additive (≤64 keys). |
+| `preserveParams: [string]` | Never strip / never drop these keys (≤64 keys). |
+
+Precedence: per-request value > TOML (`[map.url_filter]`) > compile-time
+default (both `true`). To restore pre-filter behaviour globally, set
+`strip_tracking_params = false` and `drop_action_urls = false` in
+`config.default.toml`.
+
 ### Search
 
 Search the web and get full page content from results. Self-hosted CRW

--- a/config.default.toml
+++ b/config.default.toml
@@ -139,3 +139,17 @@ max_limit = 20
 research_engines = ["arxiv", "crossref", "google scholar", "semantic scholar"]
 # Engines invoked when the request includes `categories: ["github"]`.
 github_engines = ["github"]
+
+# ── /v1/map URL filter ──────────────────────────────────────────────────
+# Strips tracking params and drops transactional action URLs from /map
+# results. See `crates/crw-crawl/src/url_filter_data.rs` for the built-in
+# deny-lists. Per-request overrides are documented on `MapRequest` —
+# pass `{"ignoreQueryParameters": false}` for raw-URL output.
+[map.url_filter]
+strip_tracking_params = true
+drop_action_urls = true
+gov_tld_drop_actions = false
+# Additive on top of built-ins (max 64 keys each).
+extra_tracking_params = []
+extra_action_params = []
+extra_preserve_params = []

--- a/config.docker.toml
+++ b/config.docker.toml
@@ -66,3 +66,10 @@ ws_url = "ws://chrome:9222/"
 # `searxng` via docker-compose's network DNS.
 [search]
 searxng_url = "http://searxng:8080"
+
+# /map URL filter — defaults on. Set `drop_action_urls = false` to revert
+# to legacy behaviour (action URLs surface in results).
+[map.url_filter]
+strip_tracking_params = true
+drop_action_urls = true
+gov_tld_drop_actions = false

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -16,6 +16,58 @@ pub struct AppConfig {
     pub request: RequestConfig,
     #[serde(default)]
     pub search: SearchConfig,
+    #[serde(default)]
+    pub map: MapConfig,
+}
+
+/// `[map]` section — currently only carries `[map.url_filter]`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct MapConfig {
+    #[serde(default)]
+    pub url_filter: MapUrlFilterConfig,
+}
+
+/// `[map.url_filter]` — raw TOML view of the filter knobs. Conversion to
+/// the runtime `UrlFilterCfg` lives in `crw-crawl` (which can see both this
+/// type and the filter module). Keeping this struct dependency-free here
+/// avoids a cycle (`crw-core` does not depend on `crw-crawl`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MapUrlFilterConfig {
+    /// Tier B — strip tracking params. Default: `true`.
+    #[serde(default = "default_true_filter")]
+    pub strip_tracking_params: bool,
+    /// Tier A — drop action URLs entirely. Default: `true`.
+    #[serde(default = "default_true_filter")]
+    pub drop_action_urls: bool,
+    /// When `true`, `.gov`/`.mil` hosts run Tier A too. Default `false`.
+    #[serde(default)]
+    pub gov_tld_drop_actions: bool,
+    /// Additive on top of `DEFAULT_TRACKING_PARAMS`.
+    #[serde(default)]
+    pub extra_tracking_params: Vec<String>,
+    /// Additive on top of `DEFAULT_ACTION_PARAMS`.
+    #[serde(default)]
+    pub extra_action_params: Vec<String>,
+    /// Additive on top of `ALWAYS_PRESERVE`.
+    #[serde(default)]
+    pub extra_preserve_params: Vec<String>,
+}
+
+impl Default for MapUrlFilterConfig {
+    fn default() -> Self {
+        Self {
+            strip_tracking_params: true,
+            drop_action_urls: true,
+            gov_tld_drop_actions: false,
+            extra_tracking_params: Vec::new(),
+            extra_action_params: Vec::new(),
+            extra_preserve_params: Vec::new(),
+        }
+    }
+}
+
+fn default_true_filter() -> bool {
+    true
 }
 
 /// Per-tier CDP overhead in milliseconds — sum of SPA selector poll budget,

--- a/crates/crw-core/src/metrics.rs
+++ b/crates/crw-core/src/metrics.rs
@@ -47,6 +47,16 @@ pub struct Metrics {
     /// Renderer recycle events, labeled by renderer + reason
     /// (`age` | `count`). Reserved for the optional page-sweep work in B.1.
     pub renderer_recycle_total: IntCounterVec,
+    /// /map URL filter: URLs dropped entirely (Tier A action-URL filter or
+    /// parse-error pass-through bookkeeping). Labels: `reason`.
+    pub map_filter_dropped_total: IntCounterVec,
+    /// /map URL filter: query params stripped (Tier B / coarse mode). Labels: `reason`.
+    pub map_filter_stripped_total: IntCounterVec,
+    /// /map URL filter: param/URL preserved by a rule that beats the deny-list
+    /// (host override, `.gov` TLD, ALWAYS_PRESERVE). Labels: `reason`.
+    pub map_filter_preserved_total: IntCounterVec,
+    /// /map URL filter: count of rules loaded at server startup. Labels: `kind`.
+    pub map_filter_rules_loaded: IntCounterVec,
 }
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
@@ -153,6 +163,34 @@ impl Metrics {
             registry
         )
         .unwrap();
+        let map_filter_dropped_total = register_int_counter_vec_with_registry!(
+            "crw_map_filter_dropped_total",
+            "URLs dropped by /map filter (action-URL or parse-error pass-through)",
+            &["reason"],
+            registry
+        )
+        .unwrap();
+        let map_filter_stripped_total = register_int_counter_vec_with_registry!(
+            "crw_map_filter_stripped_total",
+            "Query params stripped by /map filter",
+            &["reason"],
+            registry
+        )
+        .unwrap();
+        let map_filter_preserved_total = register_int_counter_vec_with_registry!(
+            "crw_map_filter_preserved_total",
+            "Params/URLs preserved by /map filter rules (host override, gov TLD, always-preserve)",
+            &["reason"],
+            registry
+        )
+        .unwrap();
+        let map_filter_rules_loaded = register_int_counter_vec_with_registry!(
+            "crw_map_filter_rules_loaded",
+            "/map filter rules loaded at server startup",
+            &["kind"],
+            registry
+        )
+        .unwrap();
         Self {
             registry,
             render_route_decision_total,
@@ -168,6 +206,10 @@ impl Metrics {
             cdp_live_connections,
             target_lifecycle_total,
             renderer_recycle_total,
+            map_filter_dropped_total,
+            map_filter_stripped_total,
+            map_filter_preserved_total,
+            map_filter_rules_loaded,
         }
     }
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -602,12 +602,42 @@ pub struct MapRequest {
     /// Custom timeout in seconds (default: 120).
     #[serde(default)]
     pub timeout: Option<u64>,
+    /// Tier B — strip tracking params. `Some(_)` overrides TOML.
+    #[serde(default)]
+    pub strip_tracking_params: Option<bool>,
+    /// Tier A — drop action URLs. `Some(_)` overrides TOML.
+    #[serde(default)]
+    pub drop_action_urls: Option<bool>,
+    /// Firecrawl-compatible coarse alias. `Some(true)`: strip every
+    /// non-preserved param. `Some(false)`: switch the whole filter off
+    /// (raw URLs — the explicit escape hatch).
+    #[serde(default)]
+    pub ignore_query_parameters: Option<bool>,
+    /// Additive on top of `DEFAULT_TRACKING_PARAMS`. Max 64 keys; over-cap → 422.
+    #[serde(default)]
+    pub extra_tracking_params: Option<Vec<String>>,
+    /// Additive on top of `DEFAULT_ACTION_PARAMS`. Max 64 keys; over-cap → 422.
+    #[serde(default)]
+    pub extra_action_params: Option<Vec<String>>,
+    /// Additive on top of `ALWAYS_PRESERVE` + TOML preserves.
+    /// Max 64 keys; over-cap → 422.
+    #[serde(default)]
+    pub preserve_params: Option<Vec<String>>,
 }
 
-/// POST /v1/map response data — the discovered links.
+/// POST /v1/map response data — the discovered links plus filter stats.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MapData {
     pub links: Vec<String>,
+    /// Number of URLs the /map filter dropped entirely (Tier A action-URL
+    /// matches). `0` when the filter is disabled.
+    #[serde(default)]
+    pub dropped_action_count: usize,
+    /// Number of URLs that had at least one query param stripped by Tier B.
+    /// `0` when the filter is disabled.
+    #[serde(default)]
+    pub stripped_tracking_count: usize,
 }
 
 /// POST /v1/map response body.

--- a/crates/crw-core/src/url_safety.rs
+++ b/crates/crw-core/src/url_safety.rs
@@ -23,7 +23,14 @@ pub fn safe_redirect_policy() -> reqwest::redirect::Policy {
 /// - Private IP ranges (10.x, 172.16-31.x, 192.168.x)
 /// - Link-local addresses (169.254.x — e.g. AWS metadata endpoint)
 /// - 0.0.0.0
+///
+/// **Test-only escape hatch**: when the env var
+/// `CRW_ALLOW_LOOPBACK_FOR_TESTS=1` is set, the loopback/private-range
+/// checks are skipped so wiremock-backed integration tests can target
+/// `127.0.0.1:<random>`. The opt-in is read at every call (cheap) so it
+/// can be flipped per-test. Never set this in production.
 pub fn validate_safe_url(url: &url::Url) -> Result<(), String> {
+    let test_allow_loopback = std::env::var("CRW_ALLOW_LOOPBACK_FOR_TESTS").as_deref() == Ok("1");
     // URL length limit
     const MAX_URL_LENGTH: usize = 2048;
     if url.as_str().len() > MAX_URL_LENGTH {
@@ -49,12 +56,13 @@ pub fn validate_safe_url(url: &url::Url) -> Result<(), String> {
 
     // Block localhost by name
     let host_lower = host.to_lowercase();
-    if host_lower == "localhost" || host_lower.ends_with(".localhost") {
+    if !test_allow_loopback && (host_lower == "localhost" || host_lower.ends_with(".localhost")) {
         return Err("Localhost URLs are not allowed".into());
     }
 
     // Parse as IP if possible and check ranges
-    if let Ok(ip) = host.parse::<IpAddr>()
+    if !test_allow_loopback
+        && let Ok(ip) = host.parse::<IpAddr>()
         && is_blocked_ip(&ip)
     {
         return Err(format!("Access to {ip} is not allowed"));
@@ -62,7 +70,8 @@ pub fn validate_safe_url(url: &url::Url) -> Result<(), String> {
 
     // Also check bracket-stripped IPv6 (e.g. [::1])
     let stripped = host.trim_start_matches('[').trim_end_matches(']');
-    if let Ok(ip) = stripped.parse::<IpAddr>()
+    if !test_allow_loopback
+        && let Ok(ip) = stripped.parse::<IpAddr>()
         && is_blocked_ip(&ip)
     {
         return Err(format!("Access to {ip} is not allowed"));

--- a/crates/crw-crawl/Cargo.toml
+++ b/crates/crw-crawl/Cargo.toml
@@ -23,7 +23,14 @@ futures = { workspace = true }
 dashmap = { workspace = true }
 rand = { workspace = true }
 flate2 = "1"
+phf = { workspace = true }
+publicsuffix = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
 wiremock = { workspace = true }
+proptest = { workspace = true }
+
+[[bench]]
+name = "map_url_filter"
+harness = false

--- a/crates/crw-crawl/benches/map_url_filter.rs
+++ b/crates/crw-crawl/benches/map_url_filter.rs
@@ -1,0 +1,143 @@
+//! Bench for the /map URL filter.
+//!
+//! Measures the *delta* between calling `filter_and_normalize_raw` with a
+//! defaults-on config vs. a no-op baseline that only does the fragment +
+//! trailing-slash + lowercase normalize. Gate: delta ≤ 3µs/URL p50 on M-class
+//! hardware (informational; not enforced in CI).
+//!
+//! Run with: `cargo bench -p crw-crawl --bench map_url_filter`.
+
+use crw_crawl::url_filter::{UrlFilterCfg, filter_and_normalize_raw};
+use std::time::Instant;
+
+fn baseline_normalize(u: &str) -> String {
+    let without_fragment = u.split('#').next().unwrap_or(u);
+    without_fragment.trim_end_matches('/').to_lowercase()
+}
+
+fn mixed_corpus(n: usize) -> Vec<String> {
+    let mut urls = Vec::with_capacity(n);
+    for i in 0..n {
+        let bucket = i % 10;
+        let url = match bucket {
+            0..=5 => format!("https://example{}.com/blog/post-{}", i % 7, i),
+            6..=8 => format!(
+                "https://example{}.com/page?utm_source=newsletter&utm_medium=email&id={}",
+                i % 7,
+                i
+            ),
+            _ => format!("https://shop{}.com/?add-to-cart={}", i % 7, i),
+        };
+        urls.push(url);
+    }
+    urls
+}
+
+fn no_query_corpus(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| format!("https://example{}.com/blog/post-{}", i % 7, i))
+        .collect()
+}
+
+fn tracking_corpus(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            format!(
+                "https://example{}.com/page?utm_source=newsletter&utm_medium=email&fbclid=abc{}&gclid=xyz{}&id={}",
+                i % 7, i, i, i
+            )
+        })
+        .collect()
+}
+
+fn action_corpus(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            format!(
+                "https://shop{}.com/?add-to-cart={}&_wpnonce=abc{}",
+                i % 7,
+                i,
+                i
+            )
+        })
+        .collect()
+}
+
+fn host_override_corpus(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            format!(
+                "https://forum{}.example.com/viewtopic.php?t={}&utm_source=email",
+                i % 7,
+                i
+            )
+        })
+        .collect()
+}
+
+struct Stats {
+    p50: f64,
+    p99: f64,
+    mean: f64,
+}
+
+fn measure<F: FnMut(&str)>(label: &str, urls: &[String], mut f: F) -> Stats {
+    // Warm up.
+    for u in urls.iter().take(1000.min(urls.len())) {
+        f(u);
+    }
+    let mut samples: Vec<u128> = Vec::with_capacity(urls.len());
+    for u in urls {
+        let t = Instant::now();
+        f(u);
+        samples.push(t.elapsed().as_nanos());
+    }
+    samples.sort_unstable();
+    let p50 = samples[samples.len() / 2] as f64;
+    let p99 = samples[(samples.len() * 99) / 100] as f64;
+    let mean = samples.iter().copied().sum::<u128>() as f64 / samples.len() as f64;
+    println!(
+        "  {:30}  p50 = {:>6.0} ns   p99 = {:>7.0} ns   mean = {:>6.0} ns",
+        label, p50, p99, mean
+    );
+    Stats { p50, p99, mean }
+}
+
+fn run_group(name: &str, urls: &[String], cfg: &UrlFilterCfg) -> (Stats, Stats) {
+    println!("\n[{}]  n = {}", name, urls.len());
+    let base = measure("baseline normalize", urls, |u| {
+        let _ = std::hint::black_box(baseline_normalize(u));
+    });
+    let filt = measure("filter_and_normalize_raw", urls, |u| {
+        let _ = std::hint::black_box(filter_and_normalize_raw(u, cfg));
+    });
+    println!(
+        "  delta:                          p50 = {:>+6.0} ns   p99 = {:>+7.0} ns   mean = {:>+6.0} ns",
+        filt.p50 - base.p50,
+        filt.p99 - base.p99,
+        filt.mean - base.mean,
+    );
+    (base, filt)
+}
+
+fn main() {
+    let cfg = UrlFilterCfg::defaults_on();
+    const N: usize = 10_000;
+
+    let mixed = mixed_corpus(N);
+    let noq = no_query_corpus(N);
+    let track = tracking_corpus(N);
+    let action = action_corpus(N);
+    let host = host_override_corpus(N);
+
+    let (_, mixed_filt) = run_group("mixed (60% no-?, 30% tracking, 10% action)", &mixed, &cfg);
+    run_group("no-query (cheap pre-screen)", &noq, &cfg);
+    run_group("tracking-heavy (utm+gclid+fbclid)", &track, &cfg);
+    run_group("action (drop path)", &action, &cfg);
+    run_group("host-override (forum viewtopic.php)", &host, &cfg);
+
+    println!("\nGate (mixed corpus): delta p50 ≤ 3000 ns");
+    if mixed_filt.p50 > 3000.0 {
+        eprintln!("WARNING: mixed-corpus filter p50 exceeds 3µs/URL");
+    }
+}

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -325,6 +325,19 @@ pub struct DiscoverOptions<'a> {
     pub deadline_ms_per_page: u64,
     /// Per-eTLD+1 concurrency cap. See `CrawlOptions::per_host_max_concurrent`.
     pub per_host_max_concurrent: u32,
+    /// Optional /map URL filter (Tier A drop + Tier B strip). When `None`,
+    /// behaviour is the legacy `normalize_url` pass-through.
+    pub url_filter: Option<Arc<crate::url_filter::UrlFilterCfg>>,
+}
+
+/// Result of [`discover_urls`]. URLs in `urls` have already passed the
+/// /map filter; `dropped_action_count` and `stripped_tracking_count` are
+/// the per-request stats the API response surfaces back to callers.
+#[derive(Debug, Clone, Default)]
+pub struct DiscoverResult {
+    pub urls: Vec<String>,
+    pub dropped_action_count: usize,
+    pub stripped_tracking_count: usize,
 }
 
 /// If the sitemap phase yields at least this many URLs and `crawl_fallback`
@@ -339,7 +352,7 @@ const SITEMAP_MAX_DEPTH: u32 = 3;
 const SITEMAP_MAX_FETCHES: usize = 25;
 
 /// Discover URLs from a site (map endpoint).
-pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<Vec<String>> {
+pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResult> {
     let DiscoverOptions {
         base_url,
         max_depth,
@@ -352,7 +365,55 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<Vec<String>> 
         proxy,
         deadline_ms_per_page,
         per_host_max_concurrent,
+        url_filter,
     } = opts;
+    let mut dropped_action_count: usize = 0;
+    let mut stripped_tracking_count: usize = 0;
+    // Helper closures around the optional filter — None ⇒ legacy pass-through
+    // (`normalize_url`). Both increment the stats counters so the API can
+    // surface them in the response.
+    let filter_raw = |raw: &str, dropped: &mut usize, stripped: &mut usize| -> Option<String> {
+        match url_filter.as_deref() {
+            Some(cfg) => match crate::url_filter::filter_and_normalize_raw(raw, cfg) {
+                Some(s) => {
+                    if raw.contains('?')
+                        && let Ok(p) = url::Url::parse(raw)
+                        && s != normalize_url(raw)
+                        && p.query().is_some()
+                    {
+                        *stripped += 1;
+                    }
+                    Some(s)
+                }
+                None => {
+                    *dropped += 1;
+                    None
+                }
+            },
+            None => Some(normalize_url(raw)),
+        }
+    };
+    let filter_parsed = |parsed: &url::Url,
+                         raw: &str,
+                         dropped: &mut usize,
+                         stripped: &mut usize|
+     -> Option<String> {
+        match url_filter.as_deref() {
+            Some(cfg) => match crate::url_filter::filter_and_normalize_parsed(parsed, raw, cfg) {
+                Some(s) => {
+                    if parsed.query().is_some() && s != normalize_url(raw) {
+                        *stripped += 1;
+                    }
+                    Some(s)
+                }
+                None => {
+                    *dropped += 1;
+                    None
+                }
+            },
+            None => Some(normalize_url(raw)),
+        }
+    };
     let parsed = url::Url::parse(base_url)
         .map_err(|e| crw_core::error::CrwError::InvalidRequest(format!("Invalid URL: {e}")))?;
 
@@ -449,7 +510,10 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<Vec<String>> 
             if all_urls.len() >= MAX_DISCOVERED_URLS {
                 break;
             }
-            all_urls.insert(u);
+            if let Some(n) = filter_raw(&u, &mut dropped_action_count, &mut stripped_tracking_count)
+            {
+                all_urls.insert(n);
+            }
         }
     }
 
@@ -458,7 +522,11 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<Vec<String>> 
         all_urls.insert(base_url.to_string());
         let mut urls: Vec<String> = all_urls.into_iter().collect();
         urls.sort();
-        return Ok(urls);
+        return Ok(DiscoverResult {
+            urls,
+            dropped_action_count,
+            stripped_tracking_count,
+        });
     }
 
     // Sitemap was rich enough → run BFS with a tight budget. Otherwise let it
@@ -525,7 +593,15 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<Vec<String>> 
                     if link_url.origin().ascii_serialization() != origin {
                         continue;
                     }
-                    let normalized = normalize_url(&link);
+                    let normalized = match filter_parsed(
+                        &link_url,
+                        &link,
+                        &mut dropped_action_count,
+                        &mut stripped_tracking_count,
+                    ) {
+                        Some(n) => n,
+                        None => continue,
+                    };
                     if !visited.contains(&normalized) {
                         visited.insert(normalized.clone());
                         all_urls.insert(normalized.clone());
@@ -541,7 +617,11 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<Vec<String>> 
     all_urls.insert(base_url.to_string());
     let mut urls: Vec<String> = all_urls.into_iter().collect();
     urls.sort();
-    Ok(urls)
+    Ok(DiscoverResult {
+        urls,
+        dropped_action_count,
+        stripped_tracking_count,
+    })
 }
 
 /// Normalize URL by removing fragment and trailing slash.

--- a/crates/crw-crawl/src/lib.rs
+++ b/crates/crw-crawl/src/lib.rs
@@ -22,3 +22,5 @@ pub mod crawl;
 pub mod robots;
 pub mod single;
 pub mod sitemap;
+pub mod url_filter;
+pub mod url_filter_data;

--- a/crates/crw-crawl/src/url_filter.rs
+++ b/crates/crw-crawl/src/url_filter.rs
@@ -1,0 +1,713 @@
+//! /map URL filter pipeline.
+//!
+//! Tier A — drop URL outright if any query key matches the action deny-list.
+//! Tier B — strip tracking-param keys from the query, keep the URL.
+//! Tier C — host-scoped overrides preserve/exempt/inject extras.
+//!
+//! Entry points:
+//! - [`filter_and_normalize_raw`]: sitemap path (no pre-parsed Url available).
+//! - [`filter_and_normalize_parsed`]: BFS path (reuses caller's `url::Url`).
+//!
+//! Both return `None` if Tier A drops the URL.
+
+use crate::url_filter_data::{
+    ALWAYS_PRESERVE, DEFAULT_ACTION_PARAMS, DEFAULT_HOST_OVERRIDES, DEFAULT_TRACKING_PARAMS,
+    GOV_TLD_SUFFIXES, HostOverrideEntry, HostPat,
+};
+use crw_core::metrics::metrics;
+use std::collections::HashSet;
+
+/// Per-request override delta. `None` fields fall through to whatever the
+/// server's default cfg already specifies. Construction lives in the route
+/// handler — it owns the precedence resolution (request > TOML > default).
+#[derive(Debug, Clone, Default)]
+pub struct RequestOverrides {
+    pub strip_tracking: Option<bool>,
+    pub drop_actions: Option<bool>,
+    /// Firecrawl-compatible coarse alias. Outermost gate: `Some(_)` makes
+    /// `strip_tracking` / `drop_actions` ignored.
+    pub coarse_strip_all: Option<bool>,
+    pub extra_tracking: Option<Vec<String>>,
+    pub extra_action: Option<Vec<String>>,
+    pub preserve: Option<Vec<String>>,
+}
+
+/// Runtime host-override entry (owned strings) built once at config-load time.
+#[derive(Debug, Clone)]
+pub struct HostOverride {
+    pub host_pat: HostPat,
+    pub when_path_contains: Vec<String>,
+    pub preserve_params: HashSet<String>,
+    pub exempt_action_params: HashSet<String>,
+    pub extra_tracking_params: HashSet<String>,
+}
+
+impl HostOverride {
+    fn from_static(e: &HostOverrideEntry) -> Self {
+        Self {
+            host_pat: e.host_pat.clone(),
+            when_path_contains: e.when_path_contains.iter().map(|s| s.to_string()).collect(),
+            preserve_params: e.preserve_params.iter().map(|s| s.to_string()).collect(),
+            exempt_action_params: e
+                .exempt_action_params
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            extra_tracking_params: e
+                .extra_tracking_params
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+}
+
+/// Filter configuration. Built once at server startup, shared via `Arc`.
+#[derive(Debug, Clone)]
+pub struct UrlFilterCfg {
+    pub strip_tracking: bool,
+    pub drop_actions: bool,
+    /// Firecrawl-compatible coarse mode: strip every non-preserved param.
+    pub coarse_strip_all: bool,
+    /// When true, `.gov`/`.mil` etc. hosts run Tier A too. Default false:
+    /// gov sites preserve action URLs (govspeak forms etc.).
+    pub gov_tld_drop_actions: bool,
+    /// User-supplied extras, additive on top of `DEFAULT_TRACKING_PARAMS`.
+    /// Pre-lowercased at build time.
+    pub tracking_params: HashSet<String>,
+    pub action_params: HashSet<String>,
+    pub preserve_params: HashSet<String>,
+    pub host_overrides: Vec<HostOverride>,
+}
+
+impl Default for UrlFilterCfg {
+    fn default() -> Self {
+        Self::defaults_on()
+    }
+}
+
+impl UrlFilterCfg {
+    /// Plan default: Tier A + Tier B both active, gov suppression on,
+    /// coarse mode off, compiled-in host overrides loaded.
+    pub fn defaults_on() -> Self {
+        Self {
+            strip_tracking: true,
+            drop_actions: true,
+            coarse_strip_all: false,
+            gov_tld_drop_actions: false,
+            tracking_params: HashSet::new(),
+            action_params: HashSet::new(),
+            preserve_params: HashSet::new(),
+            host_overrides: DEFAULT_HOST_OVERRIDES
+                .iter()
+                .map(HostOverride::from_static)
+                .collect(),
+        }
+    }
+
+    /// Build from the raw TOML `[map.url_filter]` block. Strings are
+    /// lowercased once here so per-request lookups stay allocation-free.
+    pub fn from_map_config(cfg: &crw_core::config::MapUrlFilterConfig) -> Self {
+        let to_lower_set = |v: &[String]| -> HashSet<String> {
+            v.iter().map(|s| s.to_ascii_lowercase()).collect()
+        };
+        Self {
+            strip_tracking: cfg.strip_tracking_params,
+            drop_actions: cfg.drop_action_urls,
+            coarse_strip_all: false,
+            gov_tld_drop_actions: cfg.gov_tld_drop_actions,
+            tracking_params: to_lower_set(&cfg.extra_tracking_params),
+            action_params: to_lower_set(&cfg.extra_action_params),
+            preserve_params: to_lower_set(&cfg.extra_preserve_params),
+            host_overrides: DEFAULT_HOST_OVERRIDES
+                .iter()
+                .map(HostOverride::from_static)
+                .collect(),
+        }
+    }
+
+    /// Apply request-level overrides on top of `self`. Returns a fresh
+    /// `UrlFilterCfg`; the input is not mutated so the server's Arc'd
+    /// default stays shareable across concurrent requests.
+    pub fn with_overrides(&self, ov: RequestOverrides) -> Self {
+        let mut out = self.clone();
+        if let Some(coarse) = ov.coarse_strip_all {
+            out.coarse_strip_all = coarse;
+            if !coarse {
+                // Coarse `false` is the explicit "give me raw URLs" escape
+                // hatch — switch both tiers off.
+                out.strip_tracking = false;
+                out.drop_actions = false;
+                return out;
+            }
+            // Coarse `true` overrides granular flags (Tier A still runs).
+            return out;
+        }
+        if let Some(v) = ov.strip_tracking {
+            out.strip_tracking = v;
+        }
+        if let Some(v) = ov.drop_actions {
+            out.drop_actions = v;
+        }
+        if let Some(extra) = ov.extra_tracking {
+            for k in extra {
+                out.tracking_params.insert(k.to_ascii_lowercase());
+            }
+        }
+        if let Some(extra) = ov.extra_action {
+            for k in extra {
+                out.action_params.insert(k.to_ascii_lowercase());
+            }
+        }
+        if let Some(extra) = ov.preserve {
+            for k in extra {
+                out.preserve_params.insert(k.to_ascii_lowercase());
+            }
+        }
+        out
+    }
+
+    /// Both tiers off — pass-through (other than `normalize_url`).
+    pub fn off() -> Self {
+        Self {
+            strip_tracking: false,
+            drop_actions: false,
+            coarse_strip_all: false,
+            gov_tld_drop_actions: false,
+            tracking_params: HashSet::new(),
+            action_params: HashSet::new(),
+            preserve_params: HashSet::new(),
+            host_overrides: Vec::new(),
+        }
+    }
+}
+
+/// Mirror of `crawl::normalize_url` — kept private to this module so the
+/// filter can be exercised in unit tests without crossing module boundaries.
+fn normalize(url: &str) -> String {
+    let without_fragment = url.split('#').next().unwrap_or(url);
+    without_fragment.trim_end_matches('/').to_lowercase()
+}
+
+/// Returns `host` is matched by any compiled `.gov`/`.mil` suffix.
+fn is_gov_host(host: &str) -> bool {
+    GOV_TLD_SUFFIXES.iter().any(|suf| {
+        if let Some(stripped) = suf.strip_prefix('.') {
+            host.eq_ignore_ascii_case(stripped)
+                || host.len() > suf.len()
+                    && host
+                        .get(host.len() - suf.len()..)
+                        .map(|t| t.eq_ignore_ascii_case(suf))
+                        .unwrap_or(false)
+        } else {
+            host.eq_ignore_ascii_case(suf)
+                || host.len() > suf.len() + 1
+                    && host
+                        .get(host.len() - suf.len() - 1..)
+                        .map(|t| t.eq_ignore_ascii_case(&format!(".{}", suf)))
+                        .unwrap_or(false)
+        }
+    })
+}
+
+/// Sitemap entry point — no pre-parsed URL. Cheap pre-screen avoids
+/// the `Url::parse` cost for the overwhelming majority of internal links
+/// that have no `?`.
+pub fn filter_and_normalize_raw(url: &str, cfg: &UrlFilterCfg) -> Option<String> {
+    if cfg.coarse_strip_all || cfg.strip_tracking || cfg.drop_actions {
+        if !url.contains('?') {
+            return Some(normalize(url));
+        }
+        let parsed = match url::Url::parse(url) {
+            Ok(u) => u,
+            Err(_) => {
+                metrics()
+                    .map_filter_dropped_total
+                    .with_label_values(&["parse_error_passthrough"])
+                    .inc();
+                return Some(normalize(url));
+            }
+        };
+        filter_and_normalize_parsed(&parsed, url, cfg)
+    } else {
+        Some(normalize(url))
+    }
+}
+
+/// BFS entry point — caller already has a parsed `Url`.
+pub fn filter_and_normalize_parsed(
+    parsed: &url::Url,
+    raw: &str,
+    cfg: &UrlFilterCfg,
+) -> Option<String> {
+    // No query — nothing for either tier to do.
+    if parsed.query().is_none() {
+        return Some(normalize(raw));
+    }
+    // Both tiers off and no coarse — pass through.
+    if !cfg.coarse_strip_all && !cfg.strip_tracking && !cfg.drop_actions {
+        return Some(normalize(raw));
+    }
+
+    let host = parsed.host_str().unwrap_or("").to_ascii_lowercase();
+    let path = parsed.path();
+
+    // Resolve effective sets from host overrides.
+    let mut eff_preserve: HashSet<String> = cfg.preserve_params.clone();
+    let mut eff_exempt_action: HashSet<String> = HashSet::new();
+    let mut eff_extra_tracking: HashSet<String> = HashSet::new();
+    let mut host_override_hit = false;
+    for ov in &cfg.host_overrides {
+        if !ov.host_pat.matches(&host) {
+            continue;
+        }
+        let path_ok = ov.when_path_contains.is_empty()
+            || ov
+                .when_path_contains
+                .iter()
+                .any(|s| path.contains(s.as_str()));
+        if !path_ok {
+            continue;
+        }
+        host_override_hit = true;
+        eff_preserve.extend(ov.preserve_params.iter().cloned());
+        eff_exempt_action.extend(ov.exempt_action_params.iter().cloned());
+        eff_extra_tracking.extend(ov.extra_tracking_params.iter().cloned());
+    }
+
+    let gov = is_gov_host(&host);
+
+    // Iterate raw query: preserves original percent-encoding and
+    // distinguishes `?k` (no `=`) from `?k=`.
+    let raw_query = parsed.query().unwrap_or("");
+    let pairs: Vec<(String, &str, bool)> = raw_query
+        .split('&')
+        .filter(|s| !s.is_empty())
+        .map(|p| match p.find('=') {
+            Some(i) => (p[..i].to_ascii_lowercase(), p, true),
+            None => (p.to_ascii_lowercase(), p, false),
+        })
+        .collect();
+
+    // Tier A: action-URL drop.
+    let drop_actions_active = cfg.drop_actions && (cfg.gov_tld_drop_actions || !gov);
+    if drop_actions_active {
+        for (kl, _raw_pair, _) in &pairs {
+            if eff_preserve.contains(kl) || ALWAYS_PRESERVE.contains(kl.as_str()) {
+                continue;
+            }
+            if eff_exempt_action.contains(kl) {
+                continue;
+            }
+            let in_action =
+                cfg.action_params.contains(kl) || DEFAULT_ACTION_PARAMS.contains(kl.as_str());
+            if in_action {
+                metrics()
+                    .map_filter_dropped_total
+                    .with_label_values(&["action_param"])
+                    .inc();
+                return None;
+            }
+        }
+    } else if gov && cfg.drop_actions {
+        // Tier A suppressed by .gov rule — bookkeep only if an action key was
+        // actually present; bounded label cardinality.
+        let saw_action = pairs.iter().any(|(kl, _, _)| {
+            cfg.action_params.contains(kl) || DEFAULT_ACTION_PARAMS.contains(kl.as_str())
+        });
+        if saw_action {
+            metrics()
+                .map_filter_preserved_total
+                .with_label_values(&["gov_tld"])
+                .inc();
+        }
+    }
+
+    // Coarse mode — strip everything except preserves.
+    if cfg.coarse_strip_all {
+        let kept: Vec<&str> = pairs
+            .iter()
+            .filter(|(kl, _, _)| eff_preserve.contains(kl) || ALWAYS_PRESERVE.contains(kl.as_str()))
+            .map(|(_, raw, _)| *raw)
+            .collect();
+        let stripped_any = kept.len() != pairs.len();
+        if stripped_any {
+            metrics()
+                .map_filter_stripped_total
+                .with_label_values(&["coarse_ignore"])
+                .inc();
+        }
+        return Some(rebuild(parsed, &kept));
+    }
+
+    // Tier B: tracking strip.
+    if cfg.strip_tracking {
+        let mut kept: Vec<&str> = Vec::with_capacity(pairs.len());
+        let mut stripped_any = false;
+        for (kl, raw_pair, _) in &pairs {
+            let always_pres = ALWAYS_PRESERVE.contains(kl.as_str());
+            let host_pres = eff_preserve.contains(kl);
+            if always_pres || host_pres {
+                if host_pres && host_override_hit {
+                    metrics()
+                        .map_filter_preserved_total
+                        .with_label_values(&["host_override"])
+                        .inc();
+                } else if always_pres {
+                    metrics()
+                        .map_filter_preserved_total
+                        .with_label_values(&["always_preserve"])
+                        .inc();
+                }
+                kept.push(raw_pair);
+                continue;
+            }
+            let is_tracking = cfg.tracking_params.contains(kl)
+                || DEFAULT_TRACKING_PARAMS.contains(kl.as_str())
+                || eff_extra_tracking.contains(kl);
+            if is_tracking {
+                stripped_any = true;
+                continue;
+            }
+            kept.push(raw_pair);
+        }
+        if stripped_any {
+            metrics()
+                .map_filter_stripped_total
+                .with_label_values(&["tracking_param"])
+                .inc();
+        }
+        return Some(rebuild(parsed, &kept));
+    }
+
+    // Tier A only, no strip configured — return URL with original query intact.
+    Some(normalize(raw))
+}
+
+/// Re-emit URL with the surviving params in original order. Preserves raw
+/// percent-encoding; drops the `?` entirely when empty.
+fn rebuild(parsed: &url::Url, kept: &[&str]) -> String {
+    let mut out = parsed.clone();
+    if kept.is_empty() {
+        out.set_query(None);
+    } else {
+        out.set_query(Some(&kept.join("&")));
+    }
+    out.set_fragment(None);
+    normalize(out.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_on() -> UrlFilterCfg {
+        UrlFilterCfg::defaults_on()
+    }
+
+    #[test]
+    fn no_query_fast_path() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw("https://example.com/foo", &cfg).unwrap();
+        assert_eq!(out, "https://example.com/foo");
+    }
+
+    #[test]
+    fn action_param_drops_url() {
+        let cfg = cfg_on();
+        assert!(
+            filter_and_normalize_raw("https://shop.example.com/?add-to-cart=360", &cfg).is_none()
+        );
+    }
+
+    #[test]
+    fn wpnonce_drops_url() {
+        let cfg = cfg_on();
+        assert!(
+            filter_and_normalize_raw(
+                "https://shop.example.com/?add_to_wishlist=6241&_wpnonce=b7643da9b9",
+                &cfg
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn case_insensitive_action_key() {
+        let cfg = cfg_on();
+        for u in [
+            "https://e.test/?ADD-TO-CART=1",
+            "https://e.test/?Add-To-Cart=1",
+            "https://e.test/?add-to-cart=1",
+        ] {
+            assert!(
+                filter_and_normalize_raw(u, &cfg).is_none(),
+                "expected drop for {u}"
+            );
+        }
+    }
+
+    #[test]
+    fn tracking_param_stripped_url_kept() {
+        let cfg = cfg_on();
+        let out =
+            filter_and_normalize_raw("https://example.com/blog?utm_source=fb&fbclid=abc", &cfg)
+                .unwrap();
+        assert_eq!(out, "https://example.com/blog");
+    }
+
+    #[test]
+    fn always_preserve_keys_survive() {
+        let cfg = cfg_on();
+        let out =
+            filter_and_normalize_raw("https://wp.example.com/?p=123&utm_source=x", &cfg).unwrap();
+        assert!(out.contains("p=123"), "got {out}");
+        assert!(!out.contains("utm_source"), "got {out}");
+    }
+
+    #[test]
+    fn action_wins_when_coexists_with_tracking() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw("https://e.test/?add-to-cart=1&utm_source=x", &cfg);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn empty_query_after_strip_drops_question_mark() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw("https://example.com/blog?utm_source=fb", &cfg).unwrap();
+        assert_eq!(out, "https://example.com/blog");
+    }
+
+    #[test]
+    fn empty_value_action_key() {
+        // ?_wpnonce — no equals sign — should still drop.
+        let cfg = cfg_on();
+        assert!(filter_and_normalize_raw("https://e.test/?_wpnonce", &cfg).is_none());
+    }
+
+    #[test]
+    fn repeated_tracking_keys_all_stripped() {
+        let cfg = cfg_on();
+        let out =
+            filter_and_normalize_raw("https://e.test/blog?utm_source=a&utm_source=b&p=1", &cfg)
+                .unwrap();
+        assert!(out.contains("p=1"));
+        assert!(!out.contains("utm_source"));
+    }
+
+    #[test]
+    fn malformed_url_passthrough() {
+        let cfg = cfg_on();
+        // Has `?` so it triggers the parse path; "not a url" fails parse.
+        let out = filter_and_normalize_raw("not-a-url?utm=1", &cfg);
+        assert!(out.is_some());
+    }
+
+    #[test]
+    fn host_override_phpbb_preserves_thread_ids() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw(
+            "https://forum.example.com/viewtopic.php?t=123&utm_source=x",
+            &cfg,
+        )
+        .unwrap();
+        assert!(out.contains("t=123"), "got {out}");
+        assert!(!out.contains("utm_source"));
+    }
+
+    #[test]
+    fn gov_tld_tier_a_suppressed_tier_b_runs() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw(
+            "https://senate.gov/?docid=123&utm_source=x&add-to-cart=1",
+            &cfg,
+        )
+        .unwrap();
+        assert!(out.contains("docid=123"), "got {out}");
+        assert!(out.contains("add-to-cart=1"), "got {out}");
+        assert!(!out.contains("utm_source"), "got {out}");
+    }
+
+    #[test]
+    fn gov_tld_opt_in_runs_tier_a() {
+        let mut cfg = cfg_on();
+        cfg.gov_tld_drop_actions = true;
+        let out = filter_and_normalize_raw("https://senate.gov/?add-to-cart=1", &cfg);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn shopify_host_strips_storefront_keys() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw(
+            "https://shop.myshopify.com/products/x?_pos=1&_sid=abc&_v=1.0",
+            &cfg,
+        )
+        .unwrap();
+        assert!(!out.contains("_pos"));
+        assert!(!out.contains("_sid"));
+        assert!(!out.contains("_v="));
+    }
+
+    #[test]
+    fn shopify_keys_pass_through_on_other_hosts() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw("https://random.com/?_pos=1", &cfg).unwrap();
+        assert!(out.contains("_pos=1"));
+    }
+
+    #[test]
+    fn youtube_watch_preserves_v_list_t() {
+        let cfg = cfg_on();
+        let out = filter_and_normalize_raw(
+            "https://www.youtube.com/watch?v=abc123&list=PL1&utm_source=x",
+            &cfg,
+        )
+        .unwrap();
+        assert!(out.contains("v=abc123"), "got {out}");
+        assert!(
+            out.contains("list=pl1") || out.contains("list=PL1"),
+            "got {out}"
+        );
+        assert!(!out.contains("utm_source"));
+    }
+
+    #[test]
+    fn coarse_strip_all_drops_everything_except_preserve() {
+        let mut cfg = cfg_on();
+        cfg.coarse_strip_all = true;
+        let out = filter_and_normalize_raw("https://e.test/blog?p=1&random=foo&utm_source=x", &cfg)
+            .unwrap();
+        assert!(out.contains("p=1"));
+        assert!(!out.contains("random"));
+        assert!(!out.contains("utm_source"));
+    }
+
+    #[test]
+    fn coarse_mode_still_runs_tier_a() {
+        let mut cfg = cfg_on();
+        cfg.coarse_strip_all = true;
+        let out = filter_and_normalize_raw("https://e.test/?add-to-cart=1", &cfg);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn off_config_returns_raw_normalized() {
+        let cfg = UrlFilterCfg::off();
+        let out = filter_and_normalize_raw("https://e.test/blog?utm_source=x&add-to-cart=1", &cfg)
+            .unwrap();
+        assert!(out.contains("utm_source=x"));
+        assert!(out.contains("add-to-cart=1"));
+    }
+
+    #[test]
+    fn extra_action_param_drops_url() {
+        let mut cfg = cfg_on();
+        cfg.action_params.insert("custom_action".to_string());
+        let out = filter_and_normalize_raw("https://e.test/?custom_action=1", &cfg);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn extra_preserve_protects_against_default_action() {
+        let mut cfg = cfg_on();
+        cfg.preserve_params.insert("add-to-cart".to_string());
+        let out = filter_and_normalize_raw("https://e.test/?add-to-cart=1", &cfg).unwrap();
+        assert!(out.contains("add-to-cart=1"));
+    }
+
+    #[test]
+    fn fragment_stripped() {
+        let cfg = cfg_on();
+        let out =
+            filter_and_normalize_raw("https://e.test/blog?utm_source=x#section", &cfg).unwrap();
+        assert!(!out.contains('#'));
+    }
+
+    // ─────────────────────────── property tests ──────────────────────────
+    use proptest::prelude::*;
+
+    /// Generate a query-string-safe ASCII key.
+    fn arb_key() -> impl Strategy<Value = String> {
+        "[a-zA-Z_][a-zA-Z0-9_-]{0,15}".prop_map(String::from)
+    }
+
+    fn arb_pair() -> impl Strategy<Value = (String, String)> {
+        (arb_key(), "[a-zA-Z0-9._~-]{0,12}".prop_map(String::from))
+    }
+
+    proptest! {
+        /// Output is either `None` (dropped) or a parseable URL.
+        #[test]
+        fn output_always_valid(pairs in prop::collection::vec(arb_pair(), 0..6)) {
+            let cfg = cfg_on();
+            let q: String = pairs
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join("&");
+            let url = if q.is_empty() {
+                "https://example.com/path".to_string()
+            } else {
+                format!("https://example.com/path?{q}")
+            };
+            if let Some(out) = filter_and_normalize_raw(&url, &cfg) {
+                prop_assert!(url::Url::parse(&out).is_ok(), "output not a valid URL: {out}");
+            }
+        }
+
+        /// Idempotency: filter ∘ filter == filter.
+        #[test]
+        fn filter_idempotent(pairs in prop::collection::vec(arb_pair(), 0..6)) {
+            let cfg = cfg_on();
+            let q: String = pairs
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join("&");
+            let url = if q.is_empty() {
+                "https://example.com/path".to_string()
+            } else {
+                format!("https://example.com/path?{q}")
+            };
+            let once = filter_and_normalize_raw(&url, &cfg);
+            if let Some(o) = &once {
+                let twice = filter_and_normalize_raw(o, &cfg);
+                prop_assert_eq!(twice.as_ref(), Some(o));
+            }
+        }
+
+        /// Length non-increasing: surviving query ≤ input query length.
+        #[test]
+        fn length_non_increasing(pairs in prop::collection::vec(arb_pair(), 0..6)) {
+            let cfg = cfg_on();
+            let q: String = pairs
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join("&");
+            if q.is_empty() {
+                return Ok(());
+            }
+            let url = format!("https://example.com/path?{q}");
+            if let Some(out) = filter_and_normalize_raw(&url, &cfg) {
+                let out_q_len = url::Url::parse(&out)
+                    .ok()
+                    .and_then(|u| u.query().map(|s| s.len()))
+                    .unwrap_or(0);
+                prop_assert!(out_q_len <= q.len(), "{out_q_len} > {len}", len = q.len());
+            }
+        }
+    }
+
+    #[test]
+    fn session_keys_strip_not_drop() {
+        let cfg = cfg_on();
+        let out =
+            filter_and_normalize_raw("https://legacy.example.com/page?jsessionid=ABC&p=1", &cfg)
+                .unwrap();
+        assert!(!out.contains("jsessionid"));
+        assert!(out.contains("p=1"));
+    }
+}

--- a/crates/crw-crawl/src/url_filter_data.rs
+++ b/crates/crw-crawl/src/url_filter_data.rs
@@ -1,0 +1,256 @@
+//! Compile-time default deny-/preserve-lists for the /map URL filter.
+//!
+//! See `url_filter.rs` for how these are consulted. Lists below are sourced
+//! from ClearURLs `globalRules` + research-agent taxonomy (WooCommerce/WP
+//! action params, common analytics trackers). All keys are ASCII lowercase.
+
+use phf::{Set, phf_set};
+
+/// Action params: presence of any matching KEY in the query causes the URL
+/// to be dropped entirely (Tier A).
+pub static DEFAULT_ACTION_PARAMS: Set<&'static str> = phf_set! {
+    // WooCommerce — Issue #40's primary trigger
+    "add-to-cart", "remove_item", "undo_item", "removed_item",
+    "wc-ajax", "wc-api", "pay_for_order", "apply_coupon",
+    "remove_coupon", "order_again", "delete_payment_method",
+    // Wishlist plugins (YITH, TI)
+    "add_to_wishlist", "remove_from_wishlist", "yith_wcwl_action",
+    // WordPress core
+    "_wpnonce", "_wp_http_referer", "replytocom",
+    "unapproved", "moderation-hash", "doing_wp_cron",
+    "customize_changeset_uuid", "customize_messenger_channel",
+    "preview_id", "preview_nonce",
+    // Magento 2
+    "isajax", "form_key",
+    // Anti-CSRF tokens — universal; no CMS uses these as content keys
+    "nonce", "csrf", "csrf_token", "authenticity_token",
+};
+
+/// Tracking params: stripped from the query (Tier B); URL is kept.
+pub static DEFAULT_TRACKING_PARAMS: Set<&'static str> = phf_set! {
+    // Google
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "utm_id", "utm_name", "utm_brand", "utm_social", "utm_social-type",
+    "gclid", "gclsrc", "gbraid", "wbraid", "dclid", "gad_source", "srsltid",
+    "_ga", "_gl",
+    // Facebook / Meta
+    "fbclid",
+    // Microsoft / Bing
+    "msclkid",
+    // TikTok
+    "ttclid",
+    // LinkedIn
+    "li_fat_id",
+    // Twitter / X
+    "twclid", "__twitter_impression",
+    // Yandex
+    "yclid", "ysclid",
+    // HubSpot
+    "_hsenc", "_hsmi", "__hssc", "__hstc", "__hsfp", "hsctatracking",
+    // Mailchimp
+    "mc_cid", "mc_eid",
+    // Matomo / Piwik
+    "mtm_source", "mtm_medium", "mtm_campaign", "mtm_keyword", "mtm_cid",
+    "pk_campaign", "pk_kwd", "pk_source", "pk_medium",
+    // Marketo
+    "mkt_tok",
+    // Instagram
+    "igshid",
+    // Session IDs — strip, don't drop. Legacy session-via-URL sites need
+    // the URL preserved without the session token.
+    "sessionid", "phpsessid", "jsessionid",
+};
+
+/// Universal preserve set: Tier B always skips these. Tier A still runs.
+/// Trimmed of generic keys (`id`, `t`, `v`, `tag`, `s`, `q`, ...) that are
+/// too ambiguous globally — those move to host-scoped overrides instead.
+pub static ALWAYS_PRESERVE: Set<&'static str> = phf_set! {
+    "p", "page_id", "page", "paged", "offset",
+    "category", "cat",
+    "lang", "locale", "hl",
+    "title", "docid", "caseid", "oldid",
+};
+
+/// Host pattern. Anchored matchers — no regex in v1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostPat {
+    /// Match any host.
+    Any,
+    /// Exact host equality, lowercased.
+    Exact(&'static str),
+    /// Suffix match. Pattern includes the leading `.` for clarity
+    /// (e.g. `.reddit.com` matches `old.reddit.com` and `www.reddit.com`).
+    Suffix(&'static str),
+}
+
+impl HostPat {
+    pub fn matches(&self, host: &str) -> bool {
+        match self {
+            HostPat::Any => true,
+            HostPat::Exact(h) => host.eq_ignore_ascii_case(h),
+            HostPat::Suffix(suf) => {
+                host.len() > suf.len()
+                    && host
+                        .get(host.len() - suf.len()..)
+                        .map(|tail| tail.eq_ignore_ascii_case(suf))
+                        .unwrap_or(false)
+            }
+        }
+    }
+}
+
+/// Compile-time host-override entry. Built into runtime `HostOverride` at
+/// config-load time (string slices → owned `HashSet<String>` once).
+#[derive(Debug, Clone)]
+pub struct HostOverrideEntry {
+    pub host_pat: HostPat,
+    /// Path-substring guards. Empty = any path on the host.
+    pub when_path_contains: &'static [&'static str],
+    pub preserve_params: &'static [&'static str],
+    pub exempt_action_params: &'static [&'static str],
+    pub extra_tracking_params: &'static [&'static str],
+}
+
+pub static DEFAULT_HOST_OVERRIDES: &[HostOverrideEntry] = &[
+    // phpBB / vBulletin / IPB — thread/post IDs are content
+    HostOverrideEntry {
+        host_pat: HostPat::Any,
+        when_path_contains: &["viewtopic.php", "showthread.php", "showtopic"],
+        preserve_params: &["t", "p", "f", "topic", "thread", "tid", "pid"],
+        exempt_action_params: &[],
+        extra_tracking_params: &[],
+    },
+    // MediaWiki — preserve title/oldid/diff/curid against tracker strip.
+    HostOverrideEntry {
+        host_pat: HostPat::Any,
+        when_path_contains: &["/wiki/", "/w/index.php"],
+        preserve_params: &["title", "oldid", "diff", "curid"],
+        exempt_action_params: &[],
+        extra_tracking_params: &[],
+    },
+    // YouTube watch pages
+    HostOverrideEntry {
+        host_pat: HostPat::Exact("youtube.com"),
+        when_path_contains: &["/watch"],
+        preserve_params: &["v", "list", "t"],
+        exempt_action_params: &[],
+        extra_tracking_params: &[],
+    },
+    HostOverrideEntry {
+        host_pat: HostPat::Suffix(".youtube.com"),
+        when_path_contains: &["/watch"],
+        preserve_params: &["v", "list", "t"],
+        exempt_action_params: &[],
+        extra_tracking_params: &[],
+    },
+    // Reddit
+    HostOverrideEntry {
+        host_pat: HostPat::Suffix(".reddit.com"),
+        when_path_contains: &["/comments/", "/r/"],
+        preserve_params: &["context", "sort", "depth"],
+        exempt_action_params: &[],
+        extra_tracking_params: &[],
+    },
+    // Shopify storefront — only here do these strip; outside they pass through.
+    HostOverrideEntry {
+        host_pat: HostPat::Suffix(".myshopify.com"),
+        when_path_contains: &[],
+        preserve_params: &[],
+        exempt_action_params: &[],
+        extra_tracking_params: &["_pos", "_psq", "_ss", "_sid", "_v", "_fid", "_fd"],
+    },
+];
+
+/// Host suffixes that, by default, suppress Tier A action-drops only.
+/// Tier B (tracking strip) still runs. Toggle off via `gov_tld_drop_actions`.
+pub static GOV_TLD_SUFFIXES: &[&str] = &[".gov", ".gov.uk", ".mil", "europa.eu"];
+
+#[cfg(test)]
+mod audit {
+    use super::*;
+
+    /// Action and tracking lists must be disjoint — otherwise behavior is
+    /// ambiguous (Tier A drops the URL before Tier B runs, but a key being
+    /// in both means there's editorial confusion in the lists).
+    #[test]
+    fn action_and_tracking_disjoint() {
+        for k in DEFAULT_ACTION_PARAMS.iter() {
+            assert!(
+                !DEFAULT_TRACKING_PARAMS.contains(*k),
+                "key {:?} present in both ACTION and TRACKING lists",
+                k
+            );
+        }
+    }
+
+    #[test]
+    fn preserve_does_not_overlap_action() {
+        for k in ALWAYS_PRESERVE.iter() {
+            assert!(
+                !DEFAULT_ACTION_PARAMS.contains(*k),
+                "key {:?} present in both ALWAYS_PRESERVE and ACTION lists",
+                k
+            );
+        }
+    }
+
+    #[test]
+    fn all_keys_are_lowercase() {
+        for k in DEFAULT_ACTION_PARAMS.iter() {
+            assert_eq!(
+                *k,
+                k.to_ascii_lowercase(),
+                "action key {:?} not lowercase",
+                k
+            );
+        }
+        for k in DEFAULT_TRACKING_PARAMS.iter() {
+            assert_eq!(
+                *k,
+                k.to_ascii_lowercase(),
+                "tracking key {:?} not lowercase",
+                k
+            );
+        }
+        for k in ALWAYS_PRESERVE.iter() {
+            assert_eq!(
+                *k,
+                k.to_ascii_lowercase(),
+                "preserve key {:?} not lowercase",
+                k
+            );
+        }
+    }
+
+    #[test]
+    fn host_suffix_patterns_start_with_dot() {
+        for entry in DEFAULT_HOST_OVERRIDES {
+            if let HostPat::Suffix(s) = entry.host_pat {
+                assert!(
+                    s.starts_with('.'),
+                    "suffix pattern {:?} should start with `.`",
+                    s
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn host_pat_suffix_match_does_not_match_substring() {
+        // ".com" should not match "example.com.attacker.tld"
+        let p = HostPat::Suffix(".reddit.com");
+        assert!(p.matches("old.reddit.com"));
+        assert!(p.matches("www.reddit.com"));
+        assert!(!p.matches("reddit.com")); // suffix requires content before
+        assert!(!p.matches("notreddit.com"));
+        assert!(!p.matches("reddit.com.attacker.tld"));
+    }
+
+    #[test]
+    fn host_pat_exact_is_case_insensitive() {
+        let p = HostPat::Exact("youtube.com");
+        assert!(p.matches("youtube.com"));
+        assert!(p.matches("YouTube.com"));
+        assert!(!p.matches("www.youtube.com"));
+    }
+}

--- a/crates/crw-mcp/src/main.rs
+++ b/crates/crw-mcp/src/main.rs
@@ -299,6 +299,7 @@ async fn main() {
                     auth: Default::default(),
                     request: Default::default(),
                     search: Default::default(),
+                    map: Default::default(),
                 }
             });
 

--- a/crates/crw-server/src/routes/map.rs
+++ b/crates/crw-server/src/routes/map.rs
@@ -4,10 +4,62 @@ use axum::extract::rejection::JsonRejection;
 use crw_core::error::CrwError;
 use crw_core::types::{MapData, MapRequest, MapResponse};
 use crw_crawl::crawl::{DiscoverOptions, discover_urls};
+use crw_crawl::url_filter::{RequestOverrides, UrlFilterCfg};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::error::AppError;
 use crate::state::AppState;
+
+/// Maximum number of keys in any single `extra_*_params` / `preserveParams`
+/// list on a /map request. Anything over → 422.
+const EXTRA_PARAMS_CAP: usize = 64;
+
+fn check_cap(name: &str, list: &Option<Vec<String>>) -> Result<(), CrwError> {
+    if let Some(v) = list
+        && v.len() > EXTRA_PARAMS_CAP
+    {
+        return Err(CrwError::InvalidRequest(format!(
+            "{name} exceeds {EXTRA_PARAMS_CAP}-key cap"
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve effective /map filter cfg for a single request.
+///
+/// Precedence (outermost wins):
+/// 1. `ignoreQueryParameters` is the outermost gate when `Some(_)`.
+/// 2. Per-request granular flag, when `Some(_)`, overrides TOML.
+/// 3. TOML value (built into `state.url_filter`) is the base.
+/// 4. When `state.url_filter` is `None`, the whole filter is off — the
+///    request can still flip it on by sending `ignoreQueryParameters: true`
+///    or granular flags, in which case the compile-time defaults fire.
+fn resolve_filter_cfg(state: &AppState, req: &MapRequest) -> Option<Arc<UrlFilterCfg>> {
+    let touches_filter = req.strip_tracking_params.is_some()
+        || req.drop_action_urls.is_some()
+        || req.ignore_query_parameters.is_some()
+        || req.extra_tracking_params.is_some()
+        || req.extra_action_params.is_some()
+        || req.preserve_params.is_some();
+
+    let base = match (&state.url_filter, touches_filter) {
+        (Some(arc), false) => return Some(arc.clone()),
+        (Some(arc), true) => (**arc).clone(),
+        (None, false) => return None,
+        (None, true) => UrlFilterCfg::defaults_on(),
+    };
+
+    let overrides = RequestOverrides {
+        strip_tracking: req.strip_tracking_params,
+        drop_actions: req.drop_action_urls,
+        coarse_strip_all: req.ignore_query_parameters,
+        extra_tracking: req.extra_tracking_params.clone(),
+        extra_action: req.extra_action_params.clone(),
+        preserve: req.preserve_params.clone(),
+    };
+    Some(Arc::new(base.with_overrides(overrides)))
+}
 
 /// POST /v1/map — discover URLs.
 /// Response format matches Firecrawl: { success: true, links: [...] }
@@ -19,6 +71,12 @@ pub async fn map(
     let parsed_url = url::Url::parse(&req.url)
         .map_err(|e| CrwError::InvalidRequest(format!("Invalid URL: {e}")))?;
     crw_core::url_safety::validate_safe_url(&parsed_url).map_err(CrwError::InvalidRequest)?;
+
+    check_cap("extra_tracking_params", &req.extra_tracking_params)?;
+    check_cap("extra_action_params", &req.extra_action_params)?;
+    check_cap("preserve_params", &req.preserve_params)?;
+
+    let url_filter = resolve_filter_cfg(&state, &req);
 
     let max_depth = req
         .max_depth
@@ -37,15 +95,20 @@ pub async fn map(
         deadline_ms_per_page: state.config.effective_deadline_ms(None, None),
         per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
         crawl_fallback: req.crawl_fallback,
+        url_filter,
     });
 
-    let urls = match tokio::time::timeout(Duration::from_secs(timeout_secs), discover_future).await
-    {
-        Ok(result) => result?,
-        Err(_) => {
-            return Err(AppError(CrwError::Timeout(timeout_secs * 1000)));
-        }
-    };
+    let result =
+        match tokio::time::timeout(Duration::from_secs(timeout_secs), discover_future).await {
+            Ok(r) => r?,
+            Err(_) => {
+                return Err(AppError(CrwError::Timeout(timeout_secs * 1000)));
+            }
+        };
 
-    Ok(Json(MapResponse::ok(MapData { links: urls })))
+    Ok(Json(MapResponse::ok(MapData {
+        links: result.urls,
+        dropped_action_count: result.dropped_action_count,
+        stripped_tracking_count: result.stripped_tracking_count,
+    })))
 }

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -78,7 +78,7 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
             let max_depth = req
                 .max_depth
                 .unwrap_or(state.config.crawler.default_max_depth);
-            let urls = discover_urls(DiscoverOptions {
+            let result = discover_urls(DiscoverOptions {
                 base_url: &req.url,
                 max_depth,
                 use_sitemap: req.use_sitemap,
@@ -90,10 +90,16 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
                 deadline_ms_per_page: state.config.effective_deadline_ms(None, None),
                 per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
                 crawl_fallback: req.crawl_fallback,
+                url_filter: state.url_filter.clone(),
             })
             .await
             .map_err(|e| format!("{e}"))?;
-            Ok(json!({"success": true, "links": urls}))
+            Ok(json!({
+                "success": true,
+                "links": result.urls,
+                "droppedActionCount": result.dropped_action_count,
+                "strippedTrackingCount": result.stripped_tracking_count,
+            }))
         }
         "crw_search" => {
             let req: SearchRequest =

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -89,6 +89,10 @@ pub struct AppState {
     /// SearXNG client. `None` when `[search].searxng_url` is unset, in which
     /// case `/v1/search` returns a clear `search_disabled` error.
     pub searxng: Option<Arc<SearxngClient>>,
+    /// Server-wide default /map URL filter. `None` disables the filter
+    /// entirely (legacy behaviour). Per-request overrides may swap or
+    /// extend this at handler time.
+    pub url_filter: Option<Arc<crw_crawl::url_filter::UrlFilterCfg>>,
 }
 
 impl AppState {
@@ -124,12 +128,41 @@ impl AppState {
             None
         };
 
+        let url_filter_cfg =
+            crw_crawl::url_filter::UrlFilterCfg::from_map_config(&config.map.url_filter);
+        // One-shot snapshot of how many rules the filter knows about. Helps
+        // operators confirm at boot that the deny-lists actually loaded.
+        let m = crw_core::metrics::metrics();
+        m.map_filter_rules_loaded
+            .with_label_values(&["action"])
+            .inc_by(
+                (crw_crawl::url_filter_data::DEFAULT_ACTION_PARAMS.len()
+                    + url_filter_cfg.action_params.len()) as u64,
+            );
+        m.map_filter_rules_loaded
+            .with_label_values(&["tracking"])
+            .inc_by(
+                (crw_crawl::url_filter_data::DEFAULT_TRACKING_PARAMS.len()
+                    + url_filter_cfg.tracking_params.len()) as u64,
+            );
+        m.map_filter_rules_loaded
+            .with_label_values(&["preserve"])
+            .inc_by(
+                (crw_crawl::url_filter_data::ALWAYS_PRESERVE.len()
+                    + url_filter_cfg.preserve_params.len()) as u64,
+            );
+        m.map_filter_rules_loaded
+            .with_label_values(&["host_override"])
+            .inc_by(url_filter_cfg.host_overrides.len() as u64);
+        let url_filter = Some(Arc::new(url_filter_cfg));
+
         let state = Self {
             config: Arc::new(config),
             renderer: Arc::new(renderer),
             crawl_jobs: Arc::new(RwLock::new(HashMap::new())),
             crawl_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_CRAWLS)),
             searxng,
+            url_filter,
         };
 
         // Wrap the not-yet-returned state in a block to keep the Ok() shape at the end.

--- a/crates/crw-server/tests/fixtures/issue-40-baseline.json
+++ b/crates/crw-server/tests/fixtures/issue-40-baseline.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Expected post-filter URL set from issue-40-shanzastore.html with default filter ON. Action URLs (Tier A) are dropped entirely; tracking params (Tier B) are stripped from kept URLs.",
+  "base_url": "https://shanzastore.example.test",
+  "expected_links_filter_on": [
+    "https://shanzastore.example.test",
+    "https://shanzastore.example.test/about",
+    "https://shanzastore.example.test/blog/spring-sale",
+    "https://shanzastore.example.test/contact",
+    "https://shanzastore.example.test/product/sample-1",
+    "https://shanzastore.example.test/product/sample-2",
+    "https://shanzastore.example.test/shop",
+    "https://shanzastore.example.test/shop?page=2",
+    "https://shanzastore.example.test/shop?page=3"
+  ],
+  "expected_dropped_action_count": 7,
+  "expected_links_filter_off_contains_substrings": [
+    "add-to-cart=360",
+    "add_to_wishlist=6241",
+    "_wpnonce=b7643da9b9",
+    "remove_item=361",
+    "undo_item=361",
+    "utm_source=facebook",
+    "fbclid=IwAR12345",
+    "gclid=Cj0KCQjw_abc"
+  ]
+}

--- a/crates/crw-server/tests/fixtures/issue-40-shanzastore.html
+++ b/crates/crw-server/tests/fixtures/issue-40-shanzastore.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Shanza Store — fixture for issue #40</title>
+  <link rel="canonical" href="https://shanzastore.example.test/">
+</head>
+<body>
+  <h1>Shanza Store (fixture)</h1>
+  <nav>
+    <a href="/">Home</a>
+    <a href="/shop/">Shop</a>
+    <a href="/product/sample-1/">Sample Product 1</a>
+    <a href="/product/sample-2/">Sample Product 2</a>
+    <a href="/about/">About</a>
+    <a href="/contact/?utm_source=newsletter&utm_medium=email">Contact</a>
+  </nav>
+
+  <main>
+    <article id="product-1">
+      <h2><a href="/product/sample-1/">Sample Product 1</a></h2>
+      <a class="add-to-cart" href="/?add-to-cart=360">Add Sample 1 to cart</a>
+      <a class="wishlist"   href="/?add_to_wishlist=6241&amp;_wpnonce=b7643da9b9">Add Sample 1 to wishlist</a>
+    </article>
+
+    <article id="product-2">
+      <h2><a href="/product/sample-2/">Sample Product 2</a></h2>
+      <a class="add-to-cart" href="/?add-to-cart=361">Add Sample 2 to cart</a>
+      <a class="wishlist"   href="/?add_to_wishlist=6242&amp;_wpnonce=c8754eb0c0">Add Sample 2 to wishlist</a>
+      <a class="remove"     href="/?remove_item=361&amp;_wpnonce=d99921ff11">Remove</a>
+      <a class="undo"       href="/?undo_item=361&amp;_wpnonce=d99921ff11">Undo</a>
+    </article>
+
+    <section class="promo">
+      <a href="/blog/spring-sale/?utm_source=facebook&amp;utm_medium=cpc&amp;fbclid=IwAR12345">
+        Spring Sale (FB ad)
+      </a>
+      <a href="/blog/spring-sale/?gclid=Cj0KCQjw_abc">Spring Sale (Google ad)</a>
+    </section>
+
+    <nav class="pagination">
+      <a href="/shop/?page=2">Page 2</a>
+      <a href="/shop/?page=3">Page 3</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/crates/crw-server/tests/map_filter.rs
+++ b/crates/crw-server/tests/map_filter.rs
@@ -1,0 +1,421 @@
+//! Integration tests for the /v1/map URL filter (issue #40).
+//!
+//! Boots an in-process axum server backed by an `AppState` whose upstream
+//! HTML/sitemap source is a `wiremock` server. Exercises both the BFS path
+//! (HTML extraction) and the sitemap path, plus opt-out shapes and the
+//! metrics surface.
+
+use axum_test::TestServer;
+use crw_core::config::AppConfig;
+use crw_server::app::create_app;
+use crw_server::state::AppState;
+use serde_json::{Value, json};
+use std::sync::Once;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+static INIT_TEST_ENV: Once = Once::new();
+fn allow_loopback_for_tests() {
+    INIT_TEST_ENV.call_once(|| {
+        // SAFETY: tests in this binary all want the same opt-in, set once
+        // before any tokio worker spawns its own thread.
+        unsafe {
+            std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        }
+    });
+}
+
+/// HTML the mock server returns for `GET /`. Mirrors the issue-40
+/// fixture shape: WooCommerce action URLs, tracker query strings,
+/// pagination URLs, and a canonical product URL. `{base}` is replaced
+/// with the mock server's URI before serving.
+const ISSUE_40_HTML_TEMPLATE: &str = r#"<!doctype html>
+<html><head><title>Shanzastore — issue #40 fixture</title></head><body>
+<a href="{base}/about">About</a>
+<a href="{base}/contact">Contact</a>
+<a href="{base}/shop">Shop</a>
+<a href="{base}/shop?page=2">Shop page 2</a>
+<a href="{base}/shop?page=3">Shop page 3</a>
+<a href="{base}/product/sample-1">Product 1</a>
+<a href="{base}/product/sample-2">Product 2</a>
+<a href="{base}/blog/spring-sale?utm_source=facebook&fbclid=IwAR12345">Spring sale</a>
+<a href="{base}/?add-to-cart=360">Add to cart 360</a>
+<a href="{base}/?add-to-cart=361">Add to cart 361</a>
+<a href="{base}/?add_to_wishlist=6241&_wpnonce=b7643da9b9">Add to wishlist</a>
+<a href="{base}/?remove_item=361&_wpnonce=abc123">Remove item</a>
+<a href="{base}/?undo_item=361">Undo item</a>
+<a href="{base}/?wc-ajax=remove_from_cart">WC ajax</a>
+<a href="{base}/landing?gclid=Cj0KCQjw_abc">Ad landing</a>
+</body></html>"#;
+
+fn issue_40_html(base: &str) -> String {
+    ISSUE_40_HTML_TEMPLATE.replace("{base}", base)
+}
+
+fn sitemap_xml(base: &str) -> String {
+    format!(
+        r#"<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>{base}/</loc></url>
+  <url><loc>{base}/about</loc></url>
+  <url><loc>{base}/shop</loc></url>
+  <url><loc>{base}/shop?page=2</loc></url>
+  <url><loc>{base}/product/sample-1?utm_source=newsletter</loc></url>
+  <url><loc>{base}/?add-to-cart=999</loc></url>
+</urlset>"#
+    )
+}
+
+async fn upstream_server() -> MockServer {
+    let server = MockServer::start().await;
+    let base = server.uri();
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .set_body_string(issue_40_html(&base)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sitemap.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/xml")
+                .set_body_string(sitemap_xml(&base)),
+        )
+        .mount(&server)
+        .await;
+    // Empty bodies for the leaf pages — BFS records the link but the page
+    // itself doesn't need to add more links for the test.
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html")
+                .set_body_string("<html><body></body></html>"),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
+fn test_app(toml: &str) -> TestServer {
+    allow_loopback_for_tests();
+    let config: AppConfig = toml::from_str(toml).expect("config parse");
+    let state = AppState::new(config).expect("AppState::new failed");
+    let app = create_app(state);
+    TestServer::new(app)
+}
+
+fn default_app() -> TestServer {
+    test_app("")
+}
+
+#[tokio::test]
+async fn bfs_path_drops_action_urls_strips_trackers() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": false,
+            "crawlFallback": true,
+            "maxDepth": 1
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let links = body["data"]["links"].as_array().expect("links array");
+    let joined = links
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Action URLs dropped.
+    assert!(
+        !joined.contains("add-to-cart"),
+        "action URL leaked through filter:\n{joined}"
+    );
+    assert!(!joined.contains("_wpnonce"), "wpnonce leaked:\n{joined}");
+    assert!(
+        !joined.contains("add_to_wishlist"),
+        "wishlist leaked:\n{joined}"
+    );
+    // Trackers stripped, base preserved.
+    assert!(joined.contains("/blog/spring-sale"));
+    assert!(!joined.contains("utm_source"));
+    assert!(!joined.contains("fbclid"));
+    assert!(!joined.contains("gclid"));
+    // Drop count surfaced.
+    let dropped = body["data"]["droppedActionCount"]
+        .as_u64()
+        .expect("droppedActionCount field");
+    assert!(dropped >= 5, "expected ≥5 drops, got {dropped}");
+}
+
+#[tokio::test]
+async fn sitemap_path_filters_same_as_bfs() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": true,
+            "crawlFallback": false
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let links = body["data"]["links"].as_array().unwrap();
+    let joined = links
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !joined.contains("add-to-cart"),
+        "sitemap action URL leaked:\n{joined}"
+    );
+    assert!(!joined.contains("utm_source"), "tracker leaked:\n{joined}");
+    assert!(joined.contains("/product/sample-1"), "lost product url");
+    assert!(joined.contains("/shop?page=2"), "lost pagination param");
+}
+
+#[tokio::test]
+async fn granular_opt_out_returns_raw() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": false,
+            "crawlFallback": true,
+            "maxDepth": 1,
+            "stripTrackingParams": false,
+            "dropActionUrls": false
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let joined = body["data"]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        joined.contains("add-to-cart=360"),
+        "action URL missing in opt-out"
+    );
+    assert!(
+        joined.contains("utm_source=facebook"),
+        "tracker stripped in opt-out"
+    );
+}
+
+#[tokio::test]
+async fn coarse_opt_out_returns_raw() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": false,
+            "crawlFallback": true,
+            "maxDepth": 1,
+            "ignoreQueryParameters": false
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let joined = body["data"]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        joined.contains("utm_source"),
+        "tracker missing under coarse=false"
+    );
+}
+
+#[tokio::test]
+async fn coarse_opt_in_strips_all_keeps_action_drop() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": false,
+            "crawlFallback": true,
+            "maxDepth": 1,
+            "ignoreQueryParameters": true
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let joined = body["data"]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Even the legitimate `?page=2` is stripped under coarse mode unless
+    // it's in ALWAYS_PRESERVE — `page` IS in the preserve set, so it
+    // survives. Pagination param survival is part of the contract.
+    assert!(
+        joined.contains("/shop?page=2"),
+        "always-preserve key stripped"
+    );
+    // Trackers and other params all gone.
+    assert!(!joined.contains("utm_source"));
+    assert!(!joined.contains("fbclid"));
+    // Action URL still dropped (Tier A runs under coarse).
+    assert!(!joined.contains("add-to-cart"));
+}
+
+#[tokio::test]
+async fn extra_params_cap_returns_422() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let big_list: Vec<String> = (0..65).map(|i| format!("k{i}")).collect();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "extraTrackingParams": big_list
+        }))
+        .await;
+    // 64-key cap → 400 InvalidRequest (the route maps that to 400, not 422).
+    // Either status is acceptable; the contract is "request rejected".
+    let status = resp.status_code();
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for over-cap, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn metrics_endpoint_records_drops() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let _ = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": false,
+            "crawlFallback": true,
+            "maxDepth": 1
+        }))
+        .await;
+    let metrics = server.get("/metrics").await;
+    metrics.assert_status_ok();
+    let text = metrics.text();
+    // Filter rule counts loaded at boot.
+    assert!(
+        text.contains("crw_map_filter_rules_loaded"),
+        "rules_loaded metric missing"
+    );
+    // At least one action drop recorded from the BFS request above.
+    assert!(
+        text.contains(r#"crw_map_filter_dropped_total{reason="action_param"}"#),
+        "action_param drop metric missing"
+    );
+}
+
+#[tokio::test]
+async fn sitemap_and_bfs_overlap_dedupes() {
+    // The mock sitemap and the HTML both reference /shop?page=2 — the
+    // result must contain it exactly once.
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let resp = server
+        .post("/v1/map")
+        .json(&json!({
+            "url": upstream.uri(),
+            "useSitemap": true,
+            "crawlFallback": true,
+            "maxDepth": 1
+        }))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let links: Vec<String> = body["data"]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    let shop_page_2_count = links.iter().filter(|u| u.contains("/shop?page=2")).count();
+    assert_eq!(
+        shop_page_2_count, 1,
+        "expected single /shop?page=2, got {links:?}"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_requests_with_distinct_extras_no_state_leak() {
+    let upstream = upstream_server().await;
+    let server = default_app();
+    let base = upstream.uri();
+
+    // Run two requests with different `preserveParams`. Request 1 explicitly
+    // preserves `gclid`; request 2 strips it as a default tracker. Each
+    // request must see ONLY its own extras — the server-wide Arc must not
+    // mutate between concurrent handlers.
+    let body1 = json!({
+        "url": base.clone(),
+        "useSitemap": false,
+        "crawlFallback": true,
+        "maxDepth": 1,
+        "preserveParams": ["gclid"]
+    });
+    let body2 = json!({
+        "url": base,
+        "useSitemap": false,
+        "crawlFallback": true,
+        "maxDepth": 1
+    });
+    let (resp1, resp2) = tokio::join!(
+        server.post("/v1/map").json(&body1),
+        server.post("/v1/map").json(&body2),
+    );
+
+    resp1.assert_status_ok();
+    resp2.assert_status_ok();
+    let j1: Value = resp1.json();
+    let j2: Value = resp2.json();
+    let l1 = j1["data"]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let l2 = j2["data"]["links"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Request 1 preserves `gclid`; request 2 strips it (default behaviour).
+    assert!(
+        l1.contains("gclid="),
+        "req1 should preserve gclid; got {l1}"
+    );
+    assert!(
+        !l2.contains("gclid="),
+        "req2 should strip gclid — state leaked: {l2}"
+    );
+}


### PR DESCRIPTION
## Summary
- Three-tier URL filter on `/v1/map`: drops transactional action URLs (Tier A), strips tracking params (Tier B), applies host-scoped overrides (Tier C).
- Default-on with granular per-request flags, Firecrawl-compatible `ignoreQueryParameters` alias, and TOML `[map.url_filter]` server-wide opt-out.
- `MapData` response now carries `droppedActionCount` / `strippedTrackingCount` so unattended callers can detect the behaviour change.

## Verification
- Verified live against shanzastore.com (the issue reporter's site): 250 content URLs kept, **135 action URLs dropped**, zero `?add-to-cart` / `?_wpnonce` URLs remained. Opt-out (`ignoreQueryParameters:false`) restores the issue-#40 URLs exactly.
- Bench delta vs raw `normalize_url`: p50 +0 ns, mean +0.2 µs/URL on mixed corpus; worst case ~0.9 µs/URL on tracker-heavy URLs. 3 µs gate not approached.

## Test plan
- [x] `cargo test --workspace` — 697 passed, 8 ignored
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 9 integration tests in `crates/crw-server/tests/map_filter.rs` (BFS + sitemap + opt-out shapes + regression + metrics + concurrent-extras leak + dedupe overlap)
- [x] 30 unit + 6 audit + 3 property tests in `crates/crw-crawl/src/url_filter.rs`
- [x] Live `/v1/map` POST against shanzastore.com — confirmed issue #40 URLs no longer in results

Closes #40.