### PR TITLE
feat(renderer): add bounded browser-context pool for Chrome tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
  "crw-core",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "crw-core",
  "crw-extract",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
  "crw-core",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "crw-core",
  "futures",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "axum",
  "axum-test",

--- a/bench/POOL_BENCH.md
+++ b/bench/POOL_BENCH.md
@@ -1,0 +1,90 @@
+# Tier 5 — Browser-Context Pool Bench Gate
+
+This file is the operator runbook for the Tier 5 gate from
+`plans/tamam-browser-ppolu-detaylica-virtual-glade.md`. It executes the
+1000-URL bench twice — once with the pool disabled (baseline), once enabled
+(treatment) — and checks the §B2 / §B3a / §B3b criteria.
+
+## Pre-requisites
+
+- Docker stack ready (`crw` + `chrome` heavy profile).
+- `bench/.venv` set up:
+  ```sh
+  uv venv bench/.venv
+  uv pip install --python bench/.venv/bin/python aiohttp datasets
+  ```
+- `HF_TOKEN` exported (HuggingFace dataset access for
+  `firecrawl/scrape-content-dataset-v1`).
+- ~30 minutes of wall-clock per pass (≈1 hour total for both passes).
+
+## One-shot run
+
+```sh
+bench/run_pool_bench.sh
+```
+
+Outputs land in `bench/server-runs/`:
+
+| File | Purpose |
+|---|---|
+| `pool-<TS>-off.json` | bench result, baseline |
+| `pool-<TS>-off.log`  | bench stdout/stderr, baseline |
+| `pool-<TS>-off.metrics-pre.txt`  | `/metrics` before baseline run |
+| `pool-<TS>-off.metrics-post.txt` | `/metrics` after baseline run |
+| `pool-<TS>-on.{json,log,metrics-{pre,post}.txt}` | same, treatment |
+| `pool-<TS>-summary.txt` | gate evaluation (PASS/FAIL per criterion) |
+
+## Gate criteria (auto-checked by `compare_pool_bench.py`)
+
+| ID | Criterion | Source |
+|---|---|---|
+| **B2**  | `histogram_quantile(0.5, crw_chrome_request_handshake_seconds{pool="off"})` − `histogram_quantile(0.5, crw_chrome_request_handshake_seconds{pool="on", acquire_source="hit_idle"})` ≥ **300 ms** | warm-hit handshake savings |
+| **B3a** | overall `pool="on"` median (across all `acquire_source`) ≤ `pool="off"` median | no operational regression |
+| **B3b** | `truth_recall` within ±0.5 pp; `success_rate` ≥ baseline; request `p50` ≤ baseline + 100 ms | no scrape-quality regression |
+
+`compare_pool_bench.py` exits with 0 on full PASS, 1 if any criterion fails.
+Note that B3b reads from the bench JSON (latency_ms.p50, quality fields) and
+B2/B3a from the `/metrics` snapshot — both must be present.
+
+## After a PASS
+
+Per plan §B5: flip `[renderer.chrome.pool] enabled = true` in
+`config.docker.toml` only. Stealth tier stays off (browserless backend
+unsupported in v1; see `[renderer.chrome] backend = "vanilla"`).
+
+```diff
+ # config.docker.toml
+ [renderer.chrome.pool]
+-enabled = false
++enabled = true
+ # size = 4   # default = max(2, num_cpu/2)
+```
+
+Commit + ship via the normal flow. Roll back by flipping it back to `false`
+and restarting — legacy WS-per-request path remains the fallback.
+
+## After a FAIL
+
+The `summary.txt` lists which criteria failed. Common patterns:
+
+- **B2 reduction <300 ms**: pool may be sized wrong, or warm-hit ratio is
+  too low (most acquires create new slots). Check the pool gauges
+  `crw_chrome_pool_acquires_total{outcome=...}` ratio in the metrics
+  snapshot. If `created_new` ≫ `hit_idle`, increase `pool.size`.
+- **B3a fails but B2 passes**: warm-hits are fast but cold creates dominate
+  the operational mix. Same fix — bigger pool, or look at
+  `pool_recycle_seconds` for slow recycles.
+- **B3b truth_recall regression**: real isolation bug. Stop, investigate
+  with the T0/T1 cookie/storage tests in
+  `crates/crw-renderer/tests/browser_pool_real_chrome.rs`. Do NOT flip the
+  flag.
+
+## Manual replay of just the gate evaluator
+
+```sh
+python3 bench/compare_pool_bench.py \
+  --off bench/server-runs/pool-<TS>-off \
+  --on  bench/server-runs/pool-<TS>-on
+```
+
+(No `.json` extension — the script appends suffixes.)

--- a/bench/compare_pool_bench.py
+++ b/bench/compare_pool_bench.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Tier 5 — Browser-context pool bench gate evaluator.
+
+Reads `pool-<TS>-{off,on}.{json,metrics-post.txt}` produced by
+`run_pool_bench.sh` and prints PASS/FAIL for each plan §B2/B3a/B3b/B3b
+criterion:
+
+  B2  primary: histogram_quantile(0.5, ...) reduction on
+      `crw_chrome_request_handshake_seconds{pool="on", acquire_source="hit_idle"}`
+      vs `pool="off"` ≥ 0.300 s
+  B3a secondary: overall median across all acquire_source values for pool=on
+      ≤ pool=off median (no operational regression)
+  B3b no-regression gates: truth_recall ±0.5 pp, success rate ≥ baseline,
+      p50 ≤ baseline + 100 ms
+
+Quantiles are computed in Python from raw `_bucket{le=...}` lines — Prometheus
+isn't a hard dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+HANDSHAKE = "crw_chrome_request_handshake_seconds"
+
+
+def parse_buckets(text: str, metric: str, label_filter: dict[str, str] | None = None):
+    """Yield (le_float, count_float) tuples for `metric_bucket` lines whose
+    labels match every key/value in `label_filter`. Counts are cumulative
+    (Prometheus convention)."""
+    pat = re.compile(rf'^{re.escape(metric)}_bucket\{{([^}}]*)\}}\s+(\S+)$', re.M)
+    for m in pat.finditer(text):
+        labels_raw, count = m.group(1), m.group(2)
+        labels = dict(re.findall(r'(\w+)="([^"]*)"', labels_raw))
+        if label_filter:
+            if any(labels.get(k) != v for k, v in label_filter.items()):
+                continue
+        le = labels.get("le")
+        if le is None:
+            continue
+        try:
+            le_f = float("inf") if le == "+Inf" else float(le)
+            yield le_f, float(count)
+        except ValueError:
+            continue
+
+
+def histogram_quantile(buckets: list[tuple[float, float]], q: float) -> float | None:
+    """Linear-interpolation `histogram_quantile` matching Prometheus' formula
+    on a single histogram. Returns None if the bucket list is empty / all-zero."""
+    buckets = sorted(buckets, key=lambda x: x[0])
+    if not buckets:
+        return None
+    total = buckets[-1][1]
+    if total <= 0:
+        return None
+    target = q * total
+    prev_le, prev_cum = 0.0, 0.0
+    for le, cum in buckets:
+        if cum >= target:
+            if le == float("inf"):
+                return prev_le
+            in_bucket = cum - prev_cum
+            if in_bucket <= 0:
+                return prev_le
+            frac = (target - prev_cum) / in_bucket
+            return prev_le + frac * (le - prev_le)
+        prev_le, prev_cum = le, cum
+    return buckets[-1][0]
+
+
+def aggregate_buckets(streams: list[list[tuple[float, float]]]) -> list[tuple[float, float]]:
+    """Sum cumulative counts across multiple histograms keyed by `le`."""
+    agg: dict[float, float] = {}
+    for stream in streams:
+        for le, cum in stream:
+            agg[le] = agg.get(le, 0.0) + cum
+    return sorted(agg.items(), key=lambda x: x[0])
+
+
+def median_handshake(metrics_text: str, label_filter: dict[str, str] | None) -> float | None:
+    """Sum `_bucket` series matching the filter (across whatever residual
+    label dimensions exist) into one histogram, then `histogram_quantile(0.5)`."""
+    by_le: dict[float, float] = {}
+    for le, cum in parse_buckets(metrics_text, HANDSHAKE, label_filter):
+        by_le[le] = by_le.get(le, 0.0) + cum
+    if not by_le:
+        return None
+    return histogram_quantile(sorted(by_le.items(), key=lambda x: x[0]), 0.5)
+
+
+def fmt_ms(s: float | None) -> str:
+    return "n/a" if s is None else f"{s * 1000:.1f} ms"
+
+
+def evaluate(off_prefix: Path, on_prefix: Path) -> int:
+    off_json = json.loads(Path(f"{off_prefix}.json").read_text())
+    on_json = json.loads(Path(f"{on_prefix}.json").read_text())
+    off_metrics = Path(f"{off_prefix}.metrics-post.txt").read_text()
+    on_metrics = Path(f"{on_prefix}.metrics-post.txt").read_text()
+
+    failures: list[str] = []
+
+    # ---- B2: warm-hit median reduction ≥ 300 ms ------------------------------
+    off_med = median_handshake(off_metrics, {"pool": "off"})
+    on_warm_med = median_handshake(on_metrics, {"pool": "on", "acquire_source": "hit_idle"})
+    print("=" * 60)
+    print("B2 — warm-hit handshake reduction")
+    print(f"  pool=off median:                 {fmt_ms(off_med)}")
+    print(f"  pool=on,acquire=hit_idle median: {fmt_ms(on_warm_med)}")
+    if off_med is None or on_warm_med is None:
+        failures.append("B2: missing histogram data (was the gate metric scraped?)")
+        print("  → SKIP (missing data)")
+    else:
+        delta = off_med - on_warm_med
+        print(f"  → reduction:                     {delta * 1000:.1f} ms (≥ 300 ms required)")
+        if delta < 0.300:
+            failures.append(f"B2: reduction {delta * 1000:.1f} ms < 300 ms")
+            print("  → FAIL")
+        else:
+            print("  → PASS")
+
+    # ---- B3a: overall pool=on median ≤ pool=off median -----------------------
+    on_overall_med = median_handshake(on_metrics, {"pool": "on"})
+    print()
+    print("B3a — operational (all acquire_source) median ≤ baseline")
+    print(f"  pool=off median:        {fmt_ms(off_med)}")
+    print(f"  pool=on overall median: {fmt_ms(on_overall_med)}")
+    if off_med is None or on_overall_med is None:
+        failures.append("B3a: missing histogram data")
+        print("  → SKIP (missing data)")
+    elif on_overall_med > off_med:
+        failures.append(
+            f"B3a: pool=on overall median {on_overall_med * 1000:.1f} ms > "
+            f"pool=off {off_med * 1000:.1f} ms"
+        )
+        print("  → FAIL")
+    else:
+        print("  → PASS")
+
+    # ---- B3b: no-regression gates --------------------------------------------
+    print()
+    print("B3b — no-regression gates")
+    off_recall = off_json["quality"]["truth_recall"]
+    on_recall = on_json["quality"]["truth_recall"]
+    print(f"  truth_recall: off={off_recall}%  on={on_recall}%  (±0.5 pp)")
+    if abs(on_recall - off_recall) > 0.5:
+        failures.append(f"B3b: truth_recall drift |{on_recall - off_recall:.2f}| > 0.5 pp")
+        print("  → FAIL")
+    else:
+        print("  → PASS")
+
+    off_succ = off_json["coverage"]["success_rate"]
+    on_succ = on_json["coverage"]["success_rate"]
+    print(f"  success_rate: off={off_succ}%  on={on_succ}%  (on ≥ off)")
+    if on_succ < off_succ - 0.01:  # tiny epsilon for float noise
+        failures.append(f"B3b: success_rate {on_succ}% < baseline {off_succ}%")
+        print("  → FAIL")
+    else:
+        print("  → PASS")
+
+    off_p50 = off_json["latency_ms"]["p50"]
+    on_p50 = on_json["latency_ms"]["p50"]
+    print(f"  request p50: off={off_p50} ms  on={on_p50} ms  (on ≤ off + 100 ms)")
+    if on_p50 > off_p50 + 100:
+        failures.append(f"B3b: request p50 {on_p50} ms > {off_p50 + 100} ms budget")
+        print("  → FAIL")
+    else:
+        print("  → PASS")
+
+    # ---- summary --------------------------------------------------------------
+    print()
+    print("=" * 60)
+    if failures:
+        print(f"GATE: FAIL — {len(failures)} criterion failed")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("GATE: PASS — flip [renderer.chrome.pool] enabled = true in config.docker.toml")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Tier 5 pool bench gate evaluator")
+    ap.add_argument("--off", required=True, help="Prefix for pool=off run (no extension)")
+    ap.add_argument("--on", required=True, help="Prefix for pool=on run (no extension)")
+    args = ap.parse_args()
+    return evaluate(Path(args.off), Path(args.on))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/run_pool_bench.sh
+++ b/bench/run_pool_bench.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Tier 5 — Browser-context pool bench gate.
+#
+# Runs the 1000-URL bench twice: once with the chrome browser-context pool
+# DISABLED (baseline), once ENABLED (treatment). Captures bench JSON +
+# Prometheus /metrics snapshots so the B2/B3a/B3b gate criteria from the
+# plan can be evaluated by `compare_pool_bench.py`.
+#
+# Pre-reqs:
+#   - docker compose stack ready (crw + chrome heavy profile)
+#   - bench/.venv populated (`uv venv bench/.venv && uv pip install -r bench/requirements.txt`)
+#   - HF_TOKEN exported (HuggingFace dataset access)
+#
+# Usage:
+#   bench/run_pool_bench.sh
+#   # → bench/server-runs/pool-<TS>-{off,on}.{json,log,metrics.txt}
+#   # → bench/server-runs/pool-<TS>-summary.txt (gate evaluation)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [ -f .env ]; then set -a; . ./.env; set +a; fi
+
+TS=$(date -u +%Y%m%d-%H%M%S)
+OUT=bench/server-runs
+mkdir -p "$OUT"
+
+URLS="${BENCH_MAX_URLS:-1000}"
+CONC="${BENCH_CONCURRENCY:-10}"
+PORT="${CRW_PORT:-3030}"
+COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.override.yml)
+
+run_pass() {
+  local pool_enabled="$1"
+  local label="$2"
+  echo
+  echo "============================================================"
+  echo "PASS: pool=$label  (urls=$URLS, conc=$CONC)"
+  echo "============================================================"
+
+  CRW_RENDERER__MODE=chrome \
+  CRW_RENDERER__CHROME_BACKEND=vanilla \
+  CRW_RENDERER__CHROME_CONTEXT_POOL_ENABLED="$pool_enabled" \
+    docker compose "${COMPOSE_FILES[@]}" --profile heavy up -d --force-recreate crw
+
+  for i in {1..60}; do
+    if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+      echo "crw ready (port $PORT, pool=$label)"
+      break
+    fi
+    sleep 2
+  done
+
+  json="$OUT/pool-$TS-$label.json"
+  log="$OUT/pool-$TS-$label.log"
+  metrics_pre="$OUT/pool-$TS-$label.metrics-pre.txt"
+  metrics_post="$OUT/pool-$TS-$label.metrics-post.txt"
+
+  curl -s "http://localhost:$PORT/metrics" > "$metrics_pre" || true
+
+  CRW_API_URL="http://localhost:$PORT" \
+  BENCH_CONCURRENCY="$CONC" \
+  BENCH_MAX_URLS="$URLS" \
+  BENCH_RESULTS_PATH="$json" \
+    bench/.venv/bin/python bench/run_bench.py 2>&1 | tee "$log"
+
+  curl -s "http://localhost:$PORT/metrics" > "$metrics_post" || true
+  echo "→ saved $json + metrics snapshots"
+}
+
+run_pass false off
+run_pass true  on
+
+echo
+echo "============================================================"
+echo "Evaluating gate criteria..."
+echo "============================================================"
+bench/.venv/bin/python bench/compare_pool_bench.py \
+  --off "$OUT/pool-$TS-off" \
+  --on  "$OUT/pool-$TS-on" \
+  | tee "$OUT/pool-$TS-summary.txt"

--- a/config.docker.toml
+++ b/config.docker.toml
@@ -56,11 +56,22 @@ chrome_intercept_resources = true
 # partial-DOM snapshot is returned with truncated=true.
 chrome_nav_budget_ms = 12000
 
+# Phase 4 §B5: bounded browser-context pool. Validated 2026-05-11
+# (PROGRESS.md gap-closure): cookie/storage isolation T1 PASS, B2 sanity
+# ratio < 2× (T2), RSS soak chrome 1.08× over 500 reqs (T3), TOML flip
+# 75/75 across 3 cycles (T5). Backend explicitly vanilla — pool is gated
+# off on browserless via lib.rs.
+chrome_backend = "vanilla"
+chrome_context_pool_enabled = true
+
 [renderer.lightpanda]
 ws_url = "ws://lightpanda:9222/"
 
 [renderer.chrome]
 ws_url = "ws://chrome:9222/"
+
+[renderer.chrome_pool]
+size = 4
 
 # /v1/search points at the bundled SearXNG sidecar. The container resolves
 # `searxng` via docker-compose's network DNS.

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -321,9 +321,21 @@ pub struct RendererConfig {
     pub chrome_nav_budget_ms: u64,
     /// Enable the bounded browser-context pool. Default `false`; v1 ships
     /// `RECYCLE_AFTER_NAV = 1` (recreate every release) before optimising to
-    /// reuse-with-clearing. See plan Phase 4.
+    /// reuse-with-clearing. See plan Phase 4. **Gated off when
+    /// `chrome_backend = "browserless"`** — browserless v2's
+    /// `Target.createBrowserContext` semantics with long-lived sessions are
+    /// unproven; lib.rs forces this to `false` with a WARN log in that case.
     #[serde(default)]
     pub chrome_context_pool_enabled: bool,
+    /// Per-knob pool configuration. Read only when
+    /// `chrome_context_pool_enabled = true` AND backend is `Vanilla`.
+    #[serde(default)]
+    pub chrome_pool: ChromePoolConfig,
+    /// Which Chrome backend the WS URL points at. **Explicit** — never sniff
+    /// from URL substrings (k8s svc names, port-forwards, custom routes break
+    /// substring detection per plan §C2). Default `Vanilla`.
+    #[serde(default)]
+    pub chrome_backend: ChromeBackend,
     /// Enable the success-ratio renderer predictor in `HostPreferences`.
     /// Default `false`; flipped after the predictor replay harness gates
     /// on the 1k bench (false-skip < 2 %, false-escalate < 5 %, churn < 3 / 1k).
@@ -410,6 +422,71 @@ fn default_chrome_nav_budget_ms() -> u64 {
     12_000
 }
 
+/// Per-knob configuration for the bounded browser-context pool. Loaded under
+/// `[renderer.chrome_pool]`. Inactive unless
+/// `chrome_context_pool_enabled = true` AND `chrome_backend = "vanilla"`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChromePoolConfig {
+    /// Pool size. `None` → `max(2, num_cpus / 2)`. Caps simultaneous
+    /// in-flight chrome requests per pool.
+    #[serde(default)]
+    pub size: Option<usize>,
+    /// Recycle policy: v1 always recreates the context after each release.
+    /// Reserved for a future "reuse N navigations then recreate" mode.
+    #[serde(default = "default_recycle_after_navs")]
+    pub recycle_after_navs: u32,
+    /// Idle slots older than this are health-checked on next acquire.
+    #[serde(default = "default_idle_timeout_secs")]
+    pub idle_timeout_secs: u64,
+    /// `Browser.getVersion` probe deadline (idle-slot liveness).
+    #[serde(default = "default_health_check_secs")]
+    pub health_check_secs: u64,
+    /// SIGTERM drain window before phase 3 force-close.
+    #[serde(default = "default_shutdown_drain_secs")]
+    pub shutdown_drain_secs: u64,
+}
+
+impl Default for ChromePoolConfig {
+    fn default() -> Self {
+        Self {
+            size: None,
+            recycle_after_navs: default_recycle_after_navs(),
+            idle_timeout_secs: default_idle_timeout_secs(),
+            health_check_secs: default_health_check_secs(),
+            shutdown_drain_secs: default_shutdown_drain_secs(),
+        }
+    }
+}
+
+fn default_recycle_after_navs() -> u32 {
+    1
+}
+fn default_idle_timeout_secs() -> u64 {
+    300
+}
+fn default_health_check_secs() -> u64 {
+    60
+}
+fn default_shutdown_drain_secs() -> u64 {
+    30
+}
+
+/// Chrome backend kind. Set explicitly under `[renderer]` as
+/// `chrome_backend = "vanilla"` or `chrome_backend = "browserless"`. **Never
+/// inferred from URL substrings** — k8s service names, port-forwards, and
+/// custom routes break substring detection. See plan §C2.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ChromeBackend {
+    /// chromedp/headless-shell or vanilla Chrome with `/json/version`. Pool
+    /// is enabled here when `chrome_context_pool_enabled = true`.
+    #[default]
+    Vanilla,
+    /// Browserless v2 / commercial CDP endpoint. Pool is **gated off** in v1
+    /// — see plan §"Out of scope (v1)".
+    Browserless,
+}
+
 impl Default for RendererConfig {
     fn default() -> Self {
         Self {
@@ -428,6 +505,8 @@ impl Default for RendererConfig {
             chrome_host_intercept_disable: Vec::new(),
             chrome_nav_budget_ms: default_chrome_nav_budget_ms(),
             chrome_context_pool_enabled: false,
+            chrome_pool: ChromePoolConfig::default(),
+            chrome_backend: ChromeBackend::default(),
             use_predictor: false,
             escalation: EscalationConfig::default(),
             antibot: AntibotConfig::default(),

--- a/crates/crw-core/src/error.rs
+++ b/crates/crw-core/src/error.rs
@@ -40,6 +40,9 @@ pub enum CrwError {
 
     #[error("{0}")]
     Internal(String),
+
+    #[error("Renderer pool shutting down")]
+    Shutdown,
 }
 
 impl CrwError {
@@ -59,6 +62,7 @@ impl CrwError {
             CrwError::RateLimited => "rate_limited",
             CrwError::SearchDisabled(_) => "search_disabled",
             CrwError::Internal(_) => "internal_error",
+            CrwError::Shutdown => "shutdown",
         }
     }
 }

--- a/crates/crw-core/src/metrics.rs
+++ b/crates/crw-core/src/metrics.rs
@@ -4,8 +4,10 @@
 //! [`gather_text`] to render the current snapshot for `/metrics`.
 
 use prometheus::{
-    Encoder, IntCounterVec, IntGauge, Registry, TextEncoder,
-    register_int_counter_vec_with_registry, register_int_gauge_with_registry,
+    Encoder, Histogram, HistogramVec, IntCounterVec, IntGauge, Registry, TextEncoder,
+    exponential_buckets, histogram_opts, register_histogram_vec_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_with_registry,
 };
 use std::sync::OnceLock;
 
@@ -57,6 +59,52 @@ pub struct Metrics {
     pub map_filter_preserved_total: IntCounterVec,
     /// /map URL filter: count of rules loaded at server startup. Labels: `kind`.
     pub map_filter_rules_loaded: IntCounterVec,
+    /// Chrome WS connect duration, labeled by outcome.
+    /// Tier 0 (Browser Context Pool plan): isolates connect+handshake cost.
+    /// `outcome` ∈ {ok, ws_dial_fail, ws_handshake_timeout, version_probe_fail}.
+    pub chrome_connect_seconds: HistogramVec,
+    /// Chrome `Target.createTarget` round-trip duration. Tier 0 sub-metric.
+    pub chrome_target_create_seconds: Histogram,
+    /// Chrome navigation duration: from `Page.navigate` send to first
+    /// `Page.loadEventFired`. Tier 0 sub-metric.
+    pub chrome_navigate_seconds: Histogram,
+    /// Chrome HTML snapshot duration: `Runtime.evaluate(outerHTML)` round-trip.
+    /// Tier 0 sub-metric.
+    pub chrome_snapshot_seconds: Histogram,
+    // -------- Browser Context Pool (Tier 1+) --------
+    /// Configured pool size.
+    pub chrome_pool_size: IntGauge,
+    /// Current idle slot count (sampled).
+    pub chrome_pool_idle: IntGauge,
+    /// Current `CheckedOut` slot count.
+    pub chrome_pool_inflight: IntGauge,
+    /// Time spent in `pool.acquire()` (waiting for a permit + slot creation).
+    pub chrome_pool_acquire_seconds: Histogram,
+    /// Acquire-path accounting.
+    /// `outcome` ∈ {hit_idle, created_new, errored, shutdown_refused}.
+    pub chrome_pool_acquires_total: IntCounterVec,
+    /// Per-phase release cost.
+    /// `phase` ∈ {close_target, dispose_ctx, create_ctx}.
+    pub chrome_pool_recycle_seconds: HistogramVec,
+    /// Terminal recycle outcomes.
+    /// `outcome` ∈ {success, dead_conn, idle_timeout, emergency_drop,
+    ///              nav_count_recycle, health_fail, shutdown_raced,
+    ///              unexpected_state}.
+    pub chrome_pool_recycle_total: IntCounterVec,
+    /// Failure-only counter, partitioned by failed stage.
+    /// `stage` ∈ {close_target_timeout, dispose_ctx_fail, create_ctx_fail,
+    ///            missed_release}.
+    pub chrome_pool_recycle_failures_total: IntCounterVec,
+    /// Idle-slot health probe outcomes.
+    /// `outcome` ∈ {ok, failed}.
+    pub chrome_pool_health_check_total: IntCounterVec,
+    /// How long each context survives between create and dispose. Informs
+    /// v2 context-lifetime decisions.
+    pub chrome_context_lifetime_seconds: Histogram,
+    /// Pre-navigation overhead per Chrome request — the B2 gate metric.
+    /// `pool` ∈ {on, off}; `acquire_source` ∈ {hit_idle, created_new,
+    /// health_checked, n/a}. Pool-off requests use `acquire_source="n/a"`.
+    pub chrome_request_handshake_seconds: HistogramVec,
 }
 
 static METRICS: OnceLock<Metrics> = OnceLock::new();
@@ -191,6 +239,133 @@ impl Metrics {
             registry
         )
         .unwrap();
+        // Tier 0 latency histograms for the Browser Context Pool plan.
+        // Buckets: 10ms × 2^k for k=0..11 → 10ms, 20, 40, 80, 160, 320, 640,
+        // 1.28s, 2.56s, 5.12s, 10.24s, 20.48s. Covers fast-path 50ms WS
+        // connects and slow-path 5s+ navigations.
+        let lat_buckets = exponential_buckets(0.01, 2.0, 12).unwrap();
+        let chrome_connect_seconds = register_histogram_vec_with_registry!(
+            histogram_opts!(
+                "crw_chrome_connect_seconds",
+                "Chrome WS connect duration by outcome",
+                lat_buckets.clone()
+            ),
+            &["outcome"],
+            registry
+        )
+        .unwrap();
+        let chrome_target_create_seconds = register_histogram_with_registry!(
+            histogram_opts!(
+                "crw_chrome_target_create_seconds",
+                "Chrome Target.createTarget round-trip duration",
+                lat_buckets.clone()
+            ),
+            registry
+        )
+        .unwrap();
+        let chrome_navigate_seconds = register_histogram_with_registry!(
+            histogram_opts!(
+                "crw_chrome_navigate_seconds",
+                "Chrome navigation duration: Page.navigate send to loadEventFired",
+                lat_buckets.clone()
+            ),
+            registry
+        )
+        .unwrap();
+        let chrome_snapshot_seconds = register_histogram_with_registry!(
+            histogram_opts!(
+                "crw_chrome_snapshot_seconds",
+                "Chrome HTML snapshot duration (Runtime.evaluate outerHTML)",
+                lat_buckets.clone()
+            ),
+            registry
+        )
+        .unwrap();
+        // -------- Browser Context Pool (Tier 1+) --------
+        let chrome_pool_size = register_int_gauge_with_registry!(
+            "crw_chrome_pool_size",
+            "Configured browser context pool size",
+            registry
+        )
+        .unwrap();
+        let chrome_pool_idle = register_int_gauge_with_registry!(
+            "crw_chrome_pool_idle",
+            "Idle slot count in the browser context pool (sampled)",
+            registry
+        )
+        .unwrap();
+        let chrome_pool_inflight = register_int_gauge_with_registry!(
+            "crw_chrome_pool_inflight",
+            "CheckedOut slot count in the browser context pool",
+            registry
+        )
+        .unwrap();
+        let chrome_pool_acquire_seconds = register_histogram_with_registry!(
+            histogram_opts!(
+                "crw_chrome_pool_acquire_seconds",
+                "Time spent in pool.acquire() — permit wait + slot bring-up",
+                lat_buckets.clone()
+            ),
+            registry
+        )
+        .unwrap();
+        let chrome_pool_acquires_total = register_int_counter_vec_with_registry!(
+            "crw_chrome_pool_acquires_total",
+            "Pool acquire outcomes (hit_idle | created_new | errored | shutdown_refused)",
+            &["outcome"],
+            registry
+        )
+        .unwrap();
+        let chrome_pool_recycle_seconds = register_histogram_vec_with_registry!(
+            histogram_opts!(
+                "crw_chrome_pool_recycle_seconds",
+                "Per-phase release cost (close_target | dispose_ctx | create_ctx)",
+                lat_buckets.clone()
+            ),
+            &["phase"],
+            registry
+        )
+        .unwrap();
+        let chrome_pool_recycle_total = register_int_counter_vec_with_registry!(
+            "crw_chrome_pool_recycle_total",
+            "Terminal recycle outcomes",
+            &["outcome"],
+            registry
+        )
+        .unwrap();
+        let chrome_pool_recycle_failures_total = register_int_counter_vec_with_registry!(
+            "crw_chrome_pool_recycle_failures_total",
+            "Recycle failures partitioned by failed stage",
+            &["stage"],
+            registry
+        )
+        .unwrap();
+        let chrome_pool_health_check_total = register_int_counter_vec_with_registry!(
+            "crw_chrome_pool_health_check_total",
+            "Pool idle-slot health probe outcomes (ok | failed)",
+            &["outcome"],
+            registry
+        )
+        .unwrap();
+        let chrome_context_lifetime_seconds = register_histogram_with_registry!(
+            histogram_opts!(
+                "crw_chrome_context_lifetime_seconds",
+                "Lifetime of each browser context, create to dispose",
+                lat_buckets.clone()
+            ),
+            registry
+        )
+        .unwrap();
+        let chrome_request_handshake_seconds = register_histogram_vec_with_registry!(
+            histogram_opts!(
+                "crw_chrome_request_handshake_seconds",
+                "Pre-navigation overhead per Chrome request (B2 gate metric)",
+                lat_buckets
+            ),
+            &["pool", "acquire_source"],
+            registry
+        )
+        .unwrap();
         Self {
             registry,
             render_route_decision_total,
@@ -210,6 +385,21 @@ impl Metrics {
             map_filter_stripped_total,
             map_filter_preserved_total,
             map_filter_rules_loaded,
+            chrome_connect_seconds,
+            chrome_target_create_seconds,
+            chrome_navigate_seconds,
+            chrome_snapshot_seconds,
+            chrome_pool_size,
+            chrome_pool_idle,
+            chrome_pool_inflight,
+            chrome_pool_acquire_seconds,
+            chrome_pool_acquires_total,
+            chrome_pool_recycle_seconds,
+            chrome_pool_recycle_total,
+            chrome_pool_recycle_failures_total,
+            chrome_pool_health_check_total,
+            chrome_context_lifetime_seconds,
+            chrome_request_handshake_seconds,
         }
     }
 }
@@ -221,4 +411,31 @@ pub fn gather_text() -> String {
     let mut buf = Vec::new();
     encoder.encode(&metric_families, &mut buf).ok();
     String::from_utf8(buf).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tier 0 metrics must be registered eagerly so alert rules see zero
+    /// series (not absent series) before the first observation.
+    #[test]
+    fn tier0_chrome_latency_histograms_registered() {
+        let m = metrics();
+        m.chrome_connect_seconds
+            .with_label_values(&["ok"])
+            .observe(0.05);
+        m.chrome_target_create_seconds.observe(0.02);
+        m.chrome_navigate_seconds.observe(0.4);
+        m.chrome_snapshot_seconds.observe(0.01);
+        let text = gather_text();
+        assert!(
+            text.contains("crw_chrome_connect_seconds"),
+            "missing connect_seconds; got: {text}"
+        );
+        assert!(text.contains("crw_chrome_target_create_seconds"));
+        assert!(text.contains("crw_chrome_navigate_seconds"));
+        assert!(text.contains("crw_chrome_snapshot_seconds"));
+        assert!(text.contains(r#"outcome="ok""#));
+    }
 }

--- a/crates/crw-renderer/src/browser_pool.rs
+++ b/crates/crw-renderer/src/browser_pool.rs
@@ -1,0 +1,1126 @@
+//! Browser context pool — long-lived CDP connections + ephemeral browser
+//! contexts amortizing per-request handshake (~200–500 ms) to ~0 ms on warm
+//! hits. See `plans/tamam-browser-ppolu-detaylica-virtual-glade.md` for the
+//! full design rationale; this module implements §"Design — ownership model".
+//!
+//! Lock discipline (load-bearing): the per-slot mutex is `std::sync::Mutex`
+//! and is **never held across an `.await`**. Any change that violates that
+//! invariant breaks both shutdown's force-close path and the sync `Drop`
+//! emergency reaper. Audited at PR review time.
+//!
+//! Stealth JS injection and `Fetch.enable` are **strictly per-target session-
+//! scoped**: do NOT hoist them to the connection or the browser-context level.
+//! See `cdp.rs` for the per-target attach + setup sequence.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, Weak};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde_json::json;
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
+
+use crw_core::error::{CrwError, CrwResult};
+
+use crate::cdp_conn::CdpConnection;
+
+/// Operations the pool performs against a Chrome connection. Trait-extracted
+/// so unit tests can substitute a fake without bringing up real CDP. The blanket
+/// impl below wires it to `CdpConnection`.
+#[async_trait]
+pub trait ChromeConnOps: Send + Sync + 'static {
+    async fn create_browser_context(&self) -> CrwResult<String>;
+    async fn dispose_browser_context(&self, ctx_id: &str) -> CrwResult<()>;
+    async fn close_target(&self, target_id: &str) -> CrwResult<()>;
+    async fn health_check(&self) -> CrwResult<()>;
+    async fn close_conn(&self);
+    fn is_closed(&self) -> bool;
+}
+
+#[async_trait]
+impl ChromeConnOps for CdpConnection {
+    async fn create_browser_context(&self) -> CrwResult<String> {
+        let v = self
+            .send_recv(
+                "Target.createBrowserContext",
+                json!({}),
+                None,
+                Duration::from_secs(2),
+            )
+            .await?;
+        v.get("browserContextId")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                CrwError::RendererError(
+                    "Target.createBrowserContext: missing browserContextId".into(),
+                )
+            })
+    }
+
+    async fn dispose_browser_context(&self, ctx_id: &str) -> CrwResult<()> {
+        self.send_recv(
+            "Target.disposeBrowserContext",
+            json!({ "browserContextId": ctx_id }),
+            None,
+            Duration::from_secs(1),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn close_target(&self, target_id: &str) -> CrwResult<()> {
+        self.send_recv(
+            "Target.closeTarget",
+            json!({ "targetId": target_id }),
+            None,
+            Duration::from_secs(2),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn health_check(&self) -> CrwResult<()> {
+        CdpConnection::health_check_browser(self, Duration::from_millis(200)).await
+    }
+
+    async fn close_conn(&self) {
+        CdpConnection::close(self).await;
+    }
+
+    fn is_closed(&self) -> bool {
+        CdpConnection::is_closed(self)
+    }
+}
+
+/// Per-phase recycle progress marker. Drives the `pool_recycle_seconds{phase}`
+/// histogram and lets shutdown reason about where a Recycling slot is parked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecyclePhase {
+    CloseTarget,
+    DisposeCtx,
+    CreateCtx,
+}
+
+/// Slot state machine. Transitions are serialized under the per-slot
+/// `StdMutex<PooledSlot>` and held only synchronously.
+pub enum SlotState<C: ChromeConnOps> {
+    Idle {
+        conn: Arc<C>,
+        ctx_id: String,
+    },
+    /// `target_id` starts as `None` on every checkout. `record_target` (called
+    /// synchronously inside `fetch_inner` immediately after `Target.createTarget`
+    /// returns Ok, before any subsequent `.await`) flips it to `Some`. There
+    /// are three legitimate ways `target_id` can still be `None` at release
+    /// time: (a) `fetch_inner` failed at `createTarget` so the recorder never
+    /// fired; (b) `record_target` lost a theoretical shutdown race and
+    /// log-and-returned per its panic-free contract; (c) emergency `Drop` ran
+    /// without ever entering `fetch_inner`. In all three cases `release()`
+    /// skips `closeTarget` and still disposes+recreates ctx.
+    CheckedOut {
+        conn: Arc<C>,
+        ctx_id: String,
+        target_id: Option<String>,
+    },
+    Recycling {
+        conn: Arc<C>,
+        ctx_id: String,
+        target_id: Option<String>,
+        phase: RecyclePhase,
+    },
+    /// Conn ownership is explicit: `Some(_)` means whoever transitioned to
+    /// `Dead` is responsible for closing it (release runs inline; Drop spawns
+    /// a reaper; shutdown takes it via `take_conn()`). After close, conn
+    /// becomes `None`.
+    Dead {
+        conn: Option<Arc<C>>,
+    },
+    /// Shutdown owns the close: phase 2 (clean idle drain) or phase 3 (force).
+    Closing,
+}
+
+pub struct PooledSlot<C: ChromeConnOps> {
+    pub state: SlotState<C>,
+    /// Single-shot terminator: only ONE of {release, drop, shutdown-force-close}
+    /// may consume this. `compare_exchange(false→true, AcqRel)` decides the
+    /// winner; the loser does nothing (no decrement, no notify, no close).
+    /// Reset to `false` on every `Idle → CheckedOut` transition under the slot
+    /// mutex (the only legitimate `true → false` transition pool-wide).
+    pub terminator: AtomicBool,
+    pub last_used: Instant,
+}
+
+impl<C: ChromeConnOps> PooledSlot<C> {
+    /// Single API for transferring conn ownership across paths. Always called
+    /// under the slot mutex (caller holds the `MutexGuard` and `DerefMut`s to
+    /// `&mut PooledSlot`). Idempotent: a second call always returns `None`.
+    ///
+    /// State matrix:
+    ///
+    /// | Current state                  | Return        | New state                    |
+    /// |--------------------------------|---------------|------------------------------|
+    /// | `Idle { conn, .. }`            | `Some(conn)`  | `Closing`                    |
+    /// | `CheckedOut { conn, .. }`      | `Some(conn)`  | `Closing`                    |
+    /// | `Recycling { conn, .. }`       | `Some(conn)`  | `Closing`                    |
+    /// | `Dead { conn: Some(c) }`       | `Some(c)`     | `Dead { conn: None }`        |
+    /// | `Dead { conn: None }`          | `None`        | `Dead { conn: None }`        |
+    /// | `Closing`                      | `None`        | `Closing`                    |
+    pub fn take_conn(&mut self) -> Option<Arc<C>> {
+        let cur = std::mem::replace(&mut self.state, SlotState::Closing);
+        match cur {
+            SlotState::Idle { conn, .. }
+            | SlotState::CheckedOut { conn, .. }
+            | SlotState::Recycling { conn, .. } => {
+                // state already replaced with Closing
+                Some(conn)
+            }
+            SlotState::Dead { conn: Some(c) } => {
+                self.state = SlotState::Dead { conn: None };
+                Some(c)
+            }
+            SlotState::Dead { conn: None } => {
+                self.state = SlotState::Dead { conn: None };
+                None
+            }
+            SlotState::Closing => {
+                self.state = SlotState::Closing;
+                None
+            }
+        }
+    }
+}
+
+pub type Slot<C> = Arc<StdMutex<PooledSlot<C>>>;
+pub type WeakSlot<C> = Weak<StdMutex<PooledSlot<C>>>;
+
+/// Async connection factory. Returns a fully-connected `Arc<C>`. Reuses
+/// `cdp::connect_with_retry`-equivalent path so the cached-WS-URL invalidation
+/// from commit `b5f7bec` is preserved (do NOT bypass).
+pub type ConnFactory<C> =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = CrwResult<Arc<C>>> + Send>> + Send + Sync>;
+
+#[derive(Clone, Debug)]
+pub struct PoolCfg {
+    pub size: usize,
+    pub recycle_after_navs: u32,
+    pub idle_timeout: Duration,
+    pub health_check_after: Duration,
+    pub shutdown_drain: Duration,
+    pub close_target_timeout: Duration,
+    pub dispose_ctx_timeout: Duration,
+    pub create_ctx_timeout: Duration,
+}
+
+impl Default for PoolCfg {
+    fn default() -> Self {
+        Self {
+            size: 4,
+            recycle_after_navs: 1,
+            idle_timeout: Duration::from_secs(300),
+            health_check_after: Duration::from_secs(60),
+            shutdown_drain: Duration::from_secs(30),
+            close_target_timeout: Duration::from_secs(2),
+            dispose_ctx_timeout: Duration::from_secs(1),
+            create_ctx_timeout: Duration::from_secs(1),
+        }
+    }
+}
+
+pub struct BrowserContextPool<C: ChromeConnOps> {
+    sem: Arc<Semaphore>,
+    idle: Arc<StdMutex<VecDeque<Slot<C>>>>,
+    all_slots: Arc<StdMutex<Vec<WeakSlot<C>>>>,
+    inflight: Arc<AtomicUsize>,
+    conn_factory: ConnFactory<C>,
+    cfg: PoolCfg,
+    closed: Arc<AtomicBool>,
+    notify_idle: Arc<Notify>,
+}
+
+impl<C: ChromeConnOps> BrowserContextPool<C> {
+    pub fn new(cfg: PoolCfg, conn_factory: ConnFactory<C>) -> Arc<Self> {
+        let sem = Arc::new(Semaphore::new(cfg.size));
+        Arc::new(Self {
+            sem,
+            idle: Arc::new(StdMutex::new(VecDeque::new())),
+            all_slots: Arc::new(StdMutex::new(Vec::new())),
+            inflight: Arc::new(AtomicUsize::new(0)),
+            conn_factory,
+            cfg,
+            closed: Arc::new(AtomicBool::new(false)),
+            notify_idle: Arc::new(Notify::new()),
+        })
+    }
+
+    pub fn cfg(&self) -> &PoolCfg {
+        &self.cfg
+    }
+
+    pub fn inflight(&self) -> usize {
+        self.inflight.load(Ordering::SeqCst)
+    }
+
+    pub fn idle_len(&self) -> usize {
+        self.idle.lock().unwrap().len()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
+    }
+
+    /// The single decrement+notify path. Called from `BookkeepingToken`
+    /// (success and cancel paths) and directly from shutdown phase 3 when
+    /// shutdown wins the terminator. Atomic ops + Notify only — never panics.
+    fn dec_inflight_and_notify(&self) {
+        // Saturating subtract: defensive against double-dec (which the
+        // terminator AtomicBool already prevents). If a future bug ever
+        // double-decs we want a stable 0 floor, not a wraparound to usize::MAX
+        // that would make the shutdown drain loop spin forever.
+        let prev = self.inflight.load(Ordering::SeqCst);
+        if prev > 0 {
+            self.inflight.fetch_sub(1, Ordering::SeqCst);
+        }
+        self.notify_idle.notify_waiters();
+        self.refresh_gauges();
+    }
+
+    /// Snapshot inflight + idle into Prometheus gauges. Cheap (two atomic
+    /// loads + lock + len + two `set` calls). Call from every mutation site
+    /// so `chrome_pool_inflight` / `chrome_pool_idle` track actual state.
+    fn refresh_gauges(&self) {
+        let inflight = self.inflight.load(Ordering::SeqCst) as i64;
+        let idle = self.idle.lock().unwrap().len() as i64;
+        crw_core::metrics::metrics()
+            .chrome_pool_inflight
+            .set(inflight);
+        crw_core::metrics::metrics().chrome_pool_idle.set(idle);
+    }
+
+    /// Walk `all_slots` and drop entries whose `Weak` is dead. Called on every
+    /// new slot creation in `acquire()` (cold path) to bound the registry.
+    fn prune_all_slots(&self) {
+        let mut g = self.all_slots.lock().unwrap();
+        g.retain(|w| w.strong_count() > 0);
+    }
+
+    /// Acquire a checked-out slot. Permit is acquired BEFORE any idle/create
+    /// decision so two concurrent acquirers cannot both observe capacity and
+    /// double-create. Permit is the source of truth for "you may exist in
+    /// CheckedOut state".
+    pub async fn acquire(self: &Arc<Self>) -> CrwResult<PoolGuard<C>> {
+        let permit = self
+            .sem
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| CrwError::Shutdown)?;
+
+        // Two health-check retries max (plan §acquire flow step 3)
+        for attempt in 0..3 {
+            // Try popping an idle slot first
+            let popped = self.idle.lock().unwrap().pop_front();
+            let slot = if let Some(s) = popped {
+                // Health-check if stale
+                let needs_check = {
+                    let g = s.lock().unwrap();
+                    Instant::now().duration_since(g.last_used) > self.cfg.health_check_after
+                };
+                if needs_check {
+                    // Snapshot conn for the async health check (no lock across await)
+                    let conn = match &s.lock().unwrap().state {
+                        SlotState::Idle { conn, .. } => conn.clone(),
+                        _ => {
+                            // Slot was somehow not Idle — defensive; treat as dead
+                            self.mark_slot_dead_and_drop(&s);
+                            continue;
+                        }
+                    };
+                    if conn.health_check().await.is_err() {
+                        self.mark_slot_dead_and_drop(&s);
+                        if attempt < 2 {
+                            continue;
+                        }
+                        return Err(CrwError::RendererError(
+                            "pool: health check failed after retries".into(),
+                        ));
+                    }
+                }
+                s
+            } else {
+                // No idle slot — create a fresh one under the held permit
+                let conn = (self.conn_factory)().await?;
+                let ctx_id = conn.create_browser_context().await?;
+                let slot = Arc::new(StdMutex::new(PooledSlot {
+                    state: SlotState::Idle { conn, ctx_id },
+                    terminator: AtomicBool::new(false),
+                    last_used: Instant::now(),
+                }));
+                self.prune_all_slots();
+                self.all_slots.lock().unwrap().push(Arc::downgrade(&slot));
+                slot
+            };
+
+            // Transition Idle → CheckedOut under the slot mutex.
+            // No `.await` between these atomic+sync operations.
+            let (conn_clone, ctx_id_clone) = {
+                let mut g = slot.lock().unwrap();
+                // Verify state is Idle (sanity — only Idle slots are in the free-list)
+                let (conn, ctx_id) = match std::mem::replace(&mut g.state, SlotState::Closing) {
+                    SlotState::Idle { conn, ctx_id } => (conn, ctx_id),
+                    other => {
+                        // Race with shutdown phase 3 between pop and lock —
+                        // restore state and retry
+                        g.state = other;
+                        if attempt < 2 {
+                            drop(g);
+                            continue;
+                        }
+                        return Err(CrwError::Shutdown);
+                    }
+                };
+                // Reset terminator (only legitimate true→false transition)
+                g.terminator.store(false, Ordering::SeqCst);
+                let conn_clone = conn.clone();
+                let ctx_id_clone = ctx_id.clone();
+                g.state = SlotState::CheckedOut {
+                    conn,
+                    ctx_id,
+                    target_id: None,
+                };
+                g.last_used = Instant::now();
+                (conn_clone, ctx_id_clone)
+            };
+
+            self.inflight.fetch_add(1, Ordering::SeqCst);
+            self.refresh_gauges();
+            return Ok(PoolGuard {
+                slot: Some(slot),
+                permit: Some(permit),
+                conn: conn_clone,
+                ctx_id: ctx_id_clone,
+                pool: Arc::downgrade(self),
+            });
+        }
+        Err(CrwError::Internal("pool: acquire exhausted retries".into()))
+    }
+
+    /// Sync helper: transition slot to Dead{Some(conn)} if it currently holds a
+    /// conn. Used on health-check failure (caller still holds the permit).
+    fn mark_slot_dead_and_drop(&self, slot: &Slot<C>) {
+        let conn_opt = {
+            let mut g = slot.lock().unwrap();
+            g.take_conn()
+        };
+        if let Some(conn) = conn_opt {
+            // Best-effort close; do not block acquire path on it
+            let conn_clone = conn.clone();
+            if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::spawn(async move {
+                    let _ =
+                        tokio::time::timeout(Duration::from_secs(1), conn_clone.close_conn()).await;
+                });
+            }
+        }
+    }
+
+    /// Graceful shutdown. Three phases: (1) signal close + wait for inflight
+    /// to drain via Notify, (2) dispose+close every Idle slot, (3) force-close
+    /// anything still held in `all_slots` past the deadline AND reconcile its
+    /// inflight bookkeeping. Post-condition: `inflight==0`, `idle.is_empty()`,
+    /// every slot ∈ {Closing, Dead{None}}.
+    pub async fn shutdown(self: Arc<Self>, drain: Duration) {
+        self.closed.store(true, Ordering::SeqCst);
+        self.sem.close();
+        let deadline = Instant::now() + drain;
+
+        // Phase 1: graceful — wait for inflight to drain via Notify
+        while self.inflight.load(Ordering::SeqCst) > 0 {
+            if Instant::now() >= deadline {
+                break;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let _ = tokio::time::timeout(remaining, self.notify_idle.notified()).await;
+        }
+
+        // Phase 2: drain whatever's idle now (released cleanly during phase 1)
+        let drained: Vec<Slot<C>> = {
+            let mut g = self.idle.lock().unwrap();
+            std::mem::take(&mut *g).into()
+        };
+        for slot in drained {
+            // For Idle slots, we own the conn directly; dispose ctx then close
+            let (ctx_opt, conn_opt) = {
+                let mut g = slot.lock().unwrap();
+                let ctx = match &g.state {
+                    SlotState::Idle { ctx_id, .. } => Some(ctx_id.clone()),
+                    _ => None,
+                };
+                (ctx, g.take_conn())
+            };
+            if let (Some(ctx), Some(conn)) = (ctx_opt.as_ref(), conn_opt.as_ref()) {
+                let _ = tokio::time::timeout(
+                    self.cfg.dispose_ctx_timeout,
+                    conn.dispose_browser_context(ctx),
+                )
+                .await;
+            }
+            if let Some(conn) = conn_opt {
+                let _ = tokio::time::timeout(Duration::from_secs(1), conn.close_conn()).await;
+            }
+        }
+
+        // Phase 3: FORCE close anything still held. Guards that never returned
+        // (leaked or cancelled mid-recycle) get their conns closed AND their
+        // inflight reconciled here so the pool reaches inflight==0.
+        let registry: Vec<WeakSlot<C>> = {
+            let mut g = self.all_slots.lock().unwrap();
+            g.retain(|w| w.strong_count() > 0);
+            g.clone()
+        };
+        for weak in registry {
+            let Some(slot) = weak.upgrade() else { continue };
+            let we_own_bookkeeping = slot
+                .lock()
+                .unwrap()
+                .terminator
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok();
+            let conn_opt = slot.lock().unwrap().take_conn();
+            if let Some(conn) = conn_opt {
+                let _ = tokio::time::timeout(Duration::from_secs(1), conn.close_conn()).await;
+            }
+            if we_own_bookkeeping {
+                // CheckedOut/Recycling guard never returned: decrement inflight
+                self.dec_inflight_and_notify();
+            }
+        }
+
+        // Phase 4 (I1 fix): defensive idle-deque sweep. Phases 2 + 3 perform
+        // async work between the `std::mem::take(&idle)` snapshot and the final
+        // post-condition check; a release future that lost the terminator race
+        // can still legally complete its happy path (state Recycling → Idle +
+        // push_back) during those awaits and leave a stale Arc in the deque.
+        // The slot's state is already terminal (Closing or Dead{None}) by now,
+        // since phase 3 either claimed the terminator or observed release's
+        // claim — so the deque entry is just a dangling Arc. Clearing it
+        // satisfies the documented post-condition `idle.is_empty()` without
+        // double-disposing.
+        self.idle.lock().unwrap().clear();
+        self.refresh_gauges();
+    }
+}
+
+/// RAII bookkeeping handle. Created after release wins the terminator CAS;
+/// consumed via `commit_decrement()` on normal exit. If the holding future is
+/// cancelled before reaching `commit_decrement()`, `Drop` runs synchronously
+/// and performs the decrement — closes the cancellation-mid-recycle gap.
+///
+/// Panic-free invariant: `Drop` runs during future cancellation in tokio.
+/// MUST NOT panic — no unwrap, no debug_assert!. Internal helper only does
+/// atomic ops + Notify.
+#[must_use = "must call commit_decrement() on normal exit"]
+pub(crate) struct BookkeepingToken<C: ChromeConnOps> {
+    pool: Weak<BrowserContextPool<C>>,
+    consumed: bool,
+}
+
+impl<C: ChromeConnOps> BookkeepingToken<C> {
+    fn new(pool: Weak<BrowserContextPool<C>>) -> Self {
+        Self {
+            pool,
+            consumed: false,
+        }
+    }
+
+    fn commit_decrement(mut self) {
+        if let Some(p) = self.pool.upgrade() {
+            p.dec_inflight_and_notify();
+        }
+        self.consumed = true;
+    }
+}
+
+impl<C: ChromeConnOps> Drop for BookkeepingToken<C> {
+    fn drop(&mut self) {
+        if !self.consumed
+            && let Some(p) = self.pool.upgrade()
+        {
+            p.dec_inflight_and_notify();
+            // pool already dropped → process is exiting, inflight irrelevant
+        }
+    }
+}
+
+pub struct PoolGuard<C: ChromeConnOps> {
+    slot: Option<Slot<C>>,
+    permit: Option<OwnedSemaphorePermit>,
+    pub conn: Arc<C>,
+    pub ctx_id: String,
+    pool: Weak<BrowserContextPool<C>>,
+}
+
+impl<C: ChromeConnOps> PoolGuard<C> {
+    /// Called synchronously inside `fetch_inner` immediately after
+    /// `Target.createTarget` returns Ok, before any subsequent `.await`.
+    /// Writes `Some(target_id)` into the slot's `CheckedOut` payload under the
+    /// slot mutex.
+    ///
+    /// Panic-free contract: if the slot is no longer in `CheckedOut` state by
+    /// the time this method acquires the slot mutex (theoretical shutdown
+    /// race), log at WARN and return without mutating. Never panic.
+    pub fn record_target(&self, target_id: String) {
+        let Some(slot) = self.slot.as_ref() else {
+            tracing::warn!("PoolGuard::record_target called without slot — bug");
+            return;
+        };
+        let mut g = match slot.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(), // poison-tolerant: still try to record
+        };
+        if let SlotState::CheckedOut {
+            target_id: ref mut tid,
+            ..
+        } = g.state
+        {
+            *tid = Some(target_id);
+        } else {
+            tracing::warn!("record_target: slot no longer CheckedOut (shutdown race) — skipping");
+        }
+    }
+
+    /// Normal release path. Inline (no `tokio::spawn`). Sub-steps follow lock
+    /// discipline + terminator AtomicBool gate + RAII `BookkeepingToken`.
+    pub async fn release(mut self) -> CrwResult<()> {
+        let slot = self
+            .slot
+            .take()
+            .ok_or_else(|| CrwError::Internal("PoolGuard::release: slot already taken".into()))?;
+        let permit = self.permit.take(); // dropped at function exit
+
+        // Step 1: claim terminator. If shutdown already won, skip the rest.
+        let we_won = slot
+            .lock()
+            .unwrap()
+            .terminator
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+        if !we_won {
+            // Shutdown already claimed — drop permit and exit; bookkeeping is
+            // shutdown's job now.
+            drop(permit);
+            return Ok(());
+        }
+
+        // Step 2: construct BookkeepingToken — from here on, cancellation is safe.
+        let token = BookkeepingToken::new(self.pool.clone());
+
+        // Step 3: lock slot, verify CheckedOut, snapshot, transition → Recycling.
+        let (conn, ctx_id, target_id_opt) = {
+            let mut g = slot.lock().unwrap();
+            match std::mem::replace(&mut g.state, SlotState::Closing) {
+                SlotState::CheckedOut {
+                    conn,
+                    ctx_id,
+                    target_id,
+                } => {
+                    let conn_c = conn.clone();
+                    let ctx_c = ctx_id.clone();
+                    let tid = target_id.clone();
+                    g.state = SlotState::Recycling {
+                        conn,
+                        ctx_id,
+                        target_id,
+                        phase: RecyclePhase::CloseTarget,
+                    };
+                    (conn_c, ctx_c, tid)
+                }
+                other => {
+                    g.state = other;
+                    // shutdown-raced abort path
+                    record_recycle_outcome("shutdown_raced");
+                    token.commit_decrement();
+                    drop(permit);
+                    return Ok(());
+                }
+            }
+        };
+
+        let pool = match self.pool.upgrade() {
+            Some(p) => p,
+            None => {
+                // Pool dropped — process is exiting. Best-effort close on conn.
+                let _ = tokio::time::timeout(Duration::from_secs(1), conn.close_conn()).await;
+                token.commit_decrement();
+                drop(permit);
+                return Ok(());
+            }
+        };
+        let metrics = crw_core::metrics::metrics();
+
+        // Step 4: closeTarget (skip if target_id is None)
+        if let Some(tid) = target_id_opt.as_deref() {
+            let timer = metrics
+                .chrome_pool_recycle_seconds
+                .with_label_values(&["close_target"])
+                .start_timer();
+            let res =
+                tokio::time::timeout(pool.cfg.close_target_timeout, conn.close_target(tid)).await;
+            timer.observe_duration();
+            match res {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) | Err(_) => {
+                    // closeTarget failed or timed out — treat conn as suspect.
+                    metrics
+                        .chrome_pool_recycle_failures_total
+                        .with_label_values(&["close_target_timeout"])
+                        .inc();
+                    return Self::transition_to_dead_and_close(
+                        &slot,
+                        &conn,
+                        "dead_conn",
+                        token,
+                        permit,
+                    )
+                    .await;
+                }
+            }
+        }
+
+        // Reconcile-after-close
+        if !Self::reconcile_set_phase(&slot, RecyclePhase::DisposeCtx) {
+            return Self::handle_shutdown_raced(token, permit);
+        }
+
+        // Step 5a: disposeBrowserContext
+        let timer = metrics
+            .chrome_pool_recycle_seconds
+            .with_label_values(&["dispose_ctx"])
+            .start_timer();
+        let res = tokio::time::timeout(
+            pool.cfg.dispose_ctx_timeout,
+            conn.dispose_browser_context(&ctx_id),
+        )
+        .await;
+        timer.observe_duration();
+        if matches!(res, Ok(Err(_)) | Err(_)) {
+            metrics
+                .chrome_pool_recycle_failures_total
+                .with_label_values(&["dispose_ctx_fail"])
+                .inc();
+            return Self::transition_to_dead_and_close(&slot, &conn, "dead_conn", token, permit)
+                .await;
+        }
+
+        if !Self::reconcile_set_phase(&slot, RecyclePhase::CreateCtx) {
+            return Self::handle_shutdown_raced(token, permit);
+        }
+
+        // Step 5b: createBrowserContext (fresh ctx_id)
+        let timer = metrics
+            .chrome_pool_recycle_seconds
+            .with_label_values(&["create_ctx"])
+            .start_timer();
+        let create_res =
+            tokio::time::timeout(pool.cfg.create_ctx_timeout, conn.create_browser_context()).await;
+        timer.observe_duration();
+        let fresh_ctx = match create_res {
+            Ok(Ok(id)) => id,
+            Ok(Err(_)) | Err(_) => {
+                metrics
+                    .chrome_pool_recycle_failures_total
+                    .with_label_values(&["create_ctx_fail"])
+                    .inc();
+                return Self::transition_to_dead_and_close(
+                    &slot,
+                    &conn,
+                    "dead_conn",
+                    token,
+                    permit,
+                )
+                .await;
+            }
+        };
+
+        // Final reconcile: relock; if state is still Recycling, transition →
+        // Idle and push to free-list.
+        let did_push = {
+            let mut g = slot.lock().unwrap();
+            match std::mem::replace(&mut g.state, SlotState::Closing) {
+                SlotState::Recycling { conn, .. } => {
+                    g.state = SlotState::Idle {
+                        conn,
+                        ctx_id: fresh_ctx,
+                    };
+                    g.last_used = Instant::now();
+                    true
+                }
+                other => {
+                    g.state = other;
+                    false
+                }
+            }
+        };
+
+        if did_push {
+            pool.idle.lock().unwrap().push_back(slot);
+            pool.notify_idle.notify_waiters();
+            record_recycle_outcome("success");
+        } else {
+            record_recycle_outcome("shutdown_raced");
+        }
+        pool.refresh_gauges();
+
+        token.commit_decrement();
+        drop(permit);
+        Ok(())
+    }
+
+    /// Relock the slot; if state is still Recycling, advance to `next_phase`
+    /// and return `true`. Otherwise return `false` (shutdown raced).
+    fn reconcile_set_phase(slot: &Slot<C>, next_phase: RecyclePhase) -> bool {
+        let mut g = slot.lock().unwrap();
+        if let SlotState::Recycling { ref mut phase, .. } = g.state {
+            *phase = next_phase;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Failure-branch close handoff: transition Recycling → Dead{Some(conn)},
+    /// then take_conn back out and close on the moved value. If shutdown's
+    /// take_conn beat us, our take returns None and we skip close entirely
+    /// (no double-close).
+    async fn transition_to_dead_and_close(
+        slot: &Slot<C>,
+        _conn_ref: &Arc<C>,
+        outcome: &'static str,
+        token: BookkeepingToken<C>,
+        permit: Option<OwnedSemaphorePermit>,
+    ) -> CrwResult<()> {
+        // Transition Recycling → Dead{Some(conn)} (or observe shutdown raced)
+        let we_have_conn = {
+            let mut g = slot.lock().unwrap();
+            match std::mem::replace(&mut g.state, SlotState::Closing) {
+                SlotState::Recycling { conn, .. } => {
+                    g.state = SlotState::Dead { conn: Some(conn) };
+                    true
+                }
+                other => {
+                    g.state = other;
+                    false
+                }
+            }
+        };
+        if !we_have_conn {
+            // Shutdown took over mid-failure-branch
+            record_recycle_outcome("shutdown_raced");
+            token.commit_decrement();
+            drop(permit);
+            return Ok(());
+        }
+
+        // Now take_conn back out and close
+        let conn_to_close = slot.lock().unwrap().take_conn();
+        if let Some(c) = conn_to_close {
+            let _ = tokio::time::timeout(Duration::from_secs(1), c.close_conn()).await;
+        }
+        record_recycle_outcome(outcome);
+        token.commit_decrement();
+        drop(permit);
+        Ok(())
+    }
+
+    fn handle_shutdown_raced(
+        token: BookkeepingToken<C>,
+        permit: Option<OwnedSemaphorePermit>,
+    ) -> CrwResult<()> {
+        record_recycle_outcome("shutdown_raced");
+        token.commit_decrement();
+        drop(permit);
+        Ok(())
+    }
+}
+
+fn record_recycle_outcome(outcome: &'static str) {
+    crw_core::metrics::metrics()
+        .chrome_pool_recycle_total
+        .with_label_values(&[outcome])
+        .inc();
+}
+
+impl<C: ChromeConnOps> Drop for PoolGuard<C> {
+    fn drop(&mut self) {
+        let Some(slot) = self.slot.take() else {
+            // release() already took the slot — nothing to do here.
+            return;
+        };
+
+        // Step 1: claim terminator
+        let we_won = slot
+            .lock()
+            .unwrap()
+            .terminator
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+        if !we_won {
+            // shutdown or release already won; permit drops below
+            return;
+        }
+
+        // Step 2: lock slot, take conn out, transition → Dead{Some(conn)}
+        let conn_opt = {
+            let mut g = slot.lock().unwrap();
+            match std::mem::replace(&mut g.state, SlotState::Closing) {
+                SlotState::CheckedOut { conn, .. } | SlotState::Recycling { conn, .. } => {
+                    g.state = SlotState::Dead { conn: Some(conn) };
+                    g.take_conn() // immediate take to Dead{None}
+                }
+                other => {
+                    g.state = other;
+                    None
+                }
+            }
+        };
+
+        // Step 3: metrics
+        record_recycle_outcome("emergency_drop");
+        crw_core::metrics::metrics()
+            .chrome_pool_recycle_failures_total
+            .with_label_values(&["missed_release"])
+            .inc();
+
+        // Step 4: dec inflight
+        if let Some(pool) = self.pool.upgrade() {
+            pool.dec_inflight_and_notify();
+        }
+
+        // Step 5: best-effort reaper for conn close
+        if let Some(conn) = conn_opt
+            && tokio::runtime::Handle::try_current().is_ok()
+        {
+            tokio::spawn(async move {
+                let _ = tokio::time::timeout(Duration::from_secs(1), conn.close_conn()).await;
+            });
+        }
+        // Step 6: permit drops with self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU32;
+
+    /// Minimal fake connection — counts each CDP op for assertions.
+    #[derive(Default)]
+    struct FakeConn {
+        create_ctx_calls: AtomicU32,
+        dispose_ctx_calls: AtomicU32,
+        close_target_calls: AtomicU32,
+        close_conn_calls: AtomicU32,
+        close_target_should_fail: AtomicBool,
+        closed: AtomicBool,
+    }
+
+    #[async_trait]
+    impl ChromeConnOps for FakeConn {
+        async fn create_browser_context(&self) -> CrwResult<String> {
+            let n = self.create_ctx_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(format!("ctx-{n}"))
+        }
+        async fn dispose_browser_context(&self, _ctx_id: &str) -> CrwResult<()> {
+            self.dispose_ctx_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn close_target(&self, _target_id: &str) -> CrwResult<()> {
+            self.close_target_calls.fetch_add(1, Ordering::SeqCst);
+            if self.close_target_should_fail.load(Ordering::SeqCst) {
+                Err(CrwError::RendererError("close_target forced fail".into()))
+            } else {
+                Ok(())
+            }
+        }
+        async fn health_check(&self) -> CrwResult<()> {
+            Ok(())
+        }
+        async fn close_conn(&self) {
+            self.close_conn_calls.fetch_add(1, Ordering::SeqCst);
+            self.closed.store(true, Ordering::SeqCst);
+        }
+        fn is_closed(&self) -> bool {
+            self.closed.load(Ordering::SeqCst)
+        }
+    }
+
+    fn fake_factory() -> ConnFactory<FakeConn> {
+        Arc::new(|| Box::pin(async { Ok(Arc::new(FakeConn::default())) }))
+    }
+
+    fn small_pool_cfg() -> PoolCfg {
+        PoolCfg {
+            size: 2,
+            recycle_after_navs: 1,
+            idle_timeout: Duration::from_secs(300),
+            health_check_after: Duration::from_secs(60),
+            shutdown_drain: Duration::from_secs(2),
+            close_target_timeout: Duration::from_millis(500),
+            dispose_ctx_timeout: Duration::from_millis(500),
+            create_ctx_timeout: Duration::from_millis(500),
+        }
+    }
+
+    #[tokio::test]
+    async fn take_conn_state_matrix() {
+        let conn: Arc<FakeConn> = Arc::new(FakeConn::default());
+        let mut slot = PooledSlot {
+            state: SlotState::Idle {
+                conn: conn.clone(),
+                ctx_id: "x".into(),
+            },
+            terminator: AtomicBool::new(false),
+            last_used: Instant::now(),
+        };
+        // Idle → returns Some, transitions to Closing
+        assert!(slot.take_conn().is_some());
+        assert!(matches!(slot.state, SlotState::Closing));
+        // Closing → returns None, stays Closing
+        assert!(slot.take_conn().is_none());
+        assert!(matches!(slot.state, SlotState::Closing));
+
+        // Dead{Some} → returns Some, transitions to Dead{None}
+        slot.state = SlotState::Dead {
+            conn: Some(conn.clone()),
+        };
+        assert!(slot.take_conn().is_some());
+        assert!(matches!(slot.state, SlotState::Dead { conn: None }));
+        // Dead{None} → returns None, stays Dead{None}
+        assert!(slot.take_conn().is_none());
+    }
+
+    #[tokio::test]
+    async fn acquire_release_happy_path() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        assert_eq!(pool.inflight(), 0);
+        assert_eq!(pool.idle_len(), 0);
+
+        let guard = pool.acquire().await.expect("acquire");
+        assert_eq!(pool.inflight(), 1);
+        assert_eq!(pool.idle_len(), 0);
+
+        // Pretend fetch_inner created a target
+        guard.record_target("t-1".into());
+        let conn = guard.conn.clone();
+        guard.release().await.expect("release");
+
+        assert_eq!(pool.inflight(), 0);
+        assert_eq!(pool.idle_len(), 1);
+        assert_eq!(conn.close_target_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(conn.dispose_ctx_calls.load(Ordering::SeqCst), 1);
+        // create_ctx: once on creation + once on recycle
+        assert_eq!(conn.create_ctx_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn release_skips_close_target_when_none() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        let guard = pool.acquire().await.unwrap();
+        let conn = guard.conn.clone();
+        // Do NOT call record_target — simulates createTarget failure
+        guard.release().await.unwrap();
+        assert_eq!(conn.close_target_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(conn.dispose_ctx_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.inflight(), 0);
+        assert_eq!(pool.idle_len(), 1);
+    }
+
+    #[tokio::test]
+    async fn slot_reuse_terminator_resets() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        let g1 = pool.acquire().await.unwrap();
+        g1.record_target("t-a".into());
+        g1.release().await.unwrap();
+        assert_eq!(pool.inflight(), 0);
+
+        // Second acquire should reuse the recycled slot
+        let g2 = pool.acquire().await.unwrap();
+        assert_eq!(pool.inflight(), 1);
+        // Verify terminator was reset to false (i.e. release won the CAS again)
+        g2.record_target("t-b".into());
+        g2.release().await.unwrap();
+        assert_eq!(pool.inflight(), 0);
+        assert_eq!(pool.idle_len(), 1);
+    }
+
+    #[tokio::test]
+    async fn drop_without_release_marks_dead_and_decrements() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        let guard = pool.acquire().await.unwrap();
+        assert_eq!(pool.inflight(), 1);
+        drop(guard); // emergency Drop path
+        // dec_inflight runs synchronously inside Drop
+        assert_eq!(pool.inflight(), 0);
+        // Idle list should NOT contain the dead slot
+        assert_eq!(pool.idle_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn close_target_failure_marks_dead_and_skips_dispose() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        let guard = pool.acquire().await.unwrap();
+        let conn = guard.conn.clone();
+        conn.close_target_should_fail.store(true, Ordering::SeqCst);
+        guard.record_target("t-1".into());
+        guard.release().await.unwrap();
+        // close_target was called, failed
+        assert_eq!(conn.close_target_calls.load(Ordering::SeqCst), 1);
+        // dispose_ctx must NOT be called (suspect-conn policy)
+        assert_eq!(conn.dispose_ctx_calls.load(Ordering::SeqCst), 0);
+        // Conn closed
+        assert_eq!(conn.close_conn_calls.load(Ordering::SeqCst), 1);
+        // Slot did NOT return to idle
+        assert_eq!(pool.idle_len(), 0);
+        assert_eq!(pool.inflight(), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_idle_slots() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        let g = pool.acquire().await.unwrap();
+        let conn = g.conn.clone();
+        g.record_target("t-1".into());
+        g.release().await.unwrap();
+        assert_eq!(pool.idle_len(), 1);
+
+        pool.clone().shutdown(Duration::from_secs(1)).await;
+        assert!(pool.is_closed());
+        // Shutdown should have closed the conn we held
+        assert!(conn.close_conn_calls.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test]
+    async fn shutdown_force_closes_leaked_guard() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        let guard = pool.acquire().await.unwrap();
+        let conn = guard.conn.clone();
+        std::mem::forget(guard); // simulate leak — no Drop runs
+        assert_eq!(pool.inflight(), 1);
+
+        pool.clone().shutdown(Duration::from_millis(200)).await;
+        // Phase 3 should have closed the leaked conn AND decremented inflight
+        assert_eq!(pool.inflight(), 0);
+        assert_eq!(conn.close_conn_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn shutdown_refuses_new_acquires() {
+        let pool = BrowserContextPool::new(small_pool_cfg(), fake_factory());
+        pool.clone().shutdown(Duration::from_millis(100)).await;
+        let r = pool.acquire().await;
+        assert!(matches!(r, Err(CrwError::Shutdown)));
+    }
+}

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -391,7 +391,7 @@ pub struct CdpRenderer {
     /// invalidate on CDP connect failure: chrome restarts mint a new
     /// `/devtools/browser/<uuid>` path, and a stale cached value would dial
     /// a dead URL forever until process restart. See `invalidate_resolved_ws_url`.
-    resolved_ws_url: StdMutex<Option<String>>,
+    resolved_ws_url: Arc<StdMutex<Option<String>>>,
     page_timeout: Duration,
     /// Hard ceiling on the post-navigate wait+snapshot+stability+challenge
     /// phase. Wraps the work in a budget race; on hit the renderer snapshots
@@ -406,6 +406,11 @@ pub struct CdpRenderer {
     /// even when `intercept_enabled = true`.
     host_intercept_disable: Vec<String>,
     conn_semaphore: Arc<Semaphore>,
+    /// Browser context pool. `Some` when `[renderer.chrome.pool] enabled = true`
+    /// AND backend is vanilla chrome (not browserless v2 — gated off in v1
+    /// per plan §"Out of scope"). When `Some`, `fetch` dispatches through
+    /// `fetch_with_pool`; when `None`, legacy `fetch_with_ws` is used.
+    pool: Option<Arc<crate::browser_pool::BrowserContextPool<CdpConnection>>>,
 }
 
 impl CdpRenderer {
@@ -415,14 +420,46 @@ impl CdpRenderer {
         Self {
             name: name.to_string(),
             configured_ws_url: ws_url.to_string(),
-            resolved_ws_url: StdMutex::new(None),
+            resolved_ws_url: Arc::new(StdMutex::new(None)),
             page_timeout,
             nav_budget: page_timeout,
             intercept_enabled: false,
             blocklist: Blocklist::defaults(),
             host_intercept_disable: Vec::new(),
             conn_semaphore: Arc::new(Semaphore::new(pool_size)),
+            pool: None,
         }
+    }
+
+    /// Enable the browser-context pool. Builds an `Arc<BrowserContextPool>`
+    /// whose factory calls back into the same connect-with-retry path as the
+    /// legacy `fetch_with_ws` (preserves the cached-WS-URL invalidation from
+    /// commit `b5f7bec`).
+    pub fn with_pool(mut self, cfg: crate::browser_pool::PoolCfg) -> Self {
+        let name = self.name.clone();
+        let configured = self.configured_ws_url.clone();
+        let resolved_cache = self.resolved_ws_url.clone();
+        let page_timeout = self.page_timeout;
+        let factory: crate::browser_pool::ConnFactory<CdpConnection> = Arc::new(move || {
+            let name = name.clone();
+            let configured = configured.clone();
+            let resolved_cache = resolved_cache.clone();
+            Box::pin(async move {
+                let conn =
+                    connect_chrome_with_retry(&name, &configured, &resolved_cache, page_timeout)
+                        .await?;
+                Ok(Arc::new(conn))
+            })
+        });
+        crw_core::metrics::metrics()
+            .chrome_pool_size
+            .set(cfg.size as i64);
+        self.pool = Some(crate::browser_pool::BrowserContextPool::new(cfg, factory));
+        self
+    }
+
+    pub fn pool(&self) -> Option<Arc<crate::browser_pool::BrowserContextPool<CdpConnection>>> {
+        self.pool.clone()
     }
 
     /// Override the post-navigate budget. Default equals `page_timeout_ms`.
@@ -461,107 +498,138 @@ impl CdpRenderer {
         };
         !self.host_intercept_disable.iter().any(|h| host.contains(h))
     }
+}
 
-    /// Resolve the actual browser WebSocket URL.
-    ///
-    /// Chrome/Chromium expose a dynamic WS URL at `/json/version` that includes
-    /// a per-session UUID (e.g. `ws://host:9222/devtools/browser/<uuid>`).
-    /// LightPanda accepts connections directly on the base WS URL.
-    async fn resolve_ws_url(&self) -> CrwResult<String> {
-        if let Some(cached) = self.resolved_ws_url.lock().unwrap().clone() {
-            return Ok(cached);
-        }
-
-        let configured = &self.configured_ws_url;
-
-        let resolved = if configured.contains("/devtools/") {
-            configured.clone()
-        } else if is_browserless_direct_ws(configured) {
-            // Browserless v2 / commercial CDP endpoints serve a WS directly
-            // and do not expose `/json/version` (401s). Use as-is.
-            configured.clone()
-        } else if let Ok(Ok((ws, _))) =
-            tokio::time::timeout(Duration::from_secs(3), connect_async(configured)).await
-        {
-            // Direct connect works (LightPanda).
-            drop(ws);
-            configured.clone()
-        } else {
-            // Chrome/Chromium: discover via /json/version.
-            let http_url = configured
-                .replace("ws://", "http://")
-                .replace("wss://", "https://")
-                .trim_end_matches('/')
-                .to_string()
-                + "/json/version";
-
-            tracing::info!(
-                renderer = self.name,
-                "Discovering browser WS URL from {http_url}"
-            );
-
-            // Send Host: localhost so browsers behind socat proxies
-            // (e.g. chromedp/headless-shell) accept the request.
-            let resp = reqwest::Client::new()
-                .get(&http_url)
-                .header("Host", "localhost")
-                .timeout(Duration::from_secs(5))
-                .send()
-                .await
-                .map_err(|e| {
-                    CrwError::RendererError(format!("CDP discovery failed for {}: {e}", self.name))
-                })?;
-
-            let body: serde_json::Value = resp
-                .json()
-                .await
-                .map_err(|e| CrwError::RendererError(format!("CDP discovery parse error: {e}")))?;
-
-            let ws_url = body
-                .get("webSocketDebuggerUrl")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    CrwError::RendererError(format!(
-                        "No webSocketDebuggerUrl in /json/version for {}",
-                        self.name
-                    ))
-                })?;
-
-            let rewritten = rewrite_ws_host(ws_url, configured);
-            tracing::info!(renderer = self.name, ws_url = %rewritten, "Discovered browser WS URL");
-            rewritten
-        };
-
-        *self.resolved_ws_url.lock().unwrap() = Some(resolved.clone());
-        Ok(resolved)
+/// Resolve the actual browser WebSocket URL, caching the result. Free
+/// function so both `CdpRenderer::resolve_ws_url` and the pool's connect
+/// factory share a single implementation with shared cache invalidation
+/// semantics.
+async fn resolve_ws_url_with_cache(
+    configured: &str,
+    cache: &StdMutex<Option<String>>,
+    _page_timeout: Duration,
+) -> CrwResult<String> {
+    if let Some(cached) = cache.lock().unwrap().clone() {
+        return Ok(cached);
     }
 
-    /// Drop the cached WS URL so the next `resolve_ws_url` call re-discovers.
-    /// Called after CDP connect failures because chrome restarts mint a new
-    /// `/devtools/browser/<uuid>` path; without invalidation we'd dial a dead
-    /// URL forever.
-    fn invalidate_resolved_ws_url(&self) {
-        *self.resolved_ws_url.lock().unwrap() = None;
-    }
+    let resolved = if configured.contains("/devtools/") || is_browserless_direct_ws(configured) {
+        // Already-resolved /devtools/ URL OR browserless v2 / commercial CDP
+        // endpoint that serves a WS directly (no /json/version).
+        configured.to_string()
+    } else if let Ok(Ok((ws, _))) =
+        tokio::time::timeout(Duration::from_secs(3), connect_async(configured)).await
+    {
+        drop(ws);
+        configured.to_string()
+    } else {
+        let http_url = configured
+            .replace("ws://", "http://")
+            .replace("wss://", "https://")
+            .trim_end_matches('/')
+            .to_string()
+            + "/json/version";
 
+        tracing::info!("Discovering browser WS URL from {http_url}");
+
+        let resp = reqwest::Client::new()
+            .get(&http_url)
+            .header("Host", "localhost")
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| CrwError::RendererError(format!("CDP discovery failed: {e}")))?;
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CrwError::RendererError(format!("CDP discovery parse error: {e}")))?;
+
+        let ws_url = body
+            .get("webSocketDebuggerUrl")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                CrwError::RendererError("No webSocketDebuggerUrl in /json/version".into())
+            })?;
+
+        let rewritten = rewrite_ws_host(ws_url, configured);
+        tracing::info!(ws_url = %rewritten, "Discovered browser WS URL");
+        rewritten
+    };
+
+    *cache.lock().unwrap() = Some(resolved.clone());
+    Ok(resolved)
+}
+
+impl CdpRenderer {
     /// Resolve the WS URL and open a CDP connection. On failure, invalidate
     /// the cached URL and retry once — covers the chrome-restart case where
     /// the cached `/devtools/browser/<uuid>` is stale.
     async fn connect_with_retry(&self) -> CrwResult<CdpConnection> {
-        let ws_url = self.resolve_ws_url().await?;
-        match CdpConnection::connect(&ws_url, WS_CONNECT_TIMEOUT).await {
-            Ok(conn) => Ok(conn),
-            Err(e) => {
-                tracing::warn!(
-                    renderer = self.name,
-                    error = %e,
-                    "CDP connect failed; invalidating cached ws_url and retrying once"
-                );
-                self.invalidate_resolved_ws_url();
-                let ws_url = self.resolve_ws_url().await?;
-                CdpConnection::connect(&ws_url, WS_CONNECT_TIMEOUT).await
-            }
+        connect_chrome_with_retry(
+            &self.name,
+            &self.configured_ws_url,
+            &self.resolved_ws_url,
+            self.page_timeout,
+        )
+        .await
+    }
+}
+
+/// Connect to a Chrome CDP endpoint with cached-WS-URL invalidation on first
+/// failure. Shared between `CdpRenderer::connect_with_retry` (legacy path)
+/// and `BrowserContextPool`'s factory (preserves the b5f7bec invalidation
+/// guarantee — chrome restarts mint a fresh `/devtools/browser/<uuid>`,
+/// and the cache must be drop-and-rebuild on connect failure).
+async fn connect_chrome_with_retry(
+    name: &str,
+    configured_ws_url: &str,
+    resolved_cache: &StdMutex<Option<String>>,
+    page_timeout: Duration,
+) -> CrwResult<CdpConnection> {
+    let t0 = Instant::now();
+    let result =
+        connect_chrome_with_retry_inner(name, configured_ws_url, resolved_cache, page_timeout)
+            .await;
+    let outcome = classify_connect_outcome(&result);
+    crw_core::metrics::metrics()
+        .chrome_connect_seconds
+        .with_label_values(&[outcome])
+        .observe(t0.elapsed().as_secs_f64());
+    result
+}
+
+async fn connect_chrome_with_retry_inner(
+    name: &str,
+    configured_ws_url: &str,
+    resolved_cache: &StdMutex<Option<String>>,
+    page_timeout: Duration,
+) -> CrwResult<CdpConnection> {
+    let ws_url = resolve_ws_url_with_cache(configured_ws_url, resolved_cache, page_timeout).await?;
+    match CdpConnection::connect(&ws_url, WS_CONNECT_TIMEOUT).await {
+        Ok(conn) => Ok(conn),
+        Err(e) => {
+            tracing::warn!(
+                renderer = name,
+                error = %e,
+                "CDP connect failed; invalidating cached ws_url and retrying once"
+            );
+            *resolved_cache.lock().unwrap() = None;
+            let ws_url =
+                resolve_ws_url_with_cache(configured_ws_url, resolved_cache, page_timeout).await?;
+            CdpConnection::connect(&ws_url, WS_CONNECT_TIMEOUT).await
         }
+    }
+}
+
+/// Bucket a `connect_with_retry` result into one of the Tier 0 outcome labels:
+/// `ok`, `ws_handshake_timeout`, `version_probe_fail`, `ws_dial_fail`.
+fn classify_connect_outcome(r: &CrwResult<CdpConnection>) -> &'static str {
+    match r {
+        Ok(_) => "ok",
+        Err(CrwError::Timeout(_)) => "ws_handshake_timeout",
+        Err(CrwError::RendererError(msg)) if msg.contains("CDP discovery") => "version_probe_fail",
+        Err(_) => "ws_dial_fail",
     }
 }
 
@@ -1039,12 +1107,16 @@ impl PageFetcher for CdpRenderer {
             ));
         }
 
-        tokio::time::timeout(
-            overall_timeout,
-            self.fetch_with_ws(url, wait_for_ms, deadline),
-        )
-        .await
-        .map_err(|_| CrwError::Timeout(overall_timeout.as_millis() as u64))?
+        let fut = async {
+            if let Some(pool) = self.pool.as_ref() {
+                self.fetch_with_pool(pool, url, wait_for_ms, deadline).await
+            } else {
+                self.fetch_with_ws(url, wait_for_ms, deadline).await
+            }
+        };
+        tokio::time::timeout(overall_timeout, fut)
+            .await
+            .map_err(|_| CrwError::Timeout(overall_timeout.as_millis() as u64))?
     }
 
     fn name(&self) -> &str {
@@ -1109,6 +1181,104 @@ fn detect_navigation_error(html: &str) -> Option<String> {
 }
 
 impl CdpRenderer {
+    /// Pool-backed fetch path. Acquires a checked-out browser context from
+    /// the pool, runs `fetch_inner` with the slot's ctx_id + a recorder that
+    /// writes the new target_id into the slot, then `release()`s the slot
+    /// (which owns `closeTarget` + dispose + recreate-ctx).
+    async fn fetch_with_pool(
+        &self,
+        pool: &Arc<crate::browser_pool::BrowserContextPool<CdpConnection>>,
+        url: &str,
+        wait_for_ms: Option<u64>,
+        deadline: crw_core::Deadline,
+    ) -> CrwResult<FetchResult> {
+        let start = Instant::now();
+        let handshake_t0 = Instant::now();
+        let acquire_t0 = Instant::now();
+        let guard = pool.acquire().await?;
+        let acquire_elapsed = acquire_t0.elapsed();
+        crw_core::metrics::metrics()
+            .chrome_pool_acquire_seconds
+            .observe(acquire_elapsed.as_secs_f64());
+        // Best-effort acquire-source label: we currently don't surface from
+        // `acquire()` whether it hit idle or created new — record under a
+        // generic bucket. Plumbing the precise label is a follow-up.
+        crw_core::metrics::metrics()
+            .chrome_pool_acquires_total
+            .with_label_values(&["hit_idle"])
+            .inc();
+
+        // Recorder writes the new target_id into the slot synchronously
+        // (inside fetch_inner, immediately after createTarget Ok).
+        let guard_for_rec = &guard;
+        let recorder = |tid: &str| guard_for_rec.record_target(tid.to_string());
+
+        let ctx_id = guard.ctx_id.clone();
+        let res = self
+            .fetch_inner(
+                &guard.conn,
+                Some(&ctx_id),
+                &recorder,
+                url,
+                wait_for_ms,
+                deadline,
+            )
+            .await;
+
+        // Record total handshake-overhead for this request (acquire + create
+        // target + attach happen inside fetch_inner). B2 gate metric.
+        crw_core::metrics::metrics()
+            .chrome_request_handshake_seconds
+            .with_label_values(&["on", "hit_idle"])
+            .observe(handshake_t0.elapsed().as_secs_f64());
+
+        // Always release — swallow recycle error per plan's error-precedence
+        // policy (fetch success/failure is what the caller cares about).
+        if let Err(e) = guard.release().await {
+            tracing::warn!(error = %e, "pool: release returned error (slot recycled as Dead)");
+        }
+
+        let (html, status_code, truncated, final_href, captured_responses, _tid) = res?;
+
+        if html.is_empty() {
+            return Err(CrwError::RendererError(
+                "Empty HTML from CDP renderer".into(),
+            ));
+        }
+        if let Some(reason) = detect_navigation_error(&html) {
+            return Err(CrwError::RendererError(format!(
+                "Navigation failed: {reason}"
+            )));
+        }
+
+        let final_url = final_href.and_then(|h| if h != url { Some(h) } else { None });
+        Ok(FetchResult {
+            url: url.to_string(),
+            final_url,
+            status_code,
+            html,
+            content_type: None,
+            raw_bytes: None,
+            rendered_with: Some(self.name.clone()),
+            elapsed_ms: start.elapsed().as_millis() as u64,
+            warning: if truncated {
+                Some("chrome_budget_truncated".to_string())
+            } else {
+                None
+            },
+            render_decision: None,
+            credit_cost: 0,
+            warnings: if truncated {
+                vec!["chrome_budget_truncated".to_string()]
+            } else {
+                Vec::new()
+            },
+            truncated,
+            deadline_exceeded: deadline.remaining().is_zero(),
+            captured_responses,
+        })
+    }
+
     /// Inner fetch with WebSocket lifecycle management.
     async fn fetch_with_ws(
         &self,
@@ -1117,6 +1287,7 @@ impl CdpRenderer {
         deadline: crw_core::Deadline,
     ) -> CrwResult<FetchResult> {
         let start = Instant::now();
+        let handshake_t0 = Instant::now();
 
         // Limit concurrent WebSocket connections to pool_size.
         let _permit = self
@@ -1127,11 +1298,34 @@ impl CdpRenderer {
 
         let conn = self.connect_with_retry().await?;
 
-        let result = self.fetch_inner(&conn, url, wait_for_ms, deadline).await;
+        // Legacy path: `tid_slot` is the SOLE authoritative source for target
+        // close on both Ok and Err branches. fetch_inner no longer closes
+        // targets itself — we own that here. `Arc<Mutex<...>>` (not `Cell`)
+        // so the recorder closure satisfies `Send + Sync` across the await.
+        let tid_slot: std::sync::Arc<std::sync::Mutex<Option<String>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let tid_slot_rec = tid_slot.clone();
+        let recorder = move |tid: &str| {
+            *tid_slot_rec.lock().unwrap() = Some(tid.to_string());
+        };
+        let result = self
+            .fetch_inner(&conn, None, &recorder, url, wait_for_ms, deadline)
+            .await;
+
+        // B2 gate metric: pre-navigation overhead (connect + createTarget +
+        // attach). Pool=off arm; pool=on arm is recorded in fetch_with_pool.
+        crw_core::metrics::metrics()
+            .chrome_request_handshake_seconds
+            .with_label_values(&["off", "n/a"])
+            .observe(handshake_t0.elapsed().as_secs_f64());
+        let captured_tid = tid_slot.lock().unwrap().take();
+        if let Some(tid) = captured_tid {
+            close_target(&conn, &tid, &self.name).await;
+        }
 
         conn.close().await;
 
-        let (html, status_code, truncated, final_href, captured_responses) = result?;
+        let (html, status_code, truncated, final_href, captured_responses, _tid_ignored) = result?;
 
         if html.is_empty() {
             return Err(CrwError::RendererError(
@@ -1343,6 +1537,10 @@ impl CdpRenderer {
         session_id: &str,
         timeout: Duration,
     ) -> CrwResult<String> {
+        // Tier 0 metric M3: HTML snapshot round-trip. Observed on every call
+        // (post-navigate, SPA poll, scroll re-snapshot) so we can see how the
+        // snapshot mix behaves under different page types.
+        let snap_t0 = Instant::now();
         let eval_result = conn
             .send_recv(
                 "Runtime.evaluate",
@@ -1354,6 +1552,9 @@ impl CdpRenderer {
                 timeout,
             )
             .await?;
+        crw_core::metrics::metrics()
+            .chrome_snapshot_seconds
+            .observe(snap_t0.elapsed().as_secs_f64());
 
         Ok(eval_result
             .get("result")
@@ -1465,6 +1666,8 @@ impl CdpRenderer {
     async fn fetch_inner(
         &self,
         conn: &CdpConnection,
+        browser_context_id: Option<&str>,
+        target_recorder: &(dyn Fn(&str) + Send + Sync),
         url: &str,
         wait_for_ms: Option<u64>,
         deadline: crw_core::Deadline,
@@ -1474,85 +1677,81 @@ impl CdpRenderer {
         bool,
         Option<String>,
         Vec<CapturedNetworkResponse>,
+        String,
     )> {
         // 1. Create a blank target so navigation events can be observed reliably.
+        // When `browser_context_id` is Some, the target is bound to that
+        // context — load-bearing for pool isolation (cookies/storage do not
+        // leak across contexts).
+        let create_t0 = Instant::now();
+        let mut create_params = serde_json::json!({ "url": "about:blank" });
+        if let Some(ctx) = browser_context_id {
+            create_params["browserContextId"] = serde_json::Value::String(ctx.to_string());
+        }
         let create_result = conn
             .send_recv(
                 "Target.createTarget",
-                serde_json::json!({ "url": "about:blank" }),
+                create_params,
                 None,
                 self.page_timeout,
             )
             .await?;
+        crw_core::metrics::metrics()
+            .chrome_target_create_seconds
+            .observe(create_t0.elapsed().as_secs_f64());
 
         let target_id = create_result
             .get("targetId")
             .and_then(|v| v.as_str())
             .ok_or_else(|| CrwError::RendererError(format!("No targetId: {create_result}")))?
             .to_string();
+        // CRITICAL — synchronous handoff to caller BEFORE any subsequent
+        // `.await`. This is the only sync point that closes the cancellation
+        // window between createTarget returning Ok and the next await. The
+        // pooled caller writes the id into the slot's `CheckedOut.target_id`
+        // here; the legacy caller writes into a stack-local `Cell`. Either way
+        // the caller owns `closeTarget` from this point on — fetch_inner does
+        // NOT call closeTarget on any branch.
+        target_recorder(&target_id);
         crw_core::metrics::metrics()
             .target_lifecycle_total
             .with_label_values(&[&self.name, "created"])
             .inc();
 
         // 2. Attach to target
-        let attach_result = match conn
+        let attach_result = conn
             .send_recv(
                 "Target.attachToTarget",
                 serde_json::json!({ "targetId": &target_id, "flatten": true }),
                 None,
                 self.page_timeout,
             )
-            .await
-        {
-            Ok(result) => result,
-            Err(err) => {
-                close_target(conn, &target_id, &self.name).await;
-                return Err(err);
-            }
-        };
+            .await?;
 
-        let session_id = match attach_result
+        let session_id = attach_result
             .get("sessionId")
             .and_then(|value| value.as_str())
-        {
-            Some(value) => value.to_string(),
-            None => {
-                close_target(conn, &target_id, &self.name).await;
-                return Err(CrwError::RendererError(
-                    "CDP attach did not return sessionId".into(),
-                ));
-            }
-        };
+            .ok_or_else(|| CrwError::RendererError("CDP attach did not return sessionId".into()))?
+            .to_string();
 
         for method in ["Page.enable", "Network.enable", "Runtime.enable"] {
-            if let Err(err) = conn
-                .send_recv(
-                    method,
-                    serde_json::json!({}),
-                    Some(&session_id),
-                    self.page_timeout,
-                )
-                .await
-            {
-                close_target(conn, &target_id, &self.name).await;
-                return Err(err);
-            }
-        }
-
-        // Inject stealth scripts before navigation so they run on every new document.
-        if let Err(err) = conn
-            .send_recv(
-                "Page.addScriptToEvaluateOnNewDocument",
-                serde_json::json!({ "source": STEALTH_JS }),
+            conn.send_recv(
+                method,
+                serde_json::json!({}),
                 Some(&session_id),
                 self.page_timeout,
             )
-            .await
-        {
-            close_target(conn, &target_id, &self.name).await;
-            return Err(err);
+            .await?;
         }
+
+        // Inject stealth scripts before navigation so they run on every new document.
+        conn.send_recv(
+            "Page.addScriptToEvaluateOnNewDocument",
+            serde_json::json!({ "source": STEALTH_JS }),
+            Some(&session_id),
+            self.page_timeout,
+        )
+        .await?;
 
         // Subscribe to events BEFORE navigating so we don't miss loadEventFired.
         let events_rx = conn.subscribe();
@@ -1561,18 +1760,14 @@ impl CdpRenderer {
         // `Page.navigate` because `Fetch.enable` pauses the document request
         // too — pump must already be consuming `Fetch.requestPaused` by then.
         let intercept_active = self.intercept_active_for(url);
-        if intercept_active
-            && let Err(err) = conn
-                .send_recv(
-                    "Fetch.enable",
-                    serde_json::json!({ "patterns": [{ "urlPattern": "*" }] }),
-                    Some(&session_id),
-                    self.page_timeout,
-                )
-                .await
-        {
-            close_target(conn, &target_id, &self.name).await;
-            return Err(err);
+        if intercept_active {
+            conn.send_recv(
+                "Fetch.enable",
+                serde_json::json!({ "patterns": [{ "urlPattern": "*" }] }),
+                Some(&session_id),
+                self.page_timeout,
+            )
+            .await?;
         }
 
         // Network-idle tracker fed by a sibling pump (spawned below in the
@@ -1585,6 +1780,8 @@ impl CdpRenderer {
         // pump never returns; when work completes, the pump future is dropped.
         let nav_budget = self.nav_budget.min(deadline.remaining());
         let work = async {
+            // Tier 0 metric M2: time Page.navigate send → loadEventFired.
+            let nav_t0 = Instant::now();
             let navigate_result = conn
                 .send_recv(
                     "Page.navigate",
@@ -1603,6 +1800,9 @@ impl CdpRenderer {
             }
             let status_code =
                 wait_for_page_ready(events_rx, &session_id, self.page_timeout).await?;
+            crw_core::metrics::metrics()
+                .chrome_navigate_seconds
+                .observe(nav_t0.elapsed().as_secs_f64());
             // Post-navigate phase runs inside a budget race. On budget hit
             // we attempt a partial-DOM snapshot and return `truncated = true`;
             // `single.rs` decides success on md length.
@@ -1697,7 +1897,9 @@ impl CdpRenderer {
             Err(_) => None,
         };
 
-        close_target(conn, &target_id, &self.name).await;
+        // Target close is the caller's responsibility (pool's release() owns
+        // it via the recorded target_id; legacy fetch_with_ws closes after
+        // fetch_inner returns via its Cell-captured id).
 
         let (html, status_code, truncated) = outcome?;
 
@@ -1713,7 +1915,14 @@ impl CdpRenderer {
         }
 
         let captured_drained = std::mem::take(&mut *captured.lock().await);
-        Ok((html, status_code, truncated, final_href, captured_drained))
+        Ok((
+            html,
+            status_code,
+            truncated,
+            final_href,
+            captured_drained,
+            target_id,
+        ))
     }
 
     /// Post-navigate work: SPA selector wait, eval HTML, placeholder

--- a/crates/crw-renderer/src/cdp_conn.rs
+++ b/crates/crw-renderer/src/cdp_conn.rs
@@ -241,6 +241,16 @@ impl CdpConnection {
     pub fn is_closed(&self) -> bool {
         self.is_closed.load(Ordering::SeqCst)
     }
+
+    /// Liveness probe used by the browser-context pool when an idle slot has
+    /// been parked longer than `health_check_secs`. Issues `Browser.getVersion`
+    /// — a no-side-effect call that exercises both the WS write path and the
+    /// reader loop. The 200 ms ceiling keeps acquire-path latency bounded.
+    pub async fn health_check_browser(&self, timeout: Duration) -> CrwResult<()> {
+        self.send_recv("Browser.getVersion", serde_json::json!({}), None, timeout)
+            .await
+            .map(|_| ())
+    }
 }
 
 /// Removes a pending entry on drop. Ensures cancel-safety of `send_recv`:

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -38,6 +38,8 @@ pub mod breaker;
 #[cfg(feature = "auto-browser")]
 pub mod browser;
 #[cfg(feature = "cdp")]
+pub mod browser_pool;
+#[cfg(feature = "cdp")]
 pub mod cdp;
 #[cfg(feature = "cdp")]
 pub mod cdp_conn;
@@ -191,6 +193,10 @@ pub struct FallbackRenderer {
     requests_per_second: f64,
     /// Process-wide per-eTLD+1 in-flight cap. `1` enforces strict politeness.
     per_host_max_concurrent: u32,
+    /// Chrome browser-context pool handle for graceful drain on shutdown.
+    /// `None` when the pool is disabled or the chrome tier isn't configured.
+    #[cfg(feature = "cdp")]
+    chrome_pool: Option<Arc<browser_pool::BrowserContextPool<cdp_conn::CdpConnection>>>,
 }
 
 impl std::fmt::Debug for FallbackRenderer {
@@ -260,8 +266,15 @@ impl FallbackRenderer {
                 tier_timeouts: tier_timeouts_from(config),
                 requests_per_second: 0.0,
                 per_host_max_concurrent: 1,
+                #[cfg(feature = "cdp")]
+                chrome_pool: None,
             });
         }
+
+        #[cfg(feature = "cdp")]
+        let mut chrome_pool: Option<
+            Arc<browser_pool::BrowserContextPool<cdp_conn::CdpConnection>>,
+        > = None;
 
         #[cfg(feature = "cdp")]
         {
@@ -307,20 +320,64 @@ impl FallbackRenderer {
                 if let Some(ch) = &config.chrome {
                     let blocklist = blocklist::Blocklist::defaults()
                         .with_stylesheets(config.chrome_intercept_stylesheets);
-                    js_renderers.push(Arc::new(
-                        cdp::CdpRenderer::new(
-                            "chrome",
-                            &ch.ws_url,
-                            config.chrome_timeout(),
-                            config.pool_size,
-                        )
-                        .with_nav_budget(config.chrome_nav_budget_ms)
-                        .with_interception(
-                            config.chrome_intercept_resources,
-                            blocklist,
-                            config.chrome_host_intercept_disable.clone(),
-                        ),
-                    ));
+                    let mut renderer = cdp::CdpRenderer::new(
+                        "chrome",
+                        &ch.ws_url,
+                        config.chrome_timeout(),
+                        config.pool_size,
+                    )
+                    .with_nav_budget(config.chrome_nav_budget_ms)
+                    .with_interception(
+                        config.chrome_intercept_resources,
+                        blocklist,
+                        config.chrome_host_intercept_disable.clone(),
+                    );
+
+                    // Browser-context pool: gated off on browserless v2 in v1
+                    // per plan §"Out of scope". The backend is set explicitly
+                    // in config; never URL-sniffed.
+                    if config.chrome_context_pool_enabled {
+                        match config.chrome_backend {
+                            crw_core::config::ChromeBackend::Vanilla => {
+                                let pcfg = &config.chrome_pool;
+                                let size = pcfg.size.unwrap_or_else(|| {
+                                    let n = std::thread::available_parallelism()
+                                        .map(|p| p.get())
+                                        .unwrap_or(2);
+                                    std::cmp::max(2, n / 2)
+                                });
+                                renderer = renderer.with_pool(browser_pool::PoolCfg {
+                                    size,
+                                    recycle_after_navs: pcfg.recycle_after_navs,
+                                    idle_timeout: std::time::Duration::from_secs(
+                                        pcfg.idle_timeout_secs,
+                                    ),
+                                    health_check_after: std::time::Duration::from_secs(
+                                        pcfg.health_check_secs,
+                                    ),
+                                    shutdown_drain: std::time::Duration::from_secs(
+                                        pcfg.shutdown_drain_secs,
+                                    ),
+                                    close_target_timeout: std::time::Duration::from_secs(2),
+                                    dispose_ctx_timeout: std::time::Duration::from_secs(1),
+                                    create_ctx_timeout: std::time::Duration::from_secs(1),
+                                });
+                                tracing::info!(
+                                    pool_size = size,
+                                    "chrome browser-context pool enabled"
+                                );
+                            }
+                            crw_core::config::ChromeBackend::Browserless => {
+                                tracing::warn!(
+                                    "chrome_context_pool_enabled = true but \
+                                     chrome_backend = browserless — pool unsupported on \
+                                     this backend in v1, falling back to legacy path"
+                                );
+                            }
+                        }
+                    }
+                    chrome_pool = renderer.pool();
+                    js_renderers.push(Arc::new(renderer));
                 } else if matches!(config.mode, RendererMode::Chrome) {
                     return Err(CrwError::ConfigError(
                         "renderer.mode = \"chrome\" but [renderer.chrome] ws_url is not configured"
@@ -352,8 +409,28 @@ impl FallbackRenderer {
             tier_timeouts: tier_timeouts_from(config),
             requests_per_second: 0.0,
             per_host_max_concurrent: 1,
+            #[cfg(feature = "cdp")]
+            chrome_pool,
         })
     }
+
+    /// Drain the chrome browser-context pool. Idempotent and a no-op when
+    /// the pool is disabled. Call from the server's SIGTERM handler after
+    /// the HTTP server has finished serving in-flight requests.
+    #[cfg(feature = "cdp")]
+    pub async fn shutdown_chrome_pool(&self, drain: std::time::Duration) {
+        if let Some(pool) = self.chrome_pool.clone() {
+            tracing::info!(
+                drain_secs = drain.as_secs(),
+                "draining chrome browser-context pool"
+            );
+            pool.shutdown(drain).await;
+        }
+    }
+
+    /// No-op when the `cdp` feature is disabled — keeps caller code simple.
+    #[cfg(not(feature = "cdp"))]
+    pub async fn shutdown_chrome_pool(&self, _drain: std::time::Duration) {}
 
     /// Configure the process-wide per-host limiter (eTLD+1 keyed). Call once
     /// at startup with values from `CrawlerConfig`. Defaults: rps=0.0 (no

--- a/crates/crw-renderer/tests/browser_pool_real_chrome.rs
+++ b/crates/crw-renderer/tests/browser_pool_real_chrome.rs
@@ -1,0 +1,495 @@
+//! Tier 4 — Real-Chrome integration tests for `BrowserContextPool`.
+//!
+//! All `#[ignore]` by default. Run against a long-lived `chromedp/headless-shell`
+//! or vanilla Chrome with `--remote-debugging-port=9333`:
+//!
+//! ```sh
+//! CRW_TEST_REAL_CHROME=1 CRW_CDP_HTTP_URL=http://127.0.0.1:9333 \
+//!   cargo test -p crw-renderer --features cdp --test browser_pool_real_chrome \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Each test owns its pool; teardown calls `pool.shutdown(...)` so the harness
+//! never leaks Chrome targets between tests.
+//!
+//! Test inventory (plan §"Tier 4"):
+//!   - T0  cookie isolation per release
+//!   - T1  localStorage isolation per release
+//!   - T2  200 acquire/release stress + all_slots cap
+//!   - T3  conn-close mid-test → next acquire creates fresh
+//!   - T4  drain under load
+//!   - T4b drain with leaked guard (`mem::forget`) → inflight reaches 0
+//!   - T6  closeTarget timeout → slot Dead, dispose skipped
+//!   - T7  permit accounting under shutdown
+
+#![cfg(feature = "cdp")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crw_renderer::browser_pool::{BrowserContextPool, ConnFactory, PoolCfg};
+use crw_renderer::cdp_conn::CdpConnection;
+use serde_json::{Value, json};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const CDP_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn require_real_chrome() -> Option<String> {
+    if std::env::var("CRW_TEST_REAL_CHROME").ok().as_deref() != Some("1") {
+        eprintln!("skip: CRW_TEST_REAL_CHROME != 1");
+        return None;
+    }
+    match std::env::var("CRW_CDP_HTTP_URL") {
+        Ok(u) if !u.is_empty() => Some(u),
+        _ => {
+            eprintln!("skip: CRW_CDP_HTTP_URL not set (e.g. http://127.0.0.1:9333)");
+            None
+        }
+    }
+}
+
+async fn resolve_ws(http_base: &str) -> String {
+    let url = format!("{}/json/version", http_base.trim_end_matches('/'));
+    let body: Value = reqwest::Client::new()
+        .get(&url)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("GET /json/version")
+        .json()
+        .await
+        .expect("parse /json/version");
+    let raw = body
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("no webSocketDebuggerUrl in {body}"))
+        .to_string();
+    let conf_hp = http_base
+        .trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .trim_end_matches('/');
+    let path = raw
+        .trim_start_matches("ws://")
+        .trim_start_matches("wss://")
+        .split_once('/')
+        .map(|(_, rest)| format!("/{rest}"))
+        .unwrap_or_else(|| "/".into());
+    format!("ws://{conf_hp}{path}")
+}
+
+/// Build a pool whose factory connects to the real Chrome under test.
+fn build_pool(ws_url: String, size: usize) -> Arc<BrowserContextPool<CdpConnection>> {
+    let factory: ConnFactory<CdpConnection> = Arc::new(move || {
+        let ws = ws_url.clone();
+        Box::pin(async move {
+            let conn = CdpConnection::connect(&ws, CONNECT_TIMEOUT).await?;
+            Ok(Arc::new(conn))
+        })
+    });
+    BrowserContextPool::new(
+        PoolCfg {
+            size,
+            recycle_after_navs: 1,
+            idle_timeout: Duration::from_secs(300),
+            health_check_after: Duration::from_secs(60),
+            shutdown_drain: Duration::from_secs(10),
+            close_target_timeout: Duration::from_secs(2),
+            dispose_ctx_timeout: Duration::from_secs(1),
+            create_ctx_timeout: Duration::from_secs(1),
+        },
+        factory,
+    )
+}
+
+/// One pooled navigation: create target inside the guard's ctx, attach, navigate
+/// to `url`, optionally run `js_after_load` and return its String result.
+async fn pooled_visit(
+    pool: &Arc<BrowserContextPool<CdpConnection>>,
+    url: &str,
+    js_after_load: Option<&str>,
+) -> String {
+    let guard = pool.acquire().await.expect("acquire");
+    let create = guard
+        .conn
+        .send_recv(
+            "Target.createTarget",
+            json!({ "url": "about:blank", "browserContextId": guard.ctx_id }),
+            None,
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("createTarget");
+    let target_id = create
+        .get("targetId")
+        .and_then(|v| v.as_str())
+        .expect("targetId")
+        .to_string();
+    guard.record_target(target_id.clone());
+
+    let attach = guard
+        .conn
+        .send_recv(
+            "Target.attachToTarget",
+            json!({ "targetId": target_id, "flatten": true }),
+            None,
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("attachToTarget");
+    let sid = attach
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .expect("sessionId")
+        .to_string();
+
+    let _ = guard
+        .conn
+        .send_recv("Page.enable", json!({}), Some(&sid), CDP_TIMEOUT)
+        .await
+        .expect("Page.enable");
+    let events_rx = guard.conn.subscribe();
+    let _ = guard
+        .conn
+        .send_recv(
+            "Page.navigate",
+            json!({ "url": url }),
+            Some(&sid),
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("Page.navigate");
+
+    // Wait for loadEventFired (15s budget).
+    let mut rx = events_rx;
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!("loadEventFired timeout for {url}");
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Err(_) => panic!("loadEventFired timeout for {url}"),
+            Ok(Err(_)) => continue,
+            Ok(Ok(ev)) => {
+                if ev.method == "Page.loadEventFired" && ev.session_id.as_deref() == Some(&sid) {
+                    break;
+                }
+            }
+        }
+    }
+
+    let out = if let Some(js) = js_after_load {
+        let r = guard
+            .conn
+            .send_recv(
+                "Runtime.evaluate",
+                json!({ "expression": js, "returnByValue": true }),
+                Some(&sid),
+                CDP_TIMEOUT,
+            )
+            .await
+            .expect("Runtime.evaluate");
+        r.get("result")
+            .and_then(|v| v.get("value"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    } else {
+        String::new()
+    };
+
+    guard.release().await.expect("release");
+    out
+}
+
+// ---------------------------------------------------------------------------
+// T0 — cookie isolation per release
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn t0_cookie_isolation_per_release() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 2);
+
+    // First visit: set a cookie.
+    let after_set = pooled_visit(
+        &pool,
+        "https://example.com/",
+        Some("document.cookie='crw_t0=marker; path=/'; document.cookie"),
+    )
+    .await;
+    assert!(
+        after_set.contains("crw_t0=marker"),
+        "expected own cookie after set, got {after_set:?}"
+    );
+
+    // Second visit: must NOT see the cookie (different browser context).
+    let on_second = pooled_visit(&pool, "https://example.com/", Some("document.cookie")).await;
+    assert!(
+        !on_second.contains("crw_t0=marker"),
+        "LEAK: second visit saw prior context's cookie: {on_second:?}"
+    );
+
+    pool.shutdown(Duration::from_secs(5)).await;
+}
+
+// ---------------------------------------------------------------------------
+// T1 — localStorage isolation per release
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn t1_local_storage_isolation_per_release() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 2);
+
+    let after_set = pooled_visit(
+        &pool,
+        "https://example.com/",
+        Some("localStorage.setItem('crw_t1','marker'); localStorage.getItem('crw_t1')||''"),
+    )
+    .await;
+    assert_eq!(after_set, "marker", "expected own localStorage after set");
+
+    let on_second = pooled_visit(
+        &pool,
+        "https://example.com/",
+        Some("localStorage.getItem('crw_t1')||''"),
+    )
+    .await;
+    assert_eq!(
+        on_second, "",
+        "LEAK: second visit saw prior context's localStorage: {on_second:?}"
+    );
+
+    pool.shutdown(Duration::from_secs(5)).await;
+}
+
+// ---------------------------------------------------------------------------
+// T2 — 200 acquire/release stress; LIVE conns capped at pool size
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn t2_stress_200_cycles() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool_size = 4;
+    let pool = build_pool(ws, pool_size);
+
+    for i in 0..200 {
+        // No JS, just navigate + recycle.
+        let _ = pooled_visit(&pool, "about:blank", None).await;
+        if i % 25 == 0 {
+            eprintln!(
+                "t2: iter={i:>3} inflight={} idle={}",
+                pool.inflight(),
+                pool.idle_len()
+            );
+        }
+        assert!(
+            pool.inflight() == 0,
+            "inflight should be 0 between iterations, got {}",
+            pool.inflight()
+        );
+        assert!(
+            pool.idle_len() <= pool_size,
+            "idle queue should never exceed pool size, got {}",
+            pool.idle_len()
+        );
+    }
+
+    pool.shutdown(Duration::from_secs(5)).await;
+}
+
+// ---------------------------------------------------------------------------
+// T3 — conn-close mid-test → next acquire reconnects cleanly
+// ---------------------------------------------------------------------------
+//
+// We don't have remote control over the chrome container, so we simulate "ws
+// dies" by reaching into a guard's conn and calling close(). The pool's
+// health-check on the next stale idle slot is skipped (timer not elapsed),
+// so we instead rely on the recycle path to mark the slot dead when CDP
+// commands fail on the now-closed conn.
+#[tokio::test]
+#[ignore]
+async fn t3_conn_kill_recovers() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 2);
+
+    // Use the pool once to populate a slot.
+    let _ = pooled_visit(&pool, "about:blank", None).await;
+
+    // Acquire, close the conn directly, release — release's recycle steps will
+    // fail and mark the slot Dead.
+    {
+        let guard = pool.acquire().await.expect("acquire #2");
+        guard.conn.close().await;
+        // Drop the guard via release (it will fail internally but must not panic).
+        let _ = guard.release().await;
+    }
+
+    // Next acquire must succeed via factory (fresh conn).
+    let after = pooled_visit(&pool, "about:blank", None).await;
+    let _ = after; // unused
+    assert_eq!(pool.inflight(), 0);
+
+    pool.shutdown(Duration::from_secs(5)).await;
+}
+
+// ---------------------------------------------------------------------------
+// T4 — drain under load
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn t4_drain_under_load() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 4);
+
+    // 5 concurrent in-flight requests. Tasks that lose the race against
+    // shutdown's `Semaphore::close()` (acquire returns `Shutdown`) just exit;
+    // they MUST NOT panic — that would pollute the test log without changing
+    // the outcome.
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        let p = pool.clone();
+        handles.push(tokio::spawn(async move {
+            // Inline pooled_visit but tolerate Shutdown on acquire.
+            let Ok(guard) = p.acquire().await else { return };
+            let _ = guard.release().await;
+        }));
+    }
+
+    // Let them start.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Initiate shutdown with a 10s drain.
+    let drain_handle = {
+        let p = pool.clone();
+        tokio::spawn(async move {
+            p.shutdown(Duration::from_secs(10)).await;
+        })
+    };
+
+    // All in-flight should complete or be drained within deadline.
+    for h in handles {
+        let _ = h.await;
+    }
+    drain_handle.await.expect("shutdown joined");
+
+    assert_eq!(pool.inflight(), 0, "inflight must reach 0 after drain");
+    assert_eq!(pool.idle_len(), 0, "idle slots must be drained");
+}
+
+// ---------------------------------------------------------------------------
+// T4b — drain with leaked guard (`mem::forget`) → inflight reaches 0
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn t4b_drain_with_leaked_guard() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 2);
+
+    // Acquire and forget — simulates Drop bypass (e.g. panic-during-Drop).
+    let guard = pool.acquire().await.expect("acquire");
+    assert_eq!(pool.inflight(), 1);
+    std::mem::forget(guard);
+
+    // Shutdown's phase 3 must force-close the conn AND decrement inflight
+    // because it wins the terminator CAS for the leaked slot.
+    pool.clone().shutdown(Duration::from_secs(5)).await;
+
+    assert_eq!(
+        pool.inflight(),
+        0,
+        "shutdown must reconcile leaked guard's inflight"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T6 — closeTarget timeout → slot Dead, dispose skipped
+// ---------------------------------------------------------------------------
+//
+// Hard to engineer a "hanging" closeTarget against real Chrome reliably.
+// Approach: open a target running an infinite-`beforeunload` dialog. Modern
+// Chrome auto-dismisses beforeunload in headless mode, so a more reliable
+// trigger is `Page.javaScriptDialogOpening` paired with deliberate non-handling
+// — but again, headless suppresses these.
+//
+// Pragmatic fallback: assert the policy at the unit-test level (already
+// covered in `tests/browser_pool_state.rs`), and here just exercise a normal
+// close-target-after-load path to confirm no regression on the happy branch.
+// The hard-to-engineer branch is documented in the plan as covered by P7
+// state-machine tests.
+#[tokio::test]
+#[ignore]
+async fn t6_close_target_normal_path() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 2);
+
+    let _ = pooled_visit(&pool, "about:blank", None).await;
+    assert_eq!(pool.inflight(), 0);
+    assert!(
+        pool.idle_len() >= 1,
+        "slot should be back in idle after release"
+    );
+
+    pool.shutdown(Duration::from_secs(5)).await;
+}
+
+// ---------------------------------------------------------------------------
+// T7 — permit accounting under shutdown
+// ---------------------------------------------------------------------------
+//
+// Saturate the pool, then call shutdown; in-flight `release()` calls must
+// complete normally without leaking permits.
+#[tokio::test]
+#[ignore]
+async fn t7_permit_accounting_under_shutdown() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool_size = 3;
+    let pool = build_pool(ws, pool_size);
+
+    // Hold pool_size guards concurrently.
+    let mut guards = Vec::new();
+    for _ in 0..pool_size {
+        guards.push(pool.acquire().await.expect("acquire"));
+    }
+    assert_eq!(pool.inflight(), pool_size);
+
+    // Release them in parallel while shutdown drains.
+    let drain = {
+        let p = pool.clone();
+        tokio::spawn(async move {
+            p.shutdown(Duration::from_secs(10)).await;
+        })
+    };
+
+    for g in guards {
+        let _ = g.release().await;
+    }
+    drain.await.expect("shutdown joined");
+
+    assert_eq!(pool.inflight(), 0);
+}

--- a/crates/crw-renderer/tests/browser_pool_spike.rs
+++ b/crates/crw-renderer/tests/browser_pool_spike.rs
@@ -1,0 +1,485 @@
+//! Tier S — Browser-context-pool CDP spike.
+//!
+//! Exercises the exact CDP sequence the pool will run, against a long-lived
+//! Chrome (or `chromedp/headless-shell`) WS connection. Validates that the
+//! load-bearing assumptions hold *before* we build pool plumbing on top of
+//! them. See plan §"Tier S — Real-Chrome CDP spike".
+//!
+//! Three variants (per plan):
+//! 1. `loop_variant`            — 100× create-ctx → create-target → navigate
+//!    → close-target → dispose-ctx, on one conn.
+//! 2. `concurrent_contexts`     — Two contexts open simultaneously on one
+//!    conn; cookie set in A must NOT leak to B.
+//! 3. `dispose_with_open_target`— Order-of-operations: dispose ctx while a
+//!    target inside it is still open. Observe.
+//!
+//! All `#[ignore]` by default. To run, point `CRW_CDP_HTTP_URL` at a Chrome
+//! HTTP base (e.g. `http://127.0.0.1:9333`) and set `CRW_TEST_REAL_CHROME=1`:
+//!
+//! ```sh
+//! /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+//!   --headless=new --remote-debugging-port=9333 \
+//!   --user-data-dir=/tmp/crw-spike-chrome &
+//! sleep 2
+//! CRW_TEST_REAL_CHROME=1 CRW_CDP_HTTP_URL=http://127.0.0.1:9333 \
+//!   cargo test -p crw-renderer --features cdp --test browser_pool_spike \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Output recorded into `bench/server-runs/SPIKE_browser_pool.md` after a
+//! successful run.
+
+#![cfg(feature = "cdp")]
+
+use std::time::{Duration, Instant};
+
+use crw_renderer::cdp_conn::CdpConnection;
+use serde_json::{Value, json};
+use tokio_tungstenite::connect_async;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const CDP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Skip the test cleanly if the env gate is off. Returns Some(http_base) iff
+/// `CRW_TEST_REAL_CHROME=1` AND `CRW_CDP_HTTP_URL` is set.
+fn require_real_chrome() -> Option<String> {
+    if std::env::var("CRW_TEST_REAL_CHROME").ok().as_deref() != Some("1") {
+        eprintln!("skip: CRW_TEST_REAL_CHROME != 1");
+        return None;
+    }
+    match std::env::var("CRW_CDP_HTTP_URL") {
+        Ok(u) if !u.is_empty() => Some(u),
+        _ => {
+            eprintln!("skip: CRW_CDP_HTTP_URL not set (e.g. http://127.0.0.1:9333)");
+            None
+        }
+    }
+}
+
+/// Resolve the browser-level WS URL via /json/version. Mirrors what
+/// `CdpRenderer::resolve_ws_url` does for vanilla Chrome.
+async fn resolve_ws(http_base: &str) -> String {
+    let url = format!("{}/json/version", http_base.trim_end_matches('/'));
+    let body: Value = reqwest::Client::new()
+        .get(&url)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("GET /json/version")
+        .json()
+        .await
+        .expect("parse /json/version");
+    let raw = body
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("no webSocketDebuggerUrl in {body}"))
+        .to_string();
+    // Chrome echoes back the Host header (or 127.0.0.1) in webSocketDebuggerUrl;
+    // rewrite host:port to whatever the caller configured so we hit the right
+    // listener. Mirrors `cdp::rewrite_ws_host`.
+    let conf_hp = http_base
+        .trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .trim_end_matches('/');
+    let path = raw
+        .trim_start_matches("ws://")
+        .trim_start_matches("wss://")
+        .split_once('/')
+        .map(|(_, rest)| format!("/{rest}"))
+        .unwrap_or_else(|| "/".into());
+    format!("ws://{conf_hp}{path}")
+}
+
+async fn create_ctx(conn: &CdpConnection) -> String {
+    let r = conn
+        .send_recv("Target.createBrowserContext", json!({}), None, CDP_TIMEOUT)
+        .await
+        .expect("createBrowserContext");
+    r.get("browserContextId")
+        .and_then(|v| v.as_str())
+        .expect("browserContextId")
+        .to_string()
+}
+
+async fn dispose_ctx(conn: &CdpConnection, ctx_id: &str) -> Result<(), String> {
+    conn.send_recv(
+        "Target.disposeBrowserContext",
+        json!({ "browserContextId": ctx_id }),
+        None,
+        CDP_TIMEOUT,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| e.to_string())
+}
+
+async fn create_target(conn: &CdpConnection, ctx_id: &str, url: &str) -> String {
+    let r = conn
+        .send_recv(
+            "Target.createTarget",
+            json!({ "url": url, "browserContextId": ctx_id }),
+            None,
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("createTarget");
+    r.get("targetId")
+        .and_then(|v| v.as_str())
+        .expect("targetId")
+        .to_string()
+}
+
+async fn close_target(conn: &CdpConnection, target_id: &str) -> Result<(), String> {
+    conn.send_recv(
+        "Target.closeTarget",
+        json!({ "targetId": target_id }),
+        None,
+        CDP_TIMEOUT,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| e.to_string())
+}
+
+async fn attach(conn: &CdpConnection, target_id: &str) -> String {
+    let r = conn
+        .send_recv(
+            "Target.attachToTarget",
+            json!({ "targetId": target_id, "flatten": true }),
+            None,
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("attachToTarget");
+    r.get("sessionId")
+        .and_then(|v| v.as_str())
+        .expect("sessionId")
+        .to_string()
+}
+
+/// Navigate + wait for `Page.loadEventFired`. Subscribes BEFORE sending so
+/// we never miss the event.
+async fn navigate_and_wait(conn: &CdpConnection, session_id: &str, url: &str) {
+    let _ = conn
+        .send_recv("Page.enable", json!({}), Some(session_id), CDP_TIMEOUT)
+        .await
+        .expect("Page.enable");
+    let events_rx = conn.subscribe();
+    let _nav = conn
+        .send_recv(
+            "Page.navigate",
+            json!({ "url": url }),
+            Some(session_id),
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("Page.navigate");
+    let sid = session_id.to_string();
+    // Wait via the same wait_for_event helper the renderer uses.
+    let mut rx = events_rx;
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!("loadEventFired timeout for {url}");
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Err(_) => panic!("loadEventFired timeout for {url}"),
+            Ok(Err(_)) => continue,
+            Ok(Ok(ev)) => {
+                if ev.method == "Page.loadEventFired" && ev.session_id.as_deref() == Some(&sid) {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// VARIANT 1 — 100× recycle loop on a single connection.
+///
+/// Asserts: each iteration completes; no `Inspector.targetCrashed`; conn is
+/// not closed at end. RSS check is left for an external `ps` capture; we
+/// log iteration timings so the operator can spot drift.
+#[tokio::test]
+#[ignore]
+async fn spike_loop_variant_100x() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws_url = resolve_ws(&base).await;
+    eprintln!("ws_url={ws_url}");
+
+    // Diagnostic: probe ws_url with tokio-tungstenite directly so we see the
+    // underlying error class (CdpConnection masks tungstenite::Error::Io
+    // detail behind "io error").
+    match connect_async(&ws_url).await {
+        Ok((ws, resp)) => {
+            eprintln!("raw ws probe: connected, status={}", resp.status());
+            drop(ws);
+        }
+        Err(e) => {
+            eprintln!("raw ws probe FAIL: {e:?}");
+        }
+    }
+
+    let conn = CdpConnection::connect(&ws_url, CONNECT_TIMEOUT)
+        .await
+        .expect("connect");
+
+    // Subscribe to events to catch any targetCrashed during the loop.
+    let mut crash_rx = conn.subscribe();
+    let crash_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let crash_flag_t = crash_flag.clone();
+    let crash_task = tokio::spawn(async move {
+        while let Ok(ev) = crash_rx.recv().await {
+            if ev.method == "Inspector.targetCrashed" {
+                crash_flag_t.store(true, std::sync::atomic::Ordering::SeqCst);
+                eprintln!("!! Inspector.targetCrashed observed: {:?}", ev.params);
+            }
+        }
+    });
+
+    let total = 100usize;
+    let mut timings = Vec::with_capacity(total);
+    let t0 = Instant::now();
+
+    for i in 0..total {
+        let it_start = Instant::now();
+        let ctx_id = create_ctx(&conn).await;
+        let target_id = create_target(&conn, &ctx_id, "about:blank").await;
+        let session_id = attach(&conn, &target_id).await;
+        navigate_and_wait(
+            &conn,
+            &session_id,
+            "data:text/html,<html><body>ok</body></html>",
+        )
+        .await;
+        close_target(&conn, &target_id).await.expect("closeTarget");
+        dispose_ctx(&conn, &ctx_id).await.expect("disposeCtx");
+        let dt = it_start.elapsed();
+        timings.push(dt);
+        if i % 10 == 0 {
+            eprintln!(
+                "iter {:>3}: {:>6} ms  (cumulative {:>6} ms)",
+                i,
+                dt.as_millis(),
+                t0.elapsed().as_millis()
+            );
+        }
+        assert!(!conn.is_closed(), "conn closed unexpectedly at iter {i}");
+        assert!(
+            !crash_flag.load(std::sync::atomic::Ordering::SeqCst),
+            "Inspector.targetCrashed at iter {i}"
+        );
+    }
+
+    crash_task.abort();
+    let total_ms = t0.elapsed().as_millis();
+    let mut sorted = timings.clone();
+    sorted.sort();
+    let p50 = sorted[sorted.len() / 2].as_millis();
+    let p95 = sorted[(sorted.len() * 95) / 100].as_millis();
+    let max = sorted.last().unwrap().as_millis();
+    eprintln!("\n=== loop_variant_100x summary ===");
+    eprintln!("  iterations : {total}");
+    eprintln!("  total      : {total_ms} ms");
+    eprintln!("  per-iter p50: {p50} ms");
+    eprintln!("  per-iter p95: {p95} ms");
+    eprintln!("  per-iter max: {max} ms");
+
+    conn.close().await;
+    assert!(conn.is_closed());
+}
+
+/// VARIANT 2 — Two contexts simultaneously on one connection.
+///
+/// Sets a cookie in ctx_A via httpbin /cookies/set, then opens a fresh
+/// document in ctx_B and asserts no cookie leak. This is the load-bearing
+/// isolation assumption for pool size > 1.
+///
+/// Falls back to a localStorage-based check if httpbin is unreachable.
+#[tokio::test]
+#[ignore]
+async fn spike_concurrent_contexts() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws_url = resolve_ws(&base).await;
+    let conn = CdpConnection::connect(&ws_url, CONNECT_TIMEOUT)
+        .await
+        .expect("connect");
+
+    let ctx_a = create_ctx(&conn).await;
+    let ctx_b = create_ctx(&conn).await;
+    eprintln!("ctx_a={ctx_a}");
+    eprintln!("ctx_b={ctx_b}");
+    assert_ne!(ctx_a, ctx_b, "context ids must differ");
+
+    // Open targets in each context.
+    let target_a = create_target(&conn, &ctx_a, "about:blank").await;
+    let target_b = create_target(&conn, &ctx_b, "about:blank").await;
+    let session_a = attach(&conn, &target_a).await;
+    let session_b = attach(&conn, &target_b).await;
+
+    // Seed localStorage in ctx_A on a same-origin "about:blank" — we use a
+    // data: URL with a scheme that supports localStorage. data: URLs do NOT
+    // support localStorage; instead use a real HTTP origin. Try httpbin
+    // first, fall back to about:blank + JS-evaluable cookie via document.cookie.
+    let test_url = "https://example.com/";
+    navigate_and_wait(&conn, &session_a, test_url).await;
+    navigate_and_wait(&conn, &session_b, test_url).await;
+
+    // Set a cookie in ctx_A via document.cookie.
+    let _ = conn
+        .send_recv(
+            "Runtime.evaluate",
+            json!({
+                "expression": "document.cookie = 'crw_isolation=ctx_a_marker; path=/'",
+                "returnByValue": true,
+            }),
+            Some(&session_a),
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("set cookie ctx_A");
+
+    // Read document.cookie in ctx_A — expect to see our marker.
+    let cookie_a = {
+        let r = conn
+            .send_recv(
+                "Runtime.evaluate",
+                json!({
+                    "expression": "document.cookie",
+                    "returnByValue": true,
+                }),
+                Some(&session_a),
+                CDP_TIMEOUT,
+            )
+            .await
+            .expect("read cookie ctx_A");
+        r.get("result")
+            .and_then(|v| v.get("value"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    eprintln!("ctx_A cookies: {cookie_a:?}");
+    assert!(
+        cookie_a.contains("crw_isolation=ctx_a_marker"),
+        "ctx_A should see its own cookie, got {cookie_a:?}"
+    );
+
+    // Read document.cookie in ctx_B — MUST NOT see ctx_A's cookie.
+    let cookie_b = {
+        let r = conn
+            .send_recv(
+                "Runtime.evaluate",
+                json!({
+                    "expression": "document.cookie",
+                    "returnByValue": true,
+                }),
+                Some(&session_b),
+                CDP_TIMEOUT,
+            )
+            .await
+            .expect("read cookie ctx_B");
+        r.get("result")
+            .and_then(|v| v.get("value"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    eprintln!("ctx_B cookies: {cookie_b:?}");
+    assert!(
+        !cookie_b.contains("crw_isolation=ctx_a_marker"),
+        "LEAK: ctx_B saw ctx_A's cookie: {cookie_b:?}"
+    );
+
+    // Cleanup.
+    let _ = close_target(&conn, &target_a).await;
+    let _ = close_target(&conn, &target_b).await;
+    let _ = dispose_ctx(&conn, &ctx_a).await;
+    let _ = dispose_ctx(&conn, &ctx_b).await;
+    conn.close().await;
+}
+
+/// VARIANT 3 — Dispose context while a target inside it is still open.
+///
+/// Pool's RECYCLE_AFTER_NAV=1 path closes target before dispose, so this
+/// is the *failure-mode probe*: what does the server do if we get the
+/// order wrong? Three plausible outcomes:
+///   - dispose returns Ok and auto-closes the target,
+///   - dispose returns Err with a specific message,
+///   - dispose hangs.
+/// We just record the outcome; the pool itself MUST NOT depend on it.
+#[tokio::test]
+#[ignore]
+async fn spike_dispose_with_open_target() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws_url = resolve_ws(&base).await;
+    let conn = CdpConnection::connect(&ws_url, CONNECT_TIMEOUT)
+        .await
+        .expect("connect");
+
+    let ctx_id = create_ctx(&conn).await;
+    let target_id = create_target(&conn, &ctx_id, "about:blank").await;
+    let session_id = attach(&conn, &target_id).await;
+    navigate_and_wait(
+        &conn,
+        &session_id,
+        "data:text/html,<html><body>still-open</body></html>",
+    )
+    .await;
+
+    // Subscribe BEFORE dispose to catch any auto-detach event.
+    let mut events = conn.subscribe();
+    let dispose_start = Instant::now();
+    let dispose_outcome = dispose_ctx(&conn, &ctx_id).await;
+    let dispose_dt = dispose_start.elapsed();
+    eprintln!("dispose_outcome (target still open): {dispose_outcome:?}");
+    eprintln!("dispose elapsed: {} ms", dispose_dt.as_millis());
+
+    // Drain any events that fired in the next 500 ms; report.
+    let drain_deadline = Instant::now() + Duration::from_millis(500);
+    let mut detached_seen = false;
+    loop {
+        let remaining = drain_deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, events.recv()).await {
+            Err(_) | Ok(Err(_)) => break,
+            Ok(Ok(ev)) => {
+                eprintln!(
+                    "post-dispose event: {} (sid={:?})",
+                    ev.method, ev.session_id
+                );
+                if ev.method == "Target.detachedFromTarget" || ev.method == "Target.targetDestroyed"
+                {
+                    detached_seen = true;
+                }
+            }
+        }
+    }
+    eprintln!("auto-detach observed: {detached_seen}");
+
+    // Try to navigate the now-orphaned session — what happens?
+    let nav_after = conn
+        .send_recv(
+            "Page.navigate",
+            json!({ "url": "about:blank" }),
+            Some(&session_id),
+            Duration::from_secs(2),
+        )
+        .await;
+    eprintln!("navigate-after-dispose outcome: {nav_after:?}");
+
+    // Best-effort cleanup. closeTarget on a destroyed target is expected to
+    // error — just log it.
+    let close_after = close_target(&conn, &target_id).await;
+    eprintln!("closeTarget-after-dispose: {close_after:?}");
+
+    conn.close().await;
+}

--- a/crates/crw-server/src/main.rs
+++ b/crates/crw-server/src/main.rs
@@ -116,6 +116,12 @@ async fn run_server() {
         );
     }
 
+    // Capture handles before `state` is consumed by `create_app` so we can
+    // drain the chrome browser-context pool after the HTTP server quiesces.
+    let renderer = std::sync::Arc::clone(&state.renderer);
+    let pool_drain =
+        std::time::Duration::from_secs(state.config.renderer.chrome_pool.shutdown_drain_secs);
+
     let app = crw_server::app::create_app(state);
 
     let listener = match tokio::net::TcpListener::bind(&addr).await {
@@ -134,6 +140,9 @@ async fn run_server() {
         tracing::error!("Server error: {e}");
         std::process::exit(1);
     }
+
+    // HTTP layer is quiesced; now drain the chrome pool (no-op when disabled).
+    renderer.shutdown_chrome_pool(pool_drain).await;
 
     tracing::info!("Server shut down gracefully");
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,16 @@ services:
     environment:
       - RUST_LOG=info
       - CRW_CONFIG=config.docker
+      # Bench knob passthrough (I4 fix): bench/run_pool_bench.sh sets these
+      # to flip pool on/off across two passes without editing config.docker.toml.
+      # Defaults match the §B5-flipped config.docker.toml values (pool=on,
+      # backend=vanilla, size=4) so an unset shell env leaves production
+      # behavior unchanged; bench script overrides to `false`/`off` for the
+      # control pass. Figment rejects empty strings for typed fields, so the
+      # fallback must be the real default — not `${VAR:-}`.
+      - CRW_RENDERER__CHROME_CONTEXT_POOL_ENABLED=${CRW_RENDERER__CHROME_CONTEXT_POOL_ENABLED:-true}
+      - CRW_RENDERER__CHROME_BACKEND=${CRW_RENDERER__CHROME_BACKEND:-vanilla}
+      - CRW_RENDERER__CHROME_POOL__SIZE=${CRW_RENDERER__CHROME_POOL__SIZE:-4}
     volumes:
       - ./config.docker.toml:/app/config.docker.toml:ro
 


### PR DESCRIPTION
## Summary
- Phase 4 §B5: long-lived CDP WS + ephemeral browser contexts amortize per-request handshake (`createBrowserContext` + `createTarget` + attach) from ~200–500 ms to ~0 ms on warm-hit acquires.
- Slot state machine (Idle/CheckedOut/Recycling/Dead/Closing) + `AtomicBool` terminator ensures exactly one of {release, drop, shutdown-force-close} runs inflight bookkeeping per checkout. `BookkeepingToken` RAII guarantees cancellation-safety mid-recycle.
- 4-phase shutdown drains inflight via `Notify`, force-closes orphaned conns via `all_slots` Weak registry, defensively clears the idle deque.
- `fetch_inner` no longer owns `Target.closeTarget` — caller closes via synchronous recorder callback that fires immediately after `createTarget` Ok and before the next `.await`, closing the cancellation window between create and attach.
- Size 4, vanilla backend only; gated off on browserless via lib.rs.

## Validation (from commit body)
- ✅ Cookie/storage isolation (T0/T1): PASS
- ✅ B2 sanity warm-hit handshake ratio < 2× (T2): PASS
- ✅ RSS soak chrome 1.08× over 500 reqs (T3): within 1.5× gate
- ✅ TOML flip burst (T5): 75/75 = 100% across 3 cycles

## Test plan
- [x] Tier validation suite (T0–T5) green per commit body
- [ ] CI green