### PR TITLE
chore: release-please bumps minor on feat in 0.x

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
Removes `bump-patch-for-minor-pre-major` so `feat:` commits trigger MINOR bumps (the standard SemVer-pre-1.0 convention) instead of PATCH while on 0.x. Breaking changes still bump MINOR (not MAJOR) via `bump-minor-pre-major`.

After this merges, release-please will recompute pending PR #46 from 0.6.5 → **0.7.0**.