### PR TITLE
fix: bump stale internal version pins to 0.7.0

### DIFF
--- a/crates/crw-search/Cargo.toml
+++ b/crates/crw-search/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 description = "SearXNG-backed search client and result transforms for the CRW web scraper"
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.6.1" }
+crw-core = { path = "../crw-core", version = "0.7.0" }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/crw-server/Cargo.toml
+++ b/crates/crw-server/Cargo.toml
@@ -19,7 +19,7 @@ crw-core = { path = "../crw-core", version = "0.7.0" }
 crw-renderer = { path = "../crw-renderer", version = "0.7.0" }
 crw-extract = { path = "../crw-extract", version = "0.7.0" }
 crw-crawl = { path = "../crw-crawl", version = "0.7.0" }
-crw-search = { path = "../crw-search", version = "0.6.1" }
+crw-search = { path = "../crw-search", version = "0.7.0" }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -68,6 +68,16 @@
         },
         {
           "type": "toml",
+          "path": "crates/crw-server/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-search.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-search/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-core.version"
+        },
+        {
+          "type": "toml",
           "path": "crates/crw-cli/Cargo.toml",
           "jsonpath": "$.dependencies.crw-core.version"
         },


### PR DESCRIPTION
The 0.7.0 release left `crw-search` and `crw-server` with internal version pins still pointing at `0.6.1` because `release-please-config.json` did not track them. Bumps the two pins to 0.7.0 and adds both jsonpaths to the config's `extra-files` so the next release covers them automatically.

CI on main was failing with:

```
error: failed to select a version for the requirement `crw-core = "^0.6.1"`
candidate versions found which didn't match: 0.7.0
required by package `crw-search v0.7.0`
```