### PR TITLE
chore: sync Cargo.lock to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "clap",
  "crw-core",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "crw-core",
  "crw-extract",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "clap",
  "crw-core",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "axum",
  "axum-test",


### PR DESCRIPTION
release-please does not regenerate `Cargo.lock` when it bumps `Cargo.toml` versions; CI auto-updates the lock in memory but the committed file was left at 0.6.3. Brings the lock in sync so checkout-and-build reproduces the same graph CI sees.

Best-practice follow-up (separate PR): add a workflow step that runs `cargo update --workspace --offline` and commits the result as part of release-please's Release PR, so future releases stay self-consistent.