### PR TITLE
fix(docker): include OpenAPI specs in crw-api build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,11 @@
 target
 .git
 bench
-docs
+# Exclude the 5MB docs site but keep the two OpenAPI specs that crw-server
+# embeds via include_str! (crates/crw-server/src/routes/openapi.rs).
+docs/*
+!docs/openapi.json
+!docs/openapi-3.0.json
 *.md
 tests
 .dockerignore


### PR DESCRIPTION
Fresh Docker build of crw-api failed: .dockerignore excluded docs/ but openapi.rs include_str!s docs/openapi*.json. Keep only the two specs, exclude the rest of the 5MB site. Surfaced by a production rebuild.