### PR TITLE
feat(search): passage-level relevance gate (cycle-3, gated default off)

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -153,6 +153,14 @@ pub struct SearchConfig {
     /// answer layer are untouched, so precision/SaaS-parity are preserved.
     #[serde(default)]
     pub query_expand: bool,
+    /// Passage-level relevance gate for the LLM answer path: split each scraped
+    /// source into passages and feed the answer LLM only the query-relevant
+    /// ones (DeepSeek-scored, no new ML deps). Subtractive — removes noise, never
+    /// adds sources or forces commits; falls back to the full source on any
+    /// failure (byte-identical to off), so it is monotone-safe. Defaults to
+    /// `false` (gated); answer prompt + plain path untouched.
+    #[serde(default)]
+    pub passage_select: bool,
 }
 
 impl Default for SearchConfig {
@@ -167,6 +175,7 @@ impl Default for SearchConfig {
             github_engines: default_github_engines(),
             rerank_enabled: true,
             query_expand: false,
+            passage_select: false,
         }
     }
 }

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -143,6 +143,16 @@ pub struct SearchConfig {
     /// unaffected and keeps SaaS byte-parity regardless of this flag.
     #[serde(default = "default_true_search")]
     pub rerank_enabled: bool,
+    /// Multi-query expansion for the LLM answer / summarize path: before the
+    /// SearXNG fetch, generate an entity/keyword-focused rewrite of the query,
+    /// fetch both the original and the rewrite, and UNION the candidate pools
+    /// (recall can only increase — the original's results are always kept).
+    /// Targets "retrieval-miss" failures where the answer's source never
+    /// surfaced for the user's phrasing. Costs one extra small LLM call + one
+    /// extra SearXNG fetch. Defaults to `false` (gated); the plain path and the
+    /// answer layer are untouched, so precision/SaaS-parity are preserved.
+    #[serde(default)]
+    pub query_expand: bool,
 }
 
 impl Default for SearchConfig {
@@ -156,6 +166,7 @@ impl Default for SearchConfig {
             research_engines: default_research_engines(),
             github_engines: default_github_engines(),
             rerank_enabled: true,
+            query_expand: false,
         }
     }
 }

--- a/crates/crw-extract/src/answer.rs
+++ b/crates/crw-extract/src/answer.rs
@@ -168,6 +168,122 @@ pub async fn synthesize(
     })
 }
 
+/// Only sources larger than this are worth a passage-selection pass (smaller
+/// ones already fit and carry little noise). Bounds the extra LLM cost.
+const PASSAGE_SELECT_MIN_CHARS: usize = 4096;
+/// Never reduce a source below this many chars — guards against an
+/// over-aggressive selection cutting the answer-bearing span (which would
+/// inflate NOT_ATTEMPTED). Padded with leading passages until met.
+const PASSAGE_KEEP_FLOOR: usize = 3072;
+/// Cap kept passages per source.
+const MAX_KEPT_PASSAGES: usize = 12;
+
+/// Split markdown into passages on blank-line / heading boundaries.
+fn split_passages(md: &str) -> Vec<&str> {
+    md.split("\n\n")
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+/// Ask the LLM which passages are relevant. Returns the kept indices, or `None`
+/// on any failure / empty / unparseable result (caller keeps the full source).
+async fn select_passage_indices(
+    query: &str,
+    passages: &[&str],
+    cfg: &LlmConfig,
+) -> Option<Vec<usize>> {
+    const SYS: &str = "You select which passages from a web source are relevant \
+        to answering a query. Given the query and numbered passages, return ONLY \
+        a JSON array of the integer indices of passages containing information \
+        helpful to answer the query. Be INCLUSIVE — keep any passage that might \
+        help, plus immediate context. Never return an empty array if anything is \
+        even slightly relevant. Output ONLY the JSON array, e.g. [0,2,3].";
+    let mut listing = format!("Query: {query}\n\nPassages:\n");
+    for (i, p) in passages.iter().enumerate() {
+        let head: String = p.chars().take(400).collect();
+        listing.push_str(&format!("[{i}] {head}\n"));
+    }
+    let mut leg = cfg.clone();
+    leg.max_tokens = leg.max_tokens.min(256);
+    let r = llm::chat(&leg, SYS, &listing).await.ok()?;
+    let start = r.content.find('[')?;
+    let end = r.content[start..].find(']')? + start;
+    let arr: Vec<usize> = serde_json::from_str(&r.content[start..=end]).ok()?;
+    let kept: Vec<usize> = arr.into_iter().filter(|&i| i < passages.len()).collect();
+    if kept.is_empty() { None } else { Some(kept) }
+}
+
+/// Reduce a source to its query-relevant passages. `None` means "keep the full
+/// source" (every failure path and the no-benefit path), so this is
+/// monotone-safe: it can only remove noise, never lose the source.
+async fn reduce_source(query: &str, md: &str, cfg: &LlmConfig) -> Option<String> {
+    let passages = split_passages(md);
+    if passages.len() <= 2 {
+        return None;
+    }
+    let mut keep: std::collections::BTreeSet<usize> = select_passage_indices(query, &passages, cfg)
+        .await?
+        .into_iter()
+        .collect();
+    // Lead-passage guard: always retain passage 0 (page lead / definition).
+    keep.insert(0);
+    // Floor guard: pad with leading passages until we clear PASSAGE_KEEP_FLOOR.
+    let mut kept: Vec<usize> = keep.into_iter().collect();
+    let mut size: usize = kept.iter().map(|&i| passages[i].len()).sum();
+    let mut next = 0usize;
+    while size < PASSAGE_KEEP_FLOOR && next < passages.len() {
+        if !kept.contains(&next) {
+            kept.push(next);
+            size += passages[next].len();
+        }
+        next += 1;
+    }
+    kept.sort_unstable();
+    kept.dedup();
+    kept.truncate(MAX_KEPT_PASSAGES);
+    // No benefit if we kept (nearly) everything — keep the full source.
+    if kept.len() >= passages.len() {
+        return None;
+    }
+    let assembled = kept
+        .iter()
+        .map(|&i| passages[i])
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if assembled.len() >= md.len() {
+        None
+    } else {
+        Some(assembled)
+    }
+}
+
+/// Passage-selection variant of [`synthesize`]: reduce each large source to its
+/// query-relevant passages (in parallel), then delegate to the unchanged
+/// `synthesize` (same answer prompt, citation guards, truncation). Any selection
+/// failure falls back to the full source, so output is byte-identical to
+/// `synthesize` on the fallback path — it can only remove noise, never regress.
+pub async fn synthesize_selected(
+    query: &str,
+    sources: &[Source],
+    cfg: &LlmConfig,
+    max_chars_per_source: usize,
+    user_prompt: Option<&str>,
+) -> CrwResult<AnswerResult> {
+    let reduce_futs = sources.iter().map(|(url, title, md)| async move {
+        let new_md = if md.len() >= PASSAGE_SELECT_MIN_CHARS {
+            reduce_source(query, md, cfg)
+                .await
+                .unwrap_or_else(|| md.clone())
+        } else {
+            md.clone()
+        };
+        (url.clone(), title.clone(), new_md)
+    });
+    let reduced: Vec<Source> = futures::future::join_all(reduce_futs).await;
+    synthesize(query, &reduced, cfg, max_chars_per_source, user_prompt).await
+}
+
 fn parse_answer_and_citations(
     raw: &str,
     sources: &[Source],

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -121,6 +121,41 @@ pub async fn chat(
     .await
 }
 
+/// Generate ONE entity/keyword-focused rewrite of a search query to widen
+/// retrieval recall on the answer path. The caller fetches BOTH the original
+/// and this rewrite and unions the candidate pools, so recall can only
+/// increase. Returns an empty `Vec` on any failure or when the rewrite is
+/// trivial/identical — the caller then uses the original query alone, which
+/// means this can never reduce recall or break a search.
+pub async fn expand_query(cfg: &LlmConfig, query: &str) -> Vec<String> {
+    const SYS: &str = "You rewrite a user's search query into ONE alternative \
+        web-search query that maximizes the chance of finding the answer. Keep \
+        the key named entities; use precise keywords a relevant page would \
+        contain; drop filler words. Output ONLY the rewritten query on a single \
+        line — no quotes, no labels, no explanation.";
+    let mut leg = cfg.clone();
+    leg.max_tokens = leg.max_tokens.min(120);
+    match chat(&leg, SYS, query).await {
+        Ok(r) => {
+            let v = r
+                .content
+                .trim()
+                .lines()
+                .next()
+                .unwrap_or("")
+                .trim()
+                .trim_matches('"')
+                .to_string();
+            if v.is_empty() || v.eq_ignore_ascii_case(query.trim()) {
+                Vec::new()
+            } else {
+                vec![v]
+            }
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn dispatch(
     provider: &str,

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -221,7 +221,14 @@ pub async fn search_inner(
                     }
                 }
                 if wants_answer {
-                    match synthesize_answer(&req, &data, &leg_cfg).await {
+                    match synthesize_answer(
+                        &req,
+                        &data,
+                        &leg_cfg,
+                        state.config.search.passage_select,
+                    )
+                    .await
+                    {
                         Ok((ans, cites, ans_usage, mut ans_warns)) => {
                             warnings.append(&mut ans_warns);
                             agg_answer_executed = true;
@@ -451,6 +458,7 @@ async fn synthesize_answer(
     req: &SearchRequest,
     data: &SearchData,
     cfg: &LlmConfig,
+    passage_select: bool,
 ) -> Result<
     (
         String,
@@ -488,9 +496,16 @@ async fn synthesize_answer(
     if sources.is_empty() {
         return Err("no results carry markdown to synthesize an answer from".into());
     }
-    let result = answer::synthesize(&req.query, &sources, cfg, cap, req.answer_prompt.as_deref())
-        .await
-        .map_err(|e| e.to_string())?;
+    // Passage-select reduces each large source to its query-relevant passages
+    // before synthesis (monotone-safe: falls back to the full source on any
+    // failure). Gated; off = byte-identical to plain synthesize.
+    let result = if passage_select {
+        answer::synthesize_selected(&req.query, &sources, cfg, cap, req.answer_prompt.as_deref())
+            .await
+    } else {
+        answer::synthesize(&req.query, &sources, cfg, cap, req.answer_prompt.as_deref()).await
+    }
+    .map_err(|e| e.to_string())?;
     Ok((
         result.content,
         result.citations,

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -12,7 +12,8 @@ use crw_crawl::single::scrape_url;
 use crw_extract::answer;
 use crw_extract::summary;
 use crw_search::{
-    SearchError, map_to_searxng_params, transform_flat, transform_flat_reranked, transform_grouped,
+    SearchError, SearxngClient, SearxngParams, SearxngResponse, map_to_searxng_params,
+    transform_flat, transform_flat_reranked, transform_grouped,
 };
 use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
@@ -77,18 +78,37 @@ pub async fn search_inner(
         .min(state.config.search.max_limit)
         .max(1);
 
+    // BYOK + LLM config is built up-front because multi-query expansion (below)
+    // needs the LLM *before* the SearXNG fetch. Reused by the summarize/answer
+    // legs further down. `llm_path` = this request enters LLM mode.
+    let server_llm = state.config.extraction.llm.clone();
+    let byok_llm = build_byok_search_llm_config(&req, server_llm.as_ref());
+    let effective_llm = byok_llm.as_ref().or(server_llm.as_ref());
+    let llm_path = req.answer.unwrap_or(false) || req.summarize_results.unwrap_or(false);
+
     let params = map_to_searxng_params(&req, &state.config.search);
-    let response = client
-        .fetch(&params)
-        .await
-        .map_err(|e| map_search_error(e, state.config.search.timeout_ms))?;
+    // Multi-query expansion (gated): on the LLM path, also fetch an
+    // entity/keyword rewrite of the query and UNION the pools so the answer's
+    // source is more likely to surface. Falls back to the single fetch.
+    let response = if state.config.search.query_expand
+        && llm_path
+        && let Some(llm) = effective_llm
+    {
+        fetch_expanded(&client, &req.query, &params, llm)
+            .await
+            .map_err(|e| map_search_error(e, state.config.search.timeout_ms))?
+    } else {
+        client
+            .fetch(&params)
+            .await
+            .map_err(|e| map_search_error(e, state.config.search.timeout_ms))?
+    };
 
     let has_sources = req.sources.as_ref().is_some_and(|s| !s.is_empty());
     // The LLM answer / summarize path feeds the top-N flat sources straight to
     // the model, so it must receive a clean, query-relevant pool. Re-rank the
     // flat pool on that path (unless disabled); the plain path keeps the raw
     // SaaS byte-parity `transform_flat` sort.
-    let llm_path = req.answer.unwrap_or(false) || req.summarize_results.unwrap_or(false);
     let mut data = if has_sources {
         let sources = req.sources.clone().unwrap_or_default();
         SearchData::Grouped(transform_grouped(&response, &sources, limit))
@@ -110,13 +130,7 @@ pub async fn search_inner(
         }
     }
 
-    // BYOK + LLM features. Both `summarize_results` and `answer` need an
-    // effective LlmConfig. Build it once from the BYOK request fields,
-    // falling back to server config.
-    let server_llm = state.config.extraction.llm.clone();
-    let byok_llm = build_byok_search_llm_config(&req, server_llm.as_ref());
-    let effective_llm = byok_llm.as_ref().or(server_llm.as_ref());
-
+    // `effective_llm` / `byok_llm` / `server_llm` were built up-front (above).
     let wants_summaries = req.summarize_results.unwrap_or(false);
     let wants_answer = req.answer.unwrap_or(false);
     // Wave 4 (R1): once we enter LLM mode the response MUST carry a
@@ -561,6 +575,47 @@ fn map_search_error(err: SearchError, timeout_ms: u64) -> CrwError {
         }
         SearchError::Transport(msg) => CrwError::TargetUnreachable(format!("SearXNG: {msg}")),
     }
+}
+
+/// Multi-query expansion: fetch the original query plus an LLM-generated
+/// entity/keyword rewrite, then UNION the candidate pools (dedupe by URL,
+/// original results kept first so they retain priority). Recall can only
+/// increase vs a single fetch. The original fetch's error propagates (same
+/// failure semantics as the single-fetch path); a failed variant fetch is
+/// ignored. If the rewrite is empty/trivial, this is exactly the single fetch.
+async fn fetch_expanded(
+    client: &SearxngClient,
+    query: &str,
+    base_params: &SearxngParams,
+    llm: &LlmConfig,
+) -> Result<SearxngResponse, SearchError> {
+    let mut leg = llm.clone();
+    leg.max_tokens = leg.max_tokens.min(SEARCH_LLM_MAX_TOKENS_PER_LEG);
+    let variants = crw_extract::llm::expand_query(&leg, query).await;
+    let mut merged = client.fetch(base_params).await?;
+    if variants.is_empty() {
+        return Ok(merged);
+    }
+    let mut seen: std::collections::HashSet<String> = merged
+        .results
+        .iter()
+        .filter_map(|r| r.url.clone())
+        .collect();
+    for v in variants {
+        let mut vp = base_params.clone();
+        vp.q = v;
+        if let Ok(r) = client.fetch(&vp).await {
+            for row in r.results {
+                if let Some(u) = row.url.clone()
+                    && seen.insert(u)
+                {
+                    merged.results.push(row);
+                }
+            }
+        }
+    }
+    merged.number_of_results = merged.results.len() as u64;
+    Ok(merged)
 }
 
 /// Enrich `web` (or flat) results in-place by calling the scrape pipeline


### PR DESCRIPTION
Cycle-3 from the multi-agent design+debate (passage-selection beat the multi-hop router + cross-encoder). Subtractive: split each large scraped source into passages, score with the EXISTING DeepSeek call, feed the answer LLM only query-relevant passages. Monotone-safe (lead+floor guard, full-doc fallback on any failure = byte-identical to off). Removes noise → should raise SimpleQA+FRAMES+FreshQA AND claw back the precision cycle-2 dented (4%→8% hallucination), without adding sources/forcing commits/touching the answer prompt. Gated OFF; enable+A/B after merge. Guardrail: INCORRECT must not rise above baseline 2/50.