### PR TITLE
feat(search): gated page-2 fallback for thin reranked answer pools

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -161,6 +161,16 @@ pub struct SearchConfig {
     /// `false` (gated); answer prompt + plain path untouched.
     #[serde(default)]
     pub passage_select: bool,
+    /// Page-2 fallback for the LLM answer / summarize path: if the reranked
+    /// (junk-filtered, deduped) candidate pool comes back thinner than the
+    /// answer needs (`< answer_top_n`), fetch the SAME query's SearXNG page 2
+    /// once and union it in, then re-rank. The trigger is evaluated POST-rerank,
+    /// so a junk-heavy first page does not suppress it; the extra fetch only
+    /// fires on already-under-yielding queries (QPS never doubles across the
+    /// corpus). Recall-only + abstention is untouched (a sparse page1+page2 pool
+    /// still abstains). Defaults to `false` (gated); requires `rerank_enabled`.
+    #[serde(default)]
+    pub page2_fallback: bool,
 }
 
 impl Default for SearchConfig {
@@ -176,6 +186,7 @@ impl Default for SearchConfig {
             rerank_enabled: true,
             query_expand: false,
             passage_select: false,
+            page2_fallback: false,
         }
     }
 }

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -90,7 +90,7 @@ pub async fn search_inner(
     // Multi-query expansion (gated): on the LLM path, also fetch an
     // entity/keyword rewrite of the query and UNION the pools so the answer's
     // source is more likely to surface. Falls back to the single fetch.
-    let response = if state.config.search.query_expand
+    let mut response = if state.config.search.query_expand
         && llm_path
         && let Some(llm) = effective_llm
     {
@@ -117,6 +117,48 @@ pub async fn search_inner(
     } else {
         SearchData::Flat(transform_flat(&response, limit))
     };
+
+    // Page-2 fallback (gated, default-off): when the reranked clean pool came
+    // back thinner than the answer needs (junk filter stripped a sparse first
+    // page), fetch the SAME query's page 2 ONCE, union it in (dedup by URL like
+    // `fetch_expanded`), and re-rank. Trigger is evaluated POST-rerank so a
+    // junk-heavy first page doesn't suppress it; extra load only fires on
+    // already-under-yielding queries. Recall-only — synthesis/abstention in
+    // `answer.rs` is untouched.
+    if state.config.search.page2_fallback
+        && llm_path
+        && state.config.search.rerank_enabled
+        && !has_sources
+    {
+        let top_n = req
+            .answer_top_n
+            .unwrap_or(DEFAULT_ANSWER_TOP_N)
+            .min(MAX_ANSWER_TOP_N) as usize;
+        let clean_count = match &data {
+            SearchData::Flat(v) => v.len(),
+            SearchData::Grouped(_) => top_n,
+        };
+        if clean_count < top_n {
+            let mut p2 = params.clone();
+            p2.pageno = Some(2);
+            if let Ok(resp2) = client.fetch(&p2).await {
+                let mut seen: std::collections::HashSet<String> = response
+                    .results
+                    .iter()
+                    .filter_map(|r| r.url.clone())
+                    .collect();
+                for row in resp2.results {
+                    if let Some(u) = row.url.clone()
+                        && seen.insert(u)
+                    {
+                        response.results.push(row);
+                    }
+                }
+                response.number_of_results = response.results.len() as u64;
+                data = SearchData::Flat(transform_flat_reranked(&response, &req.query, limit));
+            }
+        }
+    }
 
     let mut warning: Option<String> = None;
     let mut warnings: Vec<String> = Vec::new();


### PR DESCRIPTION
When the reranked clean pool < answer_top_n, fetch the same query's SearXNG page 2 once, union+dedup, re-rank. Trigger is POST-rerank so junk-heavy first pages don't suppress it; fires only on under-yielding queries. Recall-only, abstention untouched (moat preserved). Gated default-off. Targets the over-abstention weakness (baseline: 14 not-attempted incl SimpleQA 5, PopQA long-tail 66.7%).