### PR TITLE
feat(search): gated calibrated-answer path (cut over-abstention toward 90+)

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -171,6 +171,17 @@ pub struct SearchConfig {
     /// still abstains). Defaults to `false` (gated); requires `rerank_enabled`.
     #[serde(default)]
     pub page2_fallback: bool,
+    /// Calibrated answer path (gated): reduce recoverable OVER-abstentions by
+    /// (a) feeding more sources to the answer LLM by default (top_n 5->8, so the
+    /// answer in result #6-8 or behind a failed top-5 scrape still reaches it)
+    /// and (b) swapping the answer prompt's abstention rule for an anti-hedge
+    /// variant — commit when the sources DO contain the answer (even indirectly
+    /// / one inference step), abstain ONLY when they genuinely lack it. The
+    /// "use ONLY sources" grounding is untouched, so this is the precise inverse
+    /// of the cycle-1 blunt "always commit" failure (which forced commits on
+    /// no-source cases). Default false; A/B with an INCORRECT-guard before flip.
+    #[serde(default)]
+    pub answer_calibrated: bool,
 }
 
 impl Default for SearchConfig {
@@ -187,6 +198,7 @@ impl Default for SearchConfig {
             query_expand: false,
             passage_select: false,
             page2_fallback: false,
+            answer_calibrated: false,
         }
     }
 }

--- a/crates/crw-extract/src/answer.rs
+++ b/crates/crw-extract/src/answer.rs
@@ -41,6 +41,29 @@ Output: the answer text in your normal response, plus exactly one
 include inline `[N]` markers in the answer text — citations live only
 in the tool call."#;
 
+/// The baseline abstention rule (line in SYSTEM_PROMPT). Swapped for
+/// `CALIBRATED_CLAUSE` when the calibrated-answer flag is on.
+const HEDGE_CLAUSE: &str =
+    "- If the sources do not cover the query, say so plainly. Do not invent.";
+
+/// Calibrated abstention rule (gated). Converts recoverable OVER-abstentions:
+/// commit when the answer IS present (even indirectly / one inference step),
+/// abstain ONLY when the sources genuinely lack it. Keeps the "use ONLY
+/// sources" grounding (the moat) untouched, so this is the precise INVERSE of
+/// the cycle-1 blunt "always commit" failure (which forced commits on
+/// no-source cases and blew INCORRECT 2->17): here, no source still => abstain.
+const CALIBRATED_CLAUSE: &str = "- If the sources contain the answer — even stated indirectly, in different words, or requiring one obvious inference step (e.g. a year \"1933\" supports the decade \"the 1930s\") — give the direct answer confidently. Do NOT hedge, add disclaimers, or call the sources unclear when they in fact support an answer.\n- ONLY if the sources genuinely do not contain the information, say so plainly in one sentence. Never invent facts that are not in the sources.";
+
+/// Build the system prompt; `calibrated` swaps the abstention rule for the
+/// over-abstention-reducing variant (gated, default off).
+fn system_prompt(calibrated: bool) -> String {
+    if calibrated {
+        SYSTEM_PROMPT.replace(HEDGE_CLAUSE, CALIBRATED_CLAUSE)
+    } else {
+        SYSTEM_PROMPT.to_string()
+    }
+}
+
 pub struct AnswerResult {
     pub content: String,
     pub citations: Vec<Citation>,
@@ -81,6 +104,7 @@ pub async fn synthesize(
     cfg: &LlmConfig,
     max_chars_per_source: usize,
     user_prompt: Option<&str>,
+    calibrated: bool,
 ) -> CrwResult<AnswerResult> {
     if sources.is_empty() {
         return Err(CrwError::InvalidRequest(
@@ -113,8 +137,9 @@ pub async fn synthesize(
     // non-trivial; the current shape — model emits a `===CITATIONS===`
     // line followed by JSON — gives us structured output with a single
     // provider-agnostic call. Fabricated source_ids are rejected below.
+    let sys = system_prompt(calibrated);
     let mut augmented_prompt = format!(
-        "{SYSTEM_PROMPT}\n\nINSTEAD of calling a tool, append the citations after \
+        "{sys}\n\nINSTEAD of calling a tool, append the citations after \
          your answer in this exact format:\n\n===CITATIONS===\n[{{\"source_id\": 0, \
          \"position\": 0}}, ...]\n\nThe citations JSON must be a parseable JSON array \
          on the line after the marker. Only include source_ids you actually used."
@@ -269,6 +294,7 @@ pub async fn synthesize_selected(
     cfg: &LlmConfig,
     max_chars_per_source: usize,
     user_prompt: Option<&str>,
+    calibrated: bool,
 ) -> CrwResult<AnswerResult> {
     let reduce_futs = sources.iter().map(|(url, title, md)| async move {
         let new_md = if md.len() >= PASSAGE_SELECT_MIN_CHARS {
@@ -281,7 +307,15 @@ pub async fn synthesize_selected(
         (url.clone(), title.clone(), new_md)
     });
     let reduced: Vec<Source> = futures::future::join_all(reduce_futs).await;
-    synthesize(query, &reduced, cfg, max_chars_per_source, user_prompt).await
+    synthesize(
+        query,
+        &reduced,
+        cfg,
+        max_chars_per_source,
+        user_prompt,
+        calibrated,
+    )
+    .await
 }
 
 fn parse_answer_and_citations(

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -21,6 +21,10 @@ use std::sync::Arc;
 use tokio::task::JoinSet;
 
 const DEFAULT_ANSWER_TOP_N: u32 = 5;
+/// Default top-N for the calibrated answer path (feeds more sources so the
+/// answer in result #6-8, or behind a failed top-5 scrape, still reaches the
+/// model). Bounded by `MAX_ANSWER_TOP_N`.
+const CALIBRATED_ANSWER_TOP_N: u32 = 8;
 const MAX_ANSWER_TOP_N: u32 = 10;
 const DEFAULT_MAX_CHARS_PER_SOURCE: usize = 8192;
 
@@ -268,6 +272,7 @@ pub async fn search_inner(
                         &data,
                         &leg_cfg,
                         state.config.search.passage_select,
+                        state.config.search.answer_calibrated,
                     )
                     .await
                     {
@@ -501,6 +506,7 @@ async fn synthesize_answer(
     data: &SearchData,
     cfg: &LlmConfig,
     passage_select: bool,
+    calibrated: bool,
 ) -> Result<
     (
         String,
@@ -510,9 +516,18 @@ async fn synthesize_answer(
     ),
     String,
 > {
+    // Calibrated answer feeds more sources by default (Pattern A: the answer
+    // often sits in result #6-8, or a failed top-5 scrape thinned the pool) and
+    // uses the anti-hedge prompt clause. An explicit request `answer_top_n`
+    // still wins. Capped by MAX_ANSWER_TOP_N.
+    let default_top_n = if calibrated {
+        CALIBRATED_ANSWER_TOP_N
+    } else {
+        DEFAULT_ANSWER_TOP_N
+    };
     let top_n = req
         .answer_top_n
-        .unwrap_or(DEFAULT_ANSWER_TOP_N)
+        .unwrap_or(default_top_n)
         .min(MAX_ANSWER_TOP_N) as usize;
     let cap = req
         .max_chars_per_source
@@ -542,10 +557,25 @@ async fn synthesize_answer(
     // before synthesis (monotone-safe: falls back to the full source on any
     // failure). Gated; off = byte-identical to plain synthesize.
     let result = if passage_select {
-        answer::synthesize_selected(&req.query, &sources, cfg, cap, req.answer_prompt.as_deref())
-            .await
+        answer::synthesize_selected(
+            &req.query,
+            &sources,
+            cfg,
+            cap,
+            req.answer_prompt.as_deref(),
+            calibrated,
+        )
+        .await
     } else {
-        answer::synthesize(&req.query, &sources, cfg, cap, req.answer_prompt.as_deref()).await
+        answer::synthesize(
+            &req.query,
+            &sources,
+            cfg,
+            cap,
+            req.answer_prompt.as_deref(),
+            calibrated,
+        )
+        .await
     }
     .map_err(|e| e.to_string())?;
     Ok((


### PR DESCRIPTION
Diagnosis: 32/33 abstentions were OVER-abstentions (answer retrievable). Gated answer_calibrated = top_n 5→8 + anti-hedge SYSTEM_PROMPT clause (commit when sources DO cover, even indirectly; abstain only when genuinely absent; grounding untouched). A/B (n=152): overall 81.6→85.5% (+3.9), INCORRECT FLAT 12→12 (moat held — inverse of cycle-1), abstentions 16→10 all converting to correct. PopQA 92.3%, SimpleQA +9.2, TruthfulQA +11.3. Default-off; flip via CRW_SEARCH__ANSWER_CALIBRATED.