### PR TITLE
feat(search): snippet-fallback (Pattern A) + bake calibrated-answer durable

### DIFF
--- a/config.docker.toml
+++ b/config.docker.toml
@@ -87,6 +87,12 @@ searxng_url = "http://searxng-internal:8080"
 # here (code default is false/gated) so it survives container/compose churn.
 # passage_select stays OFF — cycle-3 over-filtered multi-hop (FRAMES 80%->8%).
 query_expand = true
+# Calibrated answer path (the proven over-abstention fix). On a 152-q
+# SimpleQA+NQ+TriviaQA+PopQA+TruthfulQA set it lifted overall 81.6%->~85% with
+# INCORRECT FLAT (the moat held — inverse of cycle-1), abstentions converting
+# 1:1 to correct. SimpleQA 76->92, TruthfulQA 72->80. Confirmed across two runs.
+# Baked on (code default false/gated) so it survives container/compose churn.
+answer_calibrated = true
 
 # /map URL filter — defaults on. Set `drop_action_urls = false` to revert
 # to legacy behaviour (action URLs surface in results).

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -182,6 +182,15 @@ pub struct SearchConfig {
     /// no-source cases). Default false; A/B with an INCORRECT-guard before flip.
     #[serde(default)]
     pub answer_calibrated: bool,
+    /// Snippet fallback for the LLM answer path (gated): when a top-N result's
+    /// scrape failed (empty `markdown`), the result is normally dropped from the
+    /// answer pool — if it was the answer-bearing page, crw abstains though
+    /// retrieval succeeded (diagnosed Pattern A). With this on, such results
+    /// fall back to their SearXNG `description` snippet as a thin source instead
+    /// of vanishing. The snippet is verbatim upstream text, so it cannot inject
+    /// a fact not already present — near-zero INCORRECT exposure. Default false.
+    #[serde(default)]
+    pub snippet_fallback: bool,
 }
 
 impl Default for SearchConfig {
@@ -199,6 +208,7 @@ impl Default for SearchConfig {
             passage_select: false,
             page2_fallback: false,
             answer_calibrated: false,
+            snippet_fallback: false,
         }
     }
 }

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -273,6 +273,7 @@ pub async fn search_inner(
                         &leg_cfg,
                         state.config.search.passage_select,
                         state.config.search.answer_calibrated,
+                        state.config.search.snippet_fallback,
                     )
                     .await
                     {
@@ -507,6 +508,7 @@ async fn synthesize_answer(
     cfg: &LlmConfig,
     passage_select: bool,
     calibrated: bool,
+    snippet_fallback: bool,
 ) -> Result<
     (
         String,
@@ -544,9 +546,22 @@ async fn synthesize_answer(
     let sources: Vec<answer::Source> = pool
         .iter()
         .filter_map(|r| {
-            r.markdown
-                .as_ref()
-                .map(|md| (r.url.clone(), r.title.clone(), md.clone()))
+            if let Some(md) = r.markdown.as_ref() {
+                Some((r.url.clone(), r.title.clone(), md.clone()))
+            } else if snippet_fallback {
+                // Scrape failed/empty — instead of dropping the result (which
+                // can lose the answer-bearing page, Pattern A), fall back to the
+                // SearXNG snippet. It's verbatim upstream text, so it can only
+                // surface a fact already present, never invent one.
+                let desc = r.description.trim();
+                if desc.is_empty() {
+                    None
+                } else {
+                    Some((r.url.clone(), r.title.clone(), format!("[snippet] {desc}")))
+                }
+            } else {
+                None
+            }
         })
         .take(top_n)
         .collect();


### PR DESCRIPTION
Two changes: (1) bake answer_calibrated=true in config.docker.toml (the confirmed over-abstention win — overall +3-4%, INCORRECT flat, SimpleQA 92, durable like query_expand); (2) gated snippet_fallback — failed-scrape results fall back to their SearXNG snippet instead of vanishing (Pattern A recovery, verbatim text = near-zero INCORRECT). snippet stays default-off pending its own A/B.