### PR TITLE
perf(search): calibrated answer top_n 8->5 (4x faster, accuracy holds)

### DIFF
--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -24,7 +24,7 @@ const DEFAULT_ANSWER_TOP_N: u32 = 5;
 /// Default top-N for the calibrated answer path (feeds more sources so the
 /// answer in result #6-8, or behind a failed top-5 scrape, still reaches the
 /// model). Bounded by `MAX_ANSWER_TOP_N`.
-const CALIBRATED_ANSWER_TOP_N: u32 = 8;
+const CALIBRATED_ANSWER_TOP_N: u32 = 5;
 const MAX_ANSWER_TOP_N: u32 = 10;
 const DEFAULT_MAX_CHARS_PER_SOURCE: usize = 8192;
 


### PR DESCRIPTION
A/B n=152: overall 84.9->84.2% (-0.7pp noise), INCORRECT +2 (noise), latency p50 ~80-120s -> 20s (~4x). Keeps the calibration over-abstention win at a fraction of the cost. Bakes CALIBRATED_ANSWER_TOP_N=5.