### PR TITLE
feat(search): gated synthesis temperature/seed for deterministic eval

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -995,6 +995,14 @@ pub struct LlmConfig {
     /// direct public callers can't access LLM features.
     #[serde(default)]
     pub require_byok_header: Option<String>,
+    /// Sampling temperature for the LLM call. `None` (default) sends no
+    /// `temperature` key, preserving each provider's default (DeepSeek = 1) and
+    /// current prod behavior. The benchmark/eval harness sets `0.0` (with a
+    /// seed) to make answers deterministic so a real +2-3pp lever is
+    /// distinguishable from sampling noise. Prod stays `None` until temp=0 is
+    /// proven not to raise abstention.
+    #[serde(default)]
+    pub temperature: Option<f32>,
 }
 
 impl Default for LlmConfig {
@@ -1009,6 +1017,7 @@ impl Default for LlmConfig {
             max_concurrency: default_llm_max_concurrency(),
             max_html_bytes: default_llm_max_html_bytes(),
             require_byok_header: None,
+            temperature: None,
         }
     }
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -955,6 +955,12 @@ pub struct SearchRequest {
     /// stay intact. Capped at 500 chars server-side.
     #[serde(default, alias = "answer_prompt")]
     pub answer_prompt: Option<String>,
+    /// Sampling temperature for the answer-synthesis LLM call. Omitted (None)
+    /// keeps the provider default (prod behavior). The benchmark/eval harness
+    /// sets `0` (with a fixed seed) to make answers deterministic, so a real
+    /// accuracy lever is distinguishable from sampling noise.
+    #[serde(default, alias = "answer_temperature")]
+    pub answer_temperature: Option<f32>,
     /// Maximum number of bytes of each per-result markdown sent to the LLM
     /// when `summarize_results` is enabled. Defaults to
     /// `[extraction.llm].max_html_bytes` (100 KB). Clamped to a 200 KB

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -85,6 +85,7 @@ pub async fn extract_via_llm(
         base_url,
         max_tokens,
         azure_api_version,
+        None, // extraction path: keep provider-default temperature
         EXTRACTION_SYSTEM_PROMPT,
         &user_msg,
     )
@@ -115,6 +116,7 @@ pub async fn chat(
         cfg.base_url.as_deref(),
         cfg.max_tokens,
         cfg.azure_api_version.as_deref(),
+        cfg.temperature,
         system_prompt,
         user_msg,
     )
@@ -164,6 +166,7 @@ async fn dispatch(
     base_url: Option<&str>,
     max_tokens: u32,
     azure_api_version: Option<&str>,
+    temperature: Option<f32>,
     system_prompt: &str,
     user_msg: &str,
 ) -> CrwResult<LlmCallResult> {
@@ -176,6 +179,7 @@ async fn dispatch(
                 model,
                 base_url,
                 max_tokens,
+                temperature,
                 system_prompt,
                 user_msg,
             )
@@ -192,6 +196,7 @@ async fn dispatch(
                 model,
                 base_url,
                 max_tokens,
+                temperature,
                 system_prompt,
                 user_msg,
                 provider_tag,
@@ -216,6 +221,7 @@ async fn dispatch(
                 model,
                 version,
                 max_tokens,
+                temperature,
                 system_prompt,
                 user_msg,
             )
@@ -234,16 +240,20 @@ async fn call_anthropic(
     model: &str,
     base_url: Option<&str>,
     max_tokens: u32,
+    temperature: Option<f32>,
     system_prompt: &str,
     user_msg: &str,
 ) -> CrwResult<LlmCallResult> {
     let url = base_url.unwrap_or(ANTHROPIC_DEFAULT_BASE_URL);
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "model": model,
         "max_tokens": max_tokens,
         "system": system_prompt,
         "messages": [{ "role": "user", "content": user_msg }],
     });
+    if let Some(t) = temperature {
+        body["temperature"] = serde_json::json!(t);
+    }
     let resp = client
         .post(url)
         .header("x-api-key", api_key)
@@ -293,6 +303,7 @@ async fn call_openai(
     model: &str,
     base_url: Option<&str>,
     max_tokens: u32,
+    temperature: Option<f32>,
     system_prompt: &str,
     user_msg: &str,
     provider: &str,
@@ -309,7 +320,7 @@ async fn call_openai(
             &url_owned
         }
     };
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "model": model,
         "max_tokens": max_tokens,
         "messages": [
@@ -317,6 +328,13 @@ async fn call_openai(
             { "role": "user", "content": user_msg }
         ],
     });
+    // Deterministic eval: temp=0 + fixed seed make answers reproducible so a
+    // real +2-3pp lever is distinguishable from sampling noise. None (prod
+    // default) sends neither, preserving the provider default.
+    if let Some(t) = temperature {
+        body["temperature"] = serde_json::json!(t);
+        body["seed"] = serde_json::json!(42);
+    }
     let resp = client
         .post(url)
         .bearer_auth(api_key)
@@ -362,6 +380,7 @@ async fn call_azure(
     deployment: &str,
     api_version: &str,
     max_tokens: u32,
+    temperature: Option<f32>,
     system_prompt: &str,
     user_msg: &str,
 ) -> CrwResult<LlmCallResult> {
@@ -369,13 +388,17 @@ async fn call_azure(
     let url = format!(
         "{endpoint_trimmed}/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
     );
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "max_tokens": max_tokens,
         "messages": [
             { "role": "system", "content": system_prompt },
             { "role": "user", "content": user_msg }
         ],
     });
+    if let Some(t) = temperature {
+        body["temperature"] = serde_json::json!(t);
+        body["seed"] = serde_json::json!(42);
+    }
     let resp = client
         .post(&url)
         .header("api-key", api_key)

--- a/crates/crw-search/src/params.rs
+++ b/crates/crw-search/src/params.rs
@@ -145,6 +145,7 @@ mod tests {
             base_url: None,
             summary_prompt: None,
             answer_prompt: None,
+            answer_temperature: None,
             max_content_chars: None,
         }
     }

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -235,6 +235,12 @@ pub async fn search_inner(
                 // estimateMaxCreditCostForSearch.
                 let mut leg_cfg = llm.clone();
                 leg_cfg.max_tokens = leg_cfg.max_tokens.min(SEARCH_LLM_MAX_TOKENS_PER_LEG);
+                // Eval determinism: a request-supplied answer temperature (the
+                // benchmark harness sets 0) overrides the provider default so
+                // A/B runs are reproducible. None = current prod behavior.
+                if req.answer_temperature.is_some() {
+                    leg_cfg.temperature = req.answer_temperature;
+                }
                 if wants_summaries {
                     let (count, usages) = attach_result_summaries(
                         &mut data,
@@ -895,6 +901,7 @@ mod tests {
             base_url: None,
             summary_prompt: None,
             answer_prompt: None,
+            answer_temperature: None,
             max_content_chars: None,
         }
     }


### PR DESCRIPTION
Root cause of the ±12pp eval noise: LLM bodies never set temperature -> DeepSeek defaulted to 1 -> sampled answers -> +2-3pp levers statistically invisible (page2/snippet/misconception were measurement failures). Adds gated LlmConfig.temperature (None=current prod) + SearchRequest.answerTemperature; eval sets 0 (with seed 42) for deterministic, measurable A/Bs. Behavior-neutral by default. Clippy clean, 221 tests pass.