### PR TITLE
feat(search): multi-variant query expansion for recall (gated)

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -153,6 +153,15 @@ pub struct SearchConfig {
     /// answer layer are untouched, so precision/SaaS-parity are preserved.
     #[serde(default)]
     pub query_expand: bool,
+    /// Number of LLM-generated query rewrites to fetch + union when
+    /// `query_expand` is on. `1` reproduces the original single-variant
+    /// behavior. Higher values request more DIVERSE reformulations
+    /// (abbreviation/acronym-expanded, keyword-focused) and fetch their pools
+    /// in parallel, raising recall on retrieval-miss queries (e.g. an
+    /// unexpanded acronym whose page never surfaced) at the cost of one extra
+    /// SearXNG fetch each. Clamped to `MAX_QUERY_EXPAND_VARIANTS` in the route.
+    #[serde(default = "default_query_expand_variants")]
+    pub query_expand_variants: usize,
     /// Passage-level relevance gate for the LLM answer path: split each scraped
     /// source into passages and feed the answer LLM only the query-relevant
     /// ones (DeepSeek-scored, no new ML deps). Subtractive — removes noise, never
@@ -205,6 +214,7 @@ impl Default for SearchConfig {
             github_engines: default_github_engines(),
             rerank_enabled: true,
             query_expand: false,
+            query_expand_variants: default_query_expand_variants(),
             passage_select: false,
             page2_fallback: false,
             answer_calibrated: false,
@@ -213,6 +223,9 @@ impl Default for SearchConfig {
     }
 }
 
+fn default_query_expand_variants() -> usize {
+    1
+}
 fn default_true_search() -> bool {
     true
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -961,6 +961,12 @@ pub struct SearchRequest {
     /// accuracy lever is distinguishable from sampling noise.
     #[serde(default, alias = "answer_temperature")]
     pub answer_temperature: Option<f32>,
+    /// Per-request override for `[search].query_expand_variants` — the number
+    /// of diverse query rewrites fetched + unioned when query expansion is on.
+    /// None uses the server config. The benchmark/eval harness sets this to A/B
+    /// recall (e.g. 1 vs 3) at a fixed answer temperature.
+    #[serde(default, alias = "query_expand_variants")]
+    pub query_expand_variants: Option<usize>,
     /// Maximum number of bytes of each per-result markdown sent to the LLM
     /// when `summarize_results` is enabled. Defaults to
     /// `[extraction.llm].max_html_bytes` (100 KB). Clamped to a 200 KB

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -129,30 +129,37 @@ pub async fn chat(
 /// increase. Returns an empty `Vec` on any failure or when the rewrite is
 /// trivial/identical — the caller then uses the original query alone, which
 /// means this can never reduce recall or break a search.
-pub async fn expand_query(cfg: &LlmConfig, query: &str) -> Vec<String> {
-    const SYS: &str = "You rewrite a user's search query into ONE alternative \
-        web-search query that maximizes the chance of finding the answer. Keep \
-        the key named entities; use precise keywords a relevant page would \
-        contain; drop filler words. Output ONLY the rewritten query on a single \
-        line — no quotes, no labels, no explanation.";
+pub async fn expand_query(cfg: &LlmConfig, query: &str, max_variants: usize) -> Vec<String> {
+    let n = max_variants.max(1);
+    let sys = format!(
+        "You rewrite a user's search query into up to {n} alternative \
+         web-search queries that maximize the chance of finding the answer. \
+         Rules: (1) EXPAND any abbreviation, acronym, or initialism to its full \
+         proper name. (2) Keep the key named entities; use precise keywords a \
+         relevant page would contain; drop filler words. (3) Make the \
+         alternatives DIVERSE — e.g. one focused on the full entity name, one on \
+         distinctive keywords. Output ONLY the rewritten queries, ONE per line: \
+         no quotes, no numbering, no labels. Output at most {n} line(s)."
+    );
     let mut leg = cfg.clone();
-    leg.max_tokens = leg.max_tokens.min(120);
-    match chat(&leg, SYS, query).await {
+    leg.max_tokens = leg.max_tokens.min(60 + 60 * n as u32);
+    match chat(&leg, &sys, query).await {
         Ok(r) => {
-            let v = r
-                .content
-                .trim()
-                .lines()
-                .next()
-                .unwrap_or("")
-                .trim()
-                .trim_matches('"')
-                .to_string();
-            if v.is_empty() || v.eq_ignore_ascii_case(query.trim()) {
-                Vec::new()
-            } else {
-                vec![v]
+            let mut out: Vec<String> = Vec::new();
+            for line in r.content.trim().lines() {
+                let v = line.trim().trim_matches('"').trim().to_string();
+                if v.is_empty() || v.eq_ignore_ascii_case(query.trim()) {
+                    continue;
+                }
+                if out.iter().any(|e| e.eq_ignore_ascii_case(&v)) {
+                    continue;
+                }
+                out.push(v);
+                if out.len() >= n {
+                    break;
+                }
             }
+            out
         }
         Err(_) => Vec::new(),
     }

--- a/crates/crw-search/src/params.rs
+++ b/crates/crw-search/src/params.rs
@@ -146,6 +146,7 @@ mod tests {
             summary_prompt: None,
             answer_prompt: None,
             answer_temperature: None,
+            query_expand_variants: None,
             max_content_chars: None,
         }
     }

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -26,6 +26,10 @@ const DEFAULT_ANSWER_TOP_N: u32 = 5;
 /// model). Bounded by `MAX_ANSWER_TOP_N`.
 const CALIBRATED_ANSWER_TOP_N: u32 = 5;
 const MAX_ANSWER_TOP_N: u32 = 10;
+/// Upper bound on query-expansion rewrites fetched + unioned per request, so a
+/// request-supplied `query_expand_variants` can't fan out unbounded SearXNG
+/// fetches. The extra pools are fetched concurrently in `fetch_expanded`.
+const MAX_QUERY_EXPAND_VARIANTS: usize = 5;
 const DEFAULT_MAX_CHARS_PER_SOURCE: usize = 8192;
 
 /// Wave 4 (R2): hard cap on `max_tokens` per LLM leg (one summary call OR
@@ -98,7 +102,13 @@ pub async fn search_inner(
         && llm_path
         && let Some(llm) = effective_llm
     {
-        fetch_expanded(&client, &req.query, &params, llm)
+        // Per-request override (eval A/B) wins over the server config; clamp so a
+        // hostile caller can't fan out unbounded SearXNG fetches.
+        let variants_n = req
+            .query_expand_variants
+            .unwrap_or(state.config.search.query_expand_variants)
+            .clamp(1, MAX_QUERY_EXPAND_VARIANTS);
+        fetch_expanded(&client, &req.query, &params, llm, variants_n)
             .await
             .map_err(|e| map_search_error(e, state.config.search.timeout_ms))?
     } else {
@@ -696,29 +706,40 @@ async fn fetch_expanded(
     query: &str,
     base_params: &SearxngParams,
     llm: &LlmConfig,
+    max_variants: usize,
 ) -> Result<SearxngResponse, SearchError> {
     let mut leg = llm.clone();
     leg.max_tokens = leg.max_tokens.min(SEARCH_LLM_MAX_TOKENS_PER_LEG);
-    let variants = crw_extract::llm::expand_query(&leg, query).await;
+    let variants = crw_extract::llm::expand_query(&leg, query, max_variants).await;
     let mut merged = client.fetch(base_params).await?;
     if variants.is_empty() {
         return Ok(merged);
     }
+    // Fetch all variant pools concurrently (bounded by the variant count) so N
+    // rewrites cost ~one extra fetch of wall-clock, not N sequential ones, then
+    // union by URL. A failed variant fetch is dropped (recall-only, never fatal).
+    let variant_responses: Vec<SearxngResponse> = stream::iter(variants)
+        .map(|v| {
+            let client = client.clone();
+            let mut vp = base_params.clone();
+            vp.q = v;
+            async move { client.fetch(&vp).await.ok() }
+        })
+        .buffer_unordered(max_variants.max(1))
+        .filter_map(|r| async move { r })
+        .collect()
+        .await;
     let mut seen: std::collections::HashSet<String> = merged
         .results
         .iter()
         .filter_map(|r| r.url.clone())
         .collect();
-    for v in variants {
-        let mut vp = base_params.clone();
-        vp.q = v;
-        if let Ok(r) = client.fetch(&vp).await {
-            for row in r.results {
-                if let Some(u) = row.url.clone()
-                    && seen.insert(u)
-                {
-                    merged.results.push(row);
-                }
+    for resp in variant_responses {
+        for row in resp.results {
+            if let Some(u) = row.url.clone()
+                && seen.insert(u)
+            {
+                merged.results.push(row);
             }
         }
     }
@@ -902,6 +923,7 @@ mod tests {
             summary_prompt: None,
             answer_prompt: None,
             answer_temperature: None,
+            query_expand_variants: None,
             max_content_chars: None,
         }
     }


### PR DESCRIPTION
Validated recall lever: a live diagnostic showed all 3 SimpleQA retrieval-misses become retrievable (pool pos 1-3) once the query is reformulated — chiefly expanding acronyms to full names (MKA->Atatürk). Generalizes expand_query to N diverse rewrites fetched concurrently + unioned. Gated: query_expand_variants config (default 1) + per-request queryExpandVariants (clamp 1..5). Recall-only, behind query_expand; answer/abstention untouched. fmt+clippy clean, suites pass.