### PR TITLE
feat(search): adaptive multi-round evidence-scout retrieval (gated)

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -162,6 +162,18 @@ pub struct SearchConfig {
     /// SearXNG fetch each. Clamped to `MAX_QUERY_EXPAND_VARIANTS` in the route.
     #[serde(default = "default_query_expand_variants")]
     pub query_expand_variants: usize,
+    /// Adaptive multi-round retrieval (the "evidence-scout" loop). When the
+    /// round-1 answer ABSTAINS (sources lacked the fact), an LLM scout reads the
+    /// round-1 evidence and emits targeted follow-up queries (acronym-expanded,
+    /// exact-entity, predicate/date-specific); their results are scraped, unioned
+    /// into the pool, and the answer is re-synthesized ONCE. Bounded (one extra
+    /// round, capped follow-up queries) so worst-case stays within the request
+    /// deadline. Only fires on abstention, so ~most queries keep the single-shot
+    /// fast path. Recall-only + monotone-safe: a still-abstaining round-2 is
+    /// discarded, keeping round-1. Targets "the answer page never entered the
+    /// first pool" — the dominant remaining miss. Defaults to `false` (gated).
+    #[serde(default)]
+    pub multi_round: bool,
     /// Passage-level relevance gate for the LLM answer path: split each scraped
     /// source into passages and feed the answer LLM only the query-relevant
     /// ones (DeepSeek-scored, no new ML deps). Subtractive — removes noise, never
@@ -215,6 +227,7 @@ impl Default for SearchConfig {
             rerank_enabled: true,
             query_expand: false,
             query_expand_variants: default_query_expand_variants(),
+            multi_round: false,
             passage_select: false,
             page2_fallback: false,
             answer_calibrated: false,

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -967,6 +967,11 @@ pub struct SearchRequest {
     /// recall (e.g. 1 vs 3) at a fixed answer temperature.
     #[serde(default, alias = "query_expand_variants")]
     pub query_expand_variants: Option<usize>,
+    /// Per-request override for `[search].multi_round` — the adaptive
+    /// evidence-scout round that fires when the round-1 answer abstains. None
+    /// uses the server config. The eval harness sets this to A/B the lever.
+    #[serde(default, alias = "multi_round")]
+    pub multi_round: Option<bool>,
     /// Maximum number of bytes of each per-result markdown sent to the LLM
     /// when `summarize_results` is enabled. Defaults to
     /// `[extraction.llm].max_html_bytes` (100 KB). Clamped to a 200 KB

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -165,6 +165,59 @@ pub async fn expand_query(cfg: &LlmConfig, query: &str, max_variants: usize) -> 
     }
 }
 
+/// Evidence-scout for adaptive multi-round retrieval. Given the question and a
+/// short excerpt of what round-1 retrieval surfaced (which did NOT answer it),
+/// produce up to `max_queries` TARGETED follow-up web-search queries to find or
+/// confirm the answer. Unlike `expand_query` (blind rephrasings), the scout is
+/// failure-aware: it leans on entity names/aliases seen in the evidence and
+/// goes harder — exact-phrase `"entity"`, full official names for any acronym,
+/// the specific predicate/date asked, or a likely authoritative source. Returns
+/// deduped queries (empty on LLM failure → caller simply skips the extra round).
+pub async fn scout_followups(
+    cfg: &LlmConfig,
+    query: &str,
+    evidence: &str,
+    max_queries: usize,
+) -> Vec<String> {
+    let n = max_queries.max(1);
+    let sys = format!(
+        "A first web search did NOT answer the user's question. You are a search \
+         strategist. Using the question and the EVIDENCE excerpt of what the first \
+         search found, write up to {n} NEW, BETTER web-search queries likely to \
+         surface or confirm the answer. Rules: (1) EXPAND every acronym/initialism \
+         to its full proper name. (2) Prefer the exact entity name(s) seen in the \
+         evidence, quoted, plus the specific thing asked (the predicate, the date, \
+         the number). (3) Try a different angle than the original phrasing — an \
+         exact-phrase query, an authoritative source guess, or the canonical \
+         entity. (4) Do NOT repeat the user's original wording. Output ONLY the \
+         queries, ONE per line: no quotes around the whole line, no numbering, no \
+         labels. Output at most {n} line(s)."
+    );
+    let user = format!("QUESTION: {query}\n\nEVIDENCE (did not answer it):\n{evidence}");
+    let mut leg = cfg.clone();
+    leg.max_tokens = leg.max_tokens.min(60 + 60 * n as u32);
+    match chat(&leg, &sys, &user).await {
+        Ok(r) => {
+            let mut out: Vec<String> = Vec::new();
+            for line in r.content.trim().lines() {
+                let v = line.trim().trim_matches('"').trim().to_string();
+                if v.is_empty() || v.eq_ignore_ascii_case(query.trim()) {
+                    continue;
+                }
+                if out.iter().any(|e| e.eq_ignore_ascii_case(&v)) {
+                    continue;
+                }
+                out.push(v);
+                if out.len() >= n {
+                    break;
+                }
+            }
+            out
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn dispatch(
     provider: &str,

--- a/crates/crw-search/src/params.rs
+++ b/crates/crw-search/src/params.rs
@@ -147,6 +147,7 @@ mod tests {
             answer_prompt: None,
             answer_temperature: None,
             query_expand_variants: None,
+            multi_round: None,
             max_content_chars: None,
         }
     }

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -30,6 +30,83 @@ const MAX_ANSWER_TOP_N: u32 = 10;
 /// request-supplied `query_expand_variants` can't fan out unbounded SearXNG
 /// fetches. The extra pools are fetched concurrently in `fetch_expanded`.
 const MAX_QUERY_EXPAND_VARIANTS: usize = 5;
+/// Adaptive multi-round: max follow-up queries the evidence-scout issues in the
+/// extra round, and how many results each contributes to the scrape pool.
+/// Bounded so the single extra round stays well within the request deadline.
+const MAX_SCOUT_QUERIES: usize = 2;
+const SCOUT_FETCH_LIMIT: u32 = 6;
+
+/// Heuristic: did the synthesized answer ABSTAIN (sources lacked the fact)?
+/// Aligned with `answer.rs`'s calibrated clause ("ONLY if the sources genuinely
+/// do not contain the information, say so plainly"). Triggers the adaptive
+/// multi-round scout. Conservative — only well-known abstention phrasings.
+fn is_abstention(answer: &str) -> bool {
+    let a = answer.to_lowercase();
+    const MARKERS: &[&str] = &[
+        "do not contain",
+        "does not contain",
+        "doesn't contain",
+        "cannot answer",
+        "can't answer",
+        "cannot determine",
+        "could not find",
+        "couldn't find",
+        "no information",
+        "do not provide",
+        "does not provide",
+        "not mentioned in",
+        "not specified",
+        "unable to answer",
+        "cannot be answered",
+        "sources do not",
+        "i cannot",
+    ];
+    MARKERS.iter().any(|m| a.contains(m))
+}
+
+/// Build a short evidence excerpt from the current candidate pool to brief the
+/// evidence-scout (title + a markdown/snippet head per source, bounded).
+fn evidence_excerpt(data: &SearchData, max_sources: usize, per_chars: usize) -> String {
+    let pool: &Vec<SearchResult> = match data {
+        SearchData::Flat(v) => v,
+        SearchData::Grouped(g) => match g.web.as_ref() {
+            Some(v) => v,
+            None => return String::new(),
+        },
+    };
+    let mut out = String::new();
+    for r in pool.iter().take(max_sources) {
+        let body = r.markdown.as_deref().unwrap_or(r.description.as_str());
+        let snip: String = body.chars().take(per_chars).collect();
+        out.push_str("- ");
+        out.push_str(&r.title);
+        out.push_str(" :: ");
+        out.push_str(snip.trim());
+        out.push('\n');
+    }
+    out
+}
+
+/// Merge freshly-scraped scout rows into the flat answer pool (dedup by URL,
+/// only rows that actually carry markdown). Returns true if any were added.
+/// Grouped data (the explicit-`sources` path) is left untouched — multi-round
+/// targets the flat answer path. Recall-only: never removes existing sources.
+fn merge_scraped(data: &mut SearchData, rows: Vec<SearchResult>) -> bool {
+    if let SearchData::Flat(pool) = data {
+        let mut seen: std::collections::HashSet<String> =
+            pool.iter().map(|r| r.url.clone()).collect();
+        let mut added = false;
+        for r in rows {
+            if r.markdown.is_some() && seen.insert(r.url.clone()) {
+                pool.push(r);
+                added = true;
+            }
+        }
+        added
+    } else {
+        false
+    }
+}
 const DEFAULT_MAX_CHARS_PER_SOURCE: usize = 8192;
 
 /// Wave 4 (R2): hard cap on `max_tokens` per LLM leg (one summary call OR
@@ -293,7 +370,7 @@ pub async fn search_inner(
                     )
                     .await
                     {
-                        Ok((ans, cites, ans_usage, mut ans_warns)) => {
+                        Ok((mut ans, mut cites, ans_usage, mut ans_warns)) => {
                             warnings.append(&mut ans_warns);
                             agg_answer_executed = true;
                             if let Some(ref u) = ans_usage {
@@ -308,6 +385,74 @@ pub async fn search_inner(
                                     &mut agg_truncated,
                                     u,
                                 );
+                            }
+                            // Adaptive multi-round (gated): if round-1 ABSTAINED,
+                            // the evidence-scout issues targeted follow-ups; we
+                            // scrape them, union into the pool, and re-synthesize
+                            // ONCE. Recall-only — a still-abstaining round-2 is
+                            // discarded (keep round-1). Only fires on abstention,
+                            // so the single-shot fast path is unchanged for hits.
+                            let want_multi =
+                                req.multi_round.unwrap_or(state.config.search.multi_round);
+                            if want_multi
+                                && is_abstention(&ans)
+                                && let Some(opts) = req.scrape_options.as_ref()
+                            {
+                                let evidence = evidence_excerpt(&data, 5, 400);
+                                let scout_qs = crw_extract::llm::scout_followups(
+                                    &leg_cfg,
+                                    &req.query,
+                                    &evidence,
+                                    MAX_SCOUT_QUERIES,
+                                )
+                                .await;
+                                let mut grew = false;
+                                for sq in scout_qs {
+                                    let mut sp = params.clone();
+                                    sp.q = sq;
+                                    if let Ok(resp2) = client.fetch(&sp).await {
+                                        let extra = transform_flat_reranked(
+                                            &resp2,
+                                            &req.query,
+                                            SCOUT_FETCH_LIMIT,
+                                        );
+                                        let mut sd = SearchData::Flat(extra);
+                                        let _ = enrich_with_scrape(&mut sd, opts, state).await;
+                                        if let SearchData::Flat(rows) = sd {
+                                            grew |= merge_scraped(&mut data, rows);
+                                        }
+                                    }
+                                }
+                                if grew
+                                    && let Ok((ans2, cites2, usage2, mut warns2)) =
+                                        synthesize_answer(
+                                            &req,
+                                            &data,
+                                            &leg_cfg,
+                                            state.config.search.passage_select,
+                                            state.config.search.answer_calibrated,
+                                            state.config.search.snippet_fallback,
+                                        )
+                                        .await
+                                    && !is_abstention(&ans2)
+                                {
+                                    ans = ans2;
+                                    cites = cites2;
+                                    warnings.append(&mut warns2);
+                                    if let Some(ref u) = usage2 {
+                                        merge_usage(
+                                            &mut agg_input_tokens,
+                                            &mut agg_output_tokens,
+                                            &mut agg_cache_hit,
+                                            &mut agg_cache_miss,
+                                            &mut agg_calls,
+                                            &mut agg_provider,
+                                            &mut agg_model,
+                                            &mut agg_truncated,
+                                            u,
+                                        );
+                                    }
+                                }
                             }
                             let aggregated = build_aggregated_usage(
                                 agg_input_tokens,
@@ -924,6 +1069,7 @@ mod tests {
             answer_prompt: None,
             answer_temperature: None,
             query_expand_variants: None,
+            multi_round: None,
             max_content_chars: None,
         }
     }


### PR DESCRIPTION
Reverse-engineering Tavily/Exa/Perplexity (+codex) found their SimpleQA edge is mostly TECHNIQUE not index, and crw's handicap is being SINGLE-SHOT. Adds a bounded adaptive multi-round loop: on round-1 abstention, an LLM evidence-scout issues targeted follow-ups -> fetch/rerank/scrape -> union -> re-synthesize ONCE; still-abstain round-2 discarded (recall-only, monotone). Gated SearchConfig.multi_round (default off) + per-request multiRound; fires only on abstention so hits keep the single-shot fast path. fmt+clippy clean, suites pass.