### PR TITLE
feat(search): pin SearXNG infoboxes/answers as structured sources (W0)

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -153,6 +153,11 @@ enabled = true
 timeout_ms = 15000
 default_limit = 5
 max_limit = 20
+# W0 (gated, default false): pin SearXNG infoboxes[]/answers[] (Wikidata/Wikipedia
+# structured facts the results[] path discards) at the front of the answer pool.
+# Still UNTRUSTED-wrapped. Flip with CRW_SEARCH__USE_STRUCTURED_SOURCES=true after
+# the diag500 re-baseline. See crates/crw-search/src/structured.rs.
+# use_structured_sources = false
 # Engines invoked when the request includes `categories: ["research"]`.
 research_engines = ["arxiv", "crossref", "google scholar", "semantic scholar"]
 # Engines invoked when the request includes `categories: ["github"]`.

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -214,6 +214,16 @@ pub struct SearchConfig {
     /// hallucination DOWN with SimpleQA accuracy NOT regressed before flip.
     #[serde(default)]
     pub answer_guarded: bool,
+    /// Use SearXNG structured sources (gated, W0). SearXNG's `infoboxes[]` /
+    /// `answers[]` arrays carry Wikidata/Wikipedia knowledge-panel facts
+    /// (entity attributes like religion/capital/director) that the `results[]`
+    /// transform path discards. With this on, those facts are parsed and pinned
+    /// as a high-trust source at the FRONT of the answer pool (still
+    /// UNTRUSTED-wrapped — widens evidence, never bypasses the safety wrapper).
+    /// Targets the obscure-entity recall gap (PopQA). Default false; A/B on
+    /// diag500 gold-in-sources with the wrong-non-abstain invariant before flip.
+    #[serde(default)]
+    pub use_structured_sources: bool,
     /// Snippet fallback for the LLM answer path (gated): when a top-N result's
     /// scrape failed (empty `markdown`), the result is normally dropped from the
     /// answer pool — if it was the answer-bearing page, crw abstains though
@@ -243,6 +253,7 @@ impl Default for SearchConfig {
             page2_fallback: false,
             answer_calibrated: false,
             answer_guarded: false,
+            use_structured_sources: false,
             snippet_fallback: false,
         }
     }

--- a/crates/crw-search/src/lib.rs
+++ b/crates/crw-search/src/lib.rs
@@ -14,9 +14,11 @@
 pub mod client;
 pub mod params;
 pub mod rerank;
+pub mod structured;
 pub mod transform;
 
 pub use client::{SearchError, SearxngClient, SearxngResponse, SearxngResult};
 pub use params::{SearxngParams, clean_query, map_to_searxng_params};
 pub use rerank::rerank;
+pub use structured::{StructuredFact, structured_facts};
 pub use transform::{transform_flat, transform_flat_reranked, transform_grouped};

--- a/crates/crw-search/src/structured.rs
+++ b/crates/crw-search/src/structured.rs
@@ -1,0 +1,179 @@
+//! Structured facts from SearXNG's `infoboxes[]` / `answers[]` arrays.
+//!
+//! SearXNG's `format=json` envelope returns five arrays; the Wikidata/Wikipedia
+//! engines emit their knowledge-panel data (entity attributes like
+//! `religion → X`, `capital → Y`) into `infoboxes[]` / `answers[]`, NOT into
+//! `results[]`. The normal transform path reads only `results[]`, so these
+//! already-retrieved structured facts were silently discarded (W0). This module
+//! parses them so the answer path can pin them as a high-trust source. They are
+//! still UNTRUSTED-wrapped by the synthesizer — this only widens the evidence,
+//! it does not bypass the safety wrapper.
+
+use crate::client::SearxngResponse;
+use serde_json::Value;
+
+/// A structured fact extracted from an infobox or a direct answer. `attributes`
+/// are the infobox key/value rows (e.g. `("religion", "Sunni Islam")`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructuredFact {
+    pub title: String,
+    pub url: String,
+    pub content: String,
+    pub attributes: Vec<(String, String)>,
+    /// Always true — marks this as a pinned structured source so a later
+    /// rerank-bypass (W1) can key off the flag, not the domain.
+    pub is_structured_source: bool,
+}
+
+impl StructuredFact {
+    /// Compact markdown body for the answer-path source (title is carried
+    /// separately in the `Source` tuple).
+    pub fn to_markdown(&self) -> String {
+        let mut s = String::new();
+        if !self.content.is_empty() {
+            s.push_str(&self.content);
+            s.push('\n');
+        }
+        for (k, v) in &self.attributes {
+            s.push_str("- ");
+            s.push_str(k);
+            s.push_str(": ");
+            s.push_str(v);
+            s.push('\n');
+        }
+        s.trim_end().to_string()
+    }
+}
+
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .map(|x| x.trim().to_string())
+        .filter(|x| !x.is_empty())
+}
+
+/// Parse `infoboxes[]` + `answers[]` into structured facts. Defensive: every
+/// field is optional, malformed/empty entries are skipped (degrade to nothing).
+pub fn structured_facts(resp: &SearxngResponse) -> Vec<StructuredFact> {
+    let mut out = Vec::new();
+
+    for ib in &resp.infoboxes {
+        let title = str_field(ib, "infobox").unwrap_or_default();
+        let url = str_field(ib, "id").unwrap_or_default();
+        let content = str_field(ib, "content").unwrap_or_default();
+        let mut attributes = Vec::new();
+        if let Some(arr) = ib.get("attributes").and_then(|x| x.as_array()) {
+            for a in arr {
+                if let (Some(label), Some(value)) = (str_field(a, "label"), str_field(a, "value")) {
+                    attributes.push((label, value));
+                }
+            }
+        }
+        // Nothing useful to feed the synthesizer.
+        if content.is_empty() && attributes.is_empty() {
+            continue;
+        }
+        out.push(StructuredFact {
+            title: if title.is_empty() {
+                "Structured fact".to_string()
+            } else {
+                title
+            },
+            url,
+            content,
+            attributes,
+            is_structured_source: true,
+        });
+    }
+
+    // `answers[]` entries are either a bare string or `{answer, url}`.
+    for ans in &resp.answers {
+        let (content, url) = match ans {
+            Value::String(t) => (t.trim().to_string(), String::new()),
+            Value::Object(_) => (
+                str_field(ans, "answer").unwrap_or_default(),
+                str_field(ans, "url").unwrap_or_default(),
+            ),
+            _ => continue,
+        };
+        if content.is_empty() {
+            continue;
+        }
+        out.push(StructuredFact {
+            title: "Direct answer".to_string(),
+            url,
+            content,
+            attributes: Vec::new(),
+            is_structured_source: true,
+        });
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn resp_with(infoboxes: Vec<Value>, answers: Vec<Value>) -> SearxngResponse {
+        SearxngResponse {
+            infoboxes,
+            answers,
+            ..SearxngResponse::default()
+        }
+    }
+
+    #[test]
+    fn parses_infobox_attributes() {
+        let r = resp_with(
+            vec![json!({
+                "infobox": "Abdullah of Pahang",
+                "id": "https://en.wikipedia.org/wiki/Abdullah_of_Pahang",
+                "content": "Sultan of Pahang",
+                "attributes": [
+                    {"label": "Religion", "value": "Sunni Islam"},
+                    {"label": "Born", "value": "1959"}
+                ]
+            })],
+            vec![],
+        );
+        let facts = structured_facts(&r);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].title, "Abdullah of Pahang");
+        assert!(facts[0].is_structured_source);
+        assert_eq!(facts[0].attributes.len(), 2);
+        let md = facts[0].to_markdown();
+        assert!(md.contains("Religion: Sunni Islam"));
+        assert!(md.contains("Sultan of Pahang"));
+    }
+
+    #[test]
+    fn parses_string_and_object_answers() {
+        let r = resp_with(
+            vec![],
+            vec![
+                json!("42 is the answer"),
+                json!({"answer": "Tokyo", "url": "https://x"}),
+            ],
+        );
+        let facts = structured_facts(&r);
+        assert_eq!(facts.len(), 2);
+        assert_eq!(facts[0].content, "42 is the answer");
+        assert_eq!(facts[1].content, "Tokyo");
+        assert_eq!(facts[1].url, "https://x");
+    }
+
+    #[test]
+    fn skips_empty_and_malformed() {
+        let r = resp_with(
+            vec![
+                json!({"infobox": "Empty"}),
+                json!({"attributes": []}),
+                json!(123),
+            ],
+            vec![json!(""), json!({"no_answer": "x"}), json!(true)],
+        );
+        assert_eq!(structured_facts(&r).len(), 0);
+    }
+}

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -209,6 +209,21 @@ pub async fn search_inner(
         SearchData::Flat(transform_flat(&response, limit))
     };
 
+    // W0: parse SearXNG's infoboxes[]/answers[] (Wikidata/Wikipedia structured
+    // facts the results[] transform discards) into pinned answer sources. Gated
+    // default-off; empty when the flag is off or no structured data was returned.
+    let structured_sources: Vec<answer::Source> = if state.config.search.use_structured_sources {
+        crw_search::structured_facts(&response)
+            .into_iter()
+            .map(|f| {
+                let md = f.to_markdown();
+                (f.url, f.title, md)
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     // Page-2 fallback (gated, default-off): when the reranked clean pool came
     // back thinner than the answer needs (junk filter stripped a sparse first
     // page), fetch the SAME query's page 2 ONCE, union it in (dedup by URL like
@@ -368,6 +383,7 @@ pub async fn search_inner(
                         state.config.search.answer_calibrated,
                         state.config.search.snippet_fallback,
                         state.config.search.answer_guarded,
+                        &structured_sources,
                     )
                     .await
                     {
@@ -434,6 +450,7 @@ pub async fn search_inner(
                                             state.config.search.answer_calibrated,
                                             state.config.search.snippet_fallback,
                                             state.config.search.answer_guarded,
+                                            &structured_sources,
                                         )
                                         .await
                                     && !is_abstention(&ans2)
@@ -665,6 +682,7 @@ async fn attach_result_summaries(
     (count, usages)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn synthesize_answer(
     req: &SearchRequest,
     data: &SearchData,
@@ -673,6 +691,8 @@ async fn synthesize_answer(
     calibrated: bool,
     snippet_fallback: bool,
     guarded: bool,
+    // W0: structured facts (infoboxes/answers) to PIN at the front of the pool.
+    structured: &[answer::Source],
 ) -> Result<
     (
         String,
@@ -707,7 +727,7 @@ async fn synthesize_answer(
             None => return Err("no web results to synthesize from".into()),
         },
     };
-    let sources: Vec<answer::Source> = pool
+    let scraped: Vec<answer::Source> = pool
         .iter()
         .filter_map(|r| {
             if let Some(md) = r.markdown.as_ref() {
@@ -729,6 +749,14 @@ async fn synthesize_answer(
         })
         .take(top_n)
         .collect();
+    // W0: PIN structured facts (Wikidata/Wikipedia infobox/answers) at the front
+    // so the synthesizer sees them first. They are still UNTRUSTED-wrapped by
+    // `answer::synthesize` — this widens evidence, it does not bypass safety.
+    let sources: Vec<answer::Source> = if structured.is_empty() {
+        scraped
+    } else {
+        structured.iter().cloned().chain(scraped).collect()
+    };
     if sources.is_empty() {
         return Err("no results carry markdown to synthesize an answer from".into());
     }


### PR DESCRIPTION
SearXNG returns Wikidata/Wikipedia structured entity facts in infoboxes[]/answers[], NOT results[] — both transform paths discarded them (root cause of PopQA ~8% recall + the gold-in-sources metric undercount). New crw-search::structured_facts() parses them; behind gated search.use_structured_sources (default off), pinned at the front of the answer pool, still UNTRUSTED-wrapped. First build of the no-AI search-recall plan. parser 3/3 + crw-core/crw-search tests pass, clippy+fmt clean. A/B = diag500 gold-in-sources re-baseline (proxy-up + proxy-down) + wrong-non-abstain invariant.