### PR TITLE
feat(mcp): emit structuredContent for crw_search; bump protocol to 2025-06-18

### DIFF
--- a/COMPATIBILITY-firecrawl.md
+++ b/COMPATIBILITY-firecrawl.md
@@ -103,6 +103,8 @@ This is a **capability matrix**, not an API-shape compatibility matrix (which th
 
 **Surface match:** both products ship MCP. Tool names differ (Firecrawl uses `firecrawl_*`, fastCRW uses `crw_*`); semantic mapping is straightforward.
 
+**Structured output:** `crw_search` additionally emits MCP-2025-06-18 `structuredContent` shaped to fastCRW's own `/v1/search` envelope (`data.results`), **not** Firecrawl's `data.web` shape — it mirrors the body fastCRW clients already consume, so this is not a Firecrawl-shape parity claim. The legacy text content block is retained for lenient clients.
+
 ---
 
 ## 8. Anti-bot / Fire-engine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
 name = "crw-mcp-proto"
 version = "0.11.0"
 dependencies = [
+ "jsonschema",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -949,6 +950,7 @@ dependencies = [
  "crw-server",
  "futures",
  "hex",
+ "jsonschema",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/crates/crw-cli/src/commands/mcp.rs
+++ b/crates/crw-cli/src/commands/mcp.rs
@@ -84,7 +84,7 @@ impl Backend {
                 let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
                 let result = self.call_tool(tool_name, arguments).await;
-                Some(tool_result_response(id, result))
+                Some(tool_result_response(id, tool_name, result))
             }
 
             _ => {

--- a/crates/crw-mcp-proto/Cargo.toml
+++ b/crates/crw-mcp-proto/Cargo.toml
@@ -13,3 +13,8 @@ description = "MCP JSON-RPC 2.0 protocol types (shared by crw-server, crw-mcp, c
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+# Validates that emitted `structuredContent` conforms to the declared
+# `outputSchema` (issue #89). Pinned to the same 0.28 line crw-extract uses.
+jsonschema = "0.28"

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -5,7 +5,16 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-pub const PROTOCOL_VERSION: &str = "2024-11-05";
+/// MCP spec revision advertised in the `initialize` handshake (lib.rs `initialize`
+/// arm). Bumped from "2024-11-05" to "2025-06-18" to legitimize tool `outputSchema`
+/// and result `structuredContent`, both introduced in the 2025-06-18 revision.
+/// There is no per-feature capability flag for structured output, so advertising
+/// the revision that defines it is the only spec-legal way to emit it.
+///
+/// NOTE: `crw-browse` is a separate rmcp-based MCP server that pins its own
+/// `ProtocolVersion::V_2024_11_05` (crw-browse/src/server.rs) and does NOT consume
+/// this constant — it intentionally stays on 2024-11-05.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
 
 // --- JSON-RPC types ---
 
@@ -193,7 +202,7 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
     let _ = proxy_mode;
     tools.push(json!({
         "name": "crw_search",
-        "description": "Search the web and return relevant results with titles, URLs, and descriptions/snippets. Backed by a SearXNG sidecar in embedded mode (no API key needed), or by the configured remote API in proxy mode (uses CRW_API_KEY).\n\nReturn shape: `{ \"success\": true, \"data\": [{ \"url\", \"title\", \"description\", \"snippet\", \"position\", \"score\" }, ...] }`. The `snippet` field is an alias of `description` — both carry the same body text so downstream LLM pipelines that ask for either get a match.\n\nExample: `crw_search(query=\"renewable energy trends 2024\", limit=3)` returns the top 3 web results with title/url/snippet.",
+        "description": "Search the web and return relevant results with titles, URLs, and descriptions/snippets. Backed by a SearXNG sidecar in embedded mode (no API key needed), or by the configured remote API in proxy mode (uses CRW_API_KEY).\n\nReturn shape: `{ \"success\": true, \"data\": { \"results\": [{ \"url\", \"title\", \"description\", \"snippet\", \"position\", \"score\" }, ...] } }`. When `sources` is set, `data.results` is instead an object grouped by source (`{ \"web\": [...], \"news\": [...], \"images\": [...] }`). The `snippet` field is an alias of `description` — both carry the same body text so downstream LLM pipelines that ask for either get a match.\n\nExample: `crw_search(query=\"renewable energy trends 2024\", limit=3)` returns the top 3 web results with title/url/snippet.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -245,32 +254,86 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
             },
             "required": ["query"]
         },
+        // Mirrors the real `SearchResponse = ApiResponse<SearchResponseData>`
+        // serializer in crw-core/src/types.rs. The Ok branch of
+        // `tool_result_response` is the only path that emits `structuredContent`,
+        // and `ApiResponse::ok` always sets `data: Some(..)` — so `data` is
+        // required and the error/error_code/warning siblings are never present
+        // on the validated value (they only appear on the err() path, which
+        // returns Err(String) and never reaches structuredContent).
+        //
+        // `data.results` is `#[serde(untagged)] enum SearchData` → a flat array
+        // (no `sources`) OR a grouped object (`web`/`news`/`images`). Hence the
+        // `oneOf`. Grouped `images` deserialize to `ImageResult` (carries
+        // `imageUrl`, NO `snippet`), so they are deliberately left unconstrained —
+        // constraining them with the text-result shape would falsely reject every
+        // real grouped-image response. No `additionalProperties: false` anywhere:
+        // SearchResult conditionally emits markdown/html/links/metadata/etc.
         "outputSchema": {
             "type": "object",
+            "$defs": {
+                "searchResultItem": {
+                    "type": "object",
+                    "properties": {
+                        "url": { "type": "string" },
+                        "title": { "type": "string" },
+                        "description": { "type": "string", "description": "Body snippet for the result. `snippet` is an alias of this field." },
+                        "snippet": { "type": "string", "description": "Alias of `description`. Always populated." },
+                        "position": { "type": "integer" },
+                        "score": { "type": "number" },
+                        "category": { "type": "string" }
+                    },
+                    "required": ["url", "title", "description", "snippet", "position"]
+                }
+            },
             "properties": {
                 "success": { "type": "boolean" },
                 "data": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "url": { "type": "string" },
-                            "title": { "type": "string" },
-                            "description": { "type": "string", "description": "Body snippet for the result. `snippet` is an alias of this field." },
-                            "snippet": { "type": "string", "description": "Alias of `description`. Always populated." },
-                            "position": { "type": "integer" },
-                            "score": { "type": "number" },
-                            "category": { "type": "string" }
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "oneOf": [
+                                { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "web": { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
+                                        "news": { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
+                                        "images": { "type": "array" }
+                                    }
+                                }
+                            ]
                         },
-                        "required": ["url", "title", "description", "snippet", "position"]
-                    }
-                }
+                        "answer": { "type": "string" },
+                        "citations": { "type": "array" },
+                        "llmUsage": { "type": "object" },
+                        "warnings": { "type": "array", "items": { "type": "string" } }
+                    },
+                    "required": ["results"]
+                },
+                "error": { "type": "string" },
+                "error_code": { "type": "string" },
+                "warning": { "type": "string" }
             },
             "required": ["success", "data"]
         }
     }));
 
     json!({ "tools": tools })
+}
+
+/// Returns the declared `outputSchema` for a tool, if it declares one.
+///
+/// Single source of truth: `structuredContent` emission is derived from the
+/// same `tool_definitions` declaration that `tools/list` advertises, so the two
+/// can never drift. Recomputes `tool_definitions` per call — `tools/call` is not
+/// hot; memoize behind a `OnceLock` only if profiling ever demands it.
+pub fn tool_output_schema(tool_name: &str) -> Option<Value> {
+    tool_definitions(false)["tools"]
+        .as_array()?
+        .iter()
+        .find(|t| t["name"] == tool_name)
+        .and_then(|t| t.get("outputSchema").cloned())
 }
 
 /// Result of handling a protocol method.
@@ -332,17 +395,41 @@ pub fn handle_protocol_method(
 }
 
 /// Wrap a tool call result into an MCP-compliant content response.
-pub fn tool_result_response(id: Value, result: Result<Value, String>) -> JsonRpcResponse {
+///
+/// On success the structured `value` is emitted **both** as a text content block
+/// (verbatim, for backward compatibility with lenient clients and clients that
+/// negotiated an older protocol revision) **and**, when the called tool declares
+/// an `outputSchema`, as a top-level `structuredContent` field (MCP 2025-06-18)
+/// so strict clients can validate it. Both representations derive from the same
+/// `value` binding, so `serde_json::from_str(content[0].text) == structuredContent`
+/// holds by construction — the two can never disagree.
+pub fn tool_result_response(
+    id: Value,
+    tool_name: &str,
+    result: Result<Value, String>,
+) -> JsonRpcResponse {
     match result {
         Ok(value) => {
             let text = serde_json::to_string_pretty(&value).unwrap_or_default();
-            JsonRpcResponse::success(
-                id,
-                json!({
-                    "content": [{"type": "text", "text": text}]
-                }),
-            )
+            let mut payload = json!({
+                "content": [{"type": "text", "text": text}]
+            });
+            // Attach structuredContent only when (a) the tool declares an
+            // outputSchema and (b) the value is a JSON object — the spec requires
+            // structuredContent to be an object. The `is_object()` guard is the
+            // proxy version-skew safety valve: in proxy mode a schema-bearing tool
+            // may yield a non-object Ok value (an upstream error string, a plain
+            // string, or a legacy top-level array) — degrade to text-only rather
+            // than ship a spec-violating structuredContent to a strict client.
+            // Locked by test T2b. Do NOT remove the is_object() guard.
+            if value.is_object() && tool_output_schema(tool_name).is_some() {
+                payload["structuredContent"] = value;
+            }
+            JsonRpcResponse::success(id, payload)
         }
+        // Err path: never attach structuredContent. `isError:true` signals
+        // failure, and strict clients must not validate outputSchema against an
+        // error result.
         Err(e) => JsonRpcResponse::success(
             id,
             json!({
@@ -474,5 +561,183 @@ mod tests {
                 "{name}: additionalProperties:false must remain off until schemas are complete"
             );
         }
+    }
+
+    // --- structuredContent emission (issue #89) ---
+
+    /// A single text-result item with every always-emitted field set, plus the
+    /// optional `score`/`category`. `snippet` mirrors `description`, matching the
+    /// real `SearchResult` serializer (snippet is an alias of description).
+    fn search_result_item(idx: u32) -> Value {
+        json!({
+            "url": format!("https://example.com/{idx}"),
+            "title": format!("Result {idx}"),
+            "description": "body text",
+            "snippet": "body text",
+            "position": idx,
+            "score": 4.0,
+            "category": "general"
+        })
+    }
+
+    /// A representative flat (`sources` unset) crw_search success value, shaped
+    /// like `ApiResponse::ok(SearchResponseData { results: Flat(..), .. })`.
+    fn representative_search_value() -> Value {
+        json!({
+            "success": true,
+            "data": { "results": [search_result_item(1), search_result_item(2)] }
+        })
+    }
+
+    /// A representative grouped (`sources` set) value: `results` is an object with
+    /// `web`/`news` (text items) and `images` (the differently-shaped ImageResult).
+    fn grouped_search_value() -> Value {
+        json!({
+            "success": true,
+            "data": { "results": {
+                "web": [search_result_item(1)],
+                "news": [search_result_item(2)],
+                "images": [{
+                    "url": "https://example.com/img",
+                    "title": "An image",
+                    "description": "alt text",
+                    "imageUrl": "https://example.com/img.png",
+                    "position": 1
+                }]
+            }}
+        })
+    }
+
+    fn result_of(resp: &JsonRpcResponse) -> &Value {
+        resp.result.as_ref().expect("success response has result")
+    }
+
+    /// T1 — crw_search Ok emits BOTH a text block and structuredContent, and the
+    /// two are byte-for-byte the same value (single-source invariant).
+    #[test]
+    fn t1_search_emits_dual_content_in_sync() {
+        let repr = representative_search_value();
+        let resp = tool_result_response(json!(1), "crw_search", Ok(repr.clone()));
+        let result = result_of(&resp);
+
+        let text = result["content"][0]["text"]
+            .as_str()
+            .expect("text content present");
+        assert_eq!(
+            result["content"][0]["type"], "text",
+            "first content block is text"
+        );
+
+        let structured = &result["structuredContent"];
+        assert!(!structured.is_null(), "structuredContent present");
+        assert_eq!(
+            structured, &repr,
+            "structuredContent is the unmodified value"
+        );
+
+        let from_text: Value = serde_json::from_str(text).expect("text is valid JSON");
+        assert_eq!(
+            &from_text, structured,
+            "from_str(content.text) == structuredContent (no drift)"
+        );
+    }
+
+    /// T2 — a tool WITHOUT an outputSchema (crw_scrape) gets text only, no
+    /// structuredContent (schema-gated emission).
+    #[test]
+    fn t2_scrape_has_no_structured_content() {
+        let resp = tool_result_response(json!(1), "crw_scrape", Ok(json!({"markdown": "hi"})));
+        let result = result_of(&resp);
+        assert!(result["content"][0]["text"].is_string());
+        assert!(
+            result.get("structuredContent").is_none(),
+            "crw_scrape declares no outputSchema → no structuredContent"
+        );
+    }
+
+    /// T2b — proxy version-skew safety valve: a schema-bearing tool whose Ok
+    /// value is NOT an object (upstream error string, or a legacy top-level
+    /// array) degrades to text-only. Locks the is_object() guard.
+    #[test]
+    fn t2b_non_object_search_value_degrades_to_text() {
+        for non_object in [json!("upstream error string"), json!([{ "url": "x" }])] {
+            let resp = tool_result_response(json!(1), "crw_search", Ok(non_object.clone()));
+            let result = result_of(&resp);
+            assert!(
+                result["content"][0]["text"].is_string(),
+                "text block carries the body"
+            );
+            assert!(
+                result.get("structuredContent").is_none(),
+                "non-object Ok value must NOT emit structuredContent: {non_object}"
+            );
+        }
+    }
+
+    /// T3 — the Err path is an isError text result with no structuredContent.
+    #[test]
+    fn t3_error_path_has_no_structured_content() {
+        let resp = tool_result_response(json!(1), "crw_search", Err("boom".into()));
+        let result = result_of(&resp);
+        assert_eq!(result["isError"], true);
+        assert_eq!(result["content"][0]["text"], "boom");
+        assert!(result.get("structuredContent").is_none());
+    }
+
+    /// T4 — emitted structuredContent validates against the declared outputSchema
+    /// for both the flat and the grouped value (using the same builders the
+    /// real serializer would feed).
+    #[test]
+    fn t4_emitted_structured_content_validates_against_schema() {
+        let schema = tool_output_schema("crw_search").expect("crw_search has outputSchema");
+        let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+
+        for value in [representative_search_value(), grouped_search_value()] {
+            let resp = tool_result_response(json!(1), "crw_search", Ok(value.clone()));
+            let structured = result_of(&resp)["structuredContent"].clone();
+            let errors: Vec<String> = validator
+                .iter_errors(&structured)
+                .map(|e| e.to_string())
+                .collect();
+            assert!(
+                errors.is_empty(),
+                "structuredContent failed schema validation for {value}:\n{}",
+                errors.join("\n")
+            );
+        }
+    }
+
+    /// T5 — the helper is the single source of truth: present for crw_search,
+    /// absent for crw_scrape, with the expected required-field structure.
+    #[test]
+    fn t5_tool_output_schema_helper() {
+        let schema = tool_output_schema("crw_search").expect("crw_search has outputSchema");
+        assert_eq!(schema["type"], "object");
+        let required = schema["required"].as_array().expect("required array");
+        assert_eq!(required, &vec![json!("success"), json!("data")]);
+        assert_eq!(schema["properties"]["data"]["type"], "object");
+        let data_required = schema["properties"]["data"]["required"]
+            .as_array()
+            .expect("data.required array");
+        assert!(data_required.iter().any(|v| v == "results"));
+
+        assert!(
+            tool_output_schema("crw_scrape").is_none(),
+            "crw_scrape declares no outputSchema"
+        );
+    }
+
+    /// T6 — the additionalProperties:false guard is scoped to inputSchema only;
+    /// the new outputSchema must not set it (the conditional SearchResult fields
+    /// would make it falsely reject real responses).
+    #[test]
+    fn t6_output_schema_does_not_set_additional_properties_false() {
+        let defs = tool_definitions(false);
+        let search = tool_by_name(&defs, "crw_search");
+        let ap = search["outputSchema"].get("additionalProperties");
+        assert!(
+            ap.is_none() || ap.and_then(|v| v.as_bool()) != Some(false),
+            "crw_search outputSchema must not set additionalProperties:false"
+        );
     }
 }

--- a/crates/crw-mcp/src/main.rs
+++ b/crates/crw-mcp/src/main.rs
@@ -112,7 +112,7 @@ impl Backend {
                 let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
                 let result = self.call_tool(tool_name, arguments).await;
-                Some(tool_result_response(id, result))
+                Some(tool_result_response(id, tool_name, result))
             }
 
             _ => {

--- a/crates/crw-server/Cargo.toml
+++ b/crates/crw-server/Cargo.toml
@@ -50,3 +50,6 @@ wiremock = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 crw-server = { path = ".", features = ["test-utils"] }
+# Validates emitted structuredContent against crw_search's declared outputSchema
+# using the REAL SearchResponse serializer (issue #89). Same 0.28 line as crw-extract.
+jsonschema = "0.28"

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -133,7 +133,7 @@ pub async fn handle_request(state: &AppState, req: JsonRpcRequest) -> Option<Jso
             let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
             let result = call_tool(state, tool_name, arguments).await;
-            Some(tool_result_response(id, result))
+            Some(tool_result_response(id, tool_name, result))
         }
 
         _ => {
@@ -174,6 +174,15 @@ pub async fn mcp_handler(
             .unwrap(),
         );
     }
+
+    // MCP 2025-06-18 requires clients to send `MCP-Protocol-Version` on every
+    // post-initialize request. We TOLERATE it: read for observability, never
+    // reject on presence, absence, or mismatch. Hard validation is deferred
+    // until client adoption is confirmed. Do NOT add a reject branch here
+    // without updating the header-tolerance test in tests/mcp.rs.
+    let _client_protocol = headers
+        .get("mcp-protocol-version")
+        .and_then(|v| v.to_str().ok());
 
     let req: JsonRpcRequest = match serde_json::from_str(&body) {
         Ok(r) => r,

--- a/crates/crw-server/tests/mcp.rs
+++ b/crates/crw-server/tests/mcp.rs
@@ -1,8 +1,13 @@
+use axum::http::{HeaderName, HeaderValue};
 use axum_test::TestServer;
 use crw_core::config::AppConfig;
+use crw_core::mcp::{tool_output_schema, tool_result_response};
+use crw_core::types::{
+    ApiResponse, GroupedSearchData, ImageResult, SearchData, SearchResponseData, SearchResult,
+};
 use crw_server::app::create_app;
 use crw_server::state::AppState;
-use serde_json::json;
+use serde_json::{Value, json};
 
 fn test_app() -> TestServer {
     let config: AppConfig = toml::from_str("").unwrap();
@@ -37,7 +42,9 @@ async fn mcp_initialize_returns_capabilities() {
     assert_eq!(json["jsonrpc"], "2.0");
     assert_eq!(json["id"], 1);
     let result = &json["result"];
-    assert!(result["protocolVersion"].is_string());
+    // T7 — protocol version is bumped to the revision that defines
+    // structuredContent/outputSchema (issue #89).
+    assert_eq!(result["protocolVersion"], "2025-06-18");
     assert!(result["capabilities"].is_object());
     assert!(result["serverInfo"]["name"].is_string());
     assert!(result["serverInfo"]["version"].is_string());
@@ -256,4 +263,193 @@ async fn mcp_missing_method_field() {
     let json: serde_json::Value = resp.json();
     // Should be a parse error since "method" is required in JsonRpcRequest
     assert_eq!(json["error"]["code"], -32700);
+}
+
+// --- structuredContent / outputSchema (issue #89) ---
+
+/// T8 — tools/list advertises crw_search with the corrected nested-shape
+/// outputSchema (data is an object whose `results` is required), not the old
+/// flat-array shape.
+#[tokio::test]
+async fn mcp_t8_search_advertises_nested_output_schema() {
+    let server = test_app();
+    let resp = server
+        .post("/mcp")
+        .content_type("application/json")
+        .json(&mcp_request("tools/list", json!(8), json!({})))
+        .await;
+    resp.assert_status_ok();
+    let json: serde_json::Value = resp.json();
+    let tools = json["result"]["tools"].as_array().unwrap();
+    let search = tools
+        .iter()
+        .find(|t| t["name"] == "crw_search")
+        .expect("crw_search tool");
+    let schema = &search["outputSchema"];
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["properties"]["data"]["type"], "object");
+    let data_required = schema["properties"]["data"]["required"]
+        .as_array()
+        .expect("data.required");
+    assert!(data_required.iter().any(|v| v == "results"));
+}
+
+/// T9 — tools/call crw_search with no SearXNG configured returns a tool error
+/// (search disabled), surfaced as isError text with no structuredContent.
+#[tokio::test]
+async fn mcp_t9_search_disabled_is_tool_error() {
+    let server = test_app();
+    let resp = server
+        .post("/mcp")
+        .content_type("application/json")
+        .json(&mcp_request(
+            "tools/call",
+            json!(9),
+            json!({"name": "crw_search", "arguments": {"query": "anything"}}),
+        ))
+        .await;
+    resp.assert_status_ok();
+    let json: serde_json::Value = resp.json();
+    let result = &json["result"];
+    assert_eq!(result["isError"], true);
+    assert!(result["content"][0]["text"].is_string());
+    assert!(result.get("structuredContent").is_none());
+}
+
+/// T10 — the MCP-Protocol-Version header is tolerated: present-correct,
+/// present-mismatched, malformed, and absent all succeed (no reject branch).
+#[tokio::test]
+async fn mcp_t10_protocol_version_header_tolerated() {
+    let server = test_app();
+    let name = HeaderName::from_static("mcp-protocol-version");
+    for header in [
+        Some("2025-06-18"),
+        Some("2024-11-05"),
+        Some("not-a-version"),
+        None,
+    ] {
+        let mut req = server.post("/mcp").content_type("application/json");
+        if let Some(v) = header {
+            req = req.add_header(name.clone(), HeaderValue::from_static(v));
+        }
+        let resp = req.json(&mcp_request("ping", json!(10), json!({}))).await;
+        resp.assert_status_ok();
+        let json: serde_json::Value = resp.json();
+        assert_eq!(
+            json["result"],
+            json!({}),
+            "ping must succeed regardless of MCP-Protocol-Version header = {header:?}"
+        );
+    }
+}
+
+// --- T12: real-serializer gate ---
+
+fn real_search_result(idx: u32) -> SearchResult {
+    SearchResult {
+        url: format!("https://example.com/{idx}"),
+        title: format!("Result {idx}"),
+        description: "body text".into(),
+        snippet: "body text".into(),
+        position: idx,
+        score: Some(4.0),
+        published_date: None,
+        category: Some("general".into()),
+        markdown: None,
+        html: None,
+        raw_html: None,
+        links: None,
+        metadata: None,
+        summary: None,
+    }
+}
+
+fn real_image_result(idx: u32) -> ImageResult {
+    ImageResult {
+        url: format!("https://example.com/img/{idx}"),
+        title: format!("Image {idx}"),
+        description: "alt text".into(),
+        image_url: format!("https://example.com/img/{idx}.png"),
+        position: idx,
+        thumbnail_url: None,
+        image_format: None,
+        resolution: None,
+    }
+}
+
+fn envelope(results: SearchData) -> SearchResponseData {
+    SearchResponseData {
+        results,
+        answer: None,
+        citations: Vec::new(),
+        llm_usage: None,
+        warnings: Vec::new(),
+    }
+}
+
+/// Emit `value` through the real MCP wrapper and return the structuredContent it
+/// produced (mirrors what the server sends on the wire).
+fn structured_content_for(value: Value) -> Value {
+    let resp = tool_result_response(json!(1), "crw_search", Ok(value));
+    resp.result
+        .expect("success response")
+        .get("structuredContent")
+        .cloned()
+        .expect("crw_search emits structuredContent for an object value")
+}
+
+/// T12 — validate the REAL `SearchResponse` serializer output (untagged enum,
+/// camelCase, every skip_serializing_if) against the declared outputSchema, on
+/// every branch: flat populated, flat empty, grouped, grouped empty. This is
+/// the gate that the original #89 schema-vs-reality drift would have failed.
+#[tokio::test]
+async fn mcp_t12_real_serializer_validates_against_output_schema() {
+    let schema = tool_output_schema("crw_search").expect("crw_search outputSchema");
+    let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+
+    let cases: Vec<(&str, SearchData)> = vec![
+        (
+            "A: flat populated",
+            SearchData::Flat(vec![real_search_result(1), real_search_result(2)]),
+        ),
+        ("B: flat empty", SearchData::Flat(vec![])),
+        (
+            "C: grouped web+news+images",
+            SearchData::Grouped(GroupedSearchData {
+                web: Some(vec![real_search_result(1)]),
+                news: Some(vec![real_search_result(2)]),
+                images: Some(vec![real_image_result(1)]),
+            }),
+        ),
+        (
+            "D: grouped empty",
+            SearchData::Grouped(GroupedSearchData::default()),
+        ),
+    ];
+
+    for (label, results) in cases {
+        let is_empty_grouped = matches!(&results, SearchData::Grouped(g) if g.web.is_none() && g.news.is_none() && g.images.is_none());
+        let response = ApiResponse::ok(envelope(results));
+        let value = serde_json::to_value(&response).expect("serialize SearchResponse");
+
+        // Sanity on case D: an empty grouped envelope serializes results to `{}`.
+        if is_empty_grouped {
+            assert_eq!(
+                value["data"]["results"],
+                json!({}),
+                "empty grouped results must serialize to an empty object"
+            );
+        }
+
+        let structured = structured_content_for(value.clone());
+        let errors: Vec<String> = validator
+            .iter_errors(&structured)
+            .map(|e| e.to_string())
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "[{label}] real serializer output failed schema validation:\n{}\nvalue: {value}",
+            errors.join("\n")
+        );
+    }
 }

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -282,7 +282,7 @@ Use [MCP Client Setup](#mcp-clients) for:
 ## Verify Installation
 
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"},"protocolVersion":"2024-11-05"}}' \
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"},"protocolVersion":"2025-06-18"}}' \
   | crw-mcp 2>/dev/null
 ```
 
@@ -293,7 +293,7 @@ Expected:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-06-18",
     "capabilities": {"tools": {}},
     "serverInfo": {"name": "crw-mcp", "version": "<current>"}
   }
@@ -322,7 +322,9 @@ AI Assistant → HTTP POST (JSON-RPC 2.0) → crw-server /mcp → Web pages
 
 In embedded mode, the scraping engine runs in-process with zero overhead. In proxy mode, tool calls are forwarded over HTTP. The HTTP transport calls `crw-server` functions directly.
 
-Protocol version: `2024-11-05`
+Protocol version: `2025-06-18`
+
+The `crw_search` tool declares an `outputSchema` and therefore returns its result both as the usual text content block and as a spec-compliant `structuredContent` object (MCP 2025-06-18) shaped like `{ success, data: { results: [...] } }` — strict clients can validate it directly, while lenient clients keep reading the text block unchanged.
 
 ## Operational Notes
 

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -728,7 +728,7 @@ codex mcp add crw -- npx crw-mcp
 <li>local embedded and fastcrw.com cloud config variants side by side</li>
 </ul>
 <h2>Verify Installation</h2>
-<pre><code class="language-bash">echo &#39;{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:1,&quot;method&quot;:&quot;initialize&quot;,&quot;params&quot;:{&quot;clientInfo&quot;:{&quot;name&quot;:&quot;test&quot;},&quot;protocolVersion&quot;:&quot;2024-11-05&quot;}}&#39; \
+<pre><code class="language-bash">echo &#39;{&quot;jsonrpc&quot;:&quot;2.0&quot;,&quot;id&quot;:1,&quot;method&quot;:&quot;initialize&quot;,&quot;params&quot;:{&quot;clientInfo&quot;:{&quot;name&quot;:&quot;test&quot;},&quot;protocolVersion&quot;:&quot;2025-06-18&quot;}}&#39; \
   | crw-mcp 2&gt;/dev/null
 </code></pre>
 <p>Expected:</p>
@@ -736,7 +736,7 @@ codex mcp add crw -- npx crw-mcp
   &quot;jsonrpc&quot;: &quot;2.0&quot;,
   &quot;id&quot;: 1,
   &quot;result&quot;: {
-    &quot;protocolVersion&quot;: &quot;2024-11-05&quot;,
+    &quot;protocolVersion&quot;: &quot;2025-06-18&quot;,
     &quot;capabilities&quot;: {&quot;tools&quot;: {}},
     &quot;serverInfo&quot;: {&quot;name&quot;: &quot;crw-mcp&quot;, &quot;version&quot;: &quot;&lt;current&gt;&quot;}
   }
@@ -753,7 +753,8 @@ codex mcp add crw -- npx crw-mcp
 <pre><code>AI Assistant → HTTP POST (JSON-RPC 2.0) → crw-server /mcp → Web pages
 </code></pre>
 <p>In embedded mode, the scraping engine runs in-process with zero overhead. In proxy mode, tool calls are forwarded over HTTP. The HTTP transport calls <code>crw-server</code> functions directly.</p>
-<p>Protocol version: <code>2024-11-05</code></p>
+<p>Protocol version: <code>2025-06-18</code></p>
+<p>The <code>crw_search</code> tool declares an <code>outputSchema</code> and returns its result both as the usual text content block and as a spec-compliant <code>structuredContent</code> object (MCP 2025-06-18) shaped like <code>{ success, data: { results: [...] } }</code> — strict clients can validate it directly, while lenient clients keep reading the text block unchanged.</p>
 <h2>Operational Notes</h2>
 <ul>
 <li>Keep MCP tool descriptions tight so the agent knows when to use <code>map</code> versus <code>scrape</code>.</li>

--- a/plans/issue-89-mcp-output-schema.md
+++ b/plans/issue-89-mcp-output-schema.md
@@ -1,0 +1,213 @@
+# Issue #89 — crw MCP outputSchema mismatch: implementation plan
+
+## Problem
+
+The crw MCP server declares an `outputSchema` for exactly one tool (`crw_search`, `crates/crw-mcp-proto/src/lib.rs:248-273`) but the shared choke point `tool_result_response` (`lib.rs:334-355`) wraps *every* tool result into a plain text content block (`content:[{type:"text", text:"<json>"}]`) and never emits `structuredContent`. Strict MCP clients (Hermes-class) that validate `result.structuredContent` against the declared `outputSchema` find nothing to validate and reject `crw_search`. There are two independent defects: (1) `structuredContent` is never emitted, and (2) the declared schema is **factually wrong** — it claims `data` is a flat array, but `call_tool`'s `crw_search` branch serializes `SearchResponse = ApiResponse<SearchResponseData>` (`crw-core/src/types.rs:1156`), which produces `{ success, data: { results: <array | {web,news,images}>, answer?, citations?, llmUsage?, warnings? } }`, where `data.results` is an untagged enum (`types.rs:1112-1117`) that is an array when `sources` is unset and an object when set. Fixing either defect alone leaves the bug live.
+
+## Decision summary
+
+- **Option B, done strictly.** Emit real `structuredContent` *and* rewrite the schema to match crw's actual `/v1/search` serializer. Both are required; neither suffices alone.
+- **Bump `PROTOCOL_VERSION` from `"2024-11-05"` to `"2025-06-18"`** (`lib.rs:8`). `outputSchema`/`structuredContent` for tools were introduced in MCP revision 2025-06-18 (PR #371); there is no per-feature capability flag (crw declares `capabilities.tools:{}`). The only spec-legal way to emit them is to advertise the revision that defines them. Emitting them under `2024-11-05` is the rejected worst-of-both-worlds half-measure.
+- **Single source of truth.** Add `tool_output_schema(tool_name) -> Option<Value>` derived from `tool_definitions`, and gate emission on it — no hardcoded `"crw_search"` literal, so a future tool that declares a schema lights up automatically.
+- **Tolerate, never reject** the new mandatory `MCP-Protocol-Version` HTTP header (PR #548). Read for observability; do not reject on presence/absence/mismatch. JSON-RPC batching (removed in 2025-06-18) was never implemented — verified no-op.
+- **Scope is surgical: `crw_search` only.** crw-browse is a separate rmcp-SDK server that pins its own protocol version (`crw-browse/src/server.rs:378`), does **not** consume `crw-mcp-proto::PROTOCOL_VERSION` (verified: 0 matches), and stays on 2024-11-05.
+
+## Changes
+
+### 1. `crates/crw-mcp-proto/src/lib.rs:8` — bump protocol version
+```rust
+/// MCP spec revision. Bumped to 2025-06-18 (from 2024-11-05) to legitimize
+/// tool `outputSchema` + result `structuredContent`, introduced in that
+/// revision (PR #371). Propagates to the `initialize` handshake at lib.rs:310.
+/// NOTE: crw-browse is a separate rmcp-based MCP server pinning its own
+/// ProtocolVersion (crw-browse/src/server.rs:378); it does NOT consume this
+/// constant and intentionally stays on 2024-11-05.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+```
+
+### 2. `crates/crw-mcp-proto/src/lib.rs:252-274` — rewrite the `crw_search` `outputSchema` to the real nested shape
+Replace the flat-array block with the envelope the server actually serializes. `data.results` uses `oneOf(array, grouped-object)`. **No `additionalProperties:false` anywhere** (`SearchResult` conditionally emits `publishedDate/markdown/html/rawHtml/links/metadata/summary`; the envelope carries `answer/citations/llmUsage/warnings/error/errorCode/warning`). Text-result items (flat `results`, grouped `web`, grouped `news`) all `$ref` a single `searchResultItem` `$def`; grouped `images` are **deliberately left unconstrained** (they are `ImageResult` — `imageUrl`, no `snippet`).
+
+```jsonc
+"outputSchema": {
+  "type": "object",
+  "$defs": {
+    "searchResultItem": {
+      "type": "object",
+      "properties": {
+        "url": {"type":"string"}, "title": {"type":"string"},
+        "description": {"type":"string"}, "snippet": {"type":"string"},
+        "position": {"type":"integer"}, "score": {"type":"number"},
+        "category": {"type":"string"}
+      },
+      "required": ["url","title","description","snippet","position"]
+    }
+  },
+  "properties": {
+    "success": { "type": "boolean" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "results": {
+          "oneOf": [
+            { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
+            { "type": "object",
+              "properties": {
+                "web":  { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
+                "news": { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
+                // IMAGES ARE A DIFFERENT SHAPE — DO NOT $ref searchResultItem.
+                // Grouped images deserialize to crw_core::types::ImageResult
+                // (types.rs:1082): { url, title, description, imageUrl, position,
+                // thumbnailUrl?, imageFormat?, resolution? } — NO `snippet`,
+                // carries `imageUrl`. $ref-ing searchResultItem would FALSELY
+                // reject every real grouped image (required `snippet` absent).
+                "images": { "type": "array" }
+              }
+              // No `required`: GroupedSearchData fields are all
+              // Option + skip_serializing_if (types.rs:1100-1105), so an empty
+              // grouped response serializes to `{}` and MUST validate.
+            }
+          ]
+        },
+        "answer":   { "type": "string" },
+        "citations":{ "type": "array" },
+        "llmUsage": { "type": "object" },
+        "warnings": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["results"]
+    },
+    "error":     { "type": "string" },
+    "errorCode": { "type": "string" },
+    "warning":   { "type": "string" }
+  },
+  "required": ["success", "data"]
+}
+```
+Required item fields are exactly those `SearchResult` guarantees (verified `types.rs:1046-1055`): `url/title/description/position` are non-`Option`; `snippet` is `#[serde(default)]` so always serialized. `score`/`category` are `Option + skip_serializing_if` → stay **optional**. `data` is required because `ApiResponse::ok` always sets `data: Some(..)` (`types.rs:522-526`), and the Ok branch of `tool_result_response` is only reached for successful calls (errors return `Err(String)` and never serialize `data`).
+> **`$ref` fallback:** if the dev-side `jsonschema` validator (change 10) cannot resolve local `$ref`, inline the identical `searchResultItem` object at the flat-array and `web`/`news` sites (NOT at `images`). The contract — same 5-field required list for text results everywhere, images unconstrained — is what matters; `$defs` is just the DRY mechanism.
+
+### 3. `crates/crw-mcp-proto/src/lib.rs:196` — fix the description prose
+Change the inline `Return shape: { "success": true, "data": [{...}] }` to the real nested shape `{ "success": true, "data": { "results": [{ "url","title","description","snippet","position","score" }, ...] } }`. Keep the existing `snippet`-is-an-alias note.
+
+### 4. `crates/crw-mcp-proto/src/lib.rs` — add single-source-of-truth helper
+Insert after `tool_definitions` (before `handle_protocol_request`):
+```rust
+/// Returns the declared `outputSchema` for a tool, if any. Single source of
+/// truth: structuredContent emission is derived from the declaration, so the
+/// two cannot drift. Recomputes tool_definitions per call (tools/call is not
+/// hot); memoize behind OnceLock only if profiling ever demands it.
+pub fn tool_output_schema(tool_name: &str) -> Option<Value> {
+    tool_definitions(false)["tools"]
+        .as_array()?
+        .iter()
+        .find(|t| t["name"] == tool_name)
+        .and_then(|t| t.get("outputSchema").cloned())
+}
+```
+
+### 5. `crates/crw-mcp-proto/src/lib.rs:334-355` — make `tool_result_response` schema-aware (dual-emit)
+New signature (arity change — compiler enforces all three call sites):
+```rust
+pub fn tool_result_response(id: Value, tool_name: &str, result: Result<Value, String>) -> JsonRpcResponse
+```
+- **Ok branch (single-source invariant):** build the structured `value` once. Serialize that *same* binding into the text block (`content:[{type:"text", text: to_string_pretty(&value)}]`) **and**, iff `tool_output_schema(tool_name).is_some() && value.is_object()`, attach top-level `"structuredContent": value.clone()`. Both representations derive from one binding, so `from_str(content[0].text) == structuredContent` holds by construction. The text block is unconditional (backward compat); `structuredContent` is additive.
+  - **The `&& value.is_object()` guard is load-bearing — DO NOT DROP.** Spec requires `structuredContent` to be a JSON object. In proxy mode a tool that declares a schema may yield a non-object Ok value (upstream HTML error string, plain string, or legacy top-level flat array); the guard degrades gracefully to text-only instead of shipping `structuredContent: "<html>"` to a strict client. Locked by test T2b. Add the comment: *"Proxy version-skew safety valve — locked by T2b. Do NOT remove the is_object() guard."*
+- **Err branch:** unchanged — `{content:[{text}], isError:true}`, **no** `structuredContent`. `isError` signals failure; strict clients must not validate `outputSchema` against error results. Keeps existing error tests green.
+
+### 6-8. Update all three call sites (arity change is compiler-enforced)
+- `crates/crw-server/src/routes/mcp.rs:136`: `Some(tool_result_response(id, tool_name, result))` (`tool_name` bound at 128).
+- `crates/crw-mcp/src/main.rs:115`: `Some(tool_result_response(id, tool_name, result))` (`tool_name` bound at 107). Covers embedded **and** proxy backends.
+- `crates/crw-cli/src/commands/mcp.rs:87`: `Some(tool_result_response(id, tool_name, result))` (`tool_name` bound at 79). **The site the issue summary missed.**
+
+### 9. `crates/crw-server/src/routes/mcp.rs` `mcp_handler` (155-) — tolerate the `MCP-Protocol-Version` header
+`headers: HeaderMap` is already a parameter (`mcp.rs:157`). After the existing content-type check (161-), add:
+```rust
+// MCP 2025-06-18 (PR #548) requires clients to send MCP-Protocol-Version on
+// every post-initialize request. We TOLERATE it: read for observability, never
+// reject on presence, absence, or mismatch. Hard validation deferred until
+// client adoption is confirmed. Do NOT add a reject branch without updating T10.
+let _client_protocol = headers
+    .get("mcp-protocol-version")
+    .and_then(|v| v.to_str().ok());
+```
+Leave the content-type validation untouched.
+
+### 10. Add `jsonschema` dev-dependency to two crates
+- `crates/crw-mcp-proto/Cargo.toml` `[dev-dependencies]` — for T4 (hand-built fixture, fast crate-local guard).
+- `crates/crw-server/Cargo.toml:46` `[dev-dependencies]` — for T12 (real-serializer validation). crw-server already depends on `crw-core` (`Cargo.toml:22`), which re-exports `crw-mcp-proto` via `crw_core::mcp::*`, so T12 reaches both the real `SearchResponse` type and `tool_output_schema`/`tool_result_response` from one crate.
+
+### 11. Sync docs + generated mirror (the bump turns published docs into a lie)
+- `docs/docs/mcp.md:285` (client proposal in Verify-Installation request): `2024-11-05` → `2025-06-18`.
+- `docs/docs/mcp.md:296` (expected `protocolVersion`): `2024-11-05` → `2025-06-18`.
+- `docs/docs/mcp.md:325` (`Protocol version:`): `2024-11-05` → `2025-06-18`.
+- `docs/docs/mcp.md` crw_search section: add one line that crw_search now emits MCP-2025-06-18 `structuredContent` mirroring `{ success, data: { results: [...] } }`, alongside the legacy text block.
+- `docs/mcp/index.html:731, 739, 756` (generated mirror): update the three `2024-11-05` literals; regenerate if docs build from source.
+
+### 12. `COMPATIBILITY-firecrawl.md` §7 — one-line note
+crw_search now additionally emits MCP-2025-06-18 `structuredContent` shaped to crw's own `/v1/search` envelope (`data.results`), explicitly **not** Firecrawl's `data.web` shape.
+
+## Test matrix
+
+All emission paths funnel through the single `tool_result_response` choke point, so the unit tests in `crw-mcp-proto` cover all three dispatch paths by construction; the arity change makes any bypassing call site a compile error.
+
+| ID | File | Assertion |
+|---|---|---|
+| **T1** | `crw-mcp-proto/src/lib.rs` `#[cfg(test)]` | `tool_result_response(id, "crw_search", Ok(repr))`: `content[0].text` present; `structuredContent` present; **`from_str(content[0].text) == structuredContent`** (single-source invariant); `structuredContent == repr` (not mutated). |
+| **T2** | same | `tool_name="crw_scrape"`, `Ok(obj)`: `content[0].text` present, `structuredContent` **absent** (schema-gate). |
+| **T2b** | same | Proxy-skew valve: `Ok(json!("upstream error string"))` and `Ok(json!([{"url":"x"}]))` through `"crw_search"` → text block carries the body, `structuredContent` **absent**. Locks the `is_object()` guard against refactor. |
+| **T3** | same | `Err("boom")`: `isError:true`, `content[0].text=="boom"`, no `structuredContent`. |
+| **T4** | same | jsonschema (hand-built): validate emitted `structuredContent` for flat `repr` **and** a grouped value (`web`/`news` items via shared `search_result_item(idx)` builder, `images` present) against `tool_output_schema("crw_search")`. |
+| **T5** | same | `tool_output_schema("crw_search").is_some()`; its `required == ["success","data"]`; `data.required` contains `results`; `data` is `type:object`; `tool_output_schema("crw_scrape").is_none()`. |
+| **T6** | same | Existing schema tests + `schemas_do_not_set_additional_properties_false` (`lib.rs:465`) stay green; confirm that guard is scoped to `inputSchema` and is **not** extended to the new `outputSchema`. |
+| **T7** | `crw-server/tests/mcp.rs:40` | Tighten `is_string()` → `assert_eq!(result["protocolVersion"], "2025-06-18")`. |
+| **T8** | same | tools/list: exactly 5 tools, same names; `crw_search` carries the nested-shape `outputSchema`. |
+| **T9** | same | tools/call `crw_search` under empty test config → deterministic `search_disabled` Err → `isError:true`, `content[0].text` set, no `structuredContent`. |
+| **T10** | same | `MCP-Protocol-Version` tolerance: POST `/mcp` with (a) `2025-06-18` → ok; (b) no header → ok; (c) `2024-11-05` and `not-a-version` → **still ok**. |
+| **T11** | same | Existing error tests unchanged: unknown-tool `isError` (`mcp.rs:157`), crawl renderer-unavailable text (`mcp.rs:235`), `-32601`/`-32700`. |
+| **T12** | `crw-server/tests/mcp.rs` | **Real-serializer gate.** Build real `crw_core::types::SearchResponse` via `ApiResponse::ok(SearchResponseData{..})`, `serde_json::to_value`, run through the real emit path, validate emitted `structuredContent` against `tool_output_schema("crw_search")` with `jsonschema`. Cases: **A** flat populated (array); **B** flat empty (`[]`); **C** grouped web+news+images (proves `ImageResult` stays unconstrained); **D** grouped empty → assert `data.results == {}` and schema accepts it. |
+
+Shared fixtures: `representative_search_value()` (asserts `snippet == description` and `snippet.is_string()` for every item) and `search_result_item(idx)` (all five required fields, `snippet == description`), used by both flat and grouped fixtures.
+
+**Route-level success path:** covered-by-construction (single choke point + compiler-enforced arity + T1/T4/T12), not by an executing route round-trip — standing up a SearXNG stub for one route is disproportionate. Belt-and-suspenders stub deferred unless requested.
+
+**Out of scope:** `crw-conformance/` (Python /v2 REST harness, zero MCP coverage — verified). Do not add MCP cases there; confirm `run.sh` stays green.
+
+**Workspace gate:** `cargo test --workspace`, `cargo fmt`, `cargo clippy` all green.
+
+## Backward compatibility & Firecrawl parity
+
+- **Lenient/older clients: zero breakage.** `structuredContent` is purely additive; `content[0].text` is retained verbatim and is the serialization of the same value (T1 locks this).
+- **Strict Hermes-class clients: now pass.** They find `result.structuredContent` and validate it against the corrected nested schema, which the real serde value satisfies on every branch (T12: flat, empty-flat, grouped, empty-grouped). Both original failure axes are eliminated.
+- **Hard-gate honesty.** The rewritten schema becomes a real gate the moment `structuredContent` is emitted. Required text-item fields are minimal and all `SearchResult`-guaranteed; `score`/`category` optional; grouped `images` (`ImageResult`) unconstrained. No previously-silent pass converts to a hard failure (T12 proves the real serializer validates on every branch).
+- **Schema mirrors crw's OWN serializer, not Firecrawl's.** crw nests results under `data.results` (array in the default no-sources case; object with `web`/`news`/`images` in the grouped case); Firecrawl nests under `data.web` (verified `crw-conformance/fixtures/firecrawl_v2/search_basic.json`). This plan does **not** claim Firecrawl-MCP-shape parity — it is correct relative to crw's `/v1/search` body, the contract crw clients already consume.
+- **No Firecrawl-parity regression.** `COMPATIBILITY-firecrawl.md` §7 is capability-level only and makes no response-shape claim. firecrawl-mcp-server uses plain text blocks; crw retains its text block, so lenient-text-convention parity is preserved. §7 gets the one-line note (change 12).
+- **Protocol bump is client-visible.** A client that doesn't support `2025-06-18` SHOULD disconnect. Verified: no in-workspace consumer of `crw-mcp-proto::PROTOCOL_VERSION` hard-pins `2024-11-05` (the only constant is `lib.rs:8`); crw clients negotiate by echoing the server's chosen version. crw-browse (separate rmcp server) is unaffected.
+
+## Rollout & release
+
+- **Commit (single PR, conventional):** `feat(mcp): emit structuredContent for crw_search; bump protocol to 2025-06-18`. release-please opens/updates the Release PR → MINOR bump **0.11.0 → 0.12.0**. Never bump version or edit CHANGELOG manually.
+- **Pre-commit (via `/commit`):** `cargo fmt`, `cargo clippy`, `cargo test --workspace` green, **plus** the repo-wide stale-version gate, which must return **zero** lines:
+  ```bash
+  grep -rn "2024-11-05" --include="*.rs" --include="*.md" --include="*.html" . | grep -v "crates/crw-browse/"
+  ```
+  (crw-browse allowlisted as the unrelated rmcp server.)
+- **CHANGELOG note** (release-please-owned): "crw_search MCP tool now emits spec-compliant `structuredContent` (MCP 2025-06-18); `initialize` protocol version bumped from 2024-11-05 to 2025-06-18. structuredContent matches crw's `/v1/search` envelope (`{success, data:{results}}`), not Firecrawl's `data.web` shape. In proxy mode, structuredContent is sourced from the upstream `/v1/search` body — use matching minor versions across a proxy boundary. The separate crw-browse MCP server is unaffected and remains on 2024-11-05."
+- **Release-checklist item:** before merging the Release PR, confirm any out-of-workspace `crw-saas`/`crw-client.ts` consumer's `initialize` handshake does not hard-pin `protocolVersion: "2024-11-05"`. No code fallback added absent an identified pinned client.
+- No data migration, no config change. Stdio and HTTP both updated via the shared choke point.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Protocol bump disconnects a client that hard-pins 2024-11-05 | Verified no in-workspace pinned consumer; crw clients echo the server's version. Release-checklist confirms out-of-workspace clients. |
+| Proxy version-skew: remote `/v1/search` body predates the 0.12.0 nested shape | Structural `is_object()` guard (locked by T2b) blocks non-object bodies. Residual: an object-envelope whose `data` is a legacy flat array passes the gate but fails strict validation — stated support boundary; documented in code comment + CHANGELOG ("use matching minor versions or run embedded"). |
+| Hand-built test fixtures drift from the real serializer (the original #89 root cause) | T12 validates the **real** `SearchResponse` serializer output (untagged enum, camelCase, every `skip_serializing_if`) against the declared schema; T4 is the cheap crate-local mirror. |
+| `jsonschema` validator can't resolve local `$ref`/`$defs` | Documented inline fallback: inline the identical `searchResultItem` at the flat/`web`/`news` sites (not `images`). |
+| Stale `2024-11-05` left in a doc/mirror | Repo-wide grep gate in pre-commit must return zero lines. |
+| Forgetting one of three call sites | Arity change on `tool_result_response` makes any missed site a compile error. |
+
+## Open questions
+
+None. All forced choices are made: `results` polymorphism kept via `oneOf` with images unconstrained; other four tools out of scope (the helper makes `crw_map` a one-line follow-up); header tolerated not validated; `jsonschema` added to both crates; `is_object()` guard kept and tested; crw-browse stays on 2024-11-05; route-level success path covered-by-construction.
+
+Plan file location for the implementing engineer: this plan is self-contained above; no separate file was written. Load-bearing source references: `crates/crw-mcp-proto/src/lib.rs` (lines 8, 196, 252-274, 334-355), `crates/crw-core/src/types.rs` (lines 507-519, 1043-1117, 1153-1156), `crates/crw-server/src/routes/mcp.rs` (lines 24, 112, 127-136, 155-161), `crates/crw-mcp/src/main.rs:115`, `crates/crw-cli/src/commands/mcp.rs:87`, `crates/crw-server/tests/mcp.rs:40`.


### PR DESCRIPTION
## Summary

Addresses the `outputSchema` mismatch reported in #89 (reference only). The `crw` MCP server declared an `outputSchema` for `crw_search` but wrapped every tool result only in a plain text content block — strict MCP clients (Hermes-class) found no `structuredContent` to validate and rejected the call. The declared schema was **also wrong**: it promised a flat `data` array, while the real `SearchResponse` serializes `{ success, data: { results: <array | {web,news,images}> } }`. Both defects had to be fixed; either alone leaves the bug live.

## What changed

- **Dual-emit (`tool_result_response`)** — on success, the value is emitted both as the legacy text block (backward compatible) **and**, when the tool declares an `outputSchema`, as a top-level `structuredContent` object. Both derive from one binding, so `from_str(content.text) == structuredContent` by construction. An `is_object()` guard is the proxy version-skew safety valve (degrades to text-only rather than ship a non-object `structuredContent`).
- **Corrected schema** — `crw_search` `outputSchema` rewritten to mirror the real serializer: nested `data.results` via `oneOf(array | grouped {web,news,images})`, grouped `images` left unconstrained (`ImageResult` carries `imageUrl`, no `snippet`). New `tool_output_schema()` helper makes emission derive from the single declaration — no hardcoded tool name, so future schema-bearing tools light up automatically.
- **Protocol bump** — `PROTOCOL_VERSION` → `2025-06-18`, the revision that introduces `structuredContent`/`outputSchema`. `crw-browse` pins its own version and is unaffected.
- **Header tolerance** — `MCP-Protocol-Version` request header is read for observability, never rejected.
- **Docs** — `docs/docs/mcp.md`, the generated `docs/mcp/index.html` mirror, and `COMPATIBILITY-firecrawl.md` §7.

## Tests (T1–T12, all green)

- `crw-mcp-proto`: dual-emit sync invariant, schema gating, **non-object guard (T2b)**, error path, jsonschema validation, helper.
- `crw-server/tests/mcp.rs`: protocol version, nested-schema advertise, search-disabled `isError`, **header tolerance (4 cases)**, and **T12 — validates the real `SearchResponse` serializer output against the declared schema across flat / empty / grouped / empty-grouped branches** (the exact drift that caused #89).

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` green

## Release

Conventional `feat:` → release-please MINOR bump (0.11.0 → 0.12.0). No manual version/CHANGELOG edits.

Refs #89 (reference only — does not auto-close)

