### PR TITLE
fix(release): bump internal dep pins and track them in release config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Internal dependency versions match workspace version
         run: bash scripts/check-internal-dep-versions.sh
 
+      # Catches the config GAP at feature-PR time, independent of version state:
+      # a new internal dep pin that isn't tracked in release-please-config.json
+      # fails here long before it can go stale on a release bump. The
+      # release-please PR itself does not trigger this CI (bot GITHUB_TOKEN),
+      # so the gap must be caught on the human PR that introduces the dep.
+      - name: Audit release-please config completeness
+        run: python3 scripts/release/audit_release_please_config.py
+
       - name: Build
         run: cargo build --workspace --all-targets
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "crw-core",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-crawl/Cargo.toml
+++ b/crates/crw-crawl/Cargo.toml
@@ -11,7 +11,7 @@ description = "Async BFS web crawler with rate limiting and robots.txt support f
 
 [dependencies]
 crw-core = { path = "../crw-core", version = "0.12.0" }
-crw-diff = { path = "../crw-diff", version = "0.11.0" }
+crw-diff = { path = "../crw-diff", version = "0.12.0" }
 crw-renderer = { path = "../crw-renderer", version = "0.12.0" }
 crw-extract = { path = "../crw-extract", version = "0.12.0" }
 reqwest = { workspace = true }

--- a/crates/crw-diff/Cargo.toml
+++ b/crates/crw-diff/Cargo.toml
@@ -13,7 +13,7 @@ description = "Stateless change-tracking diff engine for the CRW web scraper"
 # Shared types only (ChangeTrackingOptions/Result, DiffAst, etc.). This crate
 # MUST NOT depend on crw-extract — judging is injected upstream so the diff
 # engine stays pure (no LLM, no HTTP, no I/O).
-crw-core = { path = "../crw-core", version = "0.11.0" }
+crw-core = { path = "../crw-core", version = "0.12.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }

--- a/crates/crw-monitor/Cargo.toml
+++ b/crates/crw-monitor/Cargo.toml
@@ -14,11 +14,11 @@ description = "Optional self-host monitor mode for the CRW web scraper (SQLite-b
 # `crw-crawl` provides the scrape/crawl primitives; `crw-extract` provides the
 # LLM judge. None of these pull a DB dependency — the SQLite/cron/hmac stack is
 # local to this crate and feature-gated, never compiled into the default server.
-crw-core = { path = "../crw-core", version = "0.11.0" }
-crw-diff = { path = "../crw-diff", version = "0.11.0" }
-crw-crawl = { path = "../crw-crawl", version = "0.11.0" }
-crw-extract = { path = "../crw-extract", version = "0.11.0" }
-crw-renderer = { path = "../crw-renderer", version = "0.11.0" }
+crw-core = { path = "../crw-core", version = "0.12.0" }
+crw-diff = { path = "../crw-diff", version = "0.12.0" }
+crw-crawl = { path = "../crw-crawl", version = "0.12.0" }
+crw-extract = { path = "../crw-extract", version = "0.12.0" }
+crw-renderer = { path = "../crw-renderer", version = "0.12.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -16,7 +16,7 @@ auto-browser = ["dep:dirs"]
 
 [dependencies]
 crw-core = { path = "../crw-core", version = "0.12.0" }
-crw-extract = { path = "../crw-extract", version = "0.11.0" }
+crw-extract = { path = "../crw-extract", version = "0.12.0" }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"], optional = true }

--- a/crates/crw-server/Cargo.toml
+++ b/crates/crw-server/Cargo.toml
@@ -20,13 +20,13 @@ monitor = ["dep:crw-monitor"]
 
 [dependencies]
 crw-core = { path = "../crw-core", version = "0.12.0" }
-crw-diff = { path = "../crw-diff", version = "0.11.0" }
+crw-diff = { path = "../crw-diff", version = "0.12.0" }
 crw-renderer = { path = "../crw-renderer", version = "0.12.0" }
 crw-extract = { path = "../crw-extract", version = "0.12.0" }
 crw-crawl = { path = "../crw-crawl", version = "0.12.0" }
 crw-search = { path = "../crw-search", version = "0.12.0" }
 # Optional self-host monitor mode (default OFF — see the `monitor` feature).
-crw-monitor = { path = "../crw-monitor", version = "0.11.0", optional = true }
+crw-monitor = { path = "../crw-monitor", version = "0.12.0", optional = true }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -142,6 +142,56 @@
           "jsonpath": "$.dependencies.crw-renderer.version"
         },
         {
+          "type": "toml",
+          "path": "crates/crw-diff/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-core.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-renderer/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-extract.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-crawl/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-diff.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-server/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-diff.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-server/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-monitor.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-monitor/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-core.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-monitor/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-diff.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-monitor/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-crawl.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-monitor/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-extract.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/crw-monitor/Cargo.toml",
+          "jsonpath": "$.dependencies.crw-renderer.version"
+        },
+        {
           "type": "json",
           "path": "server.json",
           "jsonpath": "$.version"

--- a/scripts/release/audit_release_please_config.py
+++ b/scripts/release/audit_release_please_config.py
@@ -53,6 +53,47 @@ def _json_jsonpath_lookup(data, jsonpath: str) -> bool:
     return bool(jsonpath_ng.parse(jsonpath).find(data))
 
 
+_DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+
+
+def _internal_version_pins() -> set[tuple[str, str, str]]:
+    """Every internal `crw-*` dependency that carries an explicit version pin.
+
+    Returns (cargo_path, table, dep_name) tuples for deps that have BOTH a
+    `path` (so they resolve to a workspace crate) and a `version` requirement.
+    Those version strings must be bumped in lockstep with the workspace version
+    on every release, which means each one needs a release-please-config
+    extra-files entry. A pin without an entry is the exact bug that broke the
+    0.12.0 release (crw-diff -> crw-core stayed at 0.11.0 after the bump).
+    """
+    pins: set[tuple[str, str, str]] = set()
+    for cargo in sorted(Path("crates").glob("*/Cargo.toml")):
+        data = tomllib.loads(cargo.read_text())
+        for table in _DEP_TABLES:
+            for name, spec in data.get(table, {}).items():
+                if not name.startswith("crw-"):
+                    continue
+                if isinstance(spec, dict) and "version" in spec and "path" in spec:
+                    pins.add((cargo.as_posix(), table, name))
+    return pins
+
+
+def _config_covered_pins(cfg: dict) -> set[tuple[str, str, str]]:
+    """(path, table, dep) covered by a `$.<table>.<dep>.version` extra-file."""
+    covered: set[tuple[str, str, str]] = set()
+    for pkg in cfg.get("packages", {}).values():
+        for ef in pkg.get("extra-files", []):
+            if not isinstance(ef, dict) or ef.get("type") != "toml":
+                continue
+            path_str, jsonpath = ef.get("path"), ef.get("jsonpath")
+            if not path_str or not jsonpath:
+                continue
+            parts = re.findall(r"[\w-]+", jsonpath)
+            if len(parts) == 3 and parts[0] in _DEP_TABLES and parts[2] == "version":
+                covered.add((path_str, parts[0], parts[1]))
+    return covered
+
+
 def main(config_path: Path = Path("release-please-config.json")) -> int:
     if not config_path.exists():
         print(f"::error::{config_path} not found", file=sys.stderr)
@@ -60,6 +101,19 @@ def main(config_path: Path = Path("release-please-config.json")) -> int:
     cfg = json.loads(config_path.read_text())
 
     errors: list[str] = []
+
+    # Completeness: every internal version pin must have an extra-files entry,
+    # so release-please keeps inter-crate version requirements in lockstep with
+    # the workspace version. Missing entries silently break the build on the
+    # first bump after a crate/dep is added.
+    covered = _config_covered_pins(cfg)
+    for path_str, table, dep in sorted(_internal_version_pins()):
+        if (path_str, table, dep) not in covered:
+            errors.append(
+                f"{path_str}::$.{table}.{dep}.version: internal version pin not "
+                f"tracked in release-please-config.json extra-files "
+                f"(would go stale on the next version bump)"
+            )
     for pkg_name, pkg in cfg.get("packages", {}).items():
         for ef in pkg.get("extra-files", []):
             # Bare string form: just a path, no jsonpath.


### PR DESCRIPTION
## What

The `v0.12.0` release pipeline failed at the `check` gate and **skipped every publish job** — nothing reached crates.io / npm / mcp-registry.

Root cause: `cargo` could not resolve `crw-core = "0.11.0"` (required by `crw-diff`) against the workspace's new `0.12.0`. `crw-diff` and `crw-monitor` were added after 0.11.0 with hardcoded `version = "0.11.0"` path-dep pins but were never registered in `release-please-config.json`'s `extra-files`, so release-please bumped the package versions to 0.12.0 while leaving their dep requirements at 0.11.0.

## Changes

- Bump the 10 straggler internal dep pins to `0.12.0` so the workspace resolves again.
- Add those 10 pins to `release-please-config.json` so future bumps keep every inter-crate version requirement in lockstep — prevents recurrence.

## Verification (local, mirrors the CI `check` job)

- `cargo check --workspace` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo fmt --all -- --check` ✓
- `uv run python scripts/release/preflight.py` → `preflight OK (version 0.12.0, 10 published crates)` ✓
- `uv run python scripts/release/audit_release_please_config.py` → `audit OK (50 entries)` ✓