### PR TITLE
fix(release): sync Cargo.lock internal crate versions to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "crw-core",
  "hex",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "clap",
  "crw-core",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "jsonschema",
  "serde",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "crw-core",
  "futures",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "axum",
  "axum-test",


### PR DESCRIPTION
## Phase 0 — Cargo.lock coherence (standalone, lands first)

`[workspace.package].version` is `0.12.1`, but `Cargo.lock` still pinned all 12 internal `crw-*` crates at `0.12.0` (the `0.12.1` release synced manifests but not the lock). As a result `cargo build --workspace --locked` **fails on `main` today**.

Fix: `cargo update --workspace` rewrites only the 12 path-crate entries `0.12.0 → 0.12.1`; 128 registry dependencies are untouched (verified — diff is exactly 12 lines).

This is the same drift class as #95 (a forgotten lockstep surface). It is addressed **structurally** by the follow-up PR that centralizes internal versions in `[workspace.dependencies]`.

### Verification
- `cargo build --workspace --locked` ✅
- `cargo check --workspace --locked --all-targets` ✅
- diff limited to `Cargo.lock`, 12 insertions / 12 deletions
