### PR TITLE
refactor(release): centralize internal dep versions via [workspace.dependencies]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Audit release-please config completeness
         run: python3 scripts/release/audit_release_please_config.py
 
+      # The guards above are load-bearing; this regression suite fails red if a
+      # future change weakens them (drift/missing-entry/anti-vacuity/invalid
+      # jsonpath), instead of letting them pass vacuously.
+      - name: Guard regression tests
+        run: python3 scripts/release/test_guards.py
+
       - name: Build
         run: cargo build --workspace --all-targets
 

--- a/.github/workflows/preflight-publish.yml
+++ b/.github/workflows/preflight-publish.yml
@@ -47,6 +47,12 @@ jobs:
           set -euo pipefail
           uv run python scripts/release/audit_release_please_config.py
 
+      - name: Guard regression tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/release/test_guards.py
+
       - name: Shellcheck release scripts
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,24 @@ axum-test = "19"
 proptest = "1"
 insta = { version = "1", features = ["json"] }
 
+# Internal crates. Centralized here so the crate-to-crate version pins live in
+# ONE place: release-please bumps these via release-please-config.json
+# ($.workspace.dependencies.<crate>.version) in lockstep with
+# [workspace.package].version. Member crates inherit with `{ workspace = true }`
+# and layer their own `features` / `optional` on top. `path` is resolved
+# relative to THIS (root) manifest. Only crates that are depended upon by
+# another crate appear here; leaf binaries (crw-mcp, crw-cli) just consume.
+crw-mcp-proto = { path = "crates/crw-mcp-proto", version = "0.12.1" }
+crw-core = { path = "crates/crw-core", version = "0.12.1" }
+crw-extract = { path = "crates/crw-extract", version = "0.12.1" }
+crw-renderer = { path = "crates/crw-renderer", version = "0.12.1" }
+crw-search = { path = "crates/crw-search", version = "0.12.1" }
+crw-diff = { path = "crates/crw-diff", version = "0.12.1" }
+crw-crawl = { path = "crates/crw-crawl", version = "0.12.1" }
+crw-monitor = { path = "crates/crw-monitor", version = "0.12.1" }
+crw-server = { path = "crates/crw-server", version = "0.12.1" }
+crw-browse = { path = "crates/crw-browse", version = "0.12.1" }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/crates/crw-browse/Cargo.toml
+++ b/crates/crw-browse/Cargo.toml
@@ -11,8 +11,8 @@ description = "MCP server for interactive browser automation over CDP"
 publish = false
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-renderer = { path = "../crw-renderer", version = "0.12.1", features = ["cdp"] }
+crw-core = { workspace = true }
+crw-renderer = { workspace = true, features = ["cdp"] }
 
 rmcp = { version = "1.5", features = ["server", "macros", "transport-io"] }
 clap = { workspace = true }

--- a/crates/crw-cli/Cargo.toml
+++ b/crates/crw-cli/Cargo.toml
@@ -28,17 +28,17 @@ browse = ["dep:crw-browse", "dep:rmcp", "dep:anyhow"]
 
 [dependencies]
 # Core crates
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-renderer = { path = "../crw-renderer", version = "0.12.1", features = ["auto-browser", "cdp"] }
-crw-extract = { path = "../crw-extract", version = "0.12.1" }
-crw-crawl = { path = "../crw-crawl", version = "0.12.1" }
-crw-search = { path = "../crw-search", version = "0.12.1" }
+crw-core = { workspace = true }
+crw-renderer = { workspace = true, features = ["auto-browser", "cdp"] }
+crw-extract = { workspace = true }
+crw-crawl = { workspace = true }
+crw-search = { workspace = true }
 
 # Server (for serve + mcp-embedded + setup commands)
-crw-server = { path = "../crw-server", version = "0.12.1", optional = true, features = ["cdp"] }
+crw-server = { workspace = true, optional = true, features = ["cdp"] }
 
 # Browse (for browse command)
-crw-browse = { path = "../crw-browse", version = "0.12.1", optional = true }
+crw-browse = { workspace = true, optional = true }
 
 # Web framework (for serve command)
 axum = { workspace = true, optional = true }

--- a/crates/crw-core/Cargo.toml
+++ b/crates/crw-core/Cargo.toml
@@ -19,7 +19,7 @@ description = "Core types, config, and error handling for the CRW web scraper"
 cdp = []
 
 [dependencies]
-crw-mcp-proto = { path = "../crw-mcp-proto", version = "0.12.1" }
+crw-mcp-proto = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/crw-crawl/Cargo.toml
+++ b/crates/crw-crawl/Cargo.toml
@@ -10,10 +10,10 @@ categories.workspace = true
 description = "Async BFS web crawler with rate limiting and robots.txt support for CRW"
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-diff = { path = "../crw-diff", version = "0.12.1" }
-crw-renderer = { path = "../crw-renderer", version = "0.12.1" }
-crw-extract = { path = "../crw-extract", version = "0.12.1" }
+crw-core = { workspace = true }
+crw-diff = { workspace = true }
+crw-renderer = { workspace = true }
+crw-extract = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 scraper = { workspace = true }

--- a/crates/crw-diff/Cargo.toml
+++ b/crates/crw-diff/Cargo.toml
@@ -13,7 +13,7 @@ description = "Stateless change-tracking diff engine for the CRW web scraper"
 # Shared types only (ChangeTrackingOptions/Result, DiffAst, etc.). This crate
 # MUST NOT depend on crw-extract — judging is injected upstream so the diff
 # engine stays pure (no LLM, no HTTP, no I/O).
-crw-core = { path = "../crw-core", version = "0.12.1" }
+crw-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }

--- a/crates/crw-extract/Cargo.toml
+++ b/crates/crw-extract/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 description = "HTML extraction and markdown conversion engine for the CRW web scraper"
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
+crw-core = { workspace = true }
 lol_html = { workspace = true }
 scraper = { workspace = true }
 htmd = { workspace = true }

--- a/crates/crw-mcp/Cargo.toml
+++ b/crates/crw-mcp/Cargo.toml
@@ -18,8 +18,8 @@ default = ["embedded"]
 embedded = ["dep:crw-server"]
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-renderer = { path = "../crw-renderer", version = "0.12.1", features = ["auto-browser"] }
+crw-core = { workspace = true }
+crw-renderer = { workspace = true, features = ["auto-browser"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }
@@ -28,4 +28,4 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 
 # Embedded mode: pulls in full scraping engine
-crw-server = { path = "../crw-server", version = "0.12.1", optional = true, features = ["cdp"] }
+crw-server = { workspace = true, optional = true, features = ["cdp"] }

--- a/crates/crw-monitor/Cargo.toml
+++ b/crates/crw-monitor/Cargo.toml
@@ -14,11 +14,11 @@ description = "Optional self-host monitor mode for the CRW web scraper (SQLite-b
 # `crw-crawl` provides the scrape/crawl primitives; `crw-extract` provides the
 # LLM judge. None of these pull a DB dependency — the SQLite/cron/hmac stack is
 # local to this crate and feature-gated, never compiled into the default server.
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-diff = { path = "../crw-diff", version = "0.12.1" }
-crw-crawl = { path = "../crw-crawl", version = "0.12.1" }
-crw-extract = { path = "../crw-extract", version = "0.12.1" }
-crw-renderer = { path = "../crw-renderer", version = "0.12.1" }
+crw-core = { workspace = true }
+crw-diff = { workspace = true }
+crw-crawl = { workspace = true }
+crw-extract = { workspace = true }
+crw-renderer = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -15,8 +15,8 @@ cdp = ["tokio-tungstenite", "crw-core/cdp"]
 auto-browser = ["dep:dirs"]
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-extract = { path = "../crw-extract", version = "0.12.1" }
+crw-core = { workspace = true }
+crw-extract = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"], optional = true }

--- a/crates/crw-search/Cargo.toml
+++ b/crates/crw-search/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 description = "SearXNG-backed search client and result transforms for the CRW web scraper"
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
+crw-core = { workspace = true }
 futures = { workspace = true }
 moka = { workspace = true }
 serde = { workspace = true }

--- a/crates/crw-server/Cargo.toml
+++ b/crates/crw-server/Cargo.toml
@@ -19,14 +19,14 @@ test-utils = []
 monitor = ["dep:crw-monitor"]
 
 [dependencies]
-crw-core = { path = "../crw-core", version = "0.12.1" }
-crw-diff = { path = "../crw-diff", version = "0.12.1" }
-crw-renderer = { path = "../crw-renderer", version = "0.12.1" }
-crw-extract = { path = "../crw-extract", version = "0.12.1" }
-crw-crawl = { path = "../crw-crawl", version = "0.12.1" }
-crw-search = { path = "../crw-search", version = "0.12.1" }
+crw-core = { workspace = true }
+crw-diff = { workspace = true }
+crw-renderer = { workspace = true }
+crw-extract = { workspace = true }
+crw-crawl = { workspace = true }
+crw-search = { workspace = true }
 # Optional self-host monitor mode (default OFF — see the `monitor` feature).
-crw-monitor = { path = "../crw-monitor", version = "0.12.1", optional = true }
+crw-monitor = { workspace = true, optional = true }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,173 +23,53 @@
         },
         {
           "type": "toml",
-          "path": "crates/crw-renderer/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-mcp-proto.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-extract/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-core.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-crawl/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-extract.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-crawl/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-renderer.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-renderer.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-crawl/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-extract.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-search.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-diff.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-renderer.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-crawl.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-extract.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-monitor.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-crawl.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-server.version"
         },
         {
           "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-search.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-search/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-renderer.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-extract.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-crawl.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-search.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-server.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-cli/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-browse.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-mcp/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-mcp/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-renderer.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-mcp/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-server.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-core/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-mcp-proto.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-browse/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-browse/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-renderer.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-diff/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-renderer/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-extract.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-crawl/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-diff.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-diff.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-server/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-monitor.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-monitor/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-core.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-monitor/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-diff.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-monitor/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-crawl.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-monitor/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-extract.version"
-        },
-        {
-          "type": "toml",
-          "path": "crates/crw-monitor/Cargo.toml",
-          "jsonpath": "$.dependencies.crw-renderer.version"
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.crw-browse.version"
         },
         {
           "type": "json",

--- a/scripts/check-internal-dep-versions.sh
+++ b/scripts/check-internal-dep-versions.sh
@@ -1,82 +1,119 @@
 #!/usr/bin/env bash
 # Mechanical guard against the stale-internal-dependency-version release break.
 #
-# Every internal crate is published to crates.io, so its sibling path
-# dependencies carry a `version = "X"` compatibility assertion alongside
-# `path = "..."`. That `X` MUST equal the unified workspace version
-# (`[workspace.package].version`). If a release bumps the workspace version
-# but leaves a sibling `version` string behind, cargo can no longer resolve
-# the path crate (`^old` excludes the new version) and every publish job in
-# the Release workflow is skipped — shipping an empty tag.
+# Every internal crate is published to crates.io, so its sibling dependencies
+# carry a `version = "X"` compatibility assertion. Those versions are now
+# centralized in the root `[workspace.dependencies]` table (members inherit via
+# `{ workspace = true }`), so there is ONE place per internal crate to keep in
+# sync with the unified workspace version (`[workspace.package].version`). If a
+# release bumps the workspace version but leaves a `[workspace.dependencies]`
+# entry behind, cargo can no longer resolve the path crate (`^old` excludes the
+# new version) and every publish job in the Release workflow is skipped —
+# shipping an empty tag.
 #
-# This is exactly what happened to v0.9.0: crw-cli's crw-search/crw-server/
-# crw-browse deps stayed at "0.8.1" while the workspace went to 0.9.0. The
-# heavy `cargo build` CI step did not block the release-please PR (Cargo.lock
-# cache short-circuited resolution), so this dedicated, cache-proof invariant
-# check runs on every PR — including the release-please version-bump PR,
-# where a mismatch first becomes visible — turning a catastrophic post-tag
-# failure into a pre-merge red X.
+# This is exactly what happened to v0.9.0 (crw-cli pins stayed 0.8.1) and again
+# to v0.12.0 (crw-diff -> crw-core stayed 0.11.0). The heavy `cargo build` CI
+# step did not block the release-please PR (Cargo.lock cache short-circuited
+# resolution), so this dedicated, cache-proof invariant check turns a
+# catastrophic post-tag failure into a pre-merge red X.
 #
-# The internal-crate set is derived from `[workspace] members`, so this
-# guard never needs editing when crates are added or removed.
+# Three invariants, all derived from `[workspace] members` (so the guard never
+# needs editing when crates are added or removed):
+#   1. every internal pin in [workspace.dependencies] == the workspace version;
+#   2. anti-vacuity — there MUST be centralized internal pins (an empty scan is
+#      itself an error, so the migration to inheritance can't silently disable
+#      this guard);
+#   3. residual scan — no member manifest may re-declare an inline `path` pin
+#      for an internal crate (it must inherit), with one allowlisted exception:
+#      crw-server's self dev-dependency (`path = "."`, no version).
 #
 # Portable: bash + python3 (present on ubuntu-latest and macOS).
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Repo root defaults to this script's parent, but tests override it with a
+# fixture dir (scripts/release/test_guards.py) to exercise failure modes.
+cd "${CHECK_REPO_ROOT:-$(dirname "$0")/..}"
 
 python3 - <<'PY'
-import re, sys, glob, os
+import sys, tomllib
+from pathlib import Path
 
-root = open("Cargo.toml").read()
+root = tomllib.loads(Path("Cargo.toml").read_text())
+ws = root.get("workspace", {})
 
-m = re.search(r'\[workspace\.package\][^\[]*?\bversion\s*=\s*"([^"]+)"', root, re.S)
-if not m:
+ws_version = ws.get("package", {}).get("version")
+if not ws_version:
     print("error: could not find [workspace.package] version in root Cargo.toml")
     sys.exit(2)
-ws_version = m.group(1)
 
-# Internal crate names = basenames of [workspace] members.
-mm = re.search(r'\[workspace\][^\[]*?members\s*=\s*\[(.*?)\]', root, re.S)
-if not mm:
+members = ws.get("members")
+if not members:
     print("error: could not find [workspace] members in root Cargo.toml")
     sys.exit(2)
-members = re.findall(r'"([^"]+)"', mm.group(1))
-internal = {os.path.basename(p) for p in members}
+# Internal crate names = basenames of [workspace] members.
+internal = {Path(m).name for m in members}
 
 problems = []
-for f in sorted(glob.glob("crates/*/Cargo.toml")):
-    txt = open(f).read()
-    # Walk only dependency tables; ignore [package], [features], etc.
-    for tm in re.finditer(
-        r'^\[(?:target\.[^\]]+\.)?(dependencies|dev-dependencies|build-dependencies)\]\s*$',
-        txt, re.M):
-        start = tm.end()
-        nxt = re.search(r'^\[', txt[start:], re.M)
-        block = txt[start:start + (nxt.start() if nxt else len(txt))]
-        for dm in re.finditer(r'^([A-Za-z0-9_-]+)\s*=\s*\{([^}]*)\}', block, re.M):
-            name, body = dm.group(1), dm.group(2)
+
+# (1) Centralized internal pins in root [workspace.dependencies] must equal the
+#     workspace version.
+central = {
+    name: spec["version"]
+    for name, spec in ws.get("dependencies", {}).items()
+    if name in internal
+    and isinstance(spec, dict)
+    and "path" in spec
+    and "version" in spec
+}
+for name, ver in sorted(central.items()):
+    if ver != ws_version:
+        problems.append(
+            f'[workspace.dependencies] {name}: version "{ver}" '
+            f'must equal workspace version "{ws_version}"'
+        )
+
+# (2) Anti-vacuity: an empty centralized set means the guard would check nothing.
+if not central:
+    problems.append(
+        "no internal crate pins found in root [workspace.dependencies] — the "
+        "guard would pass vacuously; refusing to pass (did the workspace-deps "
+        "migration regress?)"
+    )
+
+# (3) Residual scan: members must inherit internal deps via `{ workspace = true }`,
+#     never re-declare an inline `path` pin (which escapes centralized bumping).
+#     Sole allowed exception: a crate's self dev-dependency (path = ".").
+ALLOWLIST = {("crates/crw-server/Cargo.toml", "crw-server")}
+_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+for cargo in sorted(Path("crates").glob("*/Cargo.toml")):
+    data = tomllib.loads(cargo.read_text())
+    for table in _TABLES:
+        for name, spec in data.get(table, {}).items():
             if name not in internal:
                 continue
-            if "path" not in body:
-                continue
-            vm = re.search(r'version\s*=\s*"([^"]+)"', body)
-            if not vm:
-                continue  # path-only dep: no version assertion to keep in sync
-            ver = vm.group(1)
-            if ver != ws_version:
-                problems.append((f, name, ver))
+            if isinstance(spec, dict) and "path" in spec:
+                if (cargo.as_posix(), name) in ALLOWLIST:
+                    continue
+                problems.append(
+                    f"{cargo.as_posix()}: {name} re-declares an inline `path` pin "
+                    f"in [{table}]; internal deps must inherit via "
+                    f"`{{ workspace = true }}` so release-please bumps them centrally"
+                )
 
 if problems:
-    print(f"❌ internal dependency version drift (workspace version is {ws_version}):\n")
-    for f, name, ver in problems:
-        print(f'  {f}: {name} = {{ ..., version = "{ver}" }}  →  must be "{ws_version}"')
+    print(f"❌ internal dependency version guard failed (workspace version is {ws_version}):\n")
+    for p in problems:
+        print(f"  {p}")
     print(
-        "\nFix: set each listed `version` to the workspace version, and add the "
-        "matching entry to release-please-config.json `extra-files` so future "
-        "releases keep it in sync automatically."
+        "\nFix: internal crate versions live ONLY in root [workspace.dependencies]; "
+        "set each to the workspace version and add the matching "
+        "release-please-config.json extra-files entry "
+        "($.workspace.dependencies.<crate>.version)."
     )
     sys.exit(1)
 
-print(f"✅ all internal path-dependency versions match workspace version {ws_version}")
+print(
+    f"✅ {len(central)} centralized internal pins all match workspace version "
+    f"{ws_version}; no stray inline pins"
+)
 PY

--- a/scripts/release/audit_release_please_config.py
+++ b/scripts/release/audit_release_please_config.py
@@ -53,33 +53,41 @@ def _json_jsonpath_lookup(data, jsonpath: str) -> bool:
     return bool(jsonpath_ng.parse(jsonpath).find(data))
 
 
-_DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+# Where centralized internal version pins live and the jsonpath segment that
+# addresses them. Internal crate-to-crate versions are declared ONCE in the
+# root `[workspace.dependencies]` table (members inherit via `workspace = true`),
+# so the only version strings release-please must bump are these.
+_WS_DEPS_PATH = "Cargo.toml"
+_WS_DEPS_TABLE = "workspace.dependencies"
 
 
 def _internal_version_pins() -> set[tuple[str, str, str]]:
-    """Every internal `crw-*` dependency that carries an explicit version pin.
+    """Every internal `crw-*` pin in root `[workspace.dependencies]`.
 
-    Returns (cargo_path, table, dep_name) tuples for deps that have BOTH a
+    Returns (cargo_path, table, dep_name) tuples for entries that carry BOTH a
     `path` (so they resolve to a workspace crate) and a `version` requirement.
     Those version strings must be bumped in lockstep with the workspace version
     on every release, which means each one needs a release-please-config
-    extra-files entry. A pin without an entry is the exact bug that broke the
-    0.12.0 release (crw-diff -> crw-core stayed at 0.11.0 after the bump).
+    extra-files entry of shape `$.workspace.dependencies.<dep>.version`. A pin
+    without an entry is the exact bug that broke the 0.12.0 release (crw-diff
+    -> crw-core stayed at 0.11.0 after the bump). Since the migration to
+    workspace inheritance, these pins are centralized in ONE file instead of
+    scattered across every member manifest.
     """
     pins: set[tuple[str, str, str]] = set()
-    for cargo in sorted(Path("crates").glob("*/Cargo.toml")):
-        data = tomllib.loads(cargo.read_text())
-        for table in _DEP_TABLES:
-            for name, spec in data.get(table, {}).items():
-                if not name.startswith("crw-"):
-                    continue
-                if isinstance(spec, dict) and "version" in spec and "path" in spec:
-                    pins.add((cargo.as_posix(), table, name))
+    root = tomllib.loads(Path(_WS_DEPS_PATH).read_text())
+    ws_deps = root.get("workspace", {}).get("dependencies", {})
+    for name, spec in ws_deps.items():
+        if not name.startswith("crw-"):
+            continue
+        if isinstance(spec, dict) and "version" in spec and "path" in spec:
+            pins.add((_WS_DEPS_PATH, _WS_DEPS_TABLE, name))
     return pins
 
 
 def _config_covered_pins(cfg: dict) -> set[tuple[str, str, str]]:
-    """(path, table, dep) covered by a `$.<table>.<dep>.version` extra-file."""
+    """(path, table, dep) covered by a `$.workspace.dependencies.<dep>.version`
+    extra-file entry into the root manifest."""
     covered: set[tuple[str, str, str]] = set()
     for pkg in cfg.get("packages", {}).values():
         for ef in pkg.get("extra-files", []):
@@ -89,8 +97,14 @@ def _config_covered_pins(cfg: dict) -> set[tuple[str, str, str]]:
             if not path_str or not jsonpath:
                 continue
             parts = re.findall(r"[\w-]+", jsonpath)
-            if len(parts) == 3 and parts[0] in _DEP_TABLES and parts[2] == "version":
-                covered.add((path_str, parts[0], parts[1]))
+            # New centralized shape: $.workspace.dependencies.<dep>.version
+            if (
+                len(parts) == 4
+                and parts[0] == "workspace"
+                and parts[1] == "dependencies"
+                and parts[3] == "version"
+            ):
+                covered.add((path_str, _WS_DEPS_TABLE, parts[2]))
     return covered
 
 
@@ -107,7 +121,18 @@ def main(config_path: Path = Path("release-please-config.json")) -> int:
     # the workspace version. Missing entries silently break the build on the
     # first bump after a crate/dep is added.
     covered = _config_covered_pins(cfg)
-    for path_str, table, dep in sorted(_internal_version_pins()):
+    required = _internal_version_pins()
+    # Anti-vacuity: an empty required set means the centralized internal pins
+    # vanished (botched migration, renamed table, parse error). Without this the
+    # completeness loop below would iterate zero times and pass silently —
+    # exactly the vacuous-green failure this guard exists to prevent.
+    if not required:
+        errors.append(
+            "no internal crw-* pins found in root [workspace.dependencies] "
+            "(expected the centralized internal crates) — completeness check "
+            "would be vacuous; refusing to pass"
+        )
+    for path_str, table, dep in sorted(required):
         if (path_str, table, dep) not in covered:
             errors.append(
                 f"{path_str}::$.{table}.{dep}.version: internal version pin not "

--- a/scripts/release/test_guards.py
+++ b/scripts/release/test_guards.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Regression tests for the release version-sync guards.
+
+The guards (`check-internal-dep-versions.sh` and `audit_release_please_config.py`)
+are load-bearing: they are the only thing standing between a forgotten version
+surface and a broken/empty release (the failure class that recurred across
+v0.9.0, v0.12.0). A guard that silently passes is worse than no guard, so these
+tests pin the load-bearing failure modes — drift, missing config entry,
+anti-vacuity, invalid jsonpath — and the green happy path. If a future refactor
+weakens a guard, one of these goes red instead of the release.
+
+Each test builds a minimal fixture workspace in a tmpdir and runs the REAL
+script entrypoints against it (the bash guard via CHECK_REPO_ROOT, the audit via
+cwd), so we test what actually ships, not a reimplementation.
+
+Dependency-free: runs under plain `uv run python scripts/release/test_guards.py`
+(no pytest needed — robust in CI without a network install) and is ALSO
+collectible by pytest if present, since the test_* functions take no fixtures.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GUARD = REPO / "scripts" / "check-internal-dep-versions.sh"
+AUDIT = REPO / "scripts" / "release" / "audit_release_please_config.py"
+
+VERSION = "1.0.0"
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def make_fixture(tmp: Path) -> None:
+    """A minimal but valid post-migration workspace: one internal dep (crw-core)
+    centralized in [workspace.dependencies], consumed by crw-server via
+    inheritance, plus crw-server's allowlisted self dev-dep."""
+    _write(
+        tmp / "Cargo.toml",
+        f"""[workspace]
+members = ["crates/crw-core", "crates/crw-server"]
+
+[workspace.package]
+version = "{VERSION}"
+
+[workspace.dependencies]
+crw-core = {{ path = "crates/crw-core", version = "{VERSION}" }}
+""",
+    )
+    _write(
+        tmp / "crates" / "crw-core" / "Cargo.toml",
+        """[package]
+name = "crw-core"
+version.workspace = true
+
+[dependencies]
+""",
+    )
+    _write(
+        tmp / "crates" / "crw-server" / "Cargo.toml",
+        """[package]
+name = "crw-server"
+version.workspace = true
+
+[dependencies]
+crw-core = { workspace = true }
+
+[dev-dependencies]
+crw-server = { path = ".", features = ["test-utils"] }
+""",
+    )
+    _write(
+        tmp / "release-please-config.json",
+        json.dumps(
+            {
+                "packages": {
+                    ".": {
+                        "extra-files": [
+                            {
+                                "type": "toml",
+                                "path": "Cargo.toml",
+                                "jsonpath": "$.workspace.package.version",
+                            },
+                            {
+                                "type": "toml",
+                                "path": "Cargo.toml",
+                                "jsonpath": "$.workspace.dependencies.crw-core.version",
+                            },
+                        ]
+                    }
+                }
+            },
+            indent=2,
+        ),
+    )
+
+
+def run_guard(fixture: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(GUARD)],
+        env={**os.environ, "CHECK_REPO_ROOT": str(fixture)},
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_audit(fixture: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(AUDIT)],
+        cwd=str(fixture),
+        capture_output=True,
+        text=True,
+    )
+
+
+def patch_toml(fixture: Path, old: str, new: str) -> None:
+    p = fixture / "Cargo.toml"
+    text = p.read_text()
+    assert old in text, f"fixture anchor not found: {old!r}"
+    p.write_text(text.replace(old, new))
+
+
+def patch_config(fixture: Path, fn) -> None:
+    p = fixture / "release-please-config.json"
+    cfg = json.loads(p.read_text())
+    fn(cfg)
+    p.write_text(json.dumps(cfg, indent=2))
+
+
+# --- happy path -----------------------------------------------------------
+
+
+def test_green_baseline(tmp_path):
+    make_fixture(tmp_path)
+    g = run_guard(tmp_path)
+    a = run_audit(tmp_path)
+    assert g.returncode == 0, g.stdout + g.stderr
+    assert a.returncode == 0, a.stdout + a.stderr
+
+
+# --- guard failure modes --------------------------------------------------
+
+
+def test_drift_pin_off_workspace_version(tmp_path):
+    """A [workspace.dependencies] pin not equal to the workspace version → red."""
+    make_fixture(tmp_path)
+    patch_toml(
+        tmp_path,
+        'crw-core = { path = "crates/crw-core", version = "1.0.0" }',
+        'crw-core = { path = "crates/crw-core", version = "0.9.0" }',
+    )
+    assert run_guard(tmp_path).returncode == 1
+
+
+def test_anti_vacuity_no_centralized_pins(tmp_path):
+    """If the centralized internal pins vanish, the guard must NOT pass vacuously."""
+    make_fixture(tmp_path)
+    patch_toml(
+        tmp_path,
+        '\ncrw-core = { path = "crates/crw-core", version = "1.0.0" }\n',
+        "\n",
+    )
+    assert run_guard(tmp_path).returncode == 1
+
+
+def test_residual_inline_pin_rejected(tmp_path):
+    """A member re-declaring an inline internal path pin (instead of inheriting) → red."""
+    make_fixture(tmp_path)
+    server = tmp_path / "crates" / "crw-server" / "Cargo.toml"
+    server.write_text(
+        server.read_text().replace(
+            "crw-core = { workspace = true }",
+            'crw-core = { path = "../crw-core", version = "1.0.0" }',
+        )
+    )
+    assert run_guard(tmp_path).returncode == 1
+
+
+def test_self_dev_dep_allowlisted(tmp_path):
+    """The crw-server self dev-dep (path = '.', no version) must stay allowed."""
+    make_fixture(tmp_path)
+    # Baseline already contains the self dev-dep; guard must be green.
+    assert run_guard(tmp_path).returncode == 0
+
+
+# --- audit failure modes --------------------------------------------------
+
+
+def test_missing_config_entry(tmp_path):
+    """An internal pin with no release-please-config entry → audit red (it would
+    go stale on the next bump — the exact v0.12.0 break)."""
+    make_fixture(tmp_path)
+
+    def drop_crw_core(cfg):
+        ef = cfg["packages"]["."]["extra-files"]
+        cfg["packages"]["."]["extra-files"] = [
+            e
+            for e in ef
+            if e.get("jsonpath") != "$.workspace.dependencies.crw-core.version"
+        ]
+
+    patch_config(tmp_path, drop_crw_core)
+    assert run_audit(tmp_path).returncode == 1
+
+
+def test_invalid_jsonpath(tmp_path):
+    """A config entry whose jsonpath doesn't resolve to a live field → audit red."""
+    make_fixture(tmp_path)
+
+    def add_bad(cfg):
+        cfg["packages"]["."]["extra-files"].append(
+            {
+                "type": "toml",
+                "path": "Cargo.toml",
+                "jsonpath": "$.workspace.dependencies.crw-nonexistent.version",
+            }
+        )
+
+    patch_config(tmp_path, add_bad)
+    assert run_audit(tmp_path).returncode == 1
+
+
+def test_audit_anti_vacuity(tmp_path):
+    """If no internal pins exist in [workspace.dependencies], the audit's
+    completeness check must refuse to pass vacuously."""
+    make_fixture(tmp_path)
+    patch_toml(
+        tmp_path,
+        '\ncrw-core = { path = "crates/crw-core", version = "1.0.0" }\n',
+        "\n",
+    )
+
+    def drop_crw_core(cfg):
+        cfg["packages"]["."]["extra-files"] = [
+            e
+            for e in cfg["packages"]["."]["extra-files"]
+            if e.get("jsonpath") != "$.workspace.dependencies.crw-core.version"
+        ]
+
+    patch_config(tmp_path, drop_crw_core)
+    assert run_audit(tmp_path).returncode == 1
+
+
+def _run_standalone() -> int:
+    """Minimal runner so the suite works without pytest installed.
+
+    pytest's `tmp_path` is a builtin fixture, so under pytest these same
+    test_* functions run unchanged; here we supply a fresh tmpdir per test.
+    """
+    tests = sorted(
+        (name, fn)
+        for name, fn in globals().items()
+        if name.startswith("test_") and callable(fn)
+    )
+    failures = 0
+    for name, fn in tests:
+        with tempfile.TemporaryDirectory() as d:
+            try:
+                fn(Path(d))
+                print(f"  PASS {name}")
+            except Exception as e:  # noqa: BLE001 — test runner surfaces all
+                failures += 1
+                print(f"  FAIL {name}: {e}")
+    total = len(tests)
+    print(f"\n{total - failures}/{total} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_standalone())


### PR DESCRIPTION
## Structural fix for the recurring release break (Closes #95)

> Supersedes #97. #97 takes the naive one-shot approach (bump pins to `0.12.0`) — which is now **stale and would re-break the build** (`main` is `0.12.1`, so pins at `0.12.0` reintroduce the mismatch), and it also drags in unrelated `claudedocs/` files. This PR removes the hazard at the root instead.

### The problem (recurring, not a one-off)
Internal crate-to-crate versions were pinned inline in **all 11 member manifests** (34 `{ path, version }` pins), and **each** had to be mirrored by a hand-maintained `release-please-config.json` `extra-files` entry. Forget one and release-please bumps the workspace version while leaving a pin stale → cargo can't resolve the path crate → the release ships broken/empty. This recurred across **v0.9.0, v0.11, v0.12.0** (#95), each patched reactively.

### The fix
- **Centralize**: the 10 depended-upon internal crates are declared **once** in root `[workspace.dependencies]`; members inherit via `{ workspace = true }` (features/optional layered per-member). The `crw-server` self dev-dep (`path = "."`, no version) is exempt — it can't inherit itself.
- **Pure refactor**: the `crw-*` dependency graph from `cargo metadata` is **byte-identical** before/after — published artifacts are unchanged (crates.io/npm/pypi consumers see no difference).
- **Config surface collapses 50 → 26 entries**: 34 scattered jsonpaths → 10 centralized `$.workspace.dependencies.<crate>.version` in one file.
- **Guards rewritten so the migration can't silently disable them** (members losing their inline `version` would make the old scan pass vacuously):
  - `check-internal-dep-versions.sh` — tomllib-based; reads the centralized pins; **anti-vacuity** (empty scan = error) + **residual scan** rejecting any member that re-declares an inline internal `path` pin (self dev-dep allowlisted).
  - `audit_release_please_config.py` — both `_internal_version_pins()` and `_config_covered_pins()` updated for the `$.workspace.dependencies.*` shape; anti-vacuity.
  - **`scripts/release/test_guards.py`** — dependency-free regression suite (drift / missing-entry / anti-vacuity / invalid-jsonpath / residual-pin / green), wired into `ci.yml` + `preflight-publish.yml` so weakening a guard fails red.

### Verification (all green locally)
- `cargo metadata` `crw-*` projection byte-identical pre/post
- `cargo check --workspace --locked --all-targets` ✅ · clippy/fmt ✅ (pre-commit) · `cargo test --workspace` ✅
- guard ✅ (10 pins) · audit ✅ (26 entries) · preflight ✅ · `test_guards.py` 8/8 ✅
- tier-0 crate `cargo publish --dry-run` succeeds (de-inline confirmed)

### Merge note
**Squash-merge this PR** (deliberate exception to the usual rebase-and-merge): a multi-commit rebase would expose intermediate states where the guards are vacuously green.
