### PR TITLE
ci(release): gate version-surface cohesion on the bump PR pre-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,10 @@ jobs:
 
       # Catches the config GAP at feature-PR time, independent of version state:
       # a new internal dep pin that isn't tracked in release-please-config.json
-      # fails here long before it can go stale on a release bump. The
-      # release-please PR itself does not trigger this CI (bot GITHUB_TOKEN),
-      # so the gap must be caught on the human PR that introduces the dep.
+      # fails here long before it can go stale on a release bump. Since
+      # release-please now authors its bump PR with an elevated token (see
+      # release-please.yml), that PR ALSO triggers this CI on its own head SHA,
+      # so a stale pin is caught pre-merge instead of post-tag.
       - name: Audit release-please config completeness
         run: python3 scripts/release/audit_release_please_config.py
 

--- a/.github/workflows/preflight-publish.yml
+++ b/.github/workflows/preflight-publish.yml
@@ -15,6 +15,8 @@ on:
       - "scripts/release/release_manifest.toml"
       - "scripts/release/preflight.py"
       - "scripts/release/audit_release_please_config.py"
+      - "scripts/release/test_guards.py"
+      - "scripts/check-internal-dep-versions.sh"
       - "npm/**/package.json"
       - "python/pyproject.toml"
       - "server.json"
@@ -34,6 +36,15 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      # Cache-proof internal-pin invariant. Runs here too (not just ci.yml) so
+      # that once the release-please bump PR triggers this workflow (via the
+      # elevated token in release-please.yml) the full guard set gates the merge.
+      - name: Internal dependency versions match workspace version
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/check-internal-dep-versions.sh
 
       - name: Run preflight (workspace + version surfaces)
         shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,23 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Author the release PR with an elevated token (NOT the default
+      # GITHUB_TOKEN). A PR opened by GITHUB_TOKEN cannot trigger other
+      # workflows, so the version-surface checks (preflight-publish.yml,
+      # ci.yml — both `on: pull_request`) never ran on the bump PR and a stale
+      # surface only surfaced post-tag. With this token the bump PR triggers
+      # those checks on its OWN head SHA, so — once `preflight-publish` is a
+      # Required status check in branch protection — a stale internal pin / npm
+      # surface BLOCKS the merge (and therefore the tag) instead of shipping a
+      # red, already-tagged release.
+      #
+      # GH_DISPATCH_PAT is the existing dispatch PAT; prefer migrating to a
+      # GitHub App installation token (actions/create-github-app-token) so the
+      # author is a bot identity with no human seat and a scoped, rotating key.
       - uses: googleapis/release-please-action@v4
         id: release
+        with:
+          token: ${{ secrets.GH_DISPATCH_PAT }}
 
   dispatch-release:
     needs: release-please

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,8 +23,15 @@ Each tag also produces `release-audit-<version>.md` as a workflow artifact and a
 
 - **Tier order & publish flags:** `scripts/release/release_manifest.toml`
 - **Workspace publishability:** `scripts/release/preflight.py` (run on every PR via `preflight-publish.yml`)
-- **release-please extra-files validity:** `scripts/release/audit_release_please_config.py`
+- **release-please extra-files validity + internal-pin completeness:** `scripts/release/audit_release_please_config.py`
+- **Internal crate-to-crate versions:** centralized in root `[workspace.dependencies]` (members inherit via `{ workspace = true }`); `scripts/check-internal-dep-versions.sh` enforces they equal the workspace version. Guarded against regression by `scripts/release/test_guards.py`.
 - **Tag → version derivation:** `release-context` job in `release.yml` (semver-validated)
+
+### Version cohesion — why the bump PR can't ship a stale surface
+
+Every version surface (workspace version, the 10 internal `[workspace.dependencies]` pins, npm main + optionalDependencies + platform packages, `pyproject.toml`, `server.json`) must move in lockstep on a release. The historical break (v0.9.0, v0.12.0) was a stale surface slipping through because the **release-please bump PR is bot-authored and bot PRs cannot trigger workflows** — so the checks only ran post-tag.
+
+Fixed by authoring the bump PR with an elevated token (`release-please.yml` → `with.token`), so it triggers `preflight-publish.yml` + `ci.yml` on its own head SHA before merge. **Operational requirement: `preflight-publish` must be a _Required_ status check in branch protection for the `main` / release-please branch** — that is what makes a red preflight *block the merge* (and therefore the tag) rather than just annotate it. Detection without the Required check is not prevention.
 
 ## Recovery runbooks
 
@@ -67,7 +74,7 @@ These tags were cut while the release pipeline silently failed (cargo publish ou
 
 1. Add the crate to the workspace as usual (no `publish` field, or `publish = true`).
 2. Decide its tier: which tier-N crates does it depend on? Add it to the next tier in `scripts/release/release_manifest.toml`.
-3. If it has its own version surfaces (`Cargo.toml` deps in other crates), add `extra-files` entries in `release-please-config.json`. Run `uv run python scripts/release/audit_release_please_config.py` to confirm the jsonpaths resolve.
+3. If other crates depend on it, add **one** entry to the root `[workspace.dependencies]` table (`<crate> = { path = "crates/<crate>", version = "<workspace version>" }`) and have every consumer inherit it via `<crate> = { workspace = true }` (layer `features` / `optional` per-member; **never** inline `version =` in a member manifest). Add the matching `release-please-config.json` extra-file `$.workspace.dependencies.<crate>.version`. Run `bash scripts/check-internal-dep-versions.sh` and `uv run python scripts/release/audit_release_please_config.py` — both fail red if the pin drifts or its config entry is missing. (npm platform packages are discovered by glob, so adding one needs no guard edit.)
 4. **First-publish ownership:** the user behind `CARGO_REGISTRY_TOKEN` becomes the initial owner. Verify the crate name is unclaimed — `curl -s https://crates.io/api/v1/crates/<name>` should return `{"errors":[{"detail":"Not Found"}]}`. After the first publish, optionally `cargo owner --add github:us:release-bots <name>`.
 5. Open a PR. `preflight-publish.yml` runs the full workspace check — green means the crate is publishable.
 

--- a/scripts/release/preflight.py
+++ b/scripts/release/preflight.py
@@ -145,32 +145,46 @@ def collect_version_surfaces(ws_version: str) -> list[tuple[str, str, str]]:
         d = tomllib.loads(py.read_text())
         rows.append((str(py), ws_version, d.get("project", {}).get("version", "MISSING")))
 
-    # npm main + platform packages
+    # npm platform packages, discovered by globbing `npm/crw-mcp-*/package.json`
+    # (the main package `npm/crw-mcp` has no trailing `-` so it is excluded).
+    # Self-deriving: adding a platform needs NO edit here — the old hardcoded
+    # 6-tuples meant a 7th platform was silently unchecked.
+    platform_pkgs = sorted(Path("npm").glob("crw-mcp-*/package.json"))
+    disk_platforms = {p.parent.name for p in platform_pkgs}
+
+    # npm main package: version + every internal optionalDependencies pin, with
+    # the platform key set read from the manifest itself.
     npm_main = Path("npm/crw-mcp/package.json")
+    opt_platforms: set[str] = set()
     if npm_main.exists():
         d = json.loads(npm_main.read_text())
         rows.append((str(npm_main) + ":version", ws_version, d.get("version", "MISSING")))
-        opt = d.get("optionalDependencies", {})
-        for plat in (
-            "crw-mcp-darwin-x64", "crw-mcp-darwin-arm64",
-            "crw-mcp-linux-x64", "crw-mcp-linux-arm64",
-            "crw-mcp-win32-x64", "crw-mcp-win32-arm64",
-        ):
-            actual = opt.get(plat, "MISSING")
+        for dep, actual in sorted(d.get("optionalDependencies", {}).items()):
+            if not dep.startswith("crw-mcp-"):
+                continue
+            opt_platforms.add(dep)
             # Accept exact, ^v, ~v.
             if actual in (ws_version, f"^{ws_version}", f"~{ws_version}"):
                 continue
-            rows.append((f"{npm_main}:optionalDependencies.{plat}", ws_version, actual))
+            rows.append((f"{npm_main}:optionalDependencies.{dep}", ws_version, actual))
 
-    for plat in (
-        "crw-mcp-darwin-x64", "crw-mcp-darwin-arm64",
-        "crw-mcp-linux-x64", "crw-mcp-linux-arm64",
-        "crw-mcp-win32-x64", "crw-mcp-win32-arm64",
-    ):
-        pkg_json = Path(f"npm/{plat}/package.json")
-        if pkg_json.exists():
-            d = json.loads(pkg_json.read_text())
-            rows.append((str(pkg_json) + ":version", ws_version, d.get("version", "MISSING")))
+        # Cross-check: every platform package on disk must be listed in
+        # optionalDependencies (and vice-versa), so a new platform can't be
+        # half-wired and silently skipped.
+        for missing in sorted(disk_platforms - opt_platforms):
+            rows.append((
+                f"{npm_main}:optionalDependencies.{missing}", ws_version,
+                "MISSING (platform package exists on disk but not in optionalDependencies)",
+            ))
+        for extra in sorted(opt_platforms - disk_platforms):
+            rows.append((
+                f"{npm_main}:optionalDependencies.{extra}", "a platform package dir",
+                "MISSING (listed in optionalDependencies but no npm/<plat>/package.json)",
+            ))
+
+    for pkg_json in platform_pkgs:
+        d = json.loads(pkg_json.read_text())
+        rows.append((str(pkg_json) + ":version", ws_version, d.get("version", "MISSING")))
 
     # server.json (MCP registry)
     sj = Path("server.json")


### PR DESCRIPTION
## Re-apply Phase 4+6 hardening lost in #102's rebase

#102 was meant to land the version-surface cohesion hardening, but a messy rebase dropped everything except the `version.txt` deletion. This PR re-applies the rest cleanly on top of the (correctly landed) structural fix from #101.

### Changes
- **Bump-PR pre-tag gate**: author the release-please PR with an elevated token (`release-please.yml` → `with.token`) so it triggers `preflight-publish.yml` + `ci.yml` on its own head SHA. *Operational requirement: mark `preflight-publish` a Required branch-protection check* so a red preflight blocks the merge (documented in `RELEASE.md`).
- **Self-deriving surfaces**: `preflight.py` globs `npm/crw-mcp-*/package.json` and reads `optionalDependencies` keys dynamically instead of three hardcoded 6-platform tuples, plus a disk↔optionalDependencies cross-check. Verified: injecting a fake platform dir makes preflight go red.
- Run `check-internal-dep-versions.sh` in `preflight-publish.yml` too.
- Correct the now-stale `ci.yml` comment about bot PRs not triggering CI.

### Verification
- `preflight.py` ✅ (self-deriving; negative probe → red) · guard ✅ · `test_guards.py` 8/8 ✅ · all YAML parses

Follow-up to #101 (merged). Validated end-to-end: release-please PR #103 now bumps the 10 centralized `[workspace.dependencies]` pins from one file, touching zero `crates/*/Cargo.toml`.
