### PR TITLE
fix(release): correct publish tier ordering + guard topology

### DIFF
--- a/scripts/release/preflight.py
+++ b/scripts/release/preflight.py
@@ -246,6 +246,29 @@ def main() -> int:
                 f"either publish those crates or remove from defaults."
             )
 
+    # 3b. Tier topology: every internal dep must publish in an EARLIER tier.
+    #     Within a tier crates are assumed independent — the driver waits for
+    #     crates.io propagation only at tier boundaries, not between same-tier
+    #     crates. A same-tier (or later) dep means a crate tries to resolve a
+    #     sibling that isn't on the index yet, which aborts the crates.io
+    #     publish from that crate onward (this skipped renderer..mcp on 0.13.0).
+    tier_of = {c: t["order"] for t in manifest["tiers"] for c in t["crates"]}
+    for pkg in meta["packages"]:
+        name = pkg["name"]
+        if name not in tier_of:
+            continue
+        for dep in pkg.get("dependencies", []):
+            if dep.get("kind") not in (None, "build"):
+                continue
+            dn = dep["name"]
+            if dn in tier_of and tier_of[dn] >= tier_of[name]:
+                errors.append(
+                    f"tier ordering: {name} (tier {tier_of[name]}) depends on "
+                    f"{dn} (tier {tier_of[dn]}) — a dependency must publish in an "
+                    f"earlier tier; move {dn} up or {name} down in "
+                    f"release_manifest.toml."
+                )
+
     # 4. Path/git deps need version field
     for pkg in meta["packages"]:
         if pkg["name"] not in published:

--- a/scripts/release/release_manifest.toml
+++ b/scripts/release/release_manifest.toml
@@ -17,26 +17,38 @@ crates = ["crw-mcp-proto"]
 order = 1
 crates = ["crw-core"]
 
+# Within a tier crates MUST be independent of each other (the driver waits for
+# crates.io propagation only at tier boundaries, not between same-tier crates).
+# crw-renderer depends on crw-extract, so it cannot share tier 2 with it — that
+# ordering bug skipped the crates.io publish from crw-renderer onward (a crate
+# tried to resolve a sibling that wasn't on the index yet). renderer gets its
+# own tier after extract.
 [[tiers]]
 order = 2
-crates = ["crw-renderer", "crw-extract", "crw-search", "crw-diff"]
+crates = ["crw-extract", "crw-search", "crw-diff"]
 
 [[tiers]]
+# crw-renderer depends on crw-extract (tier 2).
 order = 3
+crates = ["crw-renderer"]
+
+[[tiers]]
+# crw-crawl depends on crw-renderer, crw-diff, crw-extract.
+order = 4
 crates = ["crw-crawl"]
 
 [[tiers]]
 # crw-monitor depends on crw-crawl and is an optional dependency of crw-server,
 # so it must publish after crw-crawl and before crw-server.
-order = 4
+order = 5
 crates = ["crw-monitor"]
 
 [[tiers]]
-order = 5
+order = 6
 crates = ["crw-server"]
 
 [[tiers]]
-order = 6
+order = 7
 crates = ["crw-mcp"]
 
 [unpublished]


### PR DESCRIPTION
**Why 0.13.0's crates.io publish broke** (and prior releases too — crw-extract/renderer have been stuck at 0.10.0 on crates.io).

crw-renderer depends on crw-extract but shared tier 2 with it. The driver waits for crates.io propagation only at tier *boundaries*, so renderer published before extract was on the index → `failed to select a version for crw-extract = ^0.13.0` aborted the publish from renderer onward. **Not** caused by the workspace.dependencies migration (published manifests are byte-identical).

- Move crw-renderer to its own tier after crw-extract; renumber tiers.
- Add a preflight **tier-topology guard**: every internal dep must publish in an earlier tier than its dependent. Negative-tested — flags the renderer↔extract same-tier case red.

Unblocks completing the crates.io side of releases. (npm 0.13.0 failed separately on a 2FA/token issue — needs NPM_TOKEN reconfigured, not in this PR.)