### PR TITLE
ci(release): allow temporarily skipping npm via SKIP_NPM var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,11 @@ jobs:
 
   publish-npm:
     needs: [release-context, asset-gate]
+    # Temporarily disable npm publishing by setting repo variable SKIP_NPM=true
+    # (e.g. while the npm token can't publish — 2FA-bypass granular token not yet
+    # configured). The job is cleanly SKIPPED (gray), not failed/masked. Clear
+    # the SKIP_NPM repo variable to re-enable. See RELEASE.md.
+    if: ${{ vars.SKIP_NPM != 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -486,6 +491,10 @@ jobs:
       - publish-mcp-registry
       - update-apt
       - update-homebrew
+    # Run even when an optional publish job is skipped (e.g. publish-npm under
+    # SKIP_NPM) — `!cancelled()` lets verification report on whatever shipped
+    # instead of being skipped along with the gated job.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -498,6 +507,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_NPM: ${{ vars.SKIP_NPM }}
         run: |
           set -euo pipefail
           bash scripts/release/verify_publish.sh \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,18 @@ The pipeline is idempotent — re-run is safe.
 - **MCP Registry**: re-run `mcp-publisher publish`.
 - **APT/Homebrew**: re-trigger via `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
 
+### Temporarily disabling npm publishing
+
+If the npm token can't publish (npm now rejects classic automation tokens with
+`403 ... two-factor authentication ... required`), set the repo variable
+`SKIP_NPM=true` (`gh variable set SKIP_NPM --body true`). `publish-npm` is then
+cleanly **skipped** (gray, not failed) and `verify-publish` records npm as
+`skipped` — the release goes green on every other registry. **Re-enable** by
+clearing it (`gh variable delete SKIP_NPM`) once `NPM_TOKEN` is a *granular*
+access token with publish permission (these bypass 2FA), or after configuring
+npm OIDC trusted publishing for each package (the workflow already grants
+`id-token: write`).
+
 ### A version was published with broken metadata (e.g. wrong npm optionalDeps)
 
 crates.io and npm versions are **immutable**. Do not try to overwrite. Instead:

--- a/scripts/release/verify_publish.sh
+++ b/scripts/release/verify_publish.sh
@@ -33,7 +33,14 @@ run_check() {
 
 run_check "crates.io"   "$SCRIPT_DIR/verify_crates.sh"        "$v"
 run_check "PyPI"        "$SCRIPT_DIR/verify_pypi.sh"          "$v"
-run_check "npm"         "$SCRIPT_DIR/verify_npm.sh"           "$v"
+# npm can be temporarily disabled (SKIP_NPM=true) when the npm token can't
+# publish (e.g. 2FA-bypass token not yet configured). Skipping is explicit in
+# the audit — not a silent pass. Re-enable by clearing the SKIP_NPM repo var.
+if [ "${SKIP_NPM:-}" = "true" ]; then
+  results+=("| npm | skipped (SKIP_NPM) |")
+else
+  run_check "npm"       "$SCRIPT_DIR/verify_npm.sh"           "$v"
+fi
 run_check "Docker GHCR" "$SCRIPT_DIR/verify_docker.sh"        "$v"
 run_check "MCP registry""$SCRIPT_DIR/verify_mcp_registry.sh"  "$v"
 if [ -n "$corr" ]; then


### PR DESCRIPTION
npm rejects the current classic token (403, needs a 2FA-bypass granular token). Until that's reconfigured, gate `publish-npm` on `vars.SKIP_NPM != 'true'` (already set to `true`) so it is cleanly **skipped** — not a red/masked failure. `verify-publish` runs via `!cancelled()` and records npm as `skipped`. Nothing else depends on npm, so crates.io/pypi/docker/binaries/apt/homebrew ship green. Re-enable by deleting the SKIP_NPM repo variable. Documented in RELEASE.md.