### PR TITLE
ci(release): retry cross install to survive transient network errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,22 @@ jobs:
 
       - name: Install cross (Linux ARM only)
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # Retry: `cargo install cross` builds from source and pulls crates from
+        # the network; a single transient curl/HTTP2 hiccup (e.g. "Error in the
+        # HTTP2 framing layer") otherwise fails the whole arm64 binary and
+        # cascades to skip asset-gate -> pypi/npm/apt/homebrew. 3 attempts with
+        # backoff turn a flaky download into a non-event.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if cargo install cross --git https://github.com/cross-rs/cross; then
+              exit 0
+            fi
+            echo "::warning::cross install attempt ${attempt}/3 failed (transient network); retrying in $((attempt * 20))s"
+            sleep "$((attempt * 20))"
+          done
+          echo "::error::cross install failed after 3 attempts"
+          exit 1
 
       - name: Build
         shell: bash


### PR DESCRIPTION
On v0.13.2, the aarch64-linux binary failed because `cargo install cross` hit a transient `[16] Error in the HTTP2 framing layer` downloading a crate. That single network hiccup cascaded: asset-gate (needs all binaries) skipped → pypi/npm/apt/homebrew skipped. Wrap the install in 3 attempts with backoff so transient network errors don't break a release. (crates.io itself published fine — this is the binary-build leg only.)