### PR TITLE
perf(docker): cross-compile arm64 instead of QEMU (2h -> ~3min)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,60 @@
-FROM rust:1.93-bookworm AS builder
+# Cross-compiling multi-arch build.
+#
+# The builder runs on the NATIVE build platform (`--platform=$BUILDPLATFORM`)
+# and cross-compiles to the requested target arch. Previously the builder ran
+# under QEMU for linux/arm64, which emulated the *entire* Rust compile and took
+# ~2h per release. Cross-compiling on the native runner brings arm64 back to
+# minutes; only the tiny runtime layer (ca-certificates) still touches QEMU.
+FROM --platform=$BUILDPLATFORM rust:1.93-bookworm AS builder
+
+# Provided automatically by buildx: amd64 | arm64.
+ARG TARGETARCH
 
 WORKDIR /app
+
+# Install the Rust target + (for arm64) the cross linker, and record the
+# rustc target triple for the build step.
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) RUST_TARGET=x86_64-unknown-linux-gnu ;; \
+      arm64) RUST_TARGET=aarch64-unknown-linux-gnu; \
+             apt-get update; \
+             apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu; \
+             rm -rf /var/lib/apt/lists/* ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$RUST_TARGET"; \
+    echo "$RUST_TARGET" > /rust_target
+
 COPY . .
 
-RUN cargo build --release -p crw-server --features cdp -p crw-mcp -p crw-cli
+# Linker for the aarch64 cross target (ignored when building amd64 natively).
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+# The workspace release profile uses fat LTO + codegen-units=1, whose final
+# link of crw-server (aws-lc-sys + the full dep graph) needs several GB and
+# OOM-killed the docker build (see #90's 4 GB OOM warning). The container
+# binary doesn't need max LTO, so use thin LTO across more codegen units —
+# far lower peak memory and a faster link, negligible runtime difference.
+ENV CARGO_PROFILE_RELEASE_LTO=thin \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
+
+RUN set -eux; \
+    RUST_TARGET="$(cat /rust_target)"; \
+    cargo build --release --target "$RUST_TARGET" \
+      -p crw-server --features cdp -p crw-mcp -p crw-cli; \
+    mkdir -p /out; \
+    cp "target/${RUST_TARGET}/release/crw" \
+       "target/${RUST_TARGET}/release/crw-server" \
+       "target/${RUST_TARGET}/release/crw-mcp" /out/
 
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/crw /usr/local/bin/crw
-COPY --from=builder /app/target/release/crw-server /usr/local/bin/crw-server
-COPY --from=builder /app/target/release/crw-mcp /usr/local/bin/crw-mcp
+COPY --from=builder /out/crw /usr/local/bin/crw
+COPY --from=builder /out/crw-server /usr/local/bin/crw-server
+COPY --from=builder /out/crw-mcp /usr/local/bin/crw-mcp
 COPY config.default.toml /app/config.default.toml
 COPY config.docker.toml /app/config.docker.toml
 


### PR DESCRIPTION
**The last release pain point.** publish-docker took ~2h because the Dockerfile ran `cargo build` *inside* the build, so the linux/arm64 image compiled the whole workspace under QEMU emulation — and OOM-killed on the fat-LTO link (#90's 4 GB warning).

Fix: build on the native `$BUILDPLATFORM` and **cross-compile** to the target arch (rustup target + `gcc-aarch64-linux-gnu` linker), with **thin LTO + codegen-units=16** to keep the link within memory. Only the tiny runtime layer (ca-certificates) still touches QEMU.

Verified locally with `docker buildx build --platform linux/arm64`: **2m46s, no OOM** (was ~2h). The published image is identical in contents (same 3 binaries, `--features cdp`), just built faster.