### PR TITLE
fix(release): stop verify-publish reporting false failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,7 +456,17 @@ jobs:
         run: mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: mcp-publisher publish
+        # The registry intermittently returns 5xx (504 seen on v0.13.2). Retry
+        # so a transient gateway error doesn't fail an otherwise-green release.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4; do
+            if mcp-publisher publish; then exit 0; fi
+            echo "::warning::mcp-publisher publish attempt ${attempt}/4 failed (transient registry error); retrying in $((attempt * 20))s"
+            sleep "$((attempt * 20))"
+          done
+          echo "::error::mcp-publisher publish failed after 4 attempts"
+          exit 1
 
       - name: Verify
         shell: bash

--- a/scripts/release/verify_crates.sh
+++ b/scripts/release/verify_crates.sh
@@ -18,6 +18,11 @@ while [ $# -gt 0 ]; do
 done
 
 mapfile -t crates < <(awk '
+  # Reset on every section header so [unpublished]/[npm]/... crate lists are
+  # NOT treated as tier crates. inblock was never cleared before, so
+  # crw-browse/crw-cli from [unpublished] leaked in and verify reported them
+  # as MISSING on crates.io.
+  /^\[/ { inblock=0 }
   /^\[\[tiers\]\]/ { inblock=1; next }
   inblock && /^crates/ {
     s=$0; sub(/^[^=]*=\s*\[/,"",s); sub(/\]\s*$/,"",s)

--- a/scripts/release/verify_publish.sh
+++ b/scripts/release/verify_publish.sh
@@ -42,7 +42,7 @@ else
   run_check "npm"       "$SCRIPT_DIR/verify_npm.sh"           "$v"
 fi
 run_check "Docker GHCR" "$SCRIPT_DIR/verify_docker.sh"        "$v"
-run_check "MCP registry""$SCRIPT_DIR/verify_mcp_registry.sh"  "$v"
+run_check "MCP registry" "$SCRIPT_DIR/verify_mcp_registry.sh" "$v"
 if [ -n "$corr" ]; then
   run_check "APT/Homebrew" "$SCRIPT_DIR/verify_apt_homebrew.sh" "$v" "$corr"
 else


### PR DESCRIPTION
0.13.2 published everywhere (crates.io 10/10, pypi, docker, apt, homebrew) but the **verify-publish** job went red on bugs in the *verifier*, not the publishes:

- `verify_crates.sh` awk never reset `inblock` → checked `[unpublished]` crates (crw-browse, crw-cli) against crates.io → false MISSING. Reset on each section header.
- `verify_publish.sh`: `"MCP registry""$SCRIPT_DIR"` (no space) concatenated → ran the version as a command. Add space.
- `mcp-publisher publish` hit a transient 504 → retry 4x.

These are what made a fully-published release still show 'failure'. (apt/homebrew verify timeout on 0.13.2 was likely the cancel+rerun breaking the correlation id; will confirm on the next clean release.)