### PR TITLE
fix(docker): aarch64 libc headers for cross-compile + CI build guard

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+name: Docker Build
+
+# Validates the multi-arch container build (incl. the aarch64 cross-compile)
+# in CI, so a Dockerfile/toolchain break is caught on the PR instead of only
+# at release time. Builds both platforms but does NOT push.
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "config.default.toml"
+      - "config.docker.toml"
+      - ".github/workflows/docker-build.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/setup-qemu-action@v3
+
+      - name: Build multi-arch image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
+          outputs: type=cacheonly

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ RUN set -eux; \
       amd64) RUST_TARGET=x86_64-unknown-linux-gnu ;; \
       arm64) RUST_TARGET=aarch64-unknown-linux-gnu; \
              apt-get update; \
-             apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu; \
+             # crossbuild-essential-arm64 = the aarch64 gcc/g++ AND the target
+             # libc dev headers (libc6-dev-arm64-cross). The bare cross gcc
+             # alone lacks sys/types.h etc., which broke aws-lc-sys's C build.
+             apt-get install -y --no-install-recommends crossbuild-essential-arm64; \
              rm -rf /var/lib/apt/lists/* ;; \
       *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
     esac; \


### PR DESCRIPTION
**v0.13.3's publish-docker failed** — my cross-compile change installed only `gcc-aarch64-linux-gnu` (linker), not the aarch64 libc dev headers, so `aws-lc-sys`'s C build hit `sys/types.h: No such file or directory`. (It passed locally because my machine already had the headers — incomplete validation, my fault.)

- Use `crossbuild-essential-arm64` (cross gcc/g++ + `libc6-dev-arm64-cross`).
- **New `docker-build.yml`**: builds the multi-arch image (no push) on Dockerfile/Cargo PRs, so this is validated in the *real CI environment* on the PR — this very PR's docker-build job is the proof. No more discovering container breaks at release time.