### PR TITLE
fix(release): verify apt/homebrew by artifact, not flaky status-ack

### DIFF
--- a/scripts/release/verify_apt_homebrew.sh
+++ b/scripts/release/verify_apt_homebrew.sh
@@ -1,65 +1,57 @@
 #!/usr/bin/env bash
-# Verify that an APT/Homebrew dispatch was actually consumed by the
-# downstream repo and produced the expected artifact.
+# Verify that the APT/Homebrew dispatch was consumed and produced the artifact.
 #
-# Strategy (codex review v4 C5 + v5 W12):
-#   1. Search recent commits in each downstream repo for a commit status
-#      whose context = "crw-release-<version>" and description = correlation_id.
-#   2. Verify the actual artifact landed (deb file in apt-crw release; version
-#      bump in homebrew-crw Formula/crw.rb).
+# We verify the ARTIFACTS directly (the real signal), polling because the
+# downstream repos build asynchronously after the dispatch:
+#   - apt-crw:      pool/crw_<version>_amd64.deb committed to the repo.
+#   - homebrew-crw: Formula/crw.rb pinned to <version>.
 #
-# Usage: verify_apt_homebrew.sh <version> <correlation_id>
+# An earlier version also waited 30min for a `crw-release-<version>` commit
+# status on each repo, but those repos don't post that status reliably, so it
+# produced false failures even when the package shipped (and the apt check
+# looked at a GitHub *release* asset, while apt-crw actually publishes the .deb
+# by committing it to pool/). The committed artifact is the source of truth.
+#
+# Usage: verify_apt_homebrew.sh <version> [correlation_id]
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
 v="${1:?version required}"
-corr="${2:?correlation_id required}"
+: "${2:-}"  # correlation_id accepted for call compatibility; no longer used
 
-end=$((SECONDS + 1800))  # 30min per repo
-
-verify_repo_status() {
-  local repo="$1" ctx="crw-release-$v"
-  while (( SECONDS < end )); do
-    # Search the most recent 20 commits for matching status.
-    while read -r sha; do
-      [ -z "$sha" ] && continue
-      hit=$(gh api "repos/$repo/commits/$sha/statuses" 2>/dev/null \
-            | jq -r --arg c "$ctx" --arg d "$corr" \
-              '.[]? | select(.context == $c and .description == $d) | .sha' \
-            | head -1) || true
-      if [ -n "$hit" ]; then
-        notice "$repo: matched status $ctx on $sha"
-        return 0
-      fi
-    done < <(gh api "repos/$repo/commits?per_page=20" -q '.[].sha' 2>/dev/null)
-    sleep 30
-  done
-  err "$repo: no status $ctx with correlation_id=$corr found in 30min"
-  return 1
+apt_ok() {
+  # contents API returns 200 if the committed .deb exists on the default branch.
+  gh api "repos/us/apt-crw/contents/pool/crw_${v}_amd64.deb" >/dev/null 2>&1
+}
+brew_ok() {
+  gh api "repos/us/homebrew-crw/contents/Formula/crw.rb" 2>/dev/null \
+    | jq -r .content | base64 -d 2>/dev/null | grep -q "version \"$v\""
 }
 
-fail=0
-verify_repo_status us/apt-crw      || fail=1
-verify_repo_status us/homebrew-crw || fail=1
+end=$((SECONDS + 1200))  # 20min for the async downstream builds
+while (( SECONDS < end )); do
+  if apt_ok && brew_ok; then
+    printf '✓ apt-crw pool/crw_%s_amd64.deb present\n' "$v"
+    printf '✓ homebrew-crw Formula/crw.rb pinned to %s\n' "$v"
+    exit 0
+  fi
+  sleep 30
+done
 
-# Artifact verification (independent of the status check, in case the
-# downstream forgot to write the status but still produced the artifact).
-if gh release view -R us/apt-crw "v$v" --json assets \
-    -q '.assets[].name' 2>/dev/null | grep -q "crw_${v}_amd64.deb"; then
-  printf '✓ apt-crw release v%s has crw_%s_amd64.deb\n' "$v" "$v"
+# Timed out — report which artifact is still missing.
+fail=0
+if apt_ok; then
+  printf '✓ apt-crw pool/crw_%s_amd64.deb present\n' "$v"
 else
-  printf '❌ apt-crw release v%s missing crw_%s_amd64.deb\n' "$v" "$v"
+  printf '❌ apt-crw pool/crw_%s_amd64.deb missing after 20min\n' "$v"
   fail=1
 fi
-
-if gh api repos/us/homebrew-crw/contents/Formula/crw.rb 2>/dev/null \
-    | jq -r .content | base64 -d 2>/dev/null | grep -q "version \"$v\""; then
+if brew_ok; then
   printf '✓ homebrew-crw Formula/crw.rb pinned to %s\n' "$v"
 else
-  printf '❌ homebrew-crw Formula/crw.rb does not contain version "%s"\n' "$v"
+  printf '❌ homebrew-crw Formula/crw.rb not pinned to %s after 20min\n' "$v"
   fail=1
 fi
-
 exit "$fail"


### PR DESCRIPTION
(Clean re-do of #120, which accidentally included unrelated local commits.)

verify-publish went red on APT/Homebrew even though the packages shipped. Two bugs in verify_apt_homebrew.sh:
- It waited 30min for a `crw-release-<v>` commit status the downstream repos don't post → false failure.
- The apt check looked for a GitHub *release* asset, but apt-crw publishes the .deb by committing it to `pool/`.

Rewrite to poll the real artifacts (apt-crw `pool/crw_<v>_amd64.deb`; homebrew `Formula/crw.rb` version) up to 20min, passing once both are present. Companion fix in us/apt-crw#1 (merged) repaired the apt build itself — verified: apt `crw_0.13.4_amd64.deb` and homebrew formula are both present, so this verify now passes for 0.13.4.