### PR TITLE
fix env for docker CRW_AUTH__API_KEYS

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1102,9 +1102,42 @@ fn default_true_ext() -> bool {
     true
 }
 
+/// Custom deserializer for Vec<String> that accepts:
+/// - TOML array: `api_keys = ["key1", "key2"]`
+/// - JSON array: `["key1", "key2"]` (for env vars)
+/// - Comma-separated: `key1,key2` (for simple env var usage)
+fn deserialize_string_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        Vec(Vec<String>),
+        Str(String),
+    }
+
+    match StringOrVec::deserialize(deserializer)? {
+        StringOrVec::Vec(v) => Ok(v),
+        StringOrVec::Str(s) => {
+            let s = s.trim();
+            // Try JSON array first
+            if s.starts_with('[') {
+                serde_json::from_str(s).map_err(serde::de::Error::custom)
+            } else {
+                // Comma-separated fallback
+                Ok(s.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect())
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct AuthConfig {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_vec")]
     pub api_keys: Vec<String>,
 }
 

--- a/crates/crw-core/tests/config_tests.rs
+++ b/crates/crw-core/tests/config_tests.rs
@@ -80,3 +80,43 @@ fn app_config_deserialize_empty() {
     assert_eq!(config.renderer.mode, RendererMode::Auto);
     assert_eq!(config.crawler.max_concurrency, 10);
 }
+
+#[test]
+fn auth_config_api_keys_toml_array() {
+    let toml_str = r#"
+        api_keys = ["key1", "key2"]
+    "#;
+    let config: AuthConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.api_keys, vec!["key1", "key2"]);
+}
+
+#[test]
+fn auth_config_api_keys_empty() {
+    let toml_str = "";
+    let config: AuthConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.api_keys.is_empty());
+}
+
+#[test]
+fn auth_config_api_keys_json_string() {
+    // JSON array as string (what env vars pass)
+    let toml_str = r#"api_keys = "[\"key1\", \"key2\"]""#;
+    let config: AuthConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.api_keys, vec!["key1", "key2"]);
+}
+
+#[test]
+fn auth_config_api_keys_comma_separated() {
+    // Comma-separated string
+    let toml_str = r#"api_keys = "key1,key2""#;
+    let config: AuthConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.api_keys, vec!["key1", "key2"]);
+}
+
+#[test]
+fn auth_config_api_keys_comma_with_spaces() {
+    // Comma-separated with spaces
+    let toml_str = r#"api_keys = "key1, key2 , key3""#;
+    let config: AuthConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.api_keys, vec!["key1", "key2", "key3"]);
+}


### PR DESCRIPTION
root@C20241211165165:/data/conf# docker run --rm   -e CRW_AUTH__API_KEYS=["test"]   ghcr.io/us/crw:latest
ERROR crw_server: Failed to load configuration: invalid type: string "[test123456]", expected a sequence for key `auth.api_keys`