### PR TITLE
feat(release): publish crw-cli to crates.io (incl. PDF parse)

### DIFF
--- a/crates/crw-browse/Cargo.toml
+++ b/crates/crw-browse/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "MCP server for interactive browser automation over CDP"
-publish = false
 
 [dependencies]
 crw-core = { workspace = true }

--- a/crates/crw-cli/Cargo.toml
+++ b/crates/crw-cli/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "crw — Unified CLI for web scraping, crawling, search, and serving"
-publish = false
 
 [[bin]]
 name = "crw"

--- a/scripts/release/release_manifest.toml
+++ b/scripts/release/release_manifest.toml
@@ -34,8 +34,10 @@ crates = ["crw-renderer"]
 
 [[tiers]]
 # crw-crawl depends on crw-renderer, crw-diff, crw-extract.
+# crw-browse depends only on crw-core + crw-renderer and is independent of
+# crw-crawl, so it shares this tier (required by crw-cli's `browse` feature).
 order = 4
-crates = ["crw-crawl"]
+crates = ["crw-crawl", "crw-browse"]
 
 [[tiers]]
 # crw-monitor depends on crw-crawl and is an optional dependency of crw-server,
@@ -51,10 +53,17 @@ crates = ["crw-server"]
 order = 7
 crates = ["crw-mcp"]
 
+[[tiers]]
+# crw-cli (the `crw` binary) depends on crw-server (tier 6) + crw-browse
+# (tier 4), so it publishes last. Distributed both via crates.io
+# (`cargo install crw-cli`) and prebuilt release binaries (install.sh).
+order = 8
+crates = ["crw-cli"]
+
 [unpublished]
-# Internal binaries that don't need crates.io distribution.
-# Each must have `publish = false` in its Cargo.toml.
-crates = ["crw-browse", "crw-cli"]
+# Every workspace crate now publishes to crates.io. Keep this key (preflight
+# asserts each crate is either tiered or listed here — no silent third state).
+crates = []
 
 [npm]
 main_package = "crw-mcp"


### PR DESCRIPTION
## Why
`crw-cli` was set `publish = false` (3104cc5) to unblock a broken release — freezing it at **0.7.1** on crates.io while every library crate moved to **0.14.x**. So `cargo install crw-cli` gives an ancient binary with no PDF parse, no v2, etc.

## What
Re-enable crates.io publishing for `crw-cli` so it ships the current `crw` (including `crw scrape ./file.pdf` PDF→markdown via `crw-extract`'s `pdf` feature).

- Drop `publish = false` from `crw-cli` **and** `crw-browse`.
  - `crw-browse` must publish too: it's an optional dep of `crw-cli`'s default `browse` feature, and crates.io rejects a published crate that depends on an unpublished one (preflight check #3).
- `release_manifest.toml`: `crw-browse` → tier 4 (deps `crw-core`+`crw-renderer`, independent of `crw-crawl`); `crw-cli` → new tier 8 (after `crw-server`); `[unpublished]` now empty.

## Verification
- `preflight.py`: **OK — 12 published crates**, publish flags ↔ manifest consistent.
- `cargo tree -p crw-cli` shows `crw-extract` feature **pdf** → `pdf-inspector` (PDF parse is in the published CLI).
- `cargo package -p crw-browse --no-verify`: clean (31 files).
- `crw-cli` packages once `crw-browse` is on the index — the tier order (browse t4 → cli t8) guarantees this at release time.

Next release tag will publish `crw-cli` + `crw-browse` at 0.14.x. No code changes; manifest/release-config only.