### PR TITLE
fix(extract): avoid doubling chat/completions in structured base_url

### DIFF
--- a/crates/crw-extract/src/structured.rs
+++ b/crates/crw-extract/src/structured.rs
@@ -402,6 +402,21 @@ struct OpenAiFunctionCall {
     arguments: String,
 }
 
+/// Resolve the chat-completions endpoint for an OpenAI-compatible provider.
+///
+/// Idempotent: a `base_url` that already points at `…/chat/completions` is used
+/// verbatim; a bare base (or the provider default) gets `/v1/chat/completions`
+/// appended. This mirrors `llm::call_openai` so a configured base_url such as
+/// `https://api.deepseek.com/v1/chat/completions` is not doubled into
+/// `…/v1/chat/completions/v1/chat/completions` (which 404s).
+fn openai_chat_url(base_url: Option<&str>, default_base: &str) -> String {
+    match base_url {
+        Some(b) if b.contains("/chat/completions") => b.to_string(),
+        Some(b) => format!("{}/v1/chat/completions", b.trim_end_matches('/')),
+        None => format!("{}/v1/chat/completions", default_base.trim_end_matches('/')),
+    }
+}
+
 /// Call an OpenAI-compatible provider with a function-call forcing the given
 /// `schema`. `prompt` is the full user message; `tool_name`/`tool_desc` name
 /// the forced function. Shared by structured extraction and the judge.
@@ -416,9 +431,7 @@ pub(crate) async fn call_openai(
         "deepseek" => "https://api.deepseek.com",
         _ => "https://api.openai.com",
     };
-    let base_url = llm.base_url.as_deref().unwrap_or(default_base);
-
-    let url = format!("{base_url}/v1/chat/completions");
+    let url = openai_chat_url(llm.base_url.as_deref(), default_base);
 
     let body = OpenAiRequest {
         model: llm.model.clone(),
@@ -665,5 +678,37 @@ mod tests {
         // 99 'a's fit; emoji starts at byte 99 (4 bytes) — must NOT split.
         assert!(out.len() <= 100);
         assert!(out.is_char_boundary(out.len()));
+    }
+
+    #[test]
+    fn openai_url_appends_path_to_bare_base() {
+        assert_eq!(
+            openai_chat_url(Some("https://api.deepseek.com"), "https://api.openai.com"),
+            "https://api.deepseek.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn openai_url_uses_full_endpoint_verbatim() {
+        // Regression: a base_url that already includes the path must NOT be
+        // doubled into `…/v1/chat/completions/v1/chat/completions` (→ 404).
+        let full = "https://api.deepseek.com/v1/chat/completions";
+        assert_eq!(openai_chat_url(Some(full), "https://api.openai.com"), full);
+    }
+
+    #[test]
+    fn openai_url_falls_back_to_default_base() {
+        assert_eq!(
+            openai_chat_url(None, "https://api.openai.com"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn openai_url_trims_trailing_slash() {
+        assert_eq!(
+            openai_chat_url(Some("https://api.deepseek.com/"), "https://api.openai.com"),
+            "https://api.deepseek.com/v1/chat/completions"
+        );
     }
 }


### PR DESCRIPTION
## Problem

On prod (`api.fastcrw.com`), `/v1/search` with `answer:true` works (synthesizes via DeepSeek), but `/v1/scrape formats:["json"]` and `/v1/extract` fail with:

```
Extraction error: OpenAI API error (404 Not Found)
```

…even though both flags (`SEARCH_DYNAMIC_PRICING`, `EXTRACT_DYNAMIC_PRICING`) are enabled and the engine LLM env is correctly set to DeepSeek. The "OpenAI" label is misleading — the 404 actually comes from DeepSeek.

## Root cause

The two OpenAI-compatible call sites build the endpoint URL differently:

- `llm::call_openai` (search answer/summary) is **idempotent**: if `base_url` already contains `/chat/completions`, it's used verbatim.
- `structured::call_openai` (json/extract) blindly did `format!("{base_url}/v1/chat/completions")`.

Prod sets `CRW_EXTRACTION__LLM__BASE_URL=https://api.deepseek.com/v1/chat/completions` (full endpoint). So:

| Path | Resulting URL | Result |
|---|---|---|
| search answer | `…/v1/chat/completions` | ✅ 200 |
| json / extract | `…/v1/chat/completions/v1/chat/completions` | ❌ 404 |

Because the two paths append different suffixes, **no single `base_url` value satisfies both** — this requires a code fix, not a config change.

## Fix

Extract URL resolution into an idempotent `openai_chat_url()` helper mirroring `llm::call_openai`:
- base already pointing at `…/chat/completions` → used verbatim
- bare base / provider default → `/v1/chat/completions` appended

Plus 4 regression tests.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test -p crw-extract` all pass (205 tests).
- New tests cover: bare base append, full-endpoint verbatim (the regression), default-base fallback, trailing-slash trim.

## Deploy note

Prod `crw-api` builds from this repo's `main`. After merge: pull `main` on the prod host and rebuild the `crw-api` container to pick up the fix. (Deploy intentionally deferred to a separate step.)