### PR TITLE
fix(antibot): detect Google rate-limit/bot-wall pages served with HTTP 200

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "base64",
  "clap",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-extract/src/antibot.rs
+++ b/crates/crw-extract/src/antibot.rs
@@ -149,6 +149,28 @@ static TIER1_PATTERNS: Lazy<Vec<SignalPattern>> = Lazy::new(|| {
             AntibotSignal::NetworkSecurity,
             "Network security block",
         ),
+        // Google's rate-limit page ("Error 429 (Too Many Requests)!!1"). Google
+        // serves it with a real 429 over HTTP, but lightpanda/CDP renderers
+        // report the navigation as HTTP 200 with the error page as the body —
+        // so the `status == Some(429)` check below never fires and the page
+        // slips through as a successful render. Match the body so the failover
+        // loop escalates (lightpanda -> chrome -> chrome_proxy/residential).
+        (
+            Regex::new(r"(?i)you\s+have\s+sent\s+too\s+many\s+requests\s+to\s+us").unwrap(),
+            AntibotSignal::RateLimited,
+            "Google rate limit (sent too many requests)",
+        ),
+        (
+            Regex::new(r"(?i)Error\s+429\s*\(Too\s+Many\s+Requests").unwrap(),
+            AntibotSignal::RateLimited,
+            "Google rate limit (Error 429 page)",
+        ),
+        // Google's bot wall served with HTTP 200 (the /sorry reCAPTCHA page).
+        (
+            Regex::new(r"(?i)unusual\s+traffic\s+from\s+your\s+computer\s+network").unwrap(),
+            AntibotSignal::GenericBlock,
+            "Google bot wall (unusual traffic)",
+        ),
     ]
 });
 
@@ -536,6 +558,32 @@ mod tests {
     fn rate_limited_429() {
         let r = classify(Some(429), "<html><body>slow down</body></html>");
         assert_eq!(r.signal, AntibotSignal::RateLimited);
+    }
+
+    #[test]
+    fn google_429_page_served_with_200_is_blocked() {
+        // Real Google rate-limit page as returned by lightpanda/CDP: the HTTP
+        // status surfaces as 200 but the body is Google's 429 error page.
+        // Without body matching this slips through as a successful render and
+        // the failover loop never escalates to chrome_proxy.
+        let html = "<html lang=\"en\" dir=\"ltr\"><head><meta charset=\"utf-8\">\
+            <title>Error 429 (Too Many Requests)!!1</title></head><body>\
+            <main id=\"af-error-container\" role=\"main\"><a href=\"//www.google.com\">\
+            </a><p><b>429.</b> That\u{2019}s an error.</p><p>We're sorry, but you \
+            have sent too many requests to us recently. Please try again later. \
+            That\u{2019}s all we know.</p></main></body></html>";
+        let r = classify(Some(200), html);
+        assert_eq!(r.signal, AntibotSignal::RateLimited);
+    }
+
+    #[test]
+    fn google_unusual_traffic_bot_wall_is_blocked() {
+        let html = "<html><head><title>Sorry...</title></head><body>\
+            <p>Our systems have detected unusual traffic from your computer \
+            network. This page checks to see if it's really you sending the \
+            requests.</p></body></html>";
+        let r = classify(Some(200), html);
+        assert_eq!(r.signal, AntibotSignal::GenericBlock);
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Scraping Google Trends (and other Google endpoints) returned the 429 "Too Many Requests" page even though the residential `chrome_proxy` tier is provisioned and running on prod.

## Root cause
Lightpanda/CDP renderers report Google's rate-limit navigation as **HTTP 200 with the 429 error page as the body**. The antibot classifier only checked `status == Some(429)`, so the page slipped through as a successful render and the failover loop never escalated to `chrome_proxy` (residential).

## Fix
Add TIER1 body patterns so the classifier flags these regardless of HTTP status:
- `you have sent too many requests to us` → RateLimited
- `Error 429 (Too Many Requests` → RateLimited
- `unusual traffic from your computer network` → GenericBlock (/sorry bot wall)

Failover now escalates lightpanda → chrome → chrome_proxy as intended (`escalate_in_failover` is already default true).

## Tests
- 2 new unit tests using the real Google 429 HTML
- Full antibot suite green (21/21), clippy clean, release build green