### PR TITLE
fix(ci): poll npm in verify_npm_sdk + expose ./package.json export

### DIFF
--- a/scripts/release/verify_npm_sdk.sh
+++ b/scripts/release/verify_npm_sdk.sh
@@ -12,9 +12,15 @@ source "$SCRIPT_DIR/lib.sh"
 v="${1:?version required}"
 pkg="crw-sdk" # single source: keep in sync with sdks/typescript/package.json "name"
 
-# 1. Existence
-actual=$(npm view "$pkg@$v" version 2>/dev/null || echo "MISSING")
-[ "$actual" = "$v" ] || die "$pkg@$v not on npm (got: $actual)"
+# 1. Existence — poll, since npm registry propagation can lag several seconds
+# after a fresh publish (otherwise this false-fails a successful release).
+actual="MISSING"
+for _ in 1 2 3 4 5 6; do
+  actual=$(npm view "$pkg@$v" version 2>/dev/null || echo "MISSING")
+  [ "$actual" = "$v" ] && break
+  sleep 10
+done
+[ "$actual" = "$v" ] || die "$pkg@$v not on npm after retries (got: $actual)"
 
 # 2. Install + dual-format import smoke
 tmp=$(mktemp -d)

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -25,7 +25,8 @@
       "types": "./dist/esm/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist"


### PR DESCRIPTION
The 0.15.0 release published `crw-sdk` to npm successfully, but the `publish-npm-sdk` job's Verify step ran immediately after `npm publish` and false-failed on npm registry propagation lag (`crw-sdk@0.15.0 not on npm (got: MISSING)` — yet the package was live seconds later).

- `verify_npm_sdk.sh`: poll `npm view` up to 60s before failing.
- `sdks/typescript/package.json`: add the conventional `"./package.json"` subpath export so tooling (and `require('crw-sdk/package.json')`) can read the manifest.

No version/behavior change. shellcheck-clean; JS SDK build+test green (8/8).