### PR TITLE
feat(mcp): optimize MCP server for context, weight, and conformance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -817,10 +817,11 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "clap",
  "console 0.15.11",
  "crw-browse",
@@ -851,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -869,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -895,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "hex",
@@ -910,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -942,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "base64",
  "clap",
@@ -958,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "jsonschema",
  "serde",
@@ -968,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -991,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1018,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "futures",
@@ -1035,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "axum",
  "axum-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,14 @@ crw-browse = { path = "crates/crw-browse", version = "0.15.2" }
 lto = true
 codegen-units = 1
 strip = true
+
+# Size-optimized profile for the lean proxy MCP binary. Inherits release (lto +
+# codegen-units=1 + strip) and adds `opt-level = "z"` to minimize size. Scoped to
+# its own profile so it does NOT slow the CPU-bound scraping engine in the normal
+# release build. NO `panic = "abort"` — crw-extract relies on `catch_unwind` to
+# survive malformed-PDF parser panics, which abort would turn into process crashes.
+# Build the lean binary with:
+#   cargo build --profile release-small --no-default-features -p crw-mcp
+[profile.release-small]
+inherits = "release"
+opt-level = "z"

--- a/crates/crw-cli/Cargo.toml
+++ b/crates/crw-cli/Cargo.toml
@@ -60,6 +60,8 @@ serde_json = { workspace = true }
 
 # HTTP client
 reqwest = { workspace = true }
+# Base64 decode for crw_parse_file proxy forwarding (multipart upload)
+base64 = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/crw-cli/src/commands/mcp.rs
+++ b/crates/crw-cli/src/commands/mcp.rs
@@ -66,8 +66,24 @@ impl Backend {
         matches!(self, Backend::Proxy { .. })
     }
 
+    /// Whether `crw_search` should be advertised (proxy: yes; embedded: only with a
+    /// configured SearXNG backend).
+    fn search_available(&self) -> bool {
+        match self {
+            Backend::Proxy { .. } => true,
+            #[cfg(feature = "mcp-embedded")]
+            Backend::Embedded { state } => state.searxng.is_some(),
+        }
+    }
+
     async fn handle_request(&self, req: JsonRpcRequest) -> Option<JsonRpcResponse> {
-        match handle_protocol_method(SERVER_NAME, SERVER_VERSION, &req, self.is_proxy()) {
+        match handle_protocol_method(
+            SERVER_NAME,
+            SERVER_VERSION,
+            &req,
+            self.is_proxy(),
+            self.search_available(),
+        ) {
             ProtocolResult::Response(resp) => return Some(resp),
             ProtocolResult::Notification => return None,
             ProtocolResult::NotHandled => {}
@@ -81,9 +97,22 @@ impl Backend {
                     .get("name")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                // Unknown tool name → JSON-RPC -32602 (not an isError result).
+                if !crw_core::mcp::is_known_tool(tool_name) {
+                    return Some(JsonRpcResponse::error(
+                        id,
+                        -32602,
+                        format!("unknown tool: {tool_name}"),
+                    ));
+                }
+
                 let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
-                let result = self.call_tool(tool_name, arguments).await;
+                // Bound the result at the MCP layer before it reaches context.
+                let result = self
+                    .call_tool(tool_name, arguments.clone())
+                    .await
+                    .map(|v| crw_core::mcp::apply_bounds(tool_name, &arguments, v));
                 Some(tool_result_response(id, tool_name, result))
             }
 
@@ -117,6 +146,10 @@ async fn proxy_call_tool(
     tool_name: &str,
     args: Value,
 ) -> Result<Value, String> {
+    // Strip MCP-only control args (maxLength, crw_map's limit) before forwarding;
+    // bounds are applied locally to the response by apply_bounds in the dispatch.
+    let args = crw_core::mcp::strip_mcp_only_args(tool_name, args);
+
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert("content-type", "application/json".parse().unwrap());
     if let Some(key) = api_key {
@@ -182,6 +215,54 @@ async fn proxy_call_tool(
                 .headers(headers)
                 .timeout(TIMEOUT_SEARCH)
                 .json(&args)
+                .send()
+                .await
+                .map_err(|e| format!("HTTP request failed: {e}"))?;
+            parse_response(resp).await
+        }
+        "crw_parse_file" => {
+            use base64::Engine;
+            let b64 = args
+                .get("contentBase64")
+                .and_then(|v| v.as_str())
+                .ok_or("missing required parameter: contentBase64")?;
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(b64.trim())
+                .map_err(|e| format!("invalid base64 in contentBase64: {e}"))?;
+            let filename = args
+                .get("filename")
+                .and_then(|v| v.as_str())
+                .unwrap_or("document.pdf")
+                .to_string();
+            // Forward the remaining fields (formats/jsonSchema/parsers/…) as the
+            // multipart `options` JSON.
+            let mut options = args.clone();
+            if let Some(obj) = options.as_object_mut() {
+                obj.remove("contentBase64");
+                obj.remove("filename");
+            }
+            let part = reqwest::multipart::Part::bytes(bytes)
+                .file_name(filename)
+                .mime_str("application/pdf")
+                .map_err(|e| format!("invalid part: {e}"))?;
+            let form = reqwest::multipart::Form::new()
+                .part("file", part)
+                .text("options", options.to_string());
+            // Multipart sets its own content-type/boundary — use auth-only headers.
+            let mut mp_headers = reqwest::header::HeaderMap::new();
+            if let Some(key) = api_key {
+                mp_headers.insert(
+                    "authorization",
+                    format!("Bearer {key}")
+                        .parse()
+                        .map_err(|e| format!("invalid api key: {e}"))?,
+                );
+            }
+            let resp = client
+                .post(format!("{base_url}/v2/parse"))
+                .headers(mp_headers)
+                .timeout(TIMEOUT_SCRAPE)
+                .multipart(form)
                 .send()
                 .await
                 .map_err(|e| format!("HTTP request failed: {e}"))?;
@@ -354,14 +435,14 @@ async fn run_stdio_loop(backend: Backend) {
             continue;
         }
 
-        tracing::debug!("← {trimmed}");
+        tracing::debug!("← {} bytes: {:.200}", trimmed.len(), trimmed);
 
         let req: JsonRpcRequest = match serde_json::from_str(trimmed) {
             Ok(r) => r,
             Err(e) => {
                 let err = JsonRpcResponse::error(Value::Null, -32700, format!("parse error: {e}"));
                 let out = serde_json::to_string(&err).unwrap();
-                tracing::debug!("→ {out}");
+                tracing::debug!("→ {} bytes: {:.200}", out.len(), out);
                 let _ = stdout.write_all(out.as_bytes()).await;
                 let _ = stdout.write_all(b"\n").await;
                 let _ = stdout.flush().await;
@@ -371,7 +452,7 @@ async fn run_stdio_loop(backend: Backend) {
 
         if let Some(resp) = backend.handle_request(req).await {
             let out = serde_json::to_string(&resp).unwrap();
-            tracing::debug!("→ {out}");
+            tracing::debug!("→ {} bytes: {:.200}", out.len(), out);
             let _ = stdout.write_all(out.as_bytes()).await;
             let _ = stdout.write_all(b"\n").await;
             let _ = stdout.flush().await;

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -69,45 +69,57 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
     let mut tools = vec![
         json!({
             "name": "crw_scrape",
-            "description": "Scrape a single URL and return its content as markdown, HTML, or links. Use this to extract content from any web page.",
+            "title": "Scrape URL",
+            "description": "Scrape one URL to markdown, HTML, or links.",
+            "annotations": {
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true
+            },
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "url": {
                         "type": "string",
-                        "description": "The URL to scrape"
+                        "description": "URL to scrape"
                     },
                     "formats": {
                         "type": "array",
                         "items": { "type": "string", "enum": ["markdown", "html", "links"] },
-                        "description": "Output formats (default: [\"markdown\"])"
+                        "description": "Output formats (default [\"markdown\"])"
                     },
                     "onlyMainContent": {
                         "type": "boolean",
-                        "description": "Extract only the main content, removing nav/footer/etc (default: true)"
+                        "description": "Strip nav/footer; main content only (default true)"
                     },
                     "includeTags": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "CSS selectors to include (only content matching these selectors)"
+                        "description": "CSS selectors to include"
                     },
                     "excludeTags": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "CSS selectors to exclude from output"
+                        "description": "CSS selectors to exclude"
                     },
                     "renderJs": {
                         "type": "boolean",
-                        "description": "Render JavaScript before extracting (true = force JS, false = HTTP only, omit = auto-detect or use the server's render_js_default)"
+                        "description": "Force JS render (true), HTTP-only (false), omit = auto"
                     },
                     "waitFor": {
                         "type": "integer",
-                        "description": "Milliseconds to wait after JS rendering for late content/XHRs"
+                        "description": "Ms to wait after JS render for late content"
+                    },
+                    "maxLength": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Max chars per content field; 0 = unbounded (default ~15000)"
                     },
                     "renderer": {
                         "type": "string",
                         "enum": ["auto", "lightpanda", "chrome", "playwright"],
-                        "description": "Pin this request to a specific renderer. \"auto\" (default if omitted) uses the configured fallback chain. Other values hard-pin to a single renderer with no fallback. Pinning a non-auto value implies renderJs:true unless renderJs:false is set explicitly."
+                        "description": "Pin renderer; non-auto hard-pins and implies renderJs:true (default auto)"
                     }
                 },
                 "required": ["url"]
@@ -115,38 +127,47 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
         }),
         json!({
             "name": "crw_crawl",
-            "description": "Start an async crawl of a website. Returns a job ID that can be polled with crw_check_crawl_status.",
+            "title": "Crawl site",
+            "description": "Start an async site crawl; returns a job id to poll with crw_check_crawl_status.",
+            // Starting a crawl creates server-side job state (a side effect), so
+            // this is NOT read-only and NOT idempotent.
+            "annotations": {
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "openWorldHint": true
+            },
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "url": {
                         "type": "string",
-                        "description": "The starting URL to crawl"
+                        "description": "Starting URL"
                     },
                     "maxDepth": {
                         "type": "integer",
-                        "description": "Maximum crawl depth (default: 2)"
+                        "description": "Max crawl depth (default 2)"
                     },
                     "maxPages": {
                         "type": "integer",
-                        "description": "Maximum number of pages to crawl (default: 10)"
+                        "description": "Max pages to crawl (default 10)"
                     },
                     "jsonSchema": {
                         "type": "object",
-                        "description": "JSON schema for LLM-based structured data extraction on each crawled page"
+                        "description": "JSON schema for LLM extraction per page"
                     },
                     "renderJs": {
                         "type": "boolean",
-                        "description": "Render JavaScript on every crawled page (true = force JS, false = HTTP only, omit = auto-detect or use the server's render_js_default)"
+                        "description": "Force JS render (true), HTTP-only (false), omit = auto"
                     },
                     "waitFor": {
                         "type": "integer",
-                        "description": "Milliseconds to wait after JS rendering on each page"
+                        "description": "Ms to wait after JS render per page"
                     },
                     "renderer": {
                         "type": "string",
                         "enum": ["auto", "lightpanda", "chrome", "playwright"],
-                        "description": "Pin every crawled page to a specific renderer. \"auto\" (default if omitted) uses the configured fallback chain. Other values hard-pin with no fallback. Pinning a non-auto value implies renderJs:true unless renderJs:false is set explicitly."
+                        "description": "Pin renderer; non-auto hard-pins and implies renderJs:true (default auto)"
                     }
                 },
                 "required": ["url"]
@@ -154,13 +175,25 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
         }),
         json!({
             "name": "crw_check_crawl_status",
-            "description": "Check the status of an async crawl job and retrieve results.",
+            "title": "Check crawl status",
+            "description": "Poll an async crawl job and retrieve its pages.",
+            "annotations": {
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true
+            },
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "id": {
                         "type": "string",
-                        "description": "The crawl job ID returned by crw_crawl"
+                        "description": "Crawl job id from crw_crawl"
+                    },
+                    "maxLength": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Max chars per page content field; 0 = unbounded (default ~15000)"
                     }
                 },
                 "required": ["id"]
@@ -168,25 +201,37 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
         }),
         json!({
             "name": "crw_map",
-            "description": "Discover URLs on a website by crawling and/or reading its sitemap.",
+            "title": "Map site URLs",
+            "description": "Discover URLs on a site via sitemap and/or a short crawl. Returns a URL list only, no page content.",
+            "annotations": {
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true
+            },
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "url": {
                         "type": "string",
-                        "description": "The URL to map"
+                        "description": "URL to map"
                     },
                     "maxDepth": {
                         "type": "integer",
-                        "description": "Maximum crawl depth for discovery (default: 2)"
+                        "description": "Max discovery depth (default 2)"
                     },
                     "useSitemap": {
                         "type": "boolean",
-                        "description": "Whether to use the site's sitemap.xml (default: true)"
+                        "description": "Use sitemap.xml (default true)"
                     },
                     "crawlFallback": {
                         "type": "boolean",
-                        "description": "If true (default), supplements sitemap discovery with a short BFS crawl when the sitemap returns enough URLs. Set false for sitemap-only mode (faster, may miss pages not in the sitemap)."
+                        "description": "Supplement sitemap with a short BFS crawl (default true; false = sitemap-only)"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Max URLs returned; 0 = unbounded (default 100)"
                     }
                 },
                 "required": ["url"]
@@ -202,44 +247,51 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
     let _ = proxy_mode;
     tools.push(json!({
         "name": "crw_search",
-        "description": "Search the web and return relevant results with titles, URLs, and descriptions/snippets. Backed by a SearXNG sidecar in embedded mode (no API key needed), or by the configured remote API in proxy mode (uses CRW_API_KEY).\n\nReturn shape: `{ \"success\": true, \"data\": { \"results\": [{ \"url\", \"title\", \"description\", \"snippet\", \"position\", \"score\" }, ...] } }`. When `sources` is set, `data.results` is instead an object grouped by source (`{ \"web\": [...], \"news\": [...], \"images\": [...] }`). The `snippet` field is an alias of `description` — both carry the same body text so downstream LLM pipelines that ask for either get a match.\n\nExample: `crw_search(query=\"renewable energy trends 2024\", limit=3)` returns the top 3 web results with title/url/snippet.\n\nErrors: returns `search_disabled` when no SearXNG backend is configured, or `target_unreachable` / `timeout` (naming the configured host) when the backend can't be reached.",
+        "title": "Web search",
+        "description": "Search the web (needs a configured search backend; embedded uses a local SearXNG sidecar). Returns results with url/title/description/snippet.",
+        "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true
+        },
         "inputSchema": {
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "The search query"
+                    "description": "Search query"
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum number of results to return (default: 5, max: 20)"
+                    "description": "Max results (default 5, max 20)"
                 },
                 "lang": {
                     "type": "string",
-                    "description": "Language code for results (e.g. \"en\", \"tr\")"
+                    "description": "Language code, e.g. \"en\", \"tr\""
                 },
                 "country": {
                     "type": "string",
-                    "description": "Country code for results (e.g. \"us\", \"tr\"). Hint to bias regional results; ignored if the underlying engine does not support it."
+                    "description": "Country code hint, e.g. \"us\", \"tr\""
                 },
                 "tbs": {
                     "type": "string",
                     "enum": ["qdr:h", "qdr:d", "qdr:w", "qdr:m", "qdr:y"],
-                    "description": "Time filter — restrict to results from the past hour/day/week/month/year"
+                    "description": "Time filter: past hour/day/week/month/year"
                 },
                 "sources": {
                     "type": "array",
                     "items": { "type": "string", "enum": ["web", "news", "images"] },
-                    "description": "If set, returns results grouped by source instead of a flat list"
+                    "description": "If set, group results by source instead of a flat list"
                 },
                 "categories": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Bias the search towards a category. Curated values: `pdf` appends `filetype:pdf` to the query; `github`/`research` switch to topical engines. Any other value (e.g. `science`, `it`, `news`, `files`) is passed straight through to SearXNG's native `categories` routing."
+                    "description": "Category bias; e.g. \"pdf\", \"github\", \"research\", or a native SearXNG category"
                 },
                 "scrapeOptions": {
                     "type": "object",
-                    "description": "If set, each `web` result is scraped in-process and the requested formats are inlined into the response.",
+                    "description": "If set, scrape each web result and inline the requested formats",
                     "properties": {
                         "formats": {
                             "type": "array",
@@ -247,45 +299,23 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                         },
                         "onlyMainContent": {
                             "type": "boolean",
-                            "description": "Strip nav/footer/ads before serializing (default: true)"
+                            "description": "Strip nav/footer/ads (default true)"
                         }
                     }
                 }
             },
             "required": ["query"]
         },
-        // Mirrors the real `SearchResponse = ApiResponse<SearchResponseData>`
-        // serializer in crw-core/src/types.rs. The Ok branch of
-        // `tool_result_response` is the only path that emits `structuredContent`,
-        // and `ApiResponse::ok` always sets `data: Some(..)` — so `data` is
-        // required and the error/error_code/warning siblings are never present
-        // on the validated value (they only appear on the err() path, which
-        // returns Err(String) and never reaches structuredContent).
-        //
-        // `data.results` is `#[serde(untagged)] enum SearchData` → a flat array
-        // (no `sources`) OR a grouped object (`web`/`news`/`images`). Hence the
-        // `oneOf`. Grouped `images` deserialize to `ImageResult` (carries
-        // `imageUrl`, NO `snippet`), so they are deliberately left unconstrained —
-        // constraining them with the text-result shape would falsely reject every
-        // real grouped-image response. No `additionalProperties: false` anywhere:
-        // SearchResult conditionally emits markdown/html/links/metadata/etc.
+        // Intentionally minimal: declares the stable top-level contract
+        // (`{success, data:{results}}`) that strict clients validate, while leaving
+        // `results` permissive — it is a `#[serde(untagged)]` enum that serializes
+        // either as a flat array OR a grouped `{web,news,images}` object, and items
+        // carry conditional fields (markdown/html/links/imageUrl/…). A rich schema
+        // here costs ~400 tok in every `tools/list` for little client benefit and
+        // risks falsely rejecting real responses, so we keep it skeletal. No
+        // `additionalProperties:false` anywhere (conditional fields).
         "outputSchema": {
             "type": "object",
-            "$defs": {
-                "searchResultItem": {
-                    "type": "object",
-                    "properties": {
-                        "url": { "type": "string" },
-                        "title": { "type": "string" },
-                        "description": { "type": "string", "description": "Body snippet for the result. `snippet` is an alias of this field." },
-                        "snippet": { "type": "string", "description": "Alias of `description`. Always populated." },
-                        "position": { "type": "integer" },
-                        "score": { "type": "number" },
-                        "category": { "type": "string" }
-                    },
-                    "required": ["url", "title", "description", "snippet", "position"]
-                }
-            },
             "properties": {
                 "success": { "type": "boolean" },
                 "data": {
@@ -293,27 +323,13 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                     "properties": {
                         "results": {
                             "oneOf": [
-                                { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "web": { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
-                                        "news": { "type": "array", "items": { "$ref": "#/$defs/searchResultItem" } },
-                                        "images": { "type": "array" }
-                                    }
-                                }
+                                { "type": "array", "items": { "type": "object" } },
+                                { "type": "object" }
                             ]
-                        },
-                        "answer": { "type": "string" },
-                        "citations": { "type": "array" },
-                        "llmUsage": { "type": "object" },
-                        "warnings": { "type": "array", "items": { "type": "string" } }
+                        }
                     },
                     "required": ["results"]
-                },
-                "error": { "type": "string" },
-                "error_code": { "type": "string" },
-                "warning": { "type": "string" }
+                }
             },
             "required": ["success", "data"]
         }
@@ -321,31 +337,44 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
 
     tools.push(json!({
         "name": "crw_parse_file",
-        "description": "Parse an uploaded document (PDF) and return its content as markdown. Pass the file bytes base64-encoded in `contentBase64`. Use this for local PDFs that have no URL. Scanned/image-only PDFs have no text layer (no OCR) and return a warning with empty markdown.",
+        "title": "Parse PDF",
+        "description": "Parse a local PDF (base64 in contentBase64) to markdown. No OCR: scanned PDFs return empty markdown with a warning.",
+        // openWorldHint:false — operates on provided bytes, not the open web.
+        "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false
+        },
         "inputSchema": {
             "type": "object",
             "properties": {
                 "contentBase64": {
                     "type": "string",
-                    "description": "Base64-encoded bytes of the PDF file"
+                    "description": "Base64-encoded PDF bytes"
                 },
                 "filename": {
                     "type": "string",
-                    "description": "Original filename (optional; echoed in metadata.sourceFilename)"
+                    "description": "Original filename (optional)"
                 },
                 "formats": {
                     "type": "array",
                     "items": { "type": "string", "enum": ["markdown", "plainText", "links", "json", "summary"] },
-                    "description": "Output formats (default: [\"markdown\"]). json/summary require a server LLM."
+                    "description": "Output formats (default [\"markdown\"]); json/summary need a server LLM"
                 },
                 "jsonSchema": {
                     "type": "object",
-                    "description": "JSON schema for LLM-based structured extraction (when formats includes json)"
+                    "description": "JSON schema for LLM extraction (when formats has json)"
                 },
                 "parsers": {
                     "type": "array",
                     "items": { "type": "string", "enum": ["pdf"] },
-                    "description": "Document parsers to apply (default: [\"pdf\"])"
+                    "description": "Parsers to apply (default [\"pdf\"])"
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Max chars per content field; 0 = unbounded (default ~15000)"
                 }
             },
             "required": ["contentBase64"]
@@ -369,6 +398,17 @@ pub fn tool_output_schema(tool_name: &str) -> Option<Value> {
         .and_then(|t| t.get("outputSchema").cloned())
 }
 
+/// Whether `name` is one of the server's tool names. A genuinely unknown tool
+/// should be answered with a JSON-RPC `-32602` protocol error (clients degrade
+/// more gracefully than on an `isError` execution result). Checks the full set
+/// regardless of runtime availability (e.g. `crw_search` is a known name even when
+/// no search backend is configured — calling it then yields a clear runtime error).
+pub fn is_known_tool(name: &str) -> bool {
+    tool_definitions(false)["tools"]
+        .as_array()
+        .is_some_and(|tools| tools.iter().any(|t| t["name"] == name))
+}
+
 /// Result of handling a protocol method.
 pub enum ProtocolResult {
     /// Send this response back to the client.
@@ -380,11 +420,17 @@ pub enum ProtocolResult {
 }
 
 /// Handle common MCP protocol methods (initialize, tools/list, ping, notifications).
+///
+/// `search_available` controls whether `crw_search` is advertised in `tools/list`.
+/// Proxy callers pass `true` (the remote decides); embedded callers pass whether a
+/// search backend (SearXNG) is actually configured, so users who run `npx … crw`
+/// with no backend don't see a tool that only ever returns `search_disabled`.
 pub fn handle_protocol_method(
     server_name: &str,
     server_version: &str,
     req: &JsonRpcRequest,
     proxy_mode: bool,
+    search_available: bool,
 ) -> ProtocolResult {
     if req.jsonrpc != "2.0" {
         let id = req.id.clone().unwrap_or(Value::Null);
@@ -404,7 +450,9 @@ pub fn handle_protocol_method(
                 id,
                 json!({
                     "protocolVersion": PROTOCOL_VERSION,
-                    "capabilities": { "tools": {} },
+                    // The tool set is fixed for the lifetime of a session (it depends
+                    // only on startup config), so we never emit tools/list_changed.
+                    "capabilities": { "tools": { "listChanged": false } },
                     "serverInfo": {
                         "name": server_name,
                         "version": server_version
@@ -415,7 +463,13 @@ pub fn handle_protocol_method(
 
         "tools/list" => {
             let id = req.id.clone().unwrap_or(Value::Null);
-            ProtocolResult::Response(JsonRpcResponse::success(id, tool_definitions(proxy_mode)))
+            let mut defs = tool_definitions(proxy_mode);
+            if !search_available
+                && let Some(tools) = defs.get_mut("tools").and_then(Value::as_array_mut)
+            {
+                tools.retain(|t| t["name"] != "crw_search");
+            }
+            ProtocolResult::Response(JsonRpcResponse::success(id, defs))
         }
 
         "ping" => {
@@ -443,7 +497,9 @@ pub fn tool_result_response(
 ) -> JsonRpcResponse {
     match result {
         Ok(value) => {
-            let text = serde_json::to_string_pretty(&value).unwrap_or_default();
+            // Compact (not pretty) — pretty-printing adds ~30% whitespace, and this
+            // text block is injected verbatim into the agent's context.
+            let text = serde_json::to_string(&value).unwrap_or_default();
             let mut payload = json!({
                 "content": [{"type": "text", "text": text}]
             });
@@ -473,6 +529,192 @@ pub fn tool_result_response(
     }
 }
 
+// --- Output bounding (MCP-layer, context-footprint control) ---
+
+/// Default per-content-field char cap for scrape/parse/crawl-status results.
+/// ~15K chars ≈ ~3.5–4K tokens — well under the typical ~25K-token client cap.
+pub const DEFAULT_MAX_LENGTH: usize = 15_000;
+/// Default cap on the number of URLs `crw_map` returns to the model.
+pub const DEFAULT_MAP_LIMIT: usize = 100;
+
+/// Large string fields on a serialized `ScrapeData` (camelCase) worth truncating.
+const SCRAPE_TEXT_FIELDS: &[&str] = &["markdown", "html", "rawHtml", "plainText", "summary"];
+
+/// Resolve an MCP-only bound argument. Returns:
+/// - `Some(default)` when the arg is absent,
+/// - `None` (= unbounded) when the arg is explicitly `0`,
+/// - `Some(n)` for a positive value.
+fn resolve_bound(args: &Value, key: &str, default: usize) -> Option<usize> {
+    match args.get(key).and_then(Value::as_u64) {
+        None => Some(default),
+        Some(0) => None,
+        Some(n) => Some(n as usize),
+    }
+}
+
+/// Truncate a string to at most `max_chars` characters on a char boundary,
+/// appending a visible marker. Returns `None` if no truncation was needed.
+fn truncate_to_chars(s: &str, max_chars: usize) -> Option<String> {
+    // `nth(max_chars)` yields the (max_chars+1)-th char; its byte offset is where
+    // we cut to keep exactly `max_chars` chars. Absent → string is short enough.
+    s.char_indices()
+        .nth(max_chars)
+        .map(|(byte_idx, _)| format!("{}\n…[truncated by crw-mcp maxLength]", &s[..byte_idx]))
+}
+
+/// Truncate the known large text fields of one serialized `ScrapeData` object,
+/// tagging it with `truncated: true` if anything was cut. Non-recursive.
+fn truncate_scrape_obj(value: &mut Value, max: usize) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    let mut any = false;
+    for field in SCRAPE_TEXT_FIELDS {
+        let cut = match obj.get(*field) {
+            Some(Value::String(s)) => truncate_to_chars(s, max),
+            _ => None,
+        };
+        if let Some(t) = cut {
+            obj.insert((*field).to_string(), Value::String(t));
+            any = true;
+        }
+    }
+    if any {
+        obj.insert("truncated".to_string(), Value::Bool(true));
+    }
+}
+
+/// The single `ScrapeData`-shaped object to truncate. The **embedded** backend
+/// returns the bare `ScrapeData` (fields at the top level); the **proxy** backend
+/// forwards the REST `ApiResponse<ScrapeData>` envelope (`{success, data:{…}}`).
+/// We unwrap the `data` envelope when present so both shapes are bounded identically.
+fn scrape_target_mut(value: &mut Value) -> Option<&mut Value> {
+    if value.get("data").is_some_and(Value::is_object) {
+        value.get_mut("data")
+    } else if value.is_object() {
+        Some(value)
+    } else {
+        None
+    }
+}
+
+/// Truncate the `links` list to `limit` with markers, wherever it lives: top-level
+/// (embedded `{success, links}`) or under the `data` envelope (proxy
+/// `ApiResponse<MapData>` = `{success, data:{links}}`).
+fn bound_map_links(value: &mut Value, limit: usize) {
+    let in_envelope = value.get("data").and_then(|d| d.get("links")).is_some();
+    let Some(container) = (if in_envelope {
+        value.get_mut("data")
+    } else {
+        Some(&mut *value)
+    }) else {
+        return;
+    };
+    let Some(total) = container
+        .get("links")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+    else {
+        return;
+    };
+    if total <= limit {
+        return;
+    }
+    if let Some(obj) = container.as_object_mut() {
+        if let Some(Value::Array(links)) = obj.get_mut("links") {
+            links.truncate(limit);
+        }
+        obj.insert("totalDiscovered".to_string(), json!(total));
+        obj.insert("truncated".to_string(), Value::Bool(true));
+    }
+}
+
+/// Truncate any scrape content inlined into `crw_search` results (via
+/// `scrapeOptions`). `results` lives at `data.results` and is either a flat array
+/// of items or a grouped `{web,news,images}` object of arrays.
+fn bound_search_results(value: &mut Value, max: usize) {
+    let Some(results) = value.get_mut("data").and_then(|d| d.get_mut("results")) else {
+        return;
+    };
+    match results {
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                truncate_scrape_obj(item, max);
+            }
+        }
+        Value::Object(groups) => {
+            for arr in groups.values_mut() {
+                if let Some(items) = arr.as_array_mut() {
+                    for item in items.iter_mut() {
+                        truncate_scrape_obj(item, max);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Bound a tool result's size at the MCP layer, driven by the call's own
+/// `maxLength`/`limit` arguments (see [`resolve_bound`] for the `0 = unbounded`
+/// opt-out). **Non-mutating** w.r.t. any stored state: it transforms an owned
+/// `Value` produced by the dispatch and returns a new one. Shared by the embedded,
+/// proxy, and CLI paths, and handles BOTH the bare (embedded) and `ApiResponse`-
+/// enveloped (proxy) result shapes so the two behave identically.
+pub fn apply_bounds(tool_name: &str, args: &Value, mut value: Value) -> Value {
+    match tool_name {
+        "crw_scrape" | "crw_parse_file" => {
+            if let Some(max) = resolve_bound(args, "maxLength", DEFAULT_MAX_LENGTH)
+                && let Some(target) = scrape_target_mut(&mut value)
+            {
+                truncate_scrape_obj(target, max);
+            }
+        }
+        "crw_check_crawl_status" => {
+            // CrawlState is returned bare (top-level `data` array) by both the
+            // embedded backend and the REST `GET /v1/crawl/{id}` endpoint.
+            if let Some(max) = resolve_bound(args, "maxLength", DEFAULT_MAX_LENGTH)
+                && let Some(pages) = value.get_mut("data").and_then(Value::as_array_mut)
+            {
+                for page in pages.iter_mut() {
+                    truncate_scrape_obj(page, max);
+                }
+            }
+        }
+        "crw_map" => {
+            if let Some(limit) = resolve_bound(args, "limit", DEFAULT_MAP_LIMIT) {
+                bound_map_links(&mut value, limit);
+            }
+        }
+        "crw_search" => {
+            if let Some(max) = resolve_bound(args, "maxLength", DEFAULT_MAX_LENGTH) {
+                bound_search_results(&mut value, max);
+            }
+        }
+        _ => {}
+    }
+    value
+}
+
+/// Remove MCP-only control args (`maxLength`, `crw_map`'s `limit`) before a proxy
+/// forwards the call to a REST endpoint that may reject unknown body fields. These
+/// are applied locally via [`apply_bounds`] on the response instead. Note
+/// `crw_search.limit` is a *real* backend param and is intentionally NOT stripped.
+pub fn strip_mcp_only_args(tool_name: &str, mut args: Value) -> Value {
+    if let Some(obj) = args.as_object_mut() {
+        match tool_name {
+            "crw_scrape" | "crw_parse_file" | "crw_check_crawl_status" => {
+                obj.remove("maxLength");
+            }
+            "crw_map" => {
+                obj.remove("limit");
+            }
+            _ => {}
+        }
+    }
+    args
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -484,6 +726,37 @@ mod tests {
             .iter()
             .find(|t| t["name"] == name)
             .unwrap_or_else(|| panic!("tool {name} not found"))
+    }
+
+    /// Token-budget regression gate for the `tools/list` payload. Every byte here
+    /// is injected into the agent's context on every turn, so this is the server's
+    /// single most important footprint metric.
+    ///
+    /// We estimate tokens as `ceil(bytes / 3)` — a deliberately *conservative*
+    /// (over-counting) heuristic: symbol-heavy JSON tokenizes at ~3–4 chars/token,
+    /// so if this estimate is under the ceiling the real (tiktoken/cl100k) count is
+    /// comfortably under too. A real tokenizer (`tiktoken-rs`) was considered but
+    /// rejected to keep this leaf crate dependency-free; the conservative estimate
+    /// is sufficient for a regression gate. Real cl100k count is ~25–30% lower.
+    ///
+    /// Baseline before the Phase 1 trim was 8233 bytes (~2744 est-tok). After the
+    /// Phase 1 trim + Phase 3 annotations/titles the full 6-tool list is ~6189 bytes
+    /// (~2063 est-tok ≈ ~1450 real cl100k tok). The ceiling is floor + ~11% so the
+    /// gate catches real bloat without churning on minor edits.
+    const TOOLS_LIST_TOKEN_CEILING: usize = 2300;
+
+    #[test]
+    fn tools_list_token_budget() {
+        let json = serde_json::to_string(&tool_definitions(false)).unwrap();
+        let est_tokens = json.len().div_ceil(3);
+        assert!(
+            est_tokens <= TOOLS_LIST_TOKEN_CEILING,
+            "tools/list footprint regressed: {} bytes ≈ {} est-tokens (ceiling {}). \
+             Trim descriptions/schemas before raising the ceiling.",
+            json.len(),
+            est_tokens,
+            TOOLS_LIST_TOKEN_CEILING
+        );
     }
 
     #[test]
@@ -772,5 +1045,284 @@ mod tests {
             ap.is_none() || ap.and_then(|v| v.as_bool()) != Some(false),
             "crw_search outputSchema must not set additionalProperties:false"
         );
+    }
+
+    // --- Output bounding (apply_bounds / strip_mcp_only_args) ---
+
+    fn long_md(chars: usize) -> String {
+        "x".repeat(chars)
+    }
+
+    /// B1 — crw_scrape truncates markdown past the default cap and tags `truncated`.
+    #[test]
+    fn b1_scrape_truncates_to_default_max_length() {
+        let value =
+            json!({ "markdown": long_md(DEFAULT_MAX_LENGTH + 500), "url": "https://e.com" });
+        let out = apply_bounds("crw_scrape", &json!({}), value);
+        let md = out["markdown"].as_str().unwrap();
+        assert!(
+            md.chars().count() <= DEFAULT_MAX_LENGTH + 40,
+            "truncated to ~cap + marker"
+        );
+        assert!(md.contains("[truncated"), "marker present");
+        assert_eq!(out["truncated"], json!(true));
+    }
+
+    /// B2 — short content is untouched and gets no `truncated` flag.
+    #[test]
+    fn b2_scrape_short_content_untouched() {
+        let value = json!({ "markdown": "hello", "url": "https://e.com" });
+        let out = apply_bounds("crw_scrape", &json!({}), value);
+        assert_eq!(out["markdown"], json!("hello"));
+        assert!(out.get("truncated").is_none());
+    }
+
+    /// B3 — explicit `maxLength: 0` opts out of bounding (unbounded).
+    #[test]
+    fn b3_scrape_max_length_zero_is_unbounded() {
+        let big = long_md(DEFAULT_MAX_LENGTH * 2);
+        let value = json!({ "markdown": big.clone() });
+        let out = apply_bounds("crw_scrape", &json!({ "maxLength": 0 }), value);
+        assert_eq!(
+            out["markdown"].as_str().unwrap().chars().count(),
+            big.chars().count()
+        );
+        assert!(out.get("truncated").is_none());
+    }
+
+    /// B4 — a custom `maxLength` is honored.
+    #[test]
+    fn b4_scrape_custom_max_length() {
+        let value = json!({ "markdown": long_md(100) });
+        let out = apply_bounds("crw_scrape", &json!({ "maxLength": 10 }), value);
+        let md = out["markdown"].as_str().unwrap();
+        assert!(md.starts_with(&"x".repeat(10)));
+        assert!(md.contains("[truncated"));
+    }
+
+    /// B5 — crw_map truncates the links list to the default limit with markers.
+    #[test]
+    fn b5_map_truncates_links_to_limit() {
+        let links: Vec<Value> = (0..250)
+            .map(|i| json!(format!("https://e.com/{i}")))
+            .collect();
+        let value = json!({ "success": true, "links": links });
+        let out = apply_bounds("crw_map", &json!({}), value);
+        assert_eq!(out["links"].as_array().unwrap().len(), DEFAULT_MAP_LIMIT);
+        assert_eq!(out["totalDiscovered"], json!(250));
+        assert_eq!(out["truncated"], json!(true));
+    }
+
+    /// B6 — crw_map `limit: 0` returns all links, no markers.
+    #[test]
+    fn b6_map_limit_zero_is_unbounded() {
+        let links: Vec<Value> = (0..250)
+            .map(|i| json!(format!("https://e.com/{i}")))
+            .collect();
+        let value = json!({ "links": links });
+        let out = apply_bounds("crw_map", &json!({ "limit": 0 }), value);
+        assert_eq!(out["links"].as_array().unwrap().len(), 250);
+        assert!(out.get("truncated").is_none());
+    }
+
+    /// B7 — crw_check_crawl_status truncates each page in `data`.
+    #[test]
+    fn b7_crawl_status_truncates_each_page() {
+        let value = json!({
+            "status": "completed",
+            "data": [
+                { "markdown": long_md(DEFAULT_MAX_LENGTH + 100), "url": "https://e.com/1" },
+                { "markdown": "short", "url": "https://e.com/2" }
+            ]
+        });
+        let out = apply_bounds("crw_check_crawl_status", &json!({}), value);
+        let pages = out["data"].as_array().unwrap();
+        assert_eq!(pages[0]["truncated"], json!(true));
+        assert!(
+            pages[0]["markdown"]
+                .as_str()
+                .unwrap()
+                .contains("[truncated")
+        );
+        assert!(pages[1].get("truncated").is_none());
+        assert_eq!(pages[1]["markdown"], json!("short"));
+    }
+
+    /// B8 — truncation cuts on a char boundary (no panic on multibyte input).
+    #[test]
+    fn b8_truncation_is_char_safe() {
+        let value = json!({ "markdown": "é".repeat(100) });
+        let out = apply_bounds("crw_scrape", &json!({ "maxLength": 10 }), value);
+        // Must not panic and must keep exactly 10 'é' chars before the marker.
+        assert!(
+            out["markdown"]
+                .as_str()
+                .unwrap()
+                .starts_with(&"é".repeat(10))
+        );
+    }
+
+    /// B9 — strip removes MCP-only args per tool, but keeps crw_search's real `limit`.
+    #[test]
+    fn b9_strip_mcp_only_args() {
+        let scrape = strip_mcp_only_args("crw_scrape", json!({ "url": "u", "maxLength": 100 }));
+        assert!(scrape.get("maxLength").is_none());
+        assert_eq!(scrape["url"], json!("u"));
+
+        let map = strip_mcp_only_args("crw_map", json!({ "url": "u", "limit": 50 }));
+        assert!(map.get("limit").is_none());
+
+        // crw_search.limit is a real backend param — must NOT be stripped.
+        let search = strip_mcp_only_args("crw_search", json!({ "query": "q", "limit": 5 }));
+        assert_eq!(search["limit"], json!(5));
+    }
+
+    /// B10 — unknown/other tools pass through apply_bounds unchanged.
+    #[test]
+    fn b10_unknown_tool_passthrough() {
+        let value = json!({ "anything": [1, 2, 3] });
+        let out = apply_bounds("crw_crawl", &json!({}), value.clone());
+        assert_eq!(out, value);
+    }
+
+    /// B11 — PROXY shape: crw_scrape `ApiResponse<ScrapeData>` envelope
+    /// (`{success, data:{markdown}}`) is truncated under `data`, not skipped.
+    #[test]
+    fn b11_scrape_proxy_envelope_is_bounded() {
+        let value = json!({
+            "success": true,
+            "data": { "markdown": long_md(DEFAULT_MAX_LENGTH + 500), "url": "https://e.com" }
+        });
+        let out = apply_bounds("crw_scrape", &json!({}), value);
+        let md = out["data"]["markdown"].as_str().unwrap();
+        assert!(
+            md.contains("[truncated"),
+            "proxy-enveloped scrape must be bounded"
+        );
+        assert_eq!(out["data"]["truncated"], json!(true));
+    }
+
+    /// B12 — PROXY shape: crw_map `ApiResponse<MapData>` envelope
+    /// (`{success, data:{links}}`) is truncated under `data`.
+    #[test]
+    fn b12_map_proxy_envelope_is_bounded() {
+        let links: Vec<Value> = (0..250)
+            .map(|i| json!(format!("https://e.com/{i}")))
+            .collect();
+        let value = json!({ "success": true, "data": { "links": links } });
+        let out = apply_bounds("crw_map", &json!({}), value);
+        assert_eq!(
+            out["data"]["links"].as_array().unwrap().len(),
+            DEFAULT_MAP_LIMIT
+        );
+        assert_eq!(out["data"]["totalDiscovered"], json!(250));
+        assert_eq!(out["data"]["truncated"], json!(true));
+    }
+
+    /// A1 — every tool advertises annotations + a title; crw_crawl is the only
+    /// non-read-only / non-idempotent tool; crw_parse_file is the only closed-world.
+    #[test]
+    fn a1_tools_advertise_annotations_and_title() {
+        let defs = tool_definitions(false);
+        for t in defs["tools"].as_array().unwrap() {
+            assert!(t["annotations"].is_object(), "{} annotations", t["name"]);
+            assert!(t["title"].is_string(), "{} title", t["name"]);
+            // destructiveHint is explicitly false everywhere (the JSON default is true).
+            assert_eq!(
+                t["annotations"]["destructiveHint"],
+                json!(false),
+                "{}",
+                t["name"]
+            );
+        }
+        let crawl = tool_by_name(&defs, "crw_crawl");
+        assert_eq!(crawl["annotations"]["readOnlyHint"], json!(false));
+        assert_eq!(crawl["annotations"]["idempotentHint"], json!(false));
+        let scrape = tool_by_name(&defs, "crw_scrape");
+        assert_eq!(scrape["annotations"]["readOnlyHint"], json!(true));
+        assert_eq!(scrape["annotations"]["openWorldHint"], json!(true));
+        let parse = tool_by_name(&defs, "crw_parse_file");
+        assert_eq!(parse["annotations"]["openWorldHint"], json!(false));
+    }
+
+    /// A2 — is_known_tool recognizes all 6 tool names, rejects others.
+    #[test]
+    fn a2_is_known_tool() {
+        for name in [
+            "crw_scrape",
+            "crw_crawl",
+            "crw_check_crawl_status",
+            "crw_map",
+            "crw_search",
+            "crw_parse_file",
+        ] {
+            assert!(is_known_tool(name), "{name} should be known");
+        }
+        assert!(!is_known_tool("nonexistent"));
+        assert!(!is_known_tool(""));
+    }
+
+    /// A3 — tools/list suppresses crw_search when no backend; includes it otherwise.
+    #[test]
+    fn a3_tools_list_conditional_search() {
+        fn list(search_available: bool) -> Vec<String> {
+            let req = JsonRpcRequest {
+                jsonrpc: "2.0".into(),
+                id: Some(json!(1)),
+                method: "tools/list".into(),
+                params: json!({}),
+            };
+            let ProtocolResult::Response(resp) =
+                handle_protocol_method("crw", "0", &req, false, search_available)
+            else {
+                panic!("expected response");
+            };
+            resp.result.unwrap()["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|t| t["name"].as_str().unwrap().to_string())
+                .collect()
+        }
+        let with = list(true);
+        assert!(with.contains(&"crw_search".to_string()));
+        assert_eq!(with.len(), 6);
+        let without = list(false);
+        assert!(!without.contains(&"crw_search".to_string()));
+        assert_eq!(without.len(), 5);
+    }
+
+    /// B13 — crw_search inlined scrape content (flat + grouped) is truncated.
+    #[test]
+    fn b13_search_inlined_content_is_bounded() {
+        // Flat results with inlined markdown.
+        let flat = json!({
+            "success": true,
+            "data": { "results": [
+                { "url": "https://e.com/1", "markdown": long_md(DEFAULT_MAX_LENGTH + 100) },
+                { "url": "https://e.com/2", "description": "no scrape content" }
+            ]}
+        });
+        let out = apply_bounds("crw_search", &json!({}), flat);
+        assert!(
+            out["data"]["results"][0]["markdown"]
+                .as_str()
+                .unwrap()
+                .contains("[truncated")
+        );
+        assert_eq!(out["data"]["results"][0]["truncated"], json!(true));
+        assert!(out["data"]["results"][1].get("truncated").is_none());
+
+        // Grouped results.
+        let grouped = json!({
+            "success": true,
+            "data": { "results": {
+                "web": [{ "url": "https://e.com/w", "html": long_md(DEFAULT_MAX_LENGTH + 100) }],
+                "news": [{ "url": "https://e.com/n", "description": "short" }]
+            }}
+        });
+        let out = apply_bounds("crw_search", &json!({}), grouped);
+        assert_eq!(out["data"]["results"]["web"][0]["truncated"], json!(true));
+        assert!(out["data"]["results"]["news"][0].get("truncated").is_none());
     }
 }

--- a/crates/crw-mcp/Cargo.toml
+++ b/crates/crw-mcp/Cargo.toml
@@ -15,11 +15,13 @@ path = "src/main.rs"
 
 [features]
 default = ["embedded"]
-embedded = ["dep:crw-server"]
+# Embedded mode pulls in the full scraping engine AND the headless-browser
+# auto-spawn (crw-renderer). A `--no-default-features` build is a lean proxy-only
+# binary that excludes both — much smaller and lower-RAM (no Chromium/CDP code).
+embedded = ["dep:crw-server", "dep:crw-renderer", "crw-renderer/auto-browser"]
 
 [dependencies]
 crw-core = { workspace = true }
-crw-renderer = { workspace = true, features = ["auto-browser"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }
@@ -28,5 +30,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 
-# Embedded mode: pulls in full scraping engine
+# Embedded mode: pulls in the full scraping engine + headless-browser auto-spawn.
+crw-renderer = { workspace = true, optional = true, features = ["auto-browser"] }
 crw-server = { workspace = true, optional = true, features = ["cdp"] }

--- a/crates/crw-mcp/src/main.rs
+++ b/crates/crw-mcp/src/main.rs
@@ -92,9 +92,26 @@ impl Backend {
         matches!(self, Backend::Proxy { .. })
     }
 
+    /// Whether `crw_search` should be advertised. Proxy: yes (the remote decides).
+    /// Embedded: only if a SearXNG backend is configured, so a no-backend install
+    /// doesn't advertise a tool that only returns `search_disabled`.
+    fn search_available(&self) -> bool {
+        match self {
+            Backend::Proxy { .. } => true,
+            #[cfg(feature = "embedded")]
+            Backend::Embedded { state } => state.searxng.is_some(),
+        }
+    }
+
     async fn handle_request(&self, req: JsonRpcRequest) -> Option<JsonRpcResponse> {
         // Handle common protocol methods via shared logic.
-        match handle_protocol_method(SERVER_NAME, SERVER_VERSION, &req, self.is_proxy()) {
+        match handle_protocol_method(
+            SERVER_NAME,
+            SERVER_VERSION,
+            &req,
+            self.is_proxy(),
+            self.search_available(),
+        ) {
             ProtocolResult::Response(resp) => return Some(resp),
             ProtocolResult::Notification => return None,
             ProtocolResult::NotHandled => {}
@@ -109,9 +126,23 @@ impl Backend {
                     .get("name")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
+                // Unknown tool name → JSON-RPC -32602 (not an isError result).
+                if !crw_core::mcp::is_known_tool(tool_name) {
+                    return Some(JsonRpcResponse::error(
+                        id,
+                        -32602,
+                        format!("unknown tool: {tool_name}"),
+                    ));
+                }
+
                 let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
-                let result = self.call_tool(tool_name, arguments).await;
+                // Bound the result at the MCP layer before it reaches context.
+                // Works for both embedded and proxy backends.
+                let result = self
+                    .call_tool(tool_name, arguments.clone())
+                    .await
+                    .map(|v| crw_core::mcp::apply_bounds(tool_name, &arguments, v));
                 Some(tool_result_response(id, tool_name, result))
             }
 
@@ -151,6 +182,11 @@ async fn proxy_call_tool(
     tool_name: &str,
     args: Value,
 ) -> Result<Value, String> {
+    // Strip MCP-only control args (maxLength, crw_map's limit) so a strict upstream
+    // doesn't reject unknown body fields; bounds are applied locally to the response
+    // by apply_bounds in the dispatch layer.
+    let args = crw_core::mcp::strip_mcp_only_args(tool_name, args);
+
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert("content-type", "application/json".parse().unwrap());
     if let Some(key) = api_key {
@@ -460,14 +496,14 @@ async fn run_stdio_loop(backend: Backend) {
             continue;
         }
 
-        tracing::debug!("← {trimmed}");
+        tracing::debug!("← {} bytes: {:.200}", trimmed.len(), trimmed);
 
         let req: JsonRpcRequest = match serde_json::from_str(trimmed) {
             Ok(r) => r,
             Err(e) => {
                 let err = JsonRpcResponse::error(Value::Null, -32700, format!("parse error: {e}"));
                 let out = serde_json::to_string(&err).unwrap();
-                tracing::debug!("→ {out}");
+                tracing::debug!("→ {} bytes: {:.200}", out.len(), out);
                 let _ = stdout.write_all(out.as_bytes()).await;
                 let _ = stdout.write_all(b"\n").await;
                 let _ = stdout.flush().await;
@@ -477,7 +513,7 @@ async fn run_stdio_loop(backend: Backend) {
 
         if let Some(resp) = backend.handle_request(req).await {
             let out = serde_json::to_string(&resp).unwrap();
-            tracing::debug!("→ {out}");
+            tracing::debug!("→ {} bytes: {:.200}", out.len(), out);
             let _ = stdout.write_all(out.as_bytes()).await;
             let _ = stdout.write_all(b"\n").await;
             let _ = stdout.flush().await;

--- a/crates/crw-mcp/src/teardown.rs
+++ b/crates/crw-mcp/src/teardown.rs
@@ -28,11 +28,14 @@ impl CmdError {
 /// stdin-EOF path don't double-run `kill_all_browsers()`.
 static TEARING_DOWN: AtomicBool = AtomicBool::new(false);
 
-/// Run `kill_all_browsers()` at most once across all callers.
+/// Run `kill_all_browsers()` at most once across all callers. In a proxy-only
+/// build (no `embedded` feature) there is no browser engine compiled in, so this
+/// is a cheap no-op guard with nothing to kill.
 fn teardown_once() {
     if TEARING_DOWN.swap(true, Ordering::SeqCst) {
         return;
     }
+    #[cfg(feature = "embedded")]
     crw_renderer::browser::kill_all_browsers();
 }
 

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -145,8 +145,15 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
 }
 
 pub async fn handle_request(state: &AppState, req: JsonRpcRequest) -> Option<JsonRpcResponse> {
-    // Handle common protocol methods via shared logic.
-    match handle_protocol_method(SERVER_NAME, SERVER_VERSION, &req, false) {
+    // Handle common protocol methods via shared logic. `crw_search` is advertised
+    // only when a SearXNG backend is configured.
+    match handle_protocol_method(
+        SERVER_NAME,
+        SERVER_VERSION,
+        &req,
+        false,
+        state.searxng.is_some(),
+    ) {
         ProtocolResult::Response(resp) => return Some(resp),
         ProtocolResult::Notification => return None,
         ProtocolResult::NotHandled => {}
@@ -161,9 +168,22 @@ pub async fn handle_request(state: &AppState, req: JsonRpcRequest) -> Option<Jso
                 .get("name")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+            // Unknown tool name → JSON-RPC -32602 (not an isError execution result).
+            if !crw_core::mcp::is_known_tool(tool_name) {
+                return Some(JsonRpcResponse::error(
+                    id,
+                    -32602,
+                    format!("unknown tool: {tool_name}"),
+                ));
+            }
+
             let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
-            let result = call_tool(state, tool_name, arguments).await;
+            // Bound the result at the MCP layer (driven by the call's own
+            // maxLength/limit args) before it reaches the model's context.
+            let result = call_tool(state, tool_name, arguments.clone())
+                .await
+                .map(|v| crw_core::mcp::apply_bounds(tool_name, &arguments, v));
             Some(tool_result_response(id, tool_name, result))
         }
 

--- a/crates/crw-server/tests/mcp.rs
+++ b/crates/crw-server/tests/mcp.rs
@@ -16,6 +16,18 @@ fn test_app() -> TestServer {
     TestServer::new(app)
 }
 
+/// Like `test_app` but with a SearXNG backend configured, so `crw_search` is
+/// advertised in `tools/list` (the URL need not be reachable — advertisement only
+/// checks that a backend is configured). The bare `test_app` has no backend, so it
+/// correctly suppresses `crw_search` from `tools/list`.
+fn test_app_with_search() -> TestServer {
+    let config: AppConfig =
+        toml::from_str("[search]\nsearxng_url = \"http://localhost:8888\"").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    let app = create_app(state);
+    TestServer::new(app)
+}
+
 fn mcp_request(
     method: &str,
     id: serde_json::Value,
@@ -52,7 +64,8 @@ async fn mcp_initialize_returns_capabilities() {
 
 #[tokio::test]
 async fn mcp_tools_list_returns_all_tools() {
-    let server = test_app();
+    // With a search backend configured, all 6 tools are advertised.
+    let server = test_app_with_search();
     let resp = server
         .post("/mcp")
         .content_type("application/json")
@@ -74,6 +87,44 @@ async fn mcp_tools_list_returns_all_tools() {
     assert!(tool_names.contains(&"crw_map"));
     assert!(tool_names.contains(&"crw_search"));
     assert!(tool_names.contains(&"crw_parse_file"));
+
+    // Every tool advertises annotations; crw_crawl is the only non-read-only one.
+    for t in tools {
+        assert!(
+            t["annotations"].is_object(),
+            "{} must advertise annotations",
+            t["name"]
+        );
+        assert!(
+            t["title"].is_string(),
+            "{} must advertise a title",
+            t["name"]
+        );
+    }
+    let crawl = tools.iter().find(|t| t["name"] == "crw_crawl").unwrap();
+    assert_eq!(crawl["annotations"]["readOnlyHint"], false);
+    assert_eq!(crawl["annotations"]["idempotentHint"], false);
+    let scrape = tools.iter().find(|t| t["name"] == "crw_scrape").unwrap();
+    assert_eq!(scrape["annotations"]["readOnlyHint"], true);
+}
+
+/// crw_search is suppressed from tools/list when no search backend is configured,
+/// so a no-backend install doesn't advertise a tool that only errors.
+#[tokio::test]
+async fn mcp_tools_list_hides_search_without_backend() {
+    let server = test_app();
+    let resp = server
+        .post("/mcp")
+        .content_type("application/json")
+        .json(&mcp_request("tools/list", json!(2), json!({})))
+        .await;
+    resp.assert_status_ok();
+    let json: serde_json::Value = resp.json();
+    let tools = json["result"]["tools"].as_array().unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert_eq!(tools.len(), 5, "crw_search hidden without a backend");
+    assert!(!names.contains(&"crw_search"));
+    assert!(names.contains(&"crw_scrape"));
 }
 
 #[tokio::test]
@@ -161,8 +212,9 @@ async fn mcp_tools_call_unknown_tool() {
         .await;
     resp.assert_status_ok();
     let json: serde_json::Value = resp.json();
-    let result = &json["result"];
-    assert_eq!(result["isError"], true);
+    // Unknown tool name → JSON-RPC -32602 protocol error (not an isError result).
+    assert_eq!(json["error"]["code"], -32602);
+    assert!(json.get("result").is_none() || json["result"].is_null());
 }
 
 #[tokio::test]
@@ -273,7 +325,7 @@ async fn mcp_missing_method_field() {
 /// flat-array shape.
 #[tokio::test]
 async fn mcp_t8_search_advertises_nested_output_schema() {
-    let server = test_app();
+    let server = test_app_with_search();
     let resp = server
         .post("/mcp")
         .content_type("application/json")

--- a/plans/mcp-optimization.md
+++ b/plans/mcp-optimization.md
@@ -1,0 +1,461 @@
+# crw-mcp Optimization — Implementation Plan
+
+> Goal: make `crw-mcp` a best-in-class MCP server — minimal context/token footprint,
+> lightest-possible runtime, frictionless install on any agent, and clean MCP design.
+> Worktree: `/Users/us/coding/crw/crw-opencore-mcp-optimize` (branch `feat/mcp-optimization`).
+
+## Context
+
+The fastCRW MCP server (`crates/crw-mcp`, with shared protocol in `crates/crw-mcp-proto`,
+the embedded backend in `crates/crw-server/src/routes/mcp.rs`, and a near-duplicate path in
+`crates/crw-cli/src/commands/mcp.rs`) is functional and Firecrawl-API-compatible. It exposes
+6 tools: `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_search`,
+`crw_parse_file`. It already advertises MCP revision `2025-06-18` and emits `structuredContent`.
+
+It is not optimized for the three things that decide whether an agent enjoys an MCP server in
+2026: **how many tokens it costs just to exist in context**, **how heavy it is to run/ship**,
+and **how painful it is to attach**.
+
+**Verified facts (research + code audit, cited):**
+- A tool's name + description + full `inputSchema`/`outputSchema` is injected into the agent's
+  system prompt **every turn**; per-tool cost ~100–1,000 tok; 20–30 tools cost 15–30 KB before
+  the first user message ([MCP #2808](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2808)).
+- **Our `tools/list` is ~13–14 KB ≈ 3,250–3,500 tok.** `crw_search` alone ≈ 700 tok: a 926-char
+  description (~231 tok, `crw-mcp-proto/src/lib.rs:205`) + a verbose `$defs`/`oneOf` `outputSchema`
+  (~450 tok, `:272-319`), including meta-prose ("`snippet` is an alias of `description`").
+- Tool results are emitted as a **pretty-printed** text block **and** as `structuredContent`
+  (`lib.rs:446-461`). Pretty-printing adds ~30% whitespace. Dual emission is **spec-recommended,
+  not a violation** — see Decision D1.
+- **No output bounds anywhere.** `crw_map` can dump up to `MAX_DISCOVERED_URLS = 5000`
+  (`crw-crawl/src/crawl.rs:17`) with no `limit` in the MCP schema (`lib.rs:169-195`). `crw_scrape`
+  serializes full markdown, no cap (`routes/mcp.rs:26-52`). **`crw_check_crawl_status` returns
+  every crawled page's markdown/html/rawHtml** — the single largest unbounded dump (`routes/mcp.rs:61-73`).
+  Claude Code hard-caps tool results at ~25K tok and spills the rest to disk
+  ([claude-code #45770](https://github.com/anthropics/claude-code/issues/45770)) — unbounded output is
+  silently lost, not helpful.
+- **No tool annotations** (`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`,
+  MCP 2025-03-26). Their JSON defaults are hostile: `destructiveHint` defaults to **true**, so
+  omitting them makes read-only tools look destructive → spurious client confirmations.
+- **Runtime weight: `crw-renderer` (auto-browser) is a non-optional dependency**
+  (`crates/crw-mcp/Cargo.toml:22`), so it compiles into **proxy mode too** — only `crw-server`
+  is feature-gated (`:32`). The embedded path also auto-spawns a headless browser (150–500 MB
+  RAM, 0.5–2 s start; `main.rs:383-408`). The lean-proxy story is blocked by this dep, not just
+  by the default feature set.
+- The release profile already sets `lto = true`, `codegen-units = 1`, `strip = true`
+  (`Cargo.toml:147-150`). It does **not** set `opt-level="z"`/`panic`. `panic = "abort"` is
+  **unsafe here**: `crw-extract/src/pdf.rs:214` uses `catch_unwind` to survive malformed-PDF
+  panics; under abort a crafted PDF crashes the whole server (Decision D4).
+- **Install scaffolding already exists**: `mcp/crw-mcp/package.json` + `bin/crw-mcp.js` implement
+  the npm `optionalDependencies` per-platform wrapper with a GitHub-download fallback; a root
+  `server.json` (name `io.github.us/crw`) already feeds the MCP registry. Phase 6 is mostly
+  *finishing/verifying*, not building from scratch.
+
+**What we are NOT doing (scope guard):**
+- Not adding Firecrawl's 20-tool surface (`batch_scrape`, `extract`, `agent`, `monitor_*`).
+  Tool *count* stays ≤ 6.
+- **Lazy/dynamic tool exposure (a "tool search" meta-pattern) is explicitly deferred.** It is
+  the single biggest token lever for *large* servers (50–90% cuts), but at 6 small tools the
+  payoff is modest, Claude Code already auto-activates native tool-search when schemas exceed
+  ~10% of context, and a meta-tool indirection hurts one-shot tool selection. Revisit only if
+  the tool count grows. (Recorded here so its absence is a decision, not an oversight.)
+- Not changing the REST/HTTP API contract or `crw-core` types. All output bounding is done at
+  the **MCP layer** (Decision D2) — no new fields on `ScrapeRequest`/`ScrapeData`/`MapRequest`.
+- Not rewriting the scraping engine, crawler, or renderer.
+- Not switching the protocol revision away from `2025-06-18`.
+- **Not flipping the default mode** from embedded → proxy in this work (Decision D3). We make a
+  lean proxy build *available*; we do not break zero-config users.
+- **Not re-implementing SSRF/URL-safety in the proxy binary.** Verified: the embedded MCP path
+  validates URLs (`routes/mcp.rs:21` → `validate_safe_url_resolved`), and **every REST endpoint
+  the proxy forwards to also validates** (`routes/scrape.rs:19`, `v2/{scrape,crawl,map,batch,
+  extract}.rs`). So SSRF is enforced server-side in both modes; the proxy binary intentionally
+  does not duplicate it (the upstream is the trust boundary). Flagged here so it's a decision, not
+  a blind spot — if a non-crw upstream is ever supported, revisit.
+
+## Decisions (resolve the blocking open questions up front)
+
+These were Open Questions in v0; reviewers (Codex + spec + token + compat) flagged that several
+are blocking and must be settled before Phase 1 touches schemas/tests.
+
+- **D1 — `content` vs `structuredContent` (was Q1).** The MCP spec *recommends* emitting both:
+  if an `outputSchema` is declared, results MUST conform to it and SHOULD also be serialized as
+  a TextContent block for back-compat
+  ([spec: server/tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)).
+  So dual emission is **not** a violation, and the v0 claim "clients SHOULD NOT forward both" was
+  a misattribution (that's community discussion [MCP #1624](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624),
+  not normative). **Decision:** keep dual emission; the real, client-independent wins are (a)
+  **minify** the text block (`to_string`, not `to_string_pretty`) and (b) **slim the
+  `crw_search` `outputSchema`** (drop per-field descriptions + `$defs` prose; keep a skeletal
+  conformant shape) — this saves ~200–300 tok in `tools/list` every turn regardless of how any
+  client forwards results. **Before** changing result emission further, empirically check what
+  Claude Code does with a result that has both fields (the *empirical check* below). If it
+  double-counts → drop the text block for schema-bearing tools; if it suppresses one → leave as
+  is. Spec note (corrected from v1): emitting `structuredContent` *without* an `outputSchema` is
+  fully legal; the **only spec-illegal combination is declaring an `outputSchema` and emitting
+  `structuredContent` that does not conform to it** (the spec says results MUST conform when a
+  schema is declared). So a slimmed `outputSchema` must still validate every real flat/grouped
+  `crw_search` response (locked by test T4).
+  - **Empirical check (do at the end of Phase 1, before Phase 2 result changes):** attach the
+    server to Claude Code, call `crw_search` (the only schema-bearing tool), and inspect whether
+    the result's `content` text counts toward conversation tokens when `structuredContent` is
+    present (via `/context` or transcript inspection). Record the finding in the PR; it decides
+    whether Phase 2 drops the text block for `crw_search`.
+- **D2 — Truncation lives at the MCP layer, not in `crw-core`.** Honors the scope guard. Bounds
+  are MCP-only arguments (`limit`, `maxLength`) parsed from `args` and applied by slicing the
+  already-returned value before serialization, plus consistent markers. No `crw-core`/`crw-crawl`
+  type changes. (For `crw_map`, slicing after `discover_urls` returns keeps `totalDiscovered`
+  knowable; we accept that discovery still does full work — bounding context, not runtime.)
+  - **Bound semantics (resolve the v2 contradiction):** **omitted = conservative bounded
+    default**; **`limit: 0` = explicit unbounded opt-out**. Schema documents this (`minimum: 0`,
+    description "0 = unbounded"). Same pattern for `maxLength` (omitted = default cap, `0` = no cap).
+  - **MCP-only args must be stripped before proxy/REST forwarding.** `limit`/`maxLength` are MCP
+    controls; a stricter/older upstream may reject unknown body fields. The proxy + cli paths
+    extract these locally, remove them from the JSON sent to `/v1/*` `/v2/*`, then apply bounds
+    to the *response*. (Embedded path: `serde` already ignores them on the typed request; still
+    apply bounds to the result.)
+  - **Bound helper signature:** a single `apply_bounds(tool_name, args, value) -> Value` living
+    next to `tool_result_response` in `crw-mcp-proto`, **non-mutating** (never writes back to the
+    stored crawl-job state), reused by embedded, proxy, and cli for parity.
+  - **`crw_scrape` MCP output projection (make it explicit, not "{markdown,url,title}-class"):**
+    the default MCP result projects exactly `{ markdown?, html?, links?, url, title, statusCode,
+    truncated? }` from `ScrapeData` and drops heavy/debug fields (`rawHtml`, `screenshot`, full
+    `metadata`, renderer/cost debug). `formats`/an explicit `include` opts heavier fields back in.
+    See Versioning for the back-compat classification of dropping `rawHtml`-by-default.
+- **D3 — Default stays `embedded`; lean proxy becomes a first-class build.** Flipping the default
+  would silently break every zero-config user (incl. the `crw-saas` prod deploy). Instead,
+  feature-gate `crw-renderer` behind `embedded` so a `--no-default-features` proxy build is tiny,
+  and document/ship it as the lean option. Any future default flip goes through a `CRW_MODE`
+  env with a one-release deprecation window — out of scope here.
+- **D4 — No `panic = "abort"`.** It breaks the `catch_unwind` malformed-PDF safety valve
+  (`crw-extract/src/pdf.rs:214`) and could leak browser child processes on panic
+  (`main.rs:422` drops guards only on the normal path). The build-size delta from abort is small;
+  not worth the crash risk. Size work uses `opt-level` + dependency gating only.
+- **D5 — Keep all current input params; trim prose only (was Q3).** Removing `includeTags`/
+  `excludeTags`/`categories` from schemas would degrade client-side validation/autocomplete for
+  introspecting consumers (n8n nodes, IDE UIs) even though `serde` tolerates extras
+  (no `additionalProperties:false`, `lib.rs:585`). Phase 1 shortens *descriptions*, it does not
+  remove parameters.
+
+## Approach
+
+1. **Cut context cost first** (highest leverage, lowest risk, mostly one file): trim every
+   description to one decisive sentence, slim the `crw_search` `outputSchema`, minify result
+   text. Add a tokenizer-based budget test + a tool-selection eval.
+2. **Bound every result path** at the MCP layer with a single shared truncation helper, opt-out
+   semantics, conservative defaults, enforced in **both** embedded and proxy modes (and the
+   `crw-cli` path), including the worst offender `crw_check_crawl_status`.
+3. **Add correct tool annotations** and tighten protocol conformance (title placement, header
+   handling, unknown-tool semantics).
+4. **Make a genuinely lean proxy binary** by feature-gating `crw-renderer`, adding `opt-level`,
+   and measuring with platform-correct tooling.
+5. **Ship the lean build + finish the (already-scaffolded) distribution**, flagging the real
+   blockers (Apple signing) honestly.
+
+**Trade-offs accepted:** shorter descriptions risk tool-selection regressions → mitigated by a
+20-prompt eval; truncation can hide content → always marked + opt-out; lean proxy needs a
+reachable API/key → documented, default stays zero-config embedded.
+
+## Phases
+
+### Phase 1 — Slash the tool-definition footprint (descriptions + outputSchema)
+**Files:** `crates/crw-mcp-proto/src/lib.rs` (`tool_definitions` ~68-356; tests ~476-776).
+- Rewrite every tool `description` to one decisive sentence; remove return-shape prose, examples,
+  and alias meta-comments from `crw_search` (`:205`). Shorten each property description to ≤ ~8
+  words. **Keep all params** (D5).
+- Slim `crw_search` `outputSchema` (`:272-319`): drop per-field `description`s and `$defs` prose,
+  keep a minimal shape that real flat/grouped responses still validate against (D1). Keep the
+  T4 schema-validation test green.
+- Add a **token-budget test** using a real tokenizer: `tiktoken-rs` as a **dev-dependency**
+  (does not bloat the release artifact — compiled only under `cargo test`; verify it builds in CI
+  with no extra toolchain before gating on it — it vendors its BPE data, no Python needed). If the
+  tokenizer is unavailable, fall back to `ceil(chars/3)` (over-counts → conservative for a ceiling
+  test; consistent with Verification). **Target ≤ 1,000 tok** (estimated floor for 6 trimmed
+  tools ~600–900 tok). Set the **CI failing ceiling to the measured post-trim floor + ~15%
+  margin**, not the aspirational 1,000 — so the gate catches regressions without churning on
+  noise. Record before/after in the PR.
+- **Verified (no action, document it):** the `initialize` response emits only `protocolVersion`,
+  `capabilities`, and `serverInfo{name,version}` (`crw-mcp-proto/src/lib.rs:401-414`) — **no
+  `instructions` field**, so there is no per-session instruction-string token cost to trim. If
+  an `instructions` string is ever added, it must be counted against the same budget.
+- Add a 20-prompt **tool-selection eval fixture** (scrape vs map vs crawl vs search vs parse)
+  run before/after trimming to catch selection regressions. Pin it for reproducibility: fixtures
+  in `tests/eval/`, graded by exact expected-tool-name match, run behind `--ignored` (manual /
+  nightly, not blocking CI), with the judging model + prompt template recorded in the fixture.
+- **Description ↔ runtime-dependency tension:** the trimmed `crw_search` sentence must still hint
+  that it needs a search backend (it fails `search_disabled` with no SearXNG), without a paragraph.
+  Suggested: *"Search the web (needs a configured search backend; embedded uses a local SearXNG
+  sidecar)."* — one sentence that preserves the signal. (See Phase 3 conditional advertisement.)
+- **Effort:** M. **Risk:** Med (selection quality; mitigated by eval).
+
+### Phase 2 — Bound & compact every result path (MCP layer)
+**Files:** `crates/crw-mcp-proto/src/lib.rs` (`tool_result_response` ~439-474; add a shared
+truncation helper); `crates/crw-server/src/routes/mcp.rs` (`call_tool` 24-145);
+`crates/crw-mcp/src/main.rs` (proxy dispatch — bounds enforced locally after `parse_response`);
+`crates/crw-cli/src/commands/mcp.rs` (the duplicate path — update or refactor to shared code).
+- Replace `to_string_pretty` with `to_string` for the text block (`lib.rs:446`); test asserts no
+  pretty whitespace.
+- **One shared truncation helper** applied consistently to: `crw_scrape` markdown/html/rawHtml,
+  `crw_parse_file` markdown, `crw_search` (result count + any `scrapeOptions`-inlined content),
+  `crw_map` links, and **`crw_check_crawl_status`** page contents. Marker is uniform:
+  `truncated: true` + `returnedLength`/`originalLength` (or `returned`/`totalDiscovered` for
+  list-shaped results), never a silent cut.
+- **MCP-layer args (D2):** add `limit` (lists) and `maxLength` (text, chars) to the relevant
+  input schemas; parse from `args`, slice the returned value. **Bound semantics (per D2):**
+  *omitted* = conservative bounded default; **`limit: 0` / `maxLength: 0` = explicit unbounded
+  opt-out** (preserves today's unbounded behavior for callers who ask for it). Schema documents
+  this (`minimum: 0`, description "0 = unbounded"). **Conservative defaults:** `crw_map` limit
+  ≈ 100; `crw_scrape`/parse `maxLength` ≈ 12–15K chars (~3–4K tok, well under the 25K client
+  cap) — callers opt *in* to bigger, not out of small.
+- **Field selection:** `rawHtml`/`html`/`links` are already `formats`-gated in extraction
+  (`crw-extract/src/lib.rs`) — they only appear when requested, so they are *not* the problem.
+  The real waste is the **always-serialized `metadata`** (and any renderer/cost/debug fields) on
+  `ScrapeData`. Phase 2 projects the MCP result to `{ markdown?, html?, links?, url, title,
+  statusCode, truncated? }` (per D2) and drops always-present `metadata`/debug from the default
+  MCP shape; a client can opt heavy fields back in. (Bigger result-token win than `maxLength` alone.)
+- **Enforce in proxy mode locally:** `crw-mcp` forwards to `/v1/*`; a remote/older server may
+  ignore the new MCP-only params, so the proxy path must strip the MCP-only args from the
+  forwarded payload and post-process/truncate responses itself (`main.rs`), not assume the
+  upstream did. Same for `crw-cli`.
+- **Close the existing `crw-cli` parity gap (verified bug):**
+  `crates/crw-cli/src/commands/mcp.rs:190` falls through to `unknown tool` for **`crw_parse_file`**
+  — it's advertised in the shared `tools/list` but unimplemented in the cli proxy dispatch (only
+  `crw_scrape`…`crw_search` exist, no `crw_parse_file` arm). Add the missing arm as part of this
+  phase, or the cli MCP advertises a tool it can't serve.
+- **Bound stderr debug logging too:** `main.rs` logs the full response JSON at `debug`
+  (`tracing::debug!("→ {out}")`, ~`:463/481`) — a 50-page `crw_check_crawl_status` result becomes
+  a multi-MB log line under `RUST_LOG=debug`. Log byte length (or a truncated prefix), not the
+  whole payload. (Operational footgun, separate from context tokens.)
+- **Shared-code strategy (clarify effort):** the cli path (`commands/mcp.rs`) is a ~400-line
+  near-copy of `crw-mcp/src/main.rs`'s proxy dispatch. Preferred: extract the proxy dispatch +
+  `apply_bounds` into a shared module in `crw-mcp-proto` (or a small shared crate) consumed by
+  both — this removes the drift class entirely (`crw_parse_file` gap above is exactly this drift).
+  If a full extraction is too large for one PR, copy `apply_bounds` into both with a shared test,
+  and file a follow-up to dedupe. State which path was taken in the PR.
+- **Effort:** L–XL (6 files incl. `crw-cli` + `teardown.rs`; shared-helper extraction can push to
+  XL). **Risk:** Med — default bounds change observable behavior (see Versioning); covered by
+  tests + opt-out.
+
+### Phase 3 — Correct tool annotations & protocol conformance
+**Files:** `crates/crw-mcp-proto/src/lib.rs` (`tool_definitions`, `handle_protocol_method`);
+`crates/crw-server/src/routes/mcp.rs` (HTTP header handling).
+- Annotations per tool (explicitly emit every value — defaults are hostile):
+  - `crw_scrape`, `crw_map`, `crw_search`, `crw_check_crawl_status`, `crw_parse_file`:
+    `readOnlyHint:true, destructiveHint:false, idempotentHint:true, openWorldHint:true`
+    (`openWorldHint:false` for `crw_parse_file` — it reads provided bytes, not the open web).
+    Note for reviewers: `idempotentHint` concerns *side-effects*, not result determinism — a
+    live `crw_search`/`crw_check_crawl_status` may return different bytes over time yet is
+    side-effect-free, so `idempotentHint:true` is correct per spec.
+  - **`crw_crawl`: `readOnlyHint:false`** (starting a job is a side effect — spec + Codex
+    consensus), `destructiveHint:false, idempotentHint:false, openWorldHint:true`.
+- Add a top-level **`title`** to each tool (`Tool.title` from `BaseMetadata`, the preferred
+  display field — **not** `annotations.title`).
+- HTTP transport: per the 2025-06-18 transports spec, an **invalid/unsupported**
+  `MCP-Protocol-Version` **SHOULD** get `400` (not a hard MUST); a *missing* header SHOULD assume
+  `2025-03-26`. Today `routes/mcp.rs:214` only reads the header. Decide: keep lenient (document
+  why) or add the 400 branch for invalid values; update the header-tolerance test either way.
+- Unknown-tool semantics: today it's `isError:true` text (`routes/mcp.rs:170`, `lib.rs:466`).
+  **Decision:** switch unknown-tool to a JSON-RPC `-32602` protocol error (clients degrade more
+  gracefully than on an `isError` text blob); tool-*execution* failures correctly stay
+  `isError:true`. Lock both with tests. (Spec doesn't mandate either, but `-32602` is the
+  better-supported convention for "this tool doesn't exist".)
+- `capabilities`: `tools:{}` is legal; consider `tools:{listChanged:false}` for explicitness.
+- **Conditional `crw_search` advertisement (frictionless-install fix):** today `crw_search` is
+  *always* in `tools/list` (`lib.rs:197`), but in embedded mode with no `[search].searxng_url` it
+  returns `search_disabled` (503) at call time (`config.rs:184`, `routes/search.rs:160`) — a
+  footgun for `npx -y @crw/mcp` users who see the tool and get an error. Suppress `crw_search`
+  from `tools/list` when the embedded backend has no search backend configured (proxy mode keeps
+  advertising it — the remote decides). Threading the config into `tool_definitions` is a small
+  signature change; alternatively keep advertising it but make the `search_disabled` error
+  actionable ("set [search].searxng_url or run the SearXNG sidecar: …"). Decide; document the
+  SearXNG sidecar in the install docs (Phase 6) either way.
+- **Effort:** S–M. **Risk:** Low.
+
+### Phase 4 — Lean runtime: feature-gate the renderer + size profile
+**Files:** `crates/crw-mcp/Cargo.toml` (the real lever); workspace `Cargo.toml` (profile/deps).
+- **Feature-gate `crw-renderer` behind `embedded`** (`crw-mcp/Cargo.toml:22`) so a
+  `--no-default-features` (proxy) build excludes the auto-browser dependency entirely. This,
+  not the profile, is what unlocks a small proxy binary. Wiring:
+  `embedded = ["dep:crw-server", "dep:crw-renderer", "crw-renderer/auto-browser"]`, with the
+  `use crw_renderer::browser;` in `main.rs:40` (already `#[cfg(feature="embedded")]`) unchanged.
+- **Hard prerequisite (verified blocker):** `crates/crw-mcp/src/teardown.rs:36` calls
+  `crw_renderer::browser::kill_all_browsers()` **unconditionally** (not feature-gated). Making
+  `crw-renderer` optional will break the proxy build until this is gated — wrap the call (and any
+  `crw_renderer` import in `teardown.rs`) in `#[cfg(feature = "embedded")]`, with a no-op fallback
+  for the proxy build (no browsers to kill). This must land *with* the dep gating, not after.
+  Verify proxy mode compiles & runs without `crw-renderer`/`crw-server`. (Confirmed: every other
+  `crw_renderer`/`crw_server` reference in `crw-mcp/src/main.rs` — lines 40, 73, 86, 346, 427 —
+  is already `#[cfg(feature="embedded")]`-gated; `teardown.rs:36` is the only ungated one.)
+- **Note (out of scope but flagged):** `crates/crw-cli/src/teardown.rs:39` has the *same*
+  unconditional `kill_all_browsers()` and `crw-cli` also hard-deps `crw-renderer`
+  (`crw-cli/Cargo.toml:31`). This work targets a lean **`crw-mcp`** binary, not a lean `crw-cli`,
+  so the cli teardown is left as-is — but record it so a future lean-cli effort knows the same
+  gating is needed there.
+- Add `opt-level = "z"` (or `"s"` — measure both) to a release profile; `lto`/`codegen-units`/
+  `strip` are **already set** (`Cargo.toml:147-150`) — do not re-add. **No `panic = "abort"`** (D4).
+- `tokio`/`reqwest` feature trimming is **cross-workspace surgery** (shared deps affect every
+  crate) — scope it carefully or skip; keep `reqwest` multipart (`crw_parse_file` needs it).
+  Replacing `reqwest` with a micro-client is over-engineering (marginal win, breaks multipart) —
+  out of scope.
+- Measure (platform-correct): binary size + `cargo bloat --release -p crw-mcp --crates`; idle
+  RSS (macOS: `/usr/bin/time -l` or `ps -o rss`, **not** GNU `time -v`); cold-start to first
+  `initialize` response via `hyperfine` (multi-run). Record proxy vs embedded numbers; target
+  proxy ≤ ~6 MB / 10–20 MB RSS, embedded documented as the heavy path. No UPX (startup penalty).
+- **Effort:** M (feature-gating may surface compile coupling). **Risk:** Low–Med.
+
+### Phase 5 — First-class lean proxy build (no default flip)
+**Files:** `crates/crw-mcp/Cargo.toml`, `crates/crw-mcp/src/main.rs`, CI release config, docs.
+- Per D3, do **not** change `default = ["embedded"]`. Instead produce a second, clearly-named
+  lean artifact (e.g. `crw-mcp` built `--no-default-features` → `crw-mcp-thin`, or a documented
+  proxy-only release binary) so each audience gets a one-line install.
+- Add an explicit `--no-browser` / env to skip auto-spawn in embedded mode for HTTP-only users
+  (`main.rs:383-408` already skips when a renderer is pre-configured; make it intentional).
+- (Deferred, documented) Any future move to proxy-first default goes through a `CRW_MODE`
+  env-var deprecation window — not in this work.
+- **Effort:** M. **Risk:** Low (additive; no behavior change for existing users).
+
+### Phase 6 — Finish & verify distribution (most scaffolding already exists)
+**Files:** `mcp/crw-mcp/*` (existing wrapper), `server.json` (existing), `.github/workflows/`,
+`docs/mcp*`.
+- **npm wrapper already implemented** (`mcp/crw-mcp/package.json` optionalDependencies +
+  `bin/crw-mcp.js` env→platform-pkg→GitHub-download fallback). Work = **test in a clean env**,
+  confirm each platform package publishes in `release.yml`, and decide on a win32 story (the
+  launcher already falls back to download for win32). Do not "rebuild" it.
+- **`server.json` already exists** (`io.github.us/crw`) and a `publish-mcp-registry` job runs.
+  Work = add the **npm/stdio** transport entry (currently OCI-only) and satisfy current registry
+  requirements: npm package `mcpName` match, MCPB `fileSha256`, package-type metadata. Keep this
+  last (few clients query the registry yet).
+- **`.mcpb` bundle:** only meaningful for the **lean** binary (bundling a 150 MB+ embedded build
+  is absurd) — **gated on Phase 5**. Treat `.mcpb`/MCPB format maturity as a risk (sparse docs,
+  Claude-Desktop-only); ship after the lean artifact exists, with a `user_config` `CRW_API_KEY`
+  (keychain) entry.
+- **macOS codesign/notarize is a real blocker, not a one-liner:** needs an Apple Developer
+  account ($99/yr), `notarytool` creds in CI secrets, and Apple's review — none exist in
+  `release.yml` today. **Flag it explicitly.** Interim: document `xattr -d com.apple.quarantine`
+  in install steps until notarization lands; npm-wrapper installs bypass Gatekeeper anyway.
+- Docs: copy-paste `claude mcp add --transport stdio crw -- npx -y @crw/mcp` (+ `--env
+  CRW_API_KEY=…`), Cursor deeplink, Claude Desktop `.mcpb`, HTTP-remote URL form. Clear startup
+  error when a required env/dependency is missing.
+- **Effort:** M (mostly verification + signing setup). **Risk:** Med (Apple signing external).
+
+## Verification
+- **Token budget:** `crw-mcp-proto` test asserts serialized `tools/list` is under the ceiling
+  using `tiktoken-rs` (or conservative `chars/3`). Record ~3,400 → ≤ ~1,000 in the PR.
+- **Tool selection:** 20-prompt eval before/after Phase 1; no regressions in tool choice.
+- **Output bounds:** unit tests for the shared truncation helper across all tool result shapes
+  (scrape/parse markdown, map links, search results + inlined content, **crawl-status pages**),
+  asserting markers + opt-out (`limit:0`=unbounded). Test minified text has no pretty whitespace.
+- **Proxy parity:** test that bounds apply in proxy mode (post-processing) and `crw-cli`, not
+  just embedded — i.e. a fat upstream response is still truncated locally.
+- **structuredContent (D1):** keep/adapt T1–T6 (`lib.rs:599-776`); slimmed `outputSchema` still
+  validates flat + grouped responses (T4).
+- **Annotations:** test each tool advertises the exact annotation set (esp. `crw_crawl`
+  `readOnlyHint:false`).
+- **Protocol:** `cargo test -p crw-server --test mcp` stays green; add invalid-version-header
+  and unknown-tool tests per Phase 3 decisions.
+- **Build/size:** `cargo build --release -p crw-mcp` (embedded) and
+  `--no-default-features` (proxy); capture binary size, idle RSS (macOS `/usr/bin/time -l`),
+  cold-start (`hyperfine`). Confirm proxy build compiles without `crw-renderer`.
+- **stdio framing smoke test (early — in Phase 2/3, not deferred to 6):** a test that drives the
+  real stdio loop end-to-end (`initialize` → `tools/list` → `tools/call`) over a pipe, so a
+  framing/newline bug is caught before distribution, not after publish. The full install smoke
+  test (below) stays in Phase 6.
+- **Install smoke test:** clean-env `npx -y @crw/mcp` → manual
+  `initialize`/`tools/list`/`tools/call` over stdio; verify `claude mcp add` attaches; verify
+  `.mcpb` installs in Claude Desktop (after Phase 5).
+- Commands: `cargo test -p crw-mcp-proto`, `cargo test -p crw-server --test mcp`,
+  `cargo clippy --all-targets`, `cargo build --release -p crw-mcp [--no-default-features]`.
+
+## Versioning & migration
+- Most changes are behavior-affecting but schema-additive → **minor** bumps. Use `feat:` commits
+  (release-please owns the bump/changelog; do not use `chore:` for the default-cap change).
+  Workspace is `0.15.2` (pre-1.0, so technically no SemVer guarantee — but treat it as if 1.0+).
+- **`crw_scrape` default field projection is subtractive, not additive.** Dropping `rawHtml`
+  (and `screenshot`/full `metadata`) from the default MCP result *removes* fields an existing
+  client may read — for a post-1.0 contract this is a **major/breaking** change, not minor.
+  Mitigation that keeps it minor: make the heavy fields **opt-in via the existing `formats`
+  param** (a client that wants `rawHtml` already passes `formats:["rawHtml"]` and still gets it),
+  and only fields *not requested via `formats`* are dropped — i.e. we stop returning rawHtml when
+  it was never asked for. **Prerequisite:** verify (in Phase 2) whether today's `crw_scrape`
+  emits `rawHtml` unconditionally or only when `formats` requests it. If unconditional, the
+  default projection is breaking and must be called out in CHANGELOG + considered for a guarded
+  rollout (e.g. an opt-out env for one release). Resolve before implementing the projection.
+  (Narrowed by review: `rawHtml`/`html`/`links` are already `formats`-gated and appear only when
+  requested, so dropping them by default is a no-op; the only genuinely-subtractive change is
+  dropping the **always-serialized `metadata`/debug** fields — scope the breaking-change analysis
+  to those.)
+- CHANGELOG must call out: new default truncation (with the `limit:0`/`maxLength:0` opt-outs),
+  the `crw_scrape` field projection, the lean `--no-default-features` build, and the
+  unknown-tool (`-32602`) / header semantics changes.
+- No `crw-core`/REST contract change (D2), so `crw-saas`, `langchain-crw`, and n8n REST consumers
+  are unaffected; only MCP-client consumers see the intentional, documented output bounds.
+
+## Remaining open questions
+- **Q-empirical (gates D1 final step):** Does Claude Code count a tool result's `content` text
+  toward context when `structuredContent` is also present? Resolved by the empirical check in
+  Phase 1 (procedure specified under D1) before Phase 2's result changes.
+- **Q-rawHtml (gates the `crw_scrape` projection):** Does today's `crw_scrape` emit `rawHtml`
+  unconditionally or only when `formats` requests it? Answer in Phase 2 decides whether the
+  default projection is minor (opt-in via `formats`) or breaking (see Versioning).
+- **Q-registry/npm scope:** Confirm npm org/scope (`@crw`? `@fastcrw`?) and the real GitHub
+  owner — `server.json:4` currently reads `io.github.us/crw` (a worktree placeholder username);
+  the wrapper's package name and `server.json` `name`/`mcpName` must all agree on the real
+  owner before publishing.
+- **Q-default-mode (future):** Whether/when to make proxy-first the default (needs the Phase 4
+  measurements + a view on what fraction of installs have a remote API/key). Deferred past D3.
+
+## Order of execution & risk table
+| Phase | Files | Effort | Risk | Order |
+|---|---|---|---|---|
+| 1 — Trim descriptions + outputSchema | `crw-mcp-proto/src/lib.rs` (+tests) | M | Med | 1 |
+| 2 — Bound & compact all results (incl. crawl-status, proxy, cli, parse_file gap) | `lib.rs`, `routes/mcp.rs`, `main.rs`, `cli/.../mcp.rs` | L–XL | Med | 2 |
+| 3 — Annotations + protocol conformance | `lib.rs`, `routes/mcp.rs` | S | Low | 3 |
+| 4 — Feature-gate renderer (+ `teardown.rs:36` cfg-gate) + size profile | `crw-mcp/Cargo.toml`, `teardown.rs`, ws `Cargo.toml` | M | Low–Med | 4 |
+| 5 — First-class lean proxy build | `crw-mcp/Cargo.toml`, `main.rs`, CI, docs | M | Low | 5 |
+| 6 — Finish/verify distribution + signing | `mcp/`, `server.json`, CI, docs | M | Med | 6 |
+
+Phases 1–3 are the context-footprint wins (highest leverage, mostly `crw-mcp-proto`). Phase 4
+unlocks the lean binary (renderer gating is the lever). Phases 5–6 are additive distribution
+work; the only external blocker is Apple signing (Phase 6).
+
+## Iteration log
+- **Iteration 0** (2026-06-13): initial plan from 5-agent parallel research (MCP design, token
+  economics, runtime weight, install UX, Firecrawl survey + crw-mcp audit).
+- **Iteration 1** (2026-06-13): 5 reviewer agents + Codex. Addressed criticals — resolved
+  blocking decisions into D1–D5; corrected `crw_crawl` annotations (`readOnlyHint:false`) and
+  the `destructiveHint`-default trap; reframed `structuredContent` as spec-recommended (fixed
+  the misattribution); added `crw_check_crawl_status` to output bounding; mandated proxy-mode +
+  `crw-cli` bound enforcement; moved truncation to the MCP layer (no `crw-core` changes);
+  dropped `panic=abort` (PDF `catch_unwind` crash risk); identified non-optional `crw-renderer`
+  as the real weight lever (feature-gate it); re-scoped Phase 6 (npm wrapper + `server.json`
+  already exist); flagged Apple signing as a real blocker; fixed macOS measurement tooling;
+  tightened the token target to ≤1,000 with a real tokenizer; added a tool-selection eval and a
+  versioning section. Deferred lazy/tool-search exposure with explicit rationale. Rejected:
+  removing input params (D5 — UX regression for introspecting consumers); replacing `reqwest`
+  (over-engineering).
+- **Iteration 2** (2026-06-13): 3 second-pass reviewers + Codex. Fixed the D1 "illegal
+  combination" mischaracterization (illegal = declared `outputSchema` + non-conformant
+  `structuredContent`); resolved the contradictory bound semantics (omitted = bounded default,
+  `0` = unbounded opt-out); mandated stripping MCP-only args before proxy/REST forwarding;
+  specified the exact `crw_scrape` output projection + reclassified dropping `rawHtml`-by-default
+  as potentially **breaking** (mitigated via `formats` opt-in; gated on Q-rawHtml); added the
+  **verified `teardown.rs:36` compile blocker** (unconditional `kill_all_browsers()`) as a hard
+  Phase-4 prerequisite with feature wiring; added the **verified `crw-cli` `crw_parse_file`
+  parity bug** (`commands/mcp.rs:190`) to Phase 2 + a shared-code extraction strategy; switched
+  the token test to `tiktoken-rs` (dev-dep) with a floor+15% CI ceiling; **verified** the
+  `initialize` response emits no `instructions` field (no hidden token cost); softened the
+  protocol-version 400 to SHOULD; picked `-32602` for unknown tools; added `idempotentHint`
+  justification; bumped Phase 2 to L–XL. No open criticals remain; the two remaining gating
+  questions (Q-empirical, Q-rawHtml) are explicit measurements scheduled inside the phases.
+- **Iteration 3** (2026-06-13): 3 confirmation reviewers + Codex → spec & feasibility consensus.
+  Final fixes: resolved the residual Phase-2 bound-semantics contradiction with D2 (omitted =
+  bounded default, `0` = unbounded); made the token-test fallback consistent (`ceil(chars/3)`) +
+  flagged `tiktoken-rs` CI build; **narrowed Q-rawHtml** (rawHtml is already `formats`-gated — the
+  real subtractive change is dropping always-serialized `metadata`); **added the embedded
+  `crw_search` SearXNG footgun fix** (conditional advertisement / actionable error — a real
+  frictionless-install gap) and the one-sentence description that preserves the backend hint;
+  **acknowledged SSRF as enforced server-side** in both modes (proxy doesn't re-validate, by
+  design); flagged the second `crw-cli/src/teardown.rs:39` compile blocker (out of scope for the
+  lean *crw-mcp* binary, recorded for a future lean-cli); added a debug-log payload-size cap
+  (stderr bloat) and an early stdio-framing smoke test; pinned the tool-selection eval for
+  reproducibility; noted the `server.json` placeholder owner. Outstanding `-32601`-vs-`-32602`
+  for unknown tools is a documented style choice, not a spec issue. **Consensus reached:** no
+  open critical/warning items; the two gating questions are scheduled measurements, not unknowns.


### PR DESCRIPTION
## Summary

Makes the fastCRW MCP server best-in-class on the three axes that matter for agents: **context footprint**, **runtime weight**, and **install/conformance**. Implemented in 4 reviewed phases (multi-agent + Codex review per phase).

| Metric | Before | After |
|---|---|---|
| `tools/list` payload | 8,233 B (~2,744 tok) | 6,189 B (~1,450 cl100k tok) |
| Lean proxy binary | 17 MB | **4.2 MB** |
| Proxy dependency crates | 407 | **44** (no Chromium/CDP) |
| Result payloads | unbounded | bounded (15K char / 100 URL, `0` = opt-out) |

## Changes

- **Trim tool definitions** — one-sentence descriptions, slimmed `crw_search` outputSchema; `tools/list` token-budget regression test.
- **Bound every result path** — `apply_bounds` truncates scrape/map/search/crawl-status/parse content at the MCP layer (`maxLength`/`limit`, `0` = unbounded), for embedded **and** proxy (envelope-aware) **and** cli; minified result text; capped debug logs. Fixes a missing `crw_parse_file` arm in the cli proxy.
- **Annotations + conformance** — MCP 2025-06-18 tool annotations (`crw_crawl` is read-write) + titles; `crw_search` suppressed from `tools/list` when no search backend is configured; `-32602` for unknown tools; `listChanged:false`.
- **Lean build** — `crw-renderer` feature-gated behind `embedded`, so `--no-default-features` yields a 4.2 MB browser-free proxy binary; size-optimized `release-small` profile (no `panic=abort` — preserves PDF `catch_unwind` safety).

## Verification

- 32 `crw-mcp-proto` + 18 `crw-server` MCP tests pass; `clippy -D warnings` clean; `cargo fmt` clean.
- Lean binary passes an end-to-end stdio smoke test (initialize 2025-06-18, 6 tools, annotations, `-32602`).

## Out of scope / deferred

- `.mcpb` bundle + macOS notarization need an Apple Developer account.
- npm wrapper + `server.json` already exist.
- `/v2/parse` not emitting `plainText` is a pre-existing v2 API gap (not introduced here).

Plan: `plans/mcp-optimization.md`.