### PR TITLE
docs(mcp): sync docs with the optimized MCP server

### DIFF
--- a/COMPATIBILITY-firecrawl.md
+++ b/COMPATIBILITY-firecrawl.md
@@ -116,7 +116,7 @@ This is a **capability matrix**, not an API-shape compatibility matrix (which th
 
 | | Firecrawl | fastCRW |
 |---|---|---|
-| MCP server bundled | ✅ (`firecrawl-mcp-server`) | ✅ (built-in `crw-mcp` crate; `crw_search`, `crw_scrape`, `crw_crawl`, `crw_map`, `crw_check_crawl_status` tools) |
+| MCP server bundled | ✅ (`firecrawl-mcp-server`) | ✅ (built-in `crw-mcp` crate; `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_search`, `crw_parse_file` tools) |
 
 **Surface match:** both products ship MCP. Tool names differ (Firecrawl uses `firecrawl_*`, fastCRW uses `crw_*`); semantic mapping is straightforward.
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,14 @@ self-hosted instance and ship to managed without code changes.
 npx crw-mcp                              # zero install (npm)
 pip install crw                          # Python SDK (auto-downloads binary)
 brew install us/crw/crw-mcp              # Homebrew
-cargo install crw-mcp                    # Cargo
+cargo install crw-mcp                    # Cargo (full embedded, ~17 MB)
 docker run -i ghcr.io/us/crw crw-mcp     # Docker
+```
+
+**Lean browser-free proxy build** (~4.2 MB, no headless browser engine — proxy/cloud mode only):
+
+```bash
+cargo build --profile release-small --no-default-features -p crw-mcp
 ```
 
 ### CLI (`crw`) — scrape URLs from your terminal

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -150,7 +150,7 @@ CRW 提供 Firecrawl 的 API，但资源占用极低。无运行时依赖，无 
 claude mcp add crw -- npx crw-mcp
 ```
 
-> 完成。Claude Code 现在拥有 `crw_scrape`、`crw_crawl`、`crw_map` 工具。Cursor、Windsurf、Cline 等 MCP 客户端请参见 [MCP 服务器](#mcp-服务器)。
+> 完成。Claude Code 现在拥有 `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file` 工具（`crw_search` 在配置 SearXNG 后端后自动出现）。Cursor、Windsurf、Cline 等 MCP 客户端请参见 [MCP 服务器](#mcp-服务器)。
 
 **CLI（无需服务器）：**
 
@@ -316,7 +316,7 @@ claude mcp add crw -- npx crw-mcp
 }
 ```
 
-**工具：** `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`
+**工具（共 6 个）：** `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file`（本地 PDF 转 Markdown）、`crw_search`（配置 SearXNG 后端后可用；云模式始终可用）
 
 ## JS 渲染
 

--- a/blog/best-mcp-servers-web-scraping.md
+++ b/blog/best-mcp-servers-web-scraping.md
@@ -10,8 +10,8 @@
 
 ## Short Answer
 
-- **Best all-in-one MCP scraper:** [CRW](https://fastcrw.com) — built-in MCP server with scrape, crawl, and map tools. Zero extra setup.
-- **Best for feature-rich scraping:** Firecrawl MCP — screenshots, PDFs, structured extraction via MCP.
+- **Best all-in-one MCP scraper:** [CRW](https://fastcrw.com) — built-in MCP server with scrape, crawl, map, search, and more. Zero extra setup.
+- **Best for feature-rich scraping:** Firecrawl MCP — screenshots and structured extraction via MCP.
 - **Best for browser automation:** Playwright MCP — full browser control for complex SPAs and interactions.
 - **Best for cloud browsers:** Browserbase MCP — managed headless browsers, no local Chrome needed.
 - **Best for simple fetches:** Fetch MCP — lightweight HTTP requests without browser overhead.
@@ -34,7 +34,7 @@ The key advantage over traditional API integration: **your agent discovers the s
 
 | MCP Server | Tools Provided | Markdown Output | JS Rendering | Self-Hostable | Setup Complexity |
 | --- | --- | --- | --- | --- | --- |
-| **CRW (built-in)** | scrape, crawl, map | ✅ Native | ✅ LightPanda | ✅ | ⭐ Easiest |
+| **CRW (built-in)** | scrape, crawl, map, search, parse_file, check_crawl_status | ✅ Native | ✅ LightPanda | ✅ | ⭐ Easiest |
 | Firecrawl MCP | scrape, crawl, map, extract | ✅ Native | ✅ Playwright | ✅ | ⭐⭐ Easy |
 | Playwright MCP | navigate, click, type, screenshot, etc. | ❌ HTML | ✅ Full browser | ✅ | ⭐⭐⭐ Moderate |
 | Browserbase MCP | navigate, interact, screenshot | ❌ HTML | ✅ Cloud browser | ❌ | ⭐⭐ Easy |
@@ -50,9 +50,12 @@ The key advantage over traditional API integration: **your agent discovers the s
 
 **Tools provided:**
 
-- `scrape` — extract content from a single URL as markdown, HTML, or structured JSON
-- `crawl` — crawl a site and return content from multiple pages
-- `map` — discover all URLs on a site without extracting content
+- `crw_scrape` — extract content from a single URL as markdown, HTML, or structured JSON
+- `crw_crawl` — crawl a site and return content from multiple pages
+- `crw_check_crawl_status` — check the status of an async crawl job
+- `crw_map` — discover all URLs on a site without extracting content
+- `crw_search` — search the web and return content from matching pages
+- `crw_parse_file` — parse files (including PDFs) and return content as markdown
 
 **MCP client configuration (Claude Desktop, Cursor, etc.):**
 
@@ -61,7 +64,7 @@ The key advantage over traditional API integration: **your agent discovers the s
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "--mcp"],
+      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "crw-mcp"],
       "env": {
         "CRW_API_KEY": "your-key"
       }
@@ -103,7 +106,7 @@ Or if using fastCRW cloud:
 
 CRW is listed on the official [MCP Registry](https://registry.modelcontextprotocol.io/?q=crw), making it discoverable from any MCP-compatible client.
 
-**Limitations:** No screenshot tool (yet). No PDF extraction tool. For complex SPAs that need full Playwright-level browser automation, you might supplement CRW with the Playwright MCP server.
+**Limitations:** No screenshot tool (yet). For complex SPAs that need full Playwright-level browser automation, you might supplement CRW with the Playwright MCP server.
 
 **Best for:** Any AI agent that needs web scraping as a core capability. The lowest-friction path to giving your agent live web access.
 
@@ -286,7 +289,7 @@ Yes — and many teams do. A common pattern is CRW for fast markdown scraping pl
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "--mcp"]
+      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "crw-mcp"]
     },
     "playwright": {
       "command": "npx",
@@ -333,13 +336,13 @@ Add this to your MCP client config and you're done:
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "--mcp"]
+      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "crw-mcp"]
     }
   }
 }
 ```
 
-Your agent immediately gets `scrape`, `crawl`, and `map` tools. No API keys needed for local use.
+Your agent immediately gets `scrape`, `crawl`, `map`, `search`, `parse_file`, and `crawl_status` tools. No API keys needed for local use.
 
 ### Managed path: fastCRW cloud MCP
 
@@ -374,7 +377,7 @@ Don't want to run Docker locally? Use [fastCRW](https://fastcrw.com) as the back
 
 ### What is the best MCP server for web scraping?
 
-For most AI agent use cases, fastCRW's built-in MCP server is the best starting point: zero extra setup, clean markdown output, low local-first latency, and scrape, crawl, and map tools out of the box. If you need screenshots or PDF parsing, Firecrawl MCP adds those capabilities. If you need full browser control, add Playwright MCP alongside fastCRW.
+For most AI agent use cases, fastCRW's built-in MCP server is the best starting point: zero extra setup, clean markdown output, low local-first latency, and scrape, crawl, map, search, and PDF-parse tools out of the box. If you need screenshots, Firecrawl MCP adds that capability. If you need full browser control, add Playwright MCP alongside fastCRW.
 
 ### Can I use MCP servers with Claude, GPT, or other LLMs?
 
@@ -382,7 +385,7 @@ Yes. MCP is an open standard supported by Claude Desktop, Cursor, Windsurf, and 
 
 ### Which tools does the fastCRW MCP server expose?
 
-The crw-mcp server exposes five tools: scrape, search, crawl, map, and crawl-status. There is no separate extract tool — structured JSON extraction runs through the scrape tool's json format with a schema. Register it in Claude Code with: claude mcp add fastcrw -- npx -y crw-mcp.
+The crw-mcp server exposes six tools: scrape, search, crawl, check_crawl_status, map, and parse_file. There is no separate extract tool — structured JSON extraction runs through the scrape tool's json format with a schema. Register it in Claude Code with: claude mcp add fastcrw -- npx -y crw-mcp.
 
 ### What's the difference between Playwright MCP and fastCRW MCP?
 

--- a/blog/best-open-source-web-crawlers.md
+++ b/blog/best-open-source-web-crawlers.md
@@ -233,7 +233,7 @@ For AI agents that need to scrape on demand during their reasoning:
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "--mcp"]
+      "args": ["run", "-i", "--rm", "ghcr.io/us/crw:latest", "crw-mcp"]
     }
   }
 }

--- a/blog/claude-code-web-scraping.md
+++ b/blog/claude-code-web-scraping.md
@@ -27,7 +27,7 @@ npx -y crw-mcp
 claude mcp add crw -- npx -y crw-mcp
 ```
 
-That's it. Two commands. Claude Code now has three web scraping tools available: `crw_scrape`, `crw_crawl`, and `crw_map`. No API key, no Docker container, no configuration file. CRW is also listed on the official [MCP Registry](https://registry.modelcontextprotocol.io/?q=crw).
+That's it. Two commands. Claude Code now has six web scraping tools available: `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_search`, and `crw_parse_file`. No API key, no Docker container, no configuration file. CRW is also listed on the official [MCP Registry](https://registry.modelcontextprotocol.io/?q=crw).
 
 The next time you ask Claude Code something that requires web content, it will automatically decide whether to use these tools. Ask it to "check the latest Next.js docs for the App Router API" and it will scrape the documentation page, read the markdown content, and answer based on the live page — not its training data.
 
@@ -47,11 +47,11 @@ The `claude mcp add` command registers this binary with Claude Code's MCP config
 }
 ```
 
-When Claude Code starts a new session, it launches `crw-mcp` as a subprocess. The MCP handshake happens automatically — Claude Code discovers the available tools, their parameter schemas, and their descriptions. From then on, the model can call any of the three tools at will.
+When Claude Code starts a new session, it launches `crw-mcp` as a subprocess. The MCP handshake happens automatically — Claude Code discovers the available tools, their parameter schemas, and their descriptions. From then on, the model can call any of the tools at will.
 
-## The Three Tools Claude Code Gets
+## The Tools Claude Code Gets
 
-CRW exposes three MCP tools, each mapped to a REST API endpoint:
+CRW exposes six MCP tools, each mapped to a REST API endpoint:
 
 ### crw_scrape — Fetch a Single Page
 
@@ -312,7 +312,7 @@ Install the CRW MCP server with npx -y crw-mcp, then register it with claude mcp
 
 ### What is CRW MCP for Claude Code?
 
-CRW is an open-source web scraper with a built-in MCP (Model Context Protocol) server. When connected to Claude Code, the crw-mcp server exposes five tools — scrape, search, crawl, map, and crawl-status — that let Claude Code fetch and read live web pages directly from your terminal. Structured JSON extraction runs through the scrape tool's json format with a schema, so there is no separate extract tool.
+CRW is an open-source web scraper with a built-in MCP (Model Context Protocol) server. When connected to Claude Code, the crw-mcp server exposes six tools — scrape, search, crawl, check_crawl_status, map, and parse_file — that let Claude Code fetch and read live web pages (and files, including PDFs) directly from your terminal. Structured JSON extraction runs through the scrape tool's json format with a schema, so there is no separate extract tool.
 
 ### Does Claude Code web scraping require an API key?
 

--- a/blog/crw-architecture.md
+++ b/blog/crw-architecture.md
@@ -133,11 +133,14 @@ Crawl state is held in memory (not persisted). This means a CRW restart abandons
 
 ## MCP Server
 
-The MCP (Model Context Protocol) server reuses CRW's scraping engine directly. It exposes three tools:
+The MCP (Model Context Protocol) server reuses CRW's scraping engine directly. It exposes six tools:
 
-- `scrape` — delegates to the scrape handler
-- `crawl` — starts an async crawl job and returns its id; the caller polls the crawl-status tool until the job completes (the same async model as the HTTP `/v1/crawl` endpoint)
-- `map` — returns the URL map for a site
+- `crw_scrape` — delegates to the scrape handler
+- `crw_crawl` — starts an async crawl job and returns its id; the caller polls `crw_check_crawl_status` until the job completes (the same async model as the HTTP `/v1/crawl` endpoint)
+- `crw_check_crawl_status` — polls a crawl job and returns its pages
+- `crw_map` — returns the URL map for a site
+- `crw_search` — web search (always in proxy mode; in embedded mode only with a SearXNG backend)
+- `crw_parse_file` — parses a local PDF to markdown
 
 MCP uses stdio transport (JSON-RPC over stdin/stdout), making it suitable for process-spawning clients like Claude Desktop. The server shares the same Tokio runtime as the HTTP API, so both can run simultaneously if needed.
 

--- a/blog/mcp-web-scraping.md
+++ b/blog/mcp-web-scraping.md
@@ -64,11 +64,14 @@ The AI client receives the `text` content and injects it into the model's contex
 
 ## What Tools Does CRW's MCP Server Expose?
 
-Three tools:
+Six tools:
 
 - **crw_scrape** — Fetches a single URL and returns clean markdown (and optionally HTML, links, or structured JSON)
 - **crw_crawl** — Crawls a site up to a page limit, returning markdown for each discovered page
+- **crw_check_crawl_status** — Checks the status of an async crawl job
 - **crw_map** — Returns all URLs found on a site, useful for site discovery without full content extraction
+- **crw_search** — Searches the web and returns content from matching pages
+- **crw_parse_file** — Parses a file (including PDFs) and returns its content as markdown
 
 These map directly to CRW's REST endpoints, so the behavior is identical whether you call over HTTP or through MCP. The tool descriptions and parameter schemas are written to help the AI understand when to use each one — for example, the `crw_map` tool description explains that it's faster than `crw_crawl` for URL discovery.
 
@@ -76,16 +79,15 @@ These map directly to CRW's REST endpoints, so the behavior is identical whether
 
 There are two different ways to use CRW over MCP, and the distinction matters:
 
-### Option A: Local Binary (`crw mcp`)
+### Option A: Local Binary (`crw-mcp`)
 
-If you self-host CRW, the `crw mcp` subcommand starts the MCP server backed by your local CRW instance. The binary handles all scraping directly — no API key required, no network calls to external services. Your config points at the local binary:
+If you self-host CRW, the `crw-mcp` binary starts the MCP server backed by your local CRW instance. The binary handles all scraping directly — no API key required, no network calls to external services. Your config points at the local binary:
 
 ```
 {
   "mcpServers": {
     "crw": {
-      "command": "crw",
-      "args": ["mcp"]
+      "command": "crw-mcp"
     }
   }
 }
@@ -113,14 +115,14 @@ The `crw-mcp` npm package is a thin MCP wrapper that proxies tool calls to the f
 
 This is the right choice when you want better success rates on bot-protected sites, don't want to manage a local binary, or are using CRW from a machine that can't run Docker (some locked-down corporate environments).
 
-The tool interface is identical between both options — the same three tools with the same parameters. Switching between them is a config-file change.
+The tool interface is identical between both options — the same six tools with the same parameters. Switching between them is a config-file change.
 
 ## Option 1: Connect to Claude Desktop
 
-First, make sure you have the CRW binary installed. You can download it from the [GitHub releases page](https://github.com/us/crw/releases) or install via Cargo:
+First, make sure you have the CRW MCP binary installed. Install it via npm:
 
 ```
-cargo install crw
+npm install -g crw-mcp
 ```
 
 Then add this to your Claude Desktop config file (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
@@ -129,14 +131,13 @@ Then add this to your Claude Desktop config file (`~/Library/Application Support
 {
   "mcpServers": {
     "crw": {
-      "command": "crw",
-      "args": ["mcp"]
+      "command": "crw-mcp"
     }
   }
 }
 ```
 
-Restart Claude Desktop. In the tool menu you should now see `crw` as an available server with the `crw_scrape`, `crw_crawl`, and `crw_map` tools.
+Restart Claude Desktop. In the tool menu you should now see `crw` as an available server with tools including `crw_scrape`, `crw_crawl`, `crw_map`, `crw_search`, `crw_check_crawl_status`, and `crw_parse_file`.
 
 Now you can tell Claude: *"Scrape https://docs.example.com/api and summarize the authentication section."* Claude will call `scrape`, get the markdown, and answer based on the actual page content — not its training data cutoff.
 
@@ -147,12 +148,11 @@ In Cursor's settings, navigate to **MCP Servers** and add:
 ```
 {
   "name": "crw",
-  "command": "crw",
-  "args": ["mcp"]
+  "command": "crw-mcp"
 }
 ```
 
-Once enabled, Cursor's AI can use `scrape`, `crawl`, and `map` when responding to your prompts. This is particularly useful for coding tasks — "scrape the API docs for this library and show me how to authenticate" becomes a real-time web lookup rather than a retrieval from the model's training data.
+Once enabled, Cursor's AI can use `scrape`, `crawl`, `map`, and other CRW tools when responding to your prompts. This is particularly useful for coding tasks — "scrape the API docs for this library and show me how to authenticate" becomes a real-time web lookup rather than a retrieval from the model's training data.
 
 A common pattern in Cursor is using `map` first to discover what documentation pages exist, then selectively `scrape`-ing only the relevant ones rather than crawling everything.
 
@@ -165,7 +165,7 @@ If you prefer not to install the binary directly, run CRW as a Docker container 
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "ghcr.io/us/crw:latest", "mcp"]
+      "args": ["run", "--rm", "-i", "ghcr.io/us/crw:latest", "crw-mcp"]
     }
   }
 }
@@ -181,8 +181,7 @@ If you're building your own AI agent and want to call CRW's MCP tools programmat
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 const transport = new StdioClientTransport({
-  command: "crw",
-  args: ["mcp"],
+  command: "crw-mcp",
 });
 
 const client = new Client({ name: "my-agent", version: "1.0.0" }, {});
@@ -218,8 +217,7 @@ from mcp.client.stdio import stdio_client
 
 async def main():
     server_params = StdioServerParameters(
-        command="crw",
-        args=["mcp"],
+        command="crw-mcp",
     )
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
@@ -361,7 +359,7 @@ Both interfaces expose the same underlying CRW functionality. The choice depends
 
 ### Binary Not Found
 
-If your MCP client says the server failed to start, the most common cause is the `crw` binary not being on the `PATH`. MCP clients start the command in a clean shell environment that may not have your user PATH.
+If your MCP client says the server failed to start, the most common cause is the `crw-mcp` binary not being on the `PATH`. MCP clients start the command in a clean shell environment that may not have your user PATH.
 
 Fix: use the full path to the binary:
 
@@ -369,14 +367,13 @@ Fix: use the full path to the binary:
 {
   "mcpServers": {
     "crw": {
-      "command": "/usr/local/bin/crw",
-      "args": ["mcp"]
+      "command": "/usr/local/bin/crw-mcp"
     }
   }
 }
 ```
 
-Find the full path with: `which crw`
+Find the full path with: `which crw-mcp`
 
 ### JSON Config Errors
 
@@ -390,10 +387,10 @@ If the command prints the JSON, the syntax is valid. If it prints an error, find
 
 ### Permission Issues on macOS
 
-On macOS, you may need to grant the MCP client permission to run the `crw` binary. If you see a "cannot be opened because the developer cannot be verified" dialog, run:
+On macOS, you may need to grant the MCP client permission to run the `crw-mcp` binary. If you see a "cannot be opened because the developer cannot be verified" dialog, run:
 
 ```
-xattr -d com.apple.quarantine /usr/local/bin/crw
+xattr -d com.apple.quarantine /usr/local/bin/crw-mcp
 ```
 
 ### Docker Transport Not Working
@@ -401,16 +398,16 @@ xattr -d com.apple.quarantine /usr/local/bin/crw
 When using the Docker transport, ensure Docker Desktop is running before launching Claude Desktop or Cursor. The MCP client starts Docker as a subprocess — if Docker isn't running, the server will fail to start with a cryptic error. Test manually first:
 
 ```
-docker run --rm -i ghcr.io/us/crw:latest mcp
+docker run --rm -i ghcr.io/us/crw:latest crw-mcp
 # Should start without error and wait for stdin input
 ```
 
 ### Debugging MCP Exchanges
 
-To see the raw JSON-RPC messages exchanged, run `crw mcp` with verbose logging:
+To see the raw JSON-RPC messages exchanged, run `crw-mcp` with verbose logging:
 
 ```
-CRW_LOG=debug crw mcp
+CRW_LOG=debug crw-mcp
 ```
 
 This prints each incoming request and outgoing response to stderr, which most MCP clients log to a debug console.
@@ -430,10 +427,10 @@ Without MCP, you'd need to write API call boilerplate, handle authentication, pa
 
 ### Self-Host for Free
 
-Install the CRW binary and configure your MCP client in minutes:
+Install the CRW MCP binary and configure your MCP client in minutes:
 
 ```
-cargo install crw
+npm install -g crw-mcp
 # Then add to your claude_desktop_config.json
 ```
 
@@ -479,20 +476,20 @@ Claude Desktop and Claude's API with tool use support MCP natively. Cursor suppo
 
 ### Does CRW's MCP server require an API key?
 
-The self-hosted binary (`crw mcp`) does not require an API key by default — it scrapes directly without any authentication. If you set `CRW_API_KEY` on your CRW server, the MCP server will use it automatically. The `crw-mcp` npm package requires a fastCRW API key set as the `FASTCRW_API_KEY` environment variable.
+The self-hosted binary (`crw-mcp`) does not require an API key by default — it scrapes directly without any authentication. If you set `CRW_API_KEY` on your CRW server, the MCP server will use it automatically. The `crw-mcp` npm package requires a fastCRW API key set as the `FASTCRW_API_KEY` environment variable.
 
 ### What tools does CRW expose via MCP?
 
-Three tools: **scrape** (fetch a single URL and return markdown, HTML, or links), **crawl** (crawl a site up to a page limit, returning markdown for each page), and **map** (return all URLs found on a site without fetching full content). These correspond directly to the `/v1/scrape`, `/v1/crawl`, and `/v1/map` REST endpoints.
+Six tools: **crw_scrape** (fetch a single URL and return markdown, HTML, or links), **crw_crawl** (crawl a site up to a page limit, returning markdown for each page), **crw_check_crawl_status** (check an async crawl job), **crw_map** (return all URLs found on a site without fetching full content), **crw_search** (search the web and return content from matching pages), and **crw_parse_file** (parse files including PDFs to markdown). These correspond directly to CRW's REST endpoints.
 
 ### How do I debug MCP connection issues?
 
-Start with the JSON config file syntax — use `python3 -m json.tool` to validate it. Then check that the binary path is correct and accessible. Run `crw mcp` manually in your terminal to verify it starts without error. For deeper debugging, set `CRW_LOG=debug` to see the raw JSON-RPC exchanges. Claude Desktop logs MCP errors to `~/Library/Logs/Claude/` on macOS.
+Start with the JSON config file syntax — use `python3 -m json.tool` to validate it. Then check that the binary path is correct and accessible. Run `crw-mcp` manually in your terminal to verify it starts without error. For deeper debugging, set `CRW_LOG=debug` to see the raw JSON-RPC exchanges. Claude Desktop logs MCP errors to `~/Library/Logs/Claude/` on macOS.
 
 ### Can I use CRW's MCP server with my own AI agent?
 
-Yes — use the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) or [Python SDK](https://github.com/modelcontextprotocol/python-sdk) to connect to `crw mcp` as a subprocess. Your agent code starts the `crw` process, connects via stdio transport, and calls tools using the standard MCP client API. See the programmatic client example above for working code.
+Yes — use the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) or [Python SDK](https://github.com/modelcontextprotocol/python-sdk) to connect to `crw-mcp` as a subprocess. Your agent code starts the `crw-mcp` process, connects via stdio transport, and calls tools using the standard MCP client API. See the programmatic client example above for working code.
 
 ### Is there a rate limit on the self-hosted MCP server?
 
-The self-hosted `crw mcp` has no built-in rate limiting — it's limited only by your server's network and CPU capacity. If you're running CRW on a shared server, you can add rate limiting via the `CRW_RATE_LIMIT` environment variable or via a reverse proxy like Nginx. fastCRW's cloud MCP applies per-plan rate limits.
+The self-hosted `crw-mcp` has no built-in rate limiting — it's limited only by your server's network and CPU capacity. If you're running CRW on a shared server, you can add rate limiting via the `CRW_RATE_LIMIT` environment variable or via a reverse proxy like Nginx. fastCRW's cloud MCP applies per-plan rate limits.

--- a/blog/playwright-vs-puppeteer-vs-crw.md
+++ b/blog/playwright-vs-puppeteer-vs-crw.md
@@ -250,7 +250,7 @@ For teams building AI agents that need web access, the MCP (Model Context Protoc
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "ghcr.io/us/crw:latest", "mcp"]
+      "args": ["run", "--rm", "-i", "ghcr.io/us/crw:latest", "crw-mcp"]
     }
   }
 }

--- a/blog/web-context-layer-ai-agents.md
+++ b/blog/web-context-layer-ai-agents.md
@@ -58,7 +58,7 @@ Here's a CRW MCP configuration for Claude Desktop. One JSON block, and the agent
   "mcpServers": {
     "crw": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "ghcr.io/us/crw:latest", "mcp"]
+      "args": ["run", "--rm", "-i", "ghcr.io/us/crw:latest", "crw-mcp"]
     }
   }
 }

--- a/blog/web-search-api-for-ai-agents.md
+++ b/blog/web-search-api-for-ai-agents.md
@@ -74,7 +74,7 @@ If you're using [Claude Code, Cursor, Windsurf, or Codex](/blog/best-mcp-servers
 npx -y crw-mcp
 ```
 
-This registers three tools with your agent:
+This registers CRW's MCP tools with your agent — the most useful for search workflows:
 
 | Tool | Description | Use Case |
 | --- | --- | --- |

--- a/blog/why-i-built-crw.md
+++ b/blog/why-i-built-crw.md
@@ -153,7 +153,7 @@ The Model Context Protocol (MCP) was announced while CRW was in development. I'd
 
 Before MCP, using CRW from an AI agent required HTTP plumbing: your agent code made fetch calls, parsed JSON, injected content into the prompt. That's not hard, but it's boilerplate that every agent has to reimplement. The agent has to know about headers, error codes, response shapes.
 
-With MCP, the agent sees three tools: `scrape`, `crawl`, `map`. It calls them with parameters. It gets back content. The transport layer is invisible. Claude Desktop, Cursor, and any other MCP-compatible AI client can use CRW without the user writing a single line of API integration code.
+With MCP, the agent sees CRW's tools — `scrape`, `crawl`, `map`, `search`, and more. It calls them with parameters. It gets back content. The transport layer is invisible. Claude Desktop, Cursor, and any other MCP-compatible AI client can use CRW without the user writing a single line of API integration code.
 
 What I didn't anticipate was how this changes the *population* of people who can use the tool. Shipping an MCP server means researchers, writers, and analysts who use Claude but don't write API integrations can get live web data in their AI workflows. That's a different audience than "developers building RAG pipelines" — and it's a much larger one.
 

--- a/crates/crw-mcp/README.md
+++ b/crates/crw-mcp/README.md
@@ -7,7 +7,7 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 
 ## Overview
 
-`crw-mcp` is a self-contained MCP server that gives any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, Windsurf, Cline, Continue.dev, OpenAI Codex CLI) 4 web scraping tools. No external server needed — just add and go.
+`crw-mcp` is a self-contained MCP server that gives any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, Windsurf, Cline, Continue.dev, OpenAI Codex CLI) 6 web scraping tools. No external server needed — just add and go.
 
 **Two modes:**
 
@@ -16,14 +16,18 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 | **Embedded** (default) | No `--api-url` set | Self-contained, zero setup |
 | **Proxy** | `--api-url` provided | Forwards to remote CRW server |
 
-**4 MCP tools:**
+**6 MCP tools:**
 
 | Tool | Description |
 |------|-------------|
-| `crw_scrape` | Scrape a single URL → markdown, HTML, JSON, links |
+| `crw_scrape` | Scrape a single URL → markdown, HTML, links |
 | `crw_crawl` | Start an async BFS crawl (returns job ID) |
 | `crw_check_crawl_status` | Poll crawl job status and retrieve results |
 | `crw_map` | Discover all URLs on a website |
+| `crw_search` | Search the web (needs a configured search backend; always available in proxy mode, available in embedded mode only when a SearXNG backend is configured) |
+| `crw_parse_file` | Parse a local PDF (base64) to markdown |
+
+> **Output bounding:** By default, content fields are truncated to ~15 000 chars and `crw_map` returns at most 100 URLs to keep agent context small. Pass `maxLength: 0` (scrape / check_status / parse_file) or `limit: 0` (map) to opt out.
 
 ## Installation
 
@@ -97,8 +101,10 @@ CRW_CRAWLER__USER_AGENT="MyBot/1.0"
 Build a slim proxy-only binary without the embedded engine:
 
 ```bash
-cargo build -p crw-mcp --no-default-features --release
+cargo build --profile release-small --no-default-features -p crw-mcp
 ```
+
+This yields a ~4.2 MB binary (vs ~17 MB for the default embedded build) because the `embedded` feature gates the headless-browser engine (`crw-renderer`) and `crw-server`.
 
 ## Setup by Client
 

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -36,19 +36,22 @@ This installs the CRW skill and MCP server to all detected AI agents (Claude Cod
 
 ## MCP Tools
 
+> **Output bounds:** By default, content is truncated to ~15 000 chars (`crw_scrape`, `crw_check_crawl_status`, `crw_parse_file`) and `crw_map` returns ≤ 100 URLs. Truncated results carry a `truncated: true` marker (`crw_map` also adds `totalDiscovered`). Pass `maxLength: 0` or `limit: 0` to opt out of bounding.
+
 ### crw_scrape
 
 Scrape a single URL and return clean content.
 
 Parameters:
 - `url` (required) — The URL to scrape
-- `formats` — Output formats: `markdown` (default), `html`, `rawHtml`, `plainText`, `links`, `json`
+- `formats` — Output formats: `markdown` (default), `html`, `links`
 - `onlyMainContent` — Strip navs/footers/sidebars. Default: `true`
+- `includeTags` — Only include content matching these CSS selectors (e.g. `["article", "main"]`)
+- `excludeTags` — Exclude content matching these CSS selectors (e.g. `["nav", "footer"]`)
 - `renderJs` — Force JavaScript rendering. Default: auto-detect (null)
-- `cssSelector` — Extract only elements matching this CSS selector
-- `xpath` — Extract only elements matching this XPath
-- `includeTags` — Only include these HTML tags (e.g. `["article", "main"]`)
-- `excludeTags` — Remove these HTML tags (e.g. `["nav", "footer"]`)
+- `waitFor` — Milliseconds to wait after page load before capturing
+- `renderer` — Renderer override (e.g. `"playwright"`)
+- `maxLength` — Truncate output to this many chars. `0` = unbounded. Default: ~15 000
 
 ### crw_crawl
 
@@ -56,8 +59,12 @@ Start an async BFS crawl from a URL. Returns a job ID — poll with `crw_check_c
 
 Parameters:
 - `url` (required) — Starting URL
-- `maxDepth` — Maximum link depth. Default: `2`, max: `10`
-- `limit` — Maximum pages to crawl. Default: `10`, max: `1000`
+- `maxDepth` — Maximum link depth. Default: `2`
+- `maxPages` — Maximum pages to crawl
+- `jsonSchema` — JSON schema for structured extraction per page
+- `renderJs` — Force JavaScript rendering
+- `waitFor` — Milliseconds to wait after page load before capturing
+- `renderer` — Renderer override
 
 Returns: `{ "id": "job-uuid" }` — use this ID with crw_check_crawl_status.
 
@@ -67,18 +74,22 @@ Poll an async crawl job for results.
 
 Parameters:
 - `id` (required) — The crawl job ID from `crw_crawl`
+- `maxLength` — Truncate each page's content fields to this many chars. `0` = unbounded. Default: ~15 000
 
 Returns: `{ "status": "pending|running|completed|failed", "data": [...] }`
 
 ### crw_search
 
-Search the web and return relevant results with titles, URLs, and descriptions.
+Search the web and return relevant results with titles, URLs, and descriptions. Always available in proxy/cloud mode; in embedded mode only when a SearXNG backend is configured.
 
 Parameters:
 - `query` (required) — The search query
 - `limit` — Maximum number of results to return. Default: `5`
 - `lang` — Language code for results (e.g. `"en"`, `"tr"`)
 - `country` — Country code for results (e.g. `"us"`, `"tr"`)
+- `tbs` — Time filter: `qdr:h|qdr:d|qdr:w|qdr:m|qdr:y` (past hour/day/week/month/year)
+- `sources` — If set, group results by source: `web`, `news`, `images`
+- `categories` — Bias toward a category (e.g. `"pdf"`, `"github"`, `"research"`, or a native SearXNG category)
 - `scrapeOptions` — Options for scraping each result page (e.g. `{"formats": ["markdown"]}`)
 
 ### crw_map
@@ -89,8 +100,22 @@ Parameters:
 - `url` (required) — The URL to map
 - `maxDepth` — Discovery depth. Default: `2`
 - `useSitemap` — Check sitemap.xml. Default: `true`
+- `crawlFallback` — Supplement sitemap discovery with a short BFS crawl. Default: `true` (`false` = sitemap-only)
+- `limit` — Maximum URLs to return. `0` = unbounded. Default: `100`
 
-Returns: `{ "links": ["url1", "url2", ...] }` — up to 5000 URLs.
+Returns: `{ "links": ["url1", "url2", ...] }`
+
+### crw_parse_file
+
+Parse a local file (PDF) into markdown or structured output without fetching from the web.
+
+Parameters:
+- `contentBase64` (required) — Base64-encoded file contents
+- `filename` — Original filename (optional, e.g. `"report.pdf"`)
+- `formats` — Output formats: `markdown` (default), `plainText`, `links`, `json`, `summary` (json/summary need a server LLM)
+- `jsonSchema` — JSON schema for LLM extraction (when `formats` includes `json`)
+- `parsers` — Document parsers to apply. Default: `["pdf"]`
+- `maxLength` — Truncate output to this many chars. `0` = unbounded. Default: ~15 000
 
 ## Common Patterns
 
@@ -103,7 +128,7 @@ crw_scrape(url="https://example.com", formats=["markdown"])
 First discover URLs, then crawl:
 ```
 crw_map(url="https://docs.example.com")  → get URL list
-crw_crawl(url="https://docs.example.com", limit=50)  → extract all content
+crw_crawl(url="https://docs.example.com", maxPages=50)  → extract all content
 crw_check_crawl_status(id="...")  → poll until completed
 ```
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -60,11 +60,16 @@ cargo build --release --bin crw-server
 # REST API server (with CDP/JS rendering)
 cargo build --release --bin crw-server --features crw-server/cdp
 
-# MCP stdio binary
+# MCP stdio binary (full embedded — ~17 MB, includes headless browser engine)
 cargo build --release --bin crw-mcp
+
+# MCP stdio binary — lean browser-free proxy (~4.2 MB, no embedded browser)
+cargo build --profile release-small --no-default-features -p crw-mcp
 ```
 
-Binaries are placed in `target/release/`.
+Binaries are placed in `target/release/` (or `target/release-small/` for the lean build).
+
+The lean build (`--no-default-features`) omits the `embedded` cargo feature that gates the headless browser engine. Use it when you want a minimal proxy-only binary that forwards requests to a remote CRW server or fastcrw.com.
 
 ## Docker
 

--- a/docs/docs/mcp-clients.md
+++ b/docs/docs/mcp-clients.md
@@ -19,23 +19,30 @@ Use one of these three patterns:
 
 | Pattern | Best when | Copy-paste shape |
 |---|---|---|
-| Embedded local | You want zero server setup and local scrape/map/crawl tools | `command: npx`, `args: ["crw-mcp"]` |
-| fastcrw.com cloud | You want hosted infrastructure and `crw_search` | same as local plus `CRW_API_URL` and `CRW_API_KEY` |
+| Embedded local | You want zero server setup and local scrape/crawl/map/parse tools | `command: npx`, `args: ["crw-mcp"]` |
+| fastcrw.com cloud | You want hosted infrastructure and always-on `crw_search` | same as local plus `CRW_API_URL` and `CRW_API_KEY` |
 | HTTP transport | Your host supports HTTP MCP and you already run `crw-server` | point the client at `http://localhost:3000/mcp` |
 | Browser automation | You need a real, stateful browser (click, nav, tree) | `command: crw-browse` (separate MCP server — self-hosted) |
 
 ## What tools you get
 
-Embedded local mode (`crw-mcp`) exposes:
+Embedded local mode (`crw-mcp`) exposes up to 6 tools:
 
 - `crw_scrape`
 - `crw_crawl`
 - `crw_check_crawl_status`
 - `crw_map`
+- `crw_parse_file` — parse a local PDF (base64) to markdown, no OCR (always present)
+- `crw_search` — only advertised when a SearXNG backend is configured; hidden otherwise
 
-fastcrw.com cloud mode exposes all of the above plus:
+fastcrw.com cloud mode exposes all 6 tools:
 
-- `crw_search`
+- `crw_scrape`
+- `crw_crawl`
+- `crw_check_crawl_status`
+- `crw_map`
+- `crw_parse_file`
+- `crw_search` — always available (managed search backend)
 
 Browser automation mode (`crw-browse`, separate server — v0.4.0+) exposes:
 
@@ -43,7 +50,7 @@ Browser automation mode (`crw-browse`, separate server — v0.4.0+) exposes:
 - `tree` — accessibility snapshot of the current page
 
 :::tip
-If you only remember one rule, remember this one: local embedded mode is the easiest setup, and fastcrw.com cloud mode is the easiest way to add web search.
+If you only remember one rule, remember this one: local embedded mode is the easiest setup (up to 6 tools, with `crw_search` appearing automatically when SearXNG is configured), and fastcrw.com cloud mode is the easiest way to get all 6 tools including always-on web search.
 :::
 
 ## Claude Code
@@ -219,7 +226,7 @@ Edit `~/.codeium/windsurf/mcp_config.json`.
 ```
 
 :::note
-Windsurf has a total MCP tool limit. CRW stays lightweight: local mode exposes 4 tools, cloud mode exposes 5.
+Windsurf has a total MCP tool limit. CRW stays lightweight: local embedded mode exposes up to 6 tools (`crw_search` is hidden unless a SearXNG backend is configured), and cloud mode always exposes all 6 tools.
 :::
 
 ## Cline

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP Server for AI Agents
 
-CRW includes a built-in MCP (Model Context Protocol) server that gives any MCP-compatible AI assistant — Claude Code, Claude Desktop, Cursor, Windsurf, Cline, Continue.dev, OpenAI Codex CLI — 4 web scraping tools. Turn any AI coding agent into a web scraper with a single command.
+CRW includes a built-in MCP (Model Context Protocol) server that gives any MCP-compatible AI assistant — Claude Code, Claude Desktop, Cursor, Windsurf, Cline, Continue.dev, OpenAI Codex CLI — 6 web scraping tools. Turn any AI coding agent into a web scraper with a single command.
 
 > Also available on the [MCP Registry](https://registry.modelcontextprotocol.io/?q=crw)
 
@@ -10,8 +10,8 @@ CRW includes a built-in MCP (Model Context Protocol) server that gives any MCP-c
 
 | Mode | When | Tools | Description |
 |------|------|-------|-------------|
-| **Embedded** (default) | No `--api-url` / `CRW_API_URL` set | scrape, crawl, map | Self-contained. No server needed. The scraping engine runs inside the MCP process. |
-| **Proxy / Server** | `--api-url` / `CRW_API_URL` set | scrape, crawl, map + **search** | Forwards tool calls to a remote CRW server — the [fastcrw.com](https://fastcrw.com) cloud **or your own self-hosted server**. `crw_search` works whenever that server has SearXNG configured (the Docker stack enables it by default). |
+| **Embedded** (default) | No `--api-url` / `CRW_API_URL` set | scrape, crawl, map, parse_file + **search** (when SearXNG configured) | Self-contained. No server needed. The scraping engine runs inside the MCP process. `crw_search` is advertised only when a SearXNG backend is configured (e.g. the Docker compose sidecar). |
+| **Proxy / Server** | `--api-url` / `CRW_API_URL` set | scrape, crawl, map, parse_file, search | Forwards tool calls to a remote CRW server — the [fastcrw.com](https://fastcrw.com) cloud **or your own self-hosted server**. `crw_search` is always advertised in proxy mode; it works whenever the server has SearXNG configured (the Docker stack enables it by default). |
 
 ## Where to use what
 
@@ -139,8 +139,10 @@ claude mcp add --transport http crw http://localhost:3000/mcp
 Build a slim proxy-only binary:
 
 ```bash
-cargo build -p crw-mcp --no-default-features --release
+cargo build --profile release-small --no-default-features -p crw-mcp
 ```
+
+This yields a ~4.2 MB binary (vs ~17 MB for the default embedded build) because the `embedded` feature gates the headless-browser engine (`crw-renderer`) and `crw-server`.
 
 ## Available Tools
 
@@ -150,7 +152,10 @@ cargo build -p crw-mcp --no-default-features --release
 | `crw_crawl` | Start async crawl → returns job ID | `POST /v1/crawl` | All modes |
 | `crw_check_crawl_status` | Poll crawl status and get results | `GET /v1/crawl/:id` | All modes |
 | `crw_map` | Discover all URLs on a site | `POST /v1/map` | All modes |
-| `crw_search` | Search the web → titles, URLs, descriptions | `POST /v1/search` | **Server with SearXNG** (cloud or self-hosted) |
+| `crw_search` | Search the web → titles, URLs, descriptions | `POST /v1/search` | Always in proxy mode; embedded only when a SearXNG backend is configured |
+| `crw_parse_file` | Parse a local PDF (base64) → markdown | `POST /v1/parse` | All modes |
+
+> **Output bounding:** Tool results are bounded by default to keep agent context small. Content fields (markdown/html/etc.) are truncated to ~15 000 chars; `crw_map` returns at most 100 URLs. Truncated responses include `truncated: true` and `totalDiscovered` markers. Pass `maxLength: 0` (scrape / check_status / parse_file) or `limit: 0` (map) to opt out.
 
 ## Browser Automation (`crw-browse`)
 
@@ -209,6 +214,10 @@ For cloud mode and file-based configs, continue in [MCP Client Setup](#mcp-clien
 | `onlyMainContent` | boolean | no | Strip nav/footer (default: true) |
 | `includeTags` | string[] | no | CSS selectors to keep |
 | `excludeTags` | string[] | no | CSS selectors to remove |
+| `renderJs` | boolean | no | Enable JS rendering via a CDP browser |
+| `waitFor` | integer | no | ms to wait after page load |
+| `renderer` | string | no | Renderer to use (e.g. `"lightpanda"`) |
+| `maxLength` | integer | no | Max chars for content fields; `0` = unlimited (default: ~15 000) |
 
 ### crw_crawl
 
@@ -217,12 +226,17 @@ For cloud mode and file-based configs, continue in [MCP Client Setup](#mcp-clien
 | `url` | string | **yes** | Starting URL |
 | `maxDepth` | integer | no | Max crawl depth (default: 2) |
 | `maxPages` | integer | no | Max pages (default: 10) |
+| `jsonSchema` | object | no | JSON schema for structured extraction |
+| `renderJs` | boolean | no | Enable JS rendering via a CDP browser |
+| `waitFor` | integer | no | ms to wait after page load |
+| `renderer` | string | no | Renderer to use (e.g. `"lightpanda"`) |
 
 ### crw_check_crawl_status
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | **yes** | Job ID from `crw_crawl` |
+| `maxLength` | integer | no | Max chars for content fields; `0` = unlimited (default: ~15 000) |
 
 ### crw_map
 
@@ -231,10 +245,12 @@ For cloud mode and file-based configs, continue in [MCP Client Setup](#mcp-clien
 | `url` | string | **yes** | URL to map |
 | `maxDepth` | integer | no | Discovery depth (default: 2) |
 | `useSitemap` | boolean | no | Read sitemap.xml (default: true) |
+| `crawlFallback` | boolean | no | Fall back to a short crawl if sitemap is absent (default: true) |
+| `limit` | integer | no | Max URLs returned; `0` = unlimited (default: 100) |
 
-### crw_search (server-backed)
+### crw_search
 
-Available when connected to a CRW **server** that has SearXNG configured — the [fastcrw.com](https://fastcrw.com) cloud, or your own self-hosted server (the Docker stack enables it by default; see [Docker → Search (SearXNG)](/docker)). Point the MCP at it with `--api-url` / `CRW_API_URL`. It is *not* available from the standalone embedded MCP binary, which has no search backend.
+In **proxy mode** `crw_search` is always advertised. In **embedded mode** it is advertised only when a SearXNG backend is configured (e.g. via the Docker compose sidecar — see [Docker → Search (SearXNG)](/docker)). With no backend configured, the tool is hidden from `tools/list`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -242,7 +258,23 @@ Available when connected to a CRW **server** that has SearXNG configured — the
 | `limit` | integer | no | Max results (default: 5) |
 | `lang` | string | no | Language code (e.g. `"en"`, `"tr"`) |
 | `country` | string | no | Country code (e.g. `"us"`, `"tr"`) |
+| `tbs` | string | no | Time-based filter (e.g. `"qdr:d"` for past day) |
+| `sources` | string[] | no | Restrict results to specific sources |
+| `categories` | string[] | no | SearXNG categories (e.g. `["general","news"]`) |
 | `scrapeOptions` | object | no | Scrape each result page (e.g. `{"formats": ["markdown"]}`) |
+
+### crw_parse_file
+
+Parse a local PDF supplied as a base64-encoded string. No OCR — works on text-layer PDFs.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `contentBase64` | string | **yes** | Base64-encoded PDF content |
+| `filename` | string | no | Original filename (used for format hints) |
+| `formats` | string[] | no | Output formats (e.g. `["markdown"]`) |
+| `jsonSchema` | object | no | JSON schema for structured extraction |
+| `parsers` | string[] | no | Parser hints to use |
+| `maxLength` | integer | no | Max chars for content fields; `0` = unlimited (default: ~15 000) |
 
 ## Example Agent Tool Flow
 

--- a/mcp/crw-mcp/package.json
+++ b/mcp/crw-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crw-mcp",
   "version": "0.15.2",
-  "description": "MCP server for CRW web scraper — scrape, crawl, and map tools for AI agents",
+  "description": "MCP server for CRW web scraper — scrape, crawl, map, search, and PDF-parse tools for AI agents",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/us/crw",
   "repository": {

--- a/mcp/crw-mcp/skills/SKILL.md
+++ b/mcp/crw-mcp/skills/SKILL.md
@@ -36,19 +36,22 @@ This installs the CRW skill and MCP server to all detected AI agents (Claude Cod
 
 ## MCP Tools
 
+> **Output bounds:** By default, content is truncated to ~15 000 chars (`crw_scrape`, `crw_check_crawl_status`, `crw_parse_file`) and `crw_map` returns ≤ 100 URLs. Truncated results carry a `truncated: true` marker (`crw_map` also adds `totalDiscovered`). Pass `maxLength: 0` or `limit: 0` to opt out of bounding.
+
 ### crw_scrape
 
 Scrape a single URL and return clean content.
 
 Parameters:
 - `url` (required) — The URL to scrape
-- `formats` — Output formats: `markdown` (default), `html`, `rawHtml`, `plainText`, `links`, `json`
+- `formats` — Output formats: `markdown` (default), `html`, `links`
 - `onlyMainContent` — Strip navs/footers/sidebars. Default: `true`
+- `includeTags` — Only include content matching these CSS selectors (e.g. `["article", "main"]`)
+- `excludeTags` — Exclude content matching these CSS selectors (e.g. `["nav", "footer"]`)
 - `renderJs` — Force JavaScript rendering. Default: auto-detect (null)
-- `cssSelector` — Extract only elements matching this CSS selector
-- `xpath` — Extract only elements matching this XPath
-- `includeTags` — Only include these HTML tags (e.g. `["article", "main"]`)
-- `excludeTags` — Remove these HTML tags (e.g. `["nav", "footer"]`)
+- `waitFor` — Milliseconds to wait after page load before capturing
+- `renderer` — Renderer override (e.g. `"playwright"`)
+- `maxLength` — Truncate output to this many chars. `0` = unbounded. Default: ~15 000
 
 ### crw_crawl
 
@@ -56,8 +59,12 @@ Start an async BFS crawl from a URL. Returns a job ID — poll with `crw_check_c
 
 Parameters:
 - `url` (required) — Starting URL
-- `maxDepth` — Maximum link depth. Default: `2`, max: `10`
-- `limit` — Maximum pages to crawl. Default: `10`, max: `1000`
+- `maxDepth` — Maximum link depth. Default: `2`
+- `maxPages` — Maximum pages to crawl
+- `jsonSchema` — JSON schema for structured extraction per page
+- `renderJs` — Force JavaScript rendering
+- `waitFor` — Milliseconds to wait after page load before capturing
+- `renderer` — Renderer override
 
 Returns: `{ "id": "job-uuid" }` — use this ID with crw_check_crawl_status.
 
@@ -67,18 +74,22 @@ Poll an async crawl job for results.
 
 Parameters:
 - `id` (required) — The crawl job ID from `crw_crawl`
+- `maxLength` — Truncate each page's content fields to this many chars. `0` = unbounded. Default: ~15 000
 
 Returns: `{ "status": "pending|running|completed|failed", "data": [...] }`
 
 ### crw_search
 
-Search the web and return relevant results with titles, URLs, and descriptions.
+Search the web and return relevant results with titles, URLs, and descriptions. Always available in proxy/cloud mode; in embedded mode only when a SearXNG backend is configured.
 
 Parameters:
 - `query` (required) — The search query
 - `limit` — Maximum number of results to return. Default: `5`
 - `lang` — Language code for results (e.g. `"en"`, `"tr"`)
 - `country` — Country code for results (e.g. `"us"`, `"tr"`)
+- `tbs` — Time filter: `qdr:h|qdr:d|qdr:w|qdr:m|qdr:y` (past hour/day/week/month/year)
+- `sources` — If set, group results by source: `web`, `news`, `images`
+- `categories` — Bias toward a category (e.g. `"pdf"`, `"github"`, `"research"`, or a native SearXNG category)
 - `scrapeOptions` — Options for scraping each result page (e.g. `{"formats": ["markdown"]}`)
 
 ### crw_map
@@ -89,8 +100,22 @@ Parameters:
 - `url` (required) — The URL to map
 - `maxDepth` — Discovery depth. Default: `2`
 - `useSitemap` — Check sitemap.xml. Default: `true`
+- `crawlFallback` — Supplement sitemap discovery with a short BFS crawl. Default: `true` (`false` = sitemap-only)
+- `limit` — Maximum URLs to return. `0` = unbounded. Default: `100`
 
-Returns: `{ "links": ["url1", "url2", ...] }` — up to 5000 URLs.
+Returns: `{ "links": ["url1", "url2", ...] }`
+
+### crw_parse_file
+
+Parse a local file (PDF) into markdown or structured output without fetching from the web.
+
+Parameters:
+- `contentBase64` (required) — Base64-encoded file contents
+- `filename` — Original filename (optional, e.g. `"report.pdf"`)
+- `formats` — Output formats: `markdown` (default), `plainText`, `links`, `json`, `summary` (json/summary need a server LLM)
+- `jsonSchema` — JSON schema for LLM extraction (when `formats` includes `json`)
+- `parsers` — Document parsers to apply. Default: `["pdf"]`
+- `maxLength` — Truncate output to this many chars. `0` = unbounded. Default: ~15 000
 
 ## Common Patterns
 
@@ -103,7 +128,7 @@ crw_scrape(url="https://example.com", formats=["markdown"])
 First discover URLs, then crawl:
 ```
 crw_map(url="https://docs.example.com")  → get URL list
-crw_crawl(url="https://docs.example.com", limit=50)  → extract all content
+crw_crawl(url="https://docs.example.com", maxPages=50)  → extract all content
 crw_check_crawl_status(id="...")  → poll until completed
 ```
 


### PR DESCRIPTION
Follow-up to #140. Updates all MCP-facing documentation to match the now-6-tool, optimized MCP server.

## What changed
- **6 tools everywhere** — added `crw_search` + `crw_parse_file` to tool lists/tables that listed only 3-5; fixed stale counts in READMEs, docs, SKILL files, COMPATIBILITY, and blog posts.
- **New params + bounding** — documented `maxLength` (scrape/check_crawl_status/parse_file) and `limit` (map), and the default output bounding (~15K chars / 100 URLs, `0` = unbounded).
- **crw_search availability** — corrected: always advertised in proxy mode; in embedded mode only when a SearXNG backend is configured (old docs wrongly said embedded never has search).
- **Lean build command** — fixed to `cargo build --profile release-small --no-default-features -p crw-mcp` (the new size profile).
- **Docker invocation** — standardized to `crw-mcp` (the image binary); the old `mcp` / `--mcp` args were wrong.
- **SKILL param accuracy** — fixed `crw_parse_file` formats (markdown/plainText/links/json/summary, not html), `crw_crawl` example (`maxPages`, not `limit`), CSS-selector wording, and `sources`/`crawlFallback` semantics.
- **Blog facts** — removed the now-false "No PDF extraction tool" claim (CRW has `crw_parse_file`) and `crw` vs `crw-mcp` binary-name inconsistencies.

## Notes
- `docs/*/index.html` static SEO mirrors are generated from these markdown sources; the `google-indexing` workflow regenerates + commits them on merge to main.
- Reviewed by multiple agents + Codex against `crates/crw-mcp-proto/src/lib.rs` (the tool-definition source of truth); all documented params/defaults verified real.
- Docs-only change (no Rust sources touched).