### PR TITLE
feat(proxy): proxy list + rotation across HTTP, JS/Chrome, crawl & map (closes #139)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -851,11 +851,12 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "config",
  "crw-mcp-proto",
  "prometheus",
+ "rand 0.9.2",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -869,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -895,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "hex",
@@ -910,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -942,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "base64",
  "clap",
@@ -958,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "jsonschema",
  "serde",
@@ -968,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -991,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1018,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "crw-core",
  "futures",
@@ -1035,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.14.0"
+version = "0.15.2"
 dependencies = [
  "axum",
  "axum-test",

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Continue.dev) live under [docs.fastcrw.com/mcp-clients/](https://docs.fastcrw.co
 | Best when | You want full data residency, AGPL is fine, you can run your own proxy strategy, latency to your infra matters more than ours. | You want zero infra, a global proxy network, a dashboard, usage metering, and AGPL carve-out for closed-source product code. |
 | Install | `docker run -p 3000:3000 ghcr.io/us/crw` or `cargo install crw-server`. | Sign up at [fastcrw.com](https://fastcrw.com) — 500 free credits, no card. |
 | Search | Bundled SearXNG sidecar (`docker compose up`). | Managed search backend. |
-| Proxy rotation | Bring your own pool (`proxy_list` + `proxy_rotation`: round_robin / random / sticky_per_host) — rotated across the HTTP fetch path; per-request BYOP supported. | Managed proxy network. |
+| Proxy rotation | Bring your own pool (`proxy_list` + `proxy_rotation`: round_robin / random / sticky_per_host) — rotated across the HTTP **and** JS/Chrome paths for scrape, crawl, and map; per-request BYOP supported. LightPanda can't proxy, so it's skipped (fail-closed) when a proxy is active. | Managed proxy network. |
 | Cost | $0 + your hosting bill. | From $13/mo; pricing on [fastcrw.com/pricing](https://fastcrw.com/pricing). |
 | License obligations | AGPL-3.0 applies if you expose the API to third parties. | AGPL carve-out included. |
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Continue.dev) live under [docs.fastcrw.com/mcp-clients/](https://docs.fastcrw.co
 | Best when | You want full data residency, AGPL is fine, you can run your own proxy strategy, latency to your infra matters more than ours. | You want zero infra, a global proxy network, a dashboard, usage metering, and AGPL carve-out for closed-source product code. |
 | Install | `docker run -p 3000:3000 ghcr.io/us/crw` or `cargo install crw-server`. | Sign up at [fastcrw.com](https://fastcrw.com) — 500 free credits, no card. |
 | Search | Bundled SearXNG sidecar (`docker compose up`). | Managed search backend. |
-| Proxy rotation | Bring your own pool via env vars. | Built-in. |
+| Proxy rotation | Bring your own pool (`proxy_list` + `proxy_rotation`: round_robin / random / sticky_per_host) — rotated across the HTTP fetch path; per-request BYOP supported. | Managed proxy network. |
 | Cost | $0 + your hosting bill. | From $13/mo; pricing on [fastcrw.com/pricing](https://fastcrw.com/pricing). |
 | License obligations | AGPL-3.0 applies if you expose the API to third parties. | AGPL carve-out included. |
 

--- a/REVIEW-FIXES.md
+++ b/REVIEW-FIXES.md
@@ -53,6 +53,30 @@ paths consume that single entry** — no re-picking, no path-specific resolution
 ## Verify
 - `cargo clippy --workspace` (default + `cdp`) clean; full test suite green.
 - New unit tests: stateless-sticky determinism; round_robin single-advance per request;
-  HTTP+CDP pick same entry; lightpanda-only+proxy → error; CLI bad `--proxy` → error;
-  socks5+auth → rejected for CDP.
+  socks5+auth → rejected for CDP; socks5h→socks5 mapping; lightpanda-only+proxy → error;
+  proxy-active prefers chrome over lightpanda; `HttpFetcher::with_proxy` fail-closed.
 - Re-run the multi-agent review workflow until 0 confirmed blocker/high findings.
+
+## Review loop outcome (CONVERGED)
+
+- **Round 1** — 17 confirmed (3 blocker, then highs/mediums/lows). Fixed in commits
+  `92c5027` + `3ff9145`.
+- **Round 2** — 11 confirmed, **4 high** — all one root: the `/map` `discover_urls`
+  path was left on the old direct/single-proxy path (BFS fetch unscoped + discovery
+  client ignored the rotator + silent-swallow). Fixed in `c920a32`.
+- **Round 3** — 8 confirmed, **0 blocker/high → `satisfied: true`**. Per-request
+  client warm-pool regression and the missing fail-closed tests were then addressed.
+
+### Remaining documented follow-ups (low / nit — non-blocking)
+- **#17 error class:** `build_client` maps a post-`parse` reqwest build failure to
+  `ConfigError` (HTTP 500) even on the per-request BYOP path (should be
+  `InvalidRequest`/400). Window is tiny — `ProxyEntry::parse` already validated
+  scheme+host, so `reqwest::Proxy::all` failing afterward is unlikely. Map at the
+  `with_proxy` call sites if surfaced.
+- **chrome_proxy tier override:** when a config/BYOP `REQUEST_PROXY` is active AND a
+  request escalates to the residential `chrome_proxy` tier, the per-request proxy
+  overrides the DataImpulse residential egress. Uncommon combo; document or skip the
+  per-request context when `self.name == "chrome_proxy"`.
+- **sticky key normalization:** BYOP sticky uses the raw host; the config rotator uses
+  `normalize_host` (eTLD+1). Mutually exclusive per request (no correctness impact);
+  unify by normalizing the BYOP host key too.

--- a/REVIEW-FIXES.md
+++ b/REVIEW-FIXES.md
@@ -1,0 +1,58 @@
+# Proxy Rotation — Multi-Agent Review Fix Plan
+
+Review: 17 findings raised, 17 confirmed (0 refuted). Deduplicated below. Many
+collapse into ONE unifying fix: **resolve the per-request proxy exactly once
+(BYOP > config), store it in `REQUEST_PROXY`, and make BOTH the HTTP and CDP
+paths consume that single entry** — no re-picking, no path-specific resolution.
+
+## Unifying refactor (fixes A, D, E, parts of integration)
+
+1. **`crw-core/proxy.rs`** — make `StickyPerHost` **stateless**: `idx = fxhash(host) % len`.
+   Removes the `Mutex<HashMap>` (→ fixes #13 unbounded growth) and the first-insert
+   `next_rr()` advance (→ removes a cursor side-effect). Replace `debug_assert!(len>0)`
+   with a real guard / keep build the sole non-empty constructor (#14).
+2. **Single resolution point.** Add `ProxyRotator::pick` usage so callers resolve ONE
+   `ProxyEntry`:
+   - `single.rs::scrape_url`: build the BYOP rotator from `req.proxy_list`/`req.proxy`
+     FIRST (InvalidRequest on bad); `resolved = byop.pick(host) ?? renderer.pick_proxy_for_url(url)`;
+     scope `REQUEST_PROXY(resolved)`. (Fixes A/#1/#4/#9.)
+   - `crawl.rs`: per page build BYOP rotator from `CrawlRequest.proxy_list` (job-scoped,
+     fail the job on bad) and resolve `REQUEST_PROXY` from it, else config. (Fixes E/#8.)
+3. **HTTP path honors `REQUEST_PROXY`.** `RotatingHttpFetcher::fetch`: if `REQUEST_PROXY`
+   is set, use the warm client whose `entry.raw()` matches; if absent (BYOP not in the
+   config pool) build a one-off client; only when `REQUEST_PROXY` is `None` fall back to
+   `rotator.pick_index`. (Fixes D/#11/#12 — single pick, HTTP+CDP aligned.) Also make the
+   plain (no-config) HTTP path honor `REQUEST_PROXY` so BYOP-with-no-config-proxy is
+   proxied, never direct.
+4. Drop the now-redundant per-request temp-fetcher branch in `single.rs` (the shared
+   renderer + `REQUEST_PROXY` covers proxy; keep the temp fetcher only for the
+   stealth-only override case).
+
+## Fail-closed fixes (blockers/highs)
+
+5. **B/#2/#3 — LightPanda escape hatch.** In `fetch_with_js`, when `proxy_active` and
+   filtering removes all renderers, return a hard `CrwError` ("proxy required but no
+   proxy-capable JS renderer"), never keep LightPanda. Add `PageFetcher::supports_proxy()`
+   (default true; LightPanda false) to generalize.
+6. **C/#5/#6 — CLI silent fallback.** Route CLI `--proxy` through `ProxyRotator::build` +
+   `with_proxy_rotator` (like the server), and/or split `HttpFetcher`: infallible no-proxy
+   ctor + fallible proxy ctor. Remove the `Option<&str> proxy → unwrap_or_else(default
+   client)` foot-gun so a bad proxy is a hard error everywhere.
+7. **F/#10 — robots/discovery.** Build the robots/discovery reqwest client from the
+   rotator (pick for the origin host) instead of the single `proxy`; replace the
+   `warn + continue direct` on bad proxy with a hard error.
+8. **G/#7 — SOCKS5+auth on CDP.** In `ProxyEntry`, expose `supports_cdp_auth()` (false for
+   socks5/socks5h with auth) and map `socks5h`→`socks5` for `chrome_proxy_server`. Reject
+   (or skip-to-error) a socks5+auth entry on the CDP path so it never silently hangs.
+
+## Low / hardening
+- #15 dispose the browser context on the malformed-`createBrowserContext` parse-failure path.
+- #16 `proxyBypassList`: omit it (Chrome bypasses loopback by default) or use `"<local>"`.
+- #17 map `RotatingHttpFetcher` build error to `InvalidRequest` on the BYOP call site.
+
+## Verify
+- `cargo clippy --workspace` (default + `cdp`) clean; full test suite green.
+- New unit tests: stateless-sticky determinism; round_robin single-advance per request;
+  HTTP+CDP pick same entry; lightpanda-only+proxy → error; CLI bad `--proxy` → error;
+  socks5+auth → rejected for CDP.
+- Re-run the multi-agent review workflow until 0 confirmed blocker/high findings.

--- a/REVIEW-FIXES.md
+++ b/REVIEW-FIXES.md
@@ -66,6 +66,27 @@ paths consume that single entry** — no re-picking, no path-specific resolution
   client ignored the rotator + silent-swallow). Fixed in `c920a32`.
 - **Round 3** — 8 confirmed, **0 blocker/high → `satisfied: true`**. Per-request
   client warm-pool regression and the missing fail-closed tests were then addressed.
+- **Round 4** — verifying the round-3 polish surfaced **1 high** (new): `crw crawl
+  --js --proxy` routed only the HTTP tier through the proxy — the CLI crawl/map
+  renderer never attached a rotator, so `REQUEST_PROXY` stayed `None` and the JS/CDP
+  tier (+ the lightpanda fail-closed guard) was bypassed → real-IP leak. Fixed in
+  `ca5d7e2` (CLI crawl/map build the renderer with a rotator from `--proxy`).
+- **Round 5** — 6 confirmed, **0 blocker/high → `satisfied: true`**. Loop converged.
+
+### Additional low/nit follow-ups (round 4–5, non-blocking)
+- **robots/sitemap client is origin-scoped:** under a multi-host crawl with
+  `sticky_per_host`, non-origin hosts' robots/sitemap fetches use the origin host's
+  proxy while their page fetches use their own — still proxied (no leak), just an
+  IP-correlation inconsistency. Per-host robots client or documentation.
+- **/map drops per-request BYOP:** `MapRequest`/`DiscoverOptions` have no
+  `proxy_list`; /map honors only the server-config rotator (fail-safe, never direct
+  when config proxy exists). Add fields if /map BYOP is desired.
+- **proxy client cache eviction:** `http_fetcher_for_request` clears the whole cache
+  at 512 entries (coarse safety valve for arbitrary BYOP; config pools never hit it).
+  Swap for LRU if a pathological BYOP workload warrants it.
+- **#15 createBrowserContext parse-failure:** if Chrome returns success without a
+  `browserContextId`, the context isn't disposed — effectively unreachable (Chrome
+  always returns the id; there is no id to dispose), accepted.
 
 ### Remaining documented follow-ups (low / nit — non-blocking)
 - **#17 error class:** `build_client` maps a post-`parse` reqwest build failure to

--- a/config.default.toml
+++ b/config.default.toml
@@ -84,9 +84,12 @@ job_ttl_secs = 3600
 #   random          — pick a random proxy per request.
 #   proxy_rotation = "sticky_per_host"
 #
-# Coverage: rotation currently applies to the HTTP fetch path (direct HTTP
-# scrapes and the HTTP pages of a crawl). JS/Chrome-rendered requests and the
-# managed-cloud proxy network are being rolled out — see ROADMAP.
+# Coverage: rotation applies to the HTTP fetch path AND the JS/Chrome (CDP) path
+# — for scrape, crawl, and map. Vanilla Chrome routes per request via a
+# per-context proxyServer; LightPanda has no proxy support and is skipped
+# (fail-closed) when a proxy is active. SOCKS5 proxies with credentials are not
+# supported on the JS/Chrome path (Chrome can't auth SOCKS) — use http/https
+# there, or a credential-less SOCKS proxy.
 # proxy_list = []
 # proxy_rotation = "sticky_per_host"
 

--- a/config.default.toml
+++ b/config.default.toml
@@ -67,6 +67,28 @@ job_ttl_secs = 3600
 # Residential proxies use real ISP IPs and are much harder for sites to detect.
 # Most providers give you a single gateway URL that auto-rotates IPs per request.
 # proxy = "http://proxy:8080"
+#
+# Proxy rotation — supply your OWN pool and crw rotates across it per request.
+# When proxy_list is non-empty it takes precedence over the single `proxy` above.
+# Each entry is validated at startup; a malformed URL is a hard error (crw never
+# silently falls back to a direct connection, which would leak your real IP).
+# Accepts a TOML array here, or a comma-separated / JSON-array string via the
+# env var CRW_CRAWLER__PROXY_LIST.
+#
+#   proxy_list = ["http://user:pass@a:8080", "http://user:pass@b:8080", "socks5://c:1080"]
+#
+# proxy_rotation strategy (default: sticky_per_host):
+#   sticky_per_host — pin each target host to one proxy (best for sessions /
+#                     anti-bot; keeps cookies + TLS coherent per host).
+#   round_robin     — cycle through the pool, one step per request.
+#   random          — pick a random proxy per request.
+#   proxy_rotation = "sticky_per_host"
+#
+# Coverage: rotation currently applies to the HTTP fetch path (direct HTTP
+# scrapes and the HTTP pages of a crawl). JS/Chrome-rendered requests and the
+# managed-cloud proxy network are being rolled out — see ROADMAP.
+# proxy_list = []
+# proxy_rotation = "sticky_per_host"
 
 [extraction]
 default_format = "markdown"

--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -139,6 +139,8 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         wait_for: None,
         renderer: None,
         country: None,
+        proxy_list: Vec::new(),
+        proxy_rotation: None,
     };
 
     let id = Uuid::new_v4();

--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -106,16 +106,27 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         ..Default::default()
     };
 
-    let renderer = match FallbackRenderer::new(
-        &renderer_config,
-        "crw/0.7.0",
-        args.proxy.as_deref(),
-        &stealth_config,
-    ) {
-        Ok(r) => Arc::new(r),
-        Err(e) => {
-            eprintln!("error: failed to build renderer: {e}");
-            return Err(CmdError::code_only(1));
+    // Attach a rotator built from --proxy so the proxy is resolved into
+    // REQUEST_PROXY for BOTH the HTTP and JS/CDP tiers (the JS tier reads only
+    // REQUEST_PROXY; passing --proxy to new() alone would leave JS direct).
+    let renderer = {
+        let build = || -> crw_core::CrwResult<FallbackRenderer> {
+            let rotator = crw_core::ProxyRotator::build(
+                &[],
+                args.proxy.as_deref(),
+                crw_core::ProxyRotation::default(),
+            )
+            .map_err(crw_core::CrwError::ConfigError)?
+            .map(Arc::new);
+            FallbackRenderer::new(&renderer_config, "crw/0.7.0", None, &stealth_config)?
+                .with_proxy_rotator(rotator)
+        };
+        match build() {
+            Ok(r) => Arc::new(r),
+            Err(e) => {
+                eprintln!("error: failed to build renderer: {e}");
+                return Err(CmdError::code_only(1));
+            }
         }
     };
 

--- a/crates/crw-cli/src/commands/map.rs
+++ b/crates/crw-cli/src/commands/map.rs
@@ -107,16 +107,26 @@ pub async fn run(mut args: MapArgs) -> Result<(), CmdError> {
         ..Default::default()
     };
 
-    let renderer = match FallbackRenderer::new(
-        &renderer_config,
-        "crw/0.7.0",
-        args.proxy.as_deref(),
-        &stealth_config,
-    ) {
-        Ok(r) => Arc::new(r),
-        Err(e) => {
-            eprintln!("error: failed to build renderer: {e}");
-            return Err(CmdError::code_only(1));
+    // Attach a rotator from --proxy so discovery page fetches resolve the proxy
+    // into REQUEST_PROXY uniformly (HTTP + any JS), matching the crawl/server path.
+    let renderer = {
+        let build = || -> crw_core::CrwResult<FallbackRenderer> {
+            let rotator = crw_core::ProxyRotator::build(
+                &[],
+                args.proxy.as_deref(),
+                crw_core::ProxyRotation::default(),
+            )
+            .map_err(crw_core::CrwError::ConfigError)?
+            .map(Arc::new);
+            FallbackRenderer::new(&renderer_config, "crw/0.7.0", None, &stealth_config)?
+                .with_proxy_rotator(rotator)
+        };
+        match build() {
+            Ok(r) => Arc::new(r),
+            Err(e) => {
+                eprintln!("error: failed to build renderer: {e}");
+                return Err(CmdError::code_only(1));
+            }
         }
     };
 

--- a/crates/crw-cli/src/commands/scrape.rs
+++ b/crates/crw-cli/src/commands/scrape.rs
@@ -764,6 +764,8 @@ fn build_request(
         filter_mode: None,
         top_k: None,
         proxy,
+        proxy_list: Vec::new(),
+        proxy_rotation: None,
         country: None,
         stealth: if stealth { Some(true) } else { None },
         actions: None,

--- a/crates/crw-core/Cargo.toml
+++ b/crates/crw-core/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 prometheus = { workspace = true }
 tokio = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -976,6 +976,16 @@ pub struct CrawlerConfig {
     /// (e.g. "http://proxy:8080" or "socks5://user:pass@proxy:1080").
     #[serde(default)]
     pub proxy: Option<String>,
+    /// Pool of proxy URLs to rotate among (HTTP, HTTPS, SOCKS5). When non-empty
+    /// this takes precedence over the single `proxy` field. Empty (default) =
+    /// no rotation. Accepts a TOML array, a JSON-array string, or a
+    /// comma-separated string (for `CRW_CRAWLER__PROXY_LIST`).
+    #[serde(default, deserialize_with = "deserialize_string_vec")]
+    pub proxy_list: Vec<String>,
+    /// Strategy for selecting from `proxy_list`: `round_robin`, `random`, or
+    /// `sticky_per_host` (default). Ignored when the list is empty.
+    #[serde(default)]
+    pub proxy_rotation: crate::proxy::ProxyRotation,
     /// TTL in seconds for completed crawl jobs before cleanup (default: 3600)
     #[serde(default = "default_job_ttl")]
     pub job_ttl_secs: u64,
@@ -1008,6 +1018,8 @@ impl Default for CrawlerConfig {
             default_max_depth: default_depth(),
             default_max_pages: default_max_pages(),
             proxy: None,
+            proxy_list: Vec::new(),
+            proxy_rotation: crate::proxy::ProxyRotation::default(),
             job_ttl_secs: default_job_ttl(),
             stealth: StealthConfig::default(),
             per_host_min_interval_ms: 0,

--- a/crates/crw-core/src/lib.rs
+++ b/crates/crw-core/src/lib.rs
@@ -21,9 +21,11 @@ pub mod deadline;
 pub mod error;
 pub mod mcp;
 pub mod metrics;
+pub mod proxy;
 pub mod types;
 pub mod url_safety;
 
 pub use config::AppConfig;
 pub use deadline::Deadline;
 pub use error::{CrwError, CrwResult};
+pub use proxy::{ProxyEntry, ProxyRotation, ProxyRotator};

--- a/crates/crw-core/src/proxy.rs
+++ b/crates/crw-core/src/proxy.rs
@@ -1,0 +1,367 @@
+//! Proxy list + rotation primitives shared across the HTTP, crawl, and CDP
+//! paths.
+//!
+//! A [`ProxyRotator`] holds a set of validated [`ProxyEntry`] and selects one
+//! per request according to a [`ProxyRotation`] strategy. The rotator is built
+//! once (from config) or per request (BYOP) and is cheap to share behind an
+//! `Arc`.
+//!
+//! # Safety
+//!
+//! Proxy URLs are validated up front via [`ProxyEntry::parse`]. A malformed
+//! entry is a hard error — we never silently fall back to a direct (no-proxy)
+//! connection, which would leak the host's real IP. Callers map the returned
+//! error string to the appropriate [`crate::CrwError`] variant
+//! (`ConfigError` at startup, `InvalidRequest` for per-request BYOP).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+/// Strategy for selecting a proxy from a [`ProxyRotator`]'s pool.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxyRotation {
+    /// Cycle through the pool in order, one step per request (process-wide).
+    RoundRobin,
+    /// Pick a uniformly random entry per request.
+    Random,
+    /// Pin each target host to a single proxy for the rotator's lifetime.
+    /// Default: keeps cookie/TLS sessions coherent per host (anti-bot systems
+    /// flag mid-session IP changes), while still spreading load across hosts.
+    #[default]
+    StickyPerHost,
+}
+
+/// A single validated proxy endpoint.
+///
+/// `raw` carries the full URL (including any `user:pass`) for `reqwest`, which
+/// honours embedded credentials. `chrome_proxy_server` is the scheme-qualified
+/// `host:port` **without** credentials, suitable for Chrome's
+/// `Target.createBrowserContext { proxyServer }` (Chrome takes creds via the
+/// `Fetch.authRequired` auth pump, not in the URL).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyEntry {
+    raw: String,
+    scheme: String,
+    chrome_proxy_server: String,
+    auth: Option<(String, String)>,
+}
+
+const ALLOWED_SCHEMES: [&str; 4] = ["http", "https", "socks5", "socks5h"];
+
+impl ProxyEntry {
+    /// Parse and validate a proxy URL. Returns an error string (no silent
+    /// fallback) when the scheme is unsupported or the host is missing.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err("empty proxy URL".to_string());
+        }
+        let url =
+            url::Url::parse(trimmed).map_err(|e| format!("invalid proxy URL '{trimmed}': {e}"))?;
+
+        let scheme = url.scheme().to_ascii_lowercase();
+        if !ALLOWED_SCHEMES.contains(&scheme.as_str()) {
+            return Err(format!(
+                "unsupported proxy scheme '{scheme}' in '{trimmed}' (allowed: http, https, socks5, socks5h)"
+            ));
+        }
+
+        let host = url
+            .host_str()
+            .ok_or_else(|| format!("proxy URL '{trimmed}' has no host"))?;
+
+        let chrome_proxy_server = match url.port() {
+            Some(port) => format!("{scheme}://{host}:{port}"),
+            None => format!("{scheme}://{host}"),
+        };
+
+        let auth = match (url.username(), url.password()) {
+            ("", _) => None,
+            (user, Some(pass)) => Some((percent_decode(user), percent_decode(pass))),
+            (user, None) => Some((percent_decode(user), String::new())),
+        };
+
+        Ok(Self {
+            raw: trimmed.to_string(),
+            scheme,
+            chrome_proxy_server,
+            auth,
+        })
+    }
+
+    /// Full proxy URL (with credentials) for `reqwest::Proxy::all`.
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// URL scheme (lowercased): `http`, `https`, `socks5`, or `socks5h`.
+    pub fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    /// Scheme-qualified `host:port` (no credentials) for Chrome `proxyServer`.
+    pub fn chrome_proxy_server(&self) -> &str {
+        &self.chrome_proxy_server
+    }
+
+    /// Optional `(username, password)` for the CDP auth pump.
+    pub fn auth(&self) -> Option<&(String, String)> {
+        self.auth.as_ref()
+    }
+}
+
+/// Minimal percent-decoding for proxy userinfo (handles `%XX`). Credentials
+/// frequently contain URL-encoded characters; `url` exposes them encoded.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(h), Some(l)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2]))
+        {
+            out.push(h << 4 | l);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// A pool of validated proxies plus a selection strategy.
+///
+/// Construct via [`ProxyRotator::build`]. Returns `Ok(None)` when there are no
+/// proxies (caller then connects directly, preserving today's behaviour).
+#[derive(Debug)]
+pub struct ProxyRotator {
+    entries: Vec<ProxyEntry>,
+    strategy: ProxyRotation,
+    rr_cursor: AtomicUsize,
+    sticky: Mutex<HashMap<String, usize>>,
+}
+
+impl ProxyRotator {
+    /// Build a rotator with precedence: a non-empty `list` wins; otherwise the
+    /// single `single` proxy becomes a pool of one; otherwise `Ok(None)`.
+    ///
+    /// Every entry is validated — any malformed URL is a hard error (no silent
+    /// no-proxy fallback). The error is a human-readable string the caller maps
+    /// to a [`crate::CrwError`].
+    pub fn build(
+        list: &[String],
+        single: Option<&str>,
+        strategy: ProxyRotation,
+    ) -> Result<Option<Self>, String> {
+        let raws: Vec<&str> = if !list.is_empty() {
+            list.iter().map(String::as_str).collect()
+        } else if let Some(s) = single.map(str::trim).filter(|s| !s.is_empty()) {
+            vec![s]
+        } else {
+            return Ok(None);
+        };
+
+        let mut entries = Vec::with_capacity(raws.len());
+        for raw in raws {
+            entries.push(ProxyEntry::parse(raw)?);
+        }
+        if entries.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            entries,
+            strategy,
+            rr_cursor: AtomicUsize::new(0),
+            sticky: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    /// Number of proxies in the pool.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Always false — `build` returns `None` for empty pools.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The validated entries, in stable index order. Callers that pre-build a
+    /// per-entry resource (e.g. one `reqwest::Client` per proxy) index into
+    /// this and select with [`Self::pick_index`].
+    pub fn entries(&self) -> &[ProxyEntry] {
+        &self.entries
+    }
+
+    /// Select a proxy for a request. `host_key` is used only by
+    /// [`ProxyRotation::StickyPerHost`]; pass the normalized target host.
+    pub fn pick(&self, host_key: Option<&str>) -> &ProxyEntry {
+        &self.entries[self.pick_index(host_key)]
+    }
+
+    /// Index into [`Self::entries`] for this request, applying the strategy.
+    pub fn pick_index(&self, host_key: Option<&str>) -> usize {
+        let len = self.entries.len();
+        debug_assert!(len > 0, "ProxyRotator must never be empty");
+        match self.strategy {
+            ProxyRotation::RoundRobin => self.next_rr() % len,
+            ProxyRotation::Random => rand::random_range(0..len),
+            ProxyRotation::StickyPerHost => match host_key {
+                Some(host) => {
+                    let mut map = self.sticky.lock().unwrap_or_else(|e| e.into_inner());
+                    *map.entry(host.to_string())
+                        .or_insert_with(|| self.next_rr() % len)
+                }
+                None => self.next_rr() % len,
+            },
+        }
+    }
+
+    fn next_rr(&self) -> usize {
+        self.rr_cursor.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_http_with_auth() {
+        let e = ProxyEntry::parse("http://user:pass@host.example:8080").unwrap();
+        assert_eq!(e.scheme(), "http");
+        assert_eq!(e.chrome_proxy_server(), "http://host.example:8080");
+        assert_eq!(e.auth(), Some(&("user".to_string(), "pass".to_string())));
+        assert_eq!(e.raw(), "http://user:pass@host.example:8080");
+    }
+
+    #[test]
+    fn parse_socks5_no_auth() {
+        let e = ProxyEntry::parse("socks5://1.2.3.4:1080").unwrap();
+        assert_eq!(e.scheme(), "socks5");
+        assert_eq!(e.chrome_proxy_server(), "socks5://1.2.3.4:1080");
+        assert!(e.auth().is_none());
+    }
+
+    #[test]
+    fn parse_percent_encoded_auth() {
+        let e = ProxyEntry::parse("http://u%40b:p%3Aw@h:8080").unwrap();
+        assert_eq!(e.auth(), Some(&("u@b".to_string(), "p:w".to_string())));
+    }
+
+    #[test]
+    fn parse_rejects_bad_scheme() {
+        assert!(ProxyEntry::parse("ftp://h:21").is_err());
+        assert!(ProxyEntry::parse("not a url").is_err());
+        assert!(ProxyEntry::parse("").is_err());
+    }
+
+    #[test]
+    fn build_empty_is_none() {
+        assert!(
+            ProxyRotator::build(&[], None, ProxyRotation::RoundRobin)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            ProxyRotator::build(&[], Some("  "), ProxyRotation::RoundRobin)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn build_single_is_pool_of_one() {
+        let r = ProxyRotator::build(&[], Some("http://h:8080"), ProxyRotation::RoundRobin)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r.pick(None).chrome_proxy_server(), "http://h:8080");
+    }
+
+    #[test]
+    fn build_list_wins_over_single() {
+        let list = vec!["http://a:1".to_string(), "http://b:2".to_string()];
+        let r = ProxyRotator::build(&list, Some("http://single:9"), ProxyRotation::RoundRobin)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn build_bad_entry_is_hard_error() {
+        let list = vec!["http://ok:1".to_string(), "ftp://bad:2".to_string()];
+        assert!(ProxyRotator::build(&list, None, ProxyRotation::RoundRobin).is_err());
+    }
+
+    #[test]
+    fn round_robin_cycles_in_order() {
+        let list = vec![
+            "http://a:1".to_string(),
+            "http://b:2".to_string(),
+            "http://c:3".to_string(),
+        ];
+        let r = ProxyRotator::build(&list, None, ProxyRotation::RoundRobin)
+            .unwrap()
+            .unwrap();
+        let seq: Vec<&str> = (0..4).map(|_| r.pick(None).raw()).collect();
+        assert_eq!(
+            seq,
+            vec!["http://a:1", "http://b:2", "http://c:3", "http://a:1"]
+        );
+    }
+
+    #[test]
+    fn random_stays_in_bounds() {
+        let list = vec!["http://a:1".to_string(), "http://b:2".to_string()];
+        let r = ProxyRotator::build(&list, None, ProxyRotation::Random)
+            .unwrap()
+            .unwrap();
+        for _ in 0..100 {
+            let raw = r.pick(None).raw();
+            assert!(raw == "http://a:1" || raw == "http://b:2");
+        }
+    }
+
+    #[test]
+    fn sticky_pins_host_to_one_proxy() {
+        let list = vec![
+            "http://a:1".to_string(),
+            "http://b:2".to_string(),
+            "http://c:3".to_string(),
+        ];
+        let r = ProxyRotator::build(&list, None, ProxyRotation::StickyPerHost)
+            .unwrap()
+            .unwrap();
+        let first = r.pick(Some("example.com")).raw().to_string();
+        for _ in 0..50 {
+            assert_eq!(r.pick(Some("example.com")).raw(), first);
+        }
+        // A different host may land on a different proxy, but is itself stable.
+        let other = r.pick(Some("other.com")).raw().to_string();
+        for _ in 0..50 {
+            assert_eq!(r.pick(Some("other.com")).raw(), other);
+        }
+    }
+
+    #[test]
+    fn default_strategy_is_sticky() {
+        assert_eq!(ProxyRotation::default(), ProxyRotation::StickyPerHost);
+    }
+}

--- a/crates/crw-core/src/proxy.rs
+++ b/crates/crw-core/src/proxy.rs
@@ -217,20 +217,13 @@ impl ProxyRotator {
         self.entries.is_empty()
     }
 
-    /// The validated entries, in stable index order. Callers that pre-build a
-    /// per-entry resource (e.g. one `reqwest::Client` per proxy) index into
-    /// this and select with [`Self::pick_index`].
-    pub fn entries(&self) -> &[ProxyEntry] {
-        &self.entries
-    }
-
     /// Select a proxy for a request. `host_key` is used only by
     /// [`ProxyRotation::StickyPerHost`]; pass the normalized target host.
     pub fn pick(&self, host_key: Option<&str>) -> &ProxyEntry {
         &self.entries[self.pick_index(host_key)]
     }
 
-    /// Index into [`Self::entries`] for this request, applying the strategy.
+    /// Index into the validated pool for this request, applying the strategy.
     ///
     /// `StickyPerHost` is **stateless**: the index is a deterministic hash of the
     /// host modulo the pool size. This keeps a host pinned to one proxy for the

--- a/crates/crw-core/src/proxy.rs
+++ b/crates/crw-core/src/proxy.rs
@@ -14,8 +14,6 @@
 //! error string to the appropriate [`crate::CrwError`] variant
 //! (`ConfigError` at startup, `InvalidRequest` for per-request BYOP).
 
-use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde::{Deserialize, Serialize};
@@ -74,9 +72,18 @@ impl ProxyEntry {
             .host_str()
             .ok_or_else(|| format!("proxy URL '{trimmed}' has no host"))?;
 
+        // Chrome's `proxyServer` only understands `socks5` (which already does
+        // remote DNS) — it does not recognize the `socks5h` scheme. Normalize so
+        // the CDP path passes a scheme Chrome accepts. (`reqwest`/`raw` keeps the
+        // original scheme for the HTTP path.)
+        let chrome_scheme = if scheme == "socks5h" {
+            "socks5"
+        } else {
+            &scheme
+        };
         let chrome_proxy_server = match url.port() {
-            Some(port) => format!("{scheme}://{host}:{port}"),
-            None => format!("{scheme}://{host}"),
+            Some(port) => format!("{chrome_scheme}://{host}:{port}"),
+            None => format!("{chrome_scheme}://{host}"),
         };
 
         let auth = match (url.username(), url.password()) {
@@ -111,6 +118,16 @@ impl ProxyEntry {
     /// Optional `(username, password)` for the CDP auth pump.
     pub fn auth(&self) -> Option<&(String, String)> {
         self.auth.as_ref()
+    }
+
+    /// Whether this proxy can authenticate on the Chrome/CDP path. Chrome's
+    /// network stack never emits `Fetch.authRequired` for SOCKS proxies, so a
+    /// `socks5`/`socks5h` proxy that carries credentials cannot authenticate via
+    /// the CDP auth pump (it would hang/fail). HTTP/HTTPS proxies and
+    /// credential-less SOCKS proxies are fine. The HTTP (reqwest) path is
+    /// unaffected — it authenticates SOCKS natively via [`Self::raw`].
+    pub fn supports_cdp_auth(&self) -> bool {
+        !(self.scheme.starts_with("socks") && self.auth.is_some())
     }
 }
 
@@ -153,7 +170,6 @@ pub struct ProxyRotator {
     entries: Vec<ProxyEntry>,
     strategy: ProxyRotation,
     rr_cursor: AtomicUsize,
-    sticky: Mutex<HashMap<String, usize>>,
 }
 
 impl ProxyRotator {
@@ -188,7 +204,6 @@ impl ProxyRotator {
             entries,
             strategy,
             rr_cursor: AtomicUsize::new(0),
-            sticky: Mutex::new(HashMap::new()),
         }))
     }
 
@@ -216,18 +231,22 @@ impl ProxyRotator {
     }
 
     /// Index into [`Self::entries`] for this request, applying the strategy.
+    ///
+    /// `StickyPerHost` is **stateless**: the index is a deterministic hash of the
+    /// host modulo the pool size. This keeps a host pinned to one proxy for the
+    /// rotator's lifetime with no per-host map (no unbounded growth, no lock, and
+    /// — crucially — no cursor side-effect, so repeated picks for the same host
+    /// are idempotent and HTTP + CDP always agree).
     pub fn pick_index(&self, host_key: Option<&str>) -> usize {
         let len = self.entries.len();
-        debug_assert!(len > 0, "ProxyRotator must never be empty");
+        if len == 0 {
+            return 0; // unreachable: `build` never yields an empty rotator.
+        }
         match self.strategy {
             ProxyRotation::RoundRobin => self.next_rr() % len,
             ProxyRotation::Random => rand::random_range(0..len),
             ProxyRotation::StickyPerHost => match host_key {
-                Some(host) => {
-                    let mut map = self.sticky.lock().unwrap_or_else(|e| e.into_inner());
-                    *map.entry(host.to_string())
-                        .or_insert_with(|| self.next_rr() % len)
-                }
+                Some(host) => (fnv1a(host) % len as u64) as usize,
                 None => self.next_rr() % len,
             },
         }
@@ -236,6 +255,17 @@ impl ProxyRotator {
     fn next_rr(&self) -> usize {
         self.rr_cursor.fetch_add(1, Ordering::Relaxed)
     }
+}
+
+/// FNV-1a 64-bit hash — small, stable, dependency-free. Used for stateless
+/// sticky-per-host proxy assignment.
+fn fnv1a(s: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 #[cfg(test)]
@@ -363,5 +393,70 @@ mod tests {
     #[test]
     fn default_strategy_is_sticky() {
         assert_eq!(ProxyRotation::default(), ProxyRotation::StickyPerHost);
+    }
+
+    #[test]
+    fn socks5h_maps_to_socks5_for_chrome() {
+        let e = ProxyEntry::parse("socks5h://host:1080").unwrap();
+        assert_eq!(e.scheme(), "socks5h"); // reqwest/raw keeps original
+        assert_eq!(e.chrome_proxy_server(), "socks5://host:1080"); // chrome normalized
+    }
+
+    #[test]
+    fn socks_with_auth_unsupported_on_cdp() {
+        let e = ProxyEntry::parse("socks5://user:pass@host:1080").unwrap();
+        assert!(!e.supports_cdp_auth());
+        let e2 = ProxyEntry::parse("socks5h://user:pass@host:1080").unwrap();
+        assert!(!e2.supports_cdp_auth());
+        // No-auth SOCKS and HTTP(+auth) are fine for CDP.
+        assert!(
+            ProxyEntry::parse("socks5://host:1080")
+                .unwrap()
+                .supports_cdp_auth()
+        );
+        assert!(
+            ProxyEntry::parse("http://user:pass@host:8080")
+                .unwrap()
+                .supports_cdp_auth()
+        );
+    }
+
+    #[test]
+    fn sticky_is_stateless_and_deterministic() {
+        // Two independent rotators with the same pool map a host identically
+        // (proves stickiness is a pure hash, not per-instance state).
+        let list = vec![
+            "http://a:1".to_string(),
+            "http://b:2".to_string(),
+            "http://c:3".to_string(),
+        ];
+        let r1 = ProxyRotator::build(&list, None, ProxyRotation::StickyPerHost)
+            .unwrap()
+            .unwrap();
+        let r2 = ProxyRotator::build(&list, None, ProxyRotation::StickyPerHost)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            r1.pick(Some("example.com")).raw(),
+            r2.pick(Some("example.com")).raw()
+        );
+        // Repeated picks never advance the round-robin cursor (idempotent).
+        let first = r1.pick(Some("example.com")).raw().to_string();
+        for _ in 0..10 {
+            assert_eq!(r1.pick(Some("example.com")).raw(), first);
+        }
+    }
+
+    #[test]
+    fn round_robin_advances_exactly_once_per_pick() {
+        let list = vec!["http://a:1".to_string(), "http://b:2".to_string()];
+        let r = ProxyRotator::build(&list, None, ProxyRotation::RoundRobin)
+            .unwrap()
+            .unwrap();
+        // Each pick advances by exactly one step (a→b→a→b).
+        assert_eq!(r.pick_index(None), 0);
+        assert_eq!(r.pick_index(None), 1);
+        assert_eq!(r.pick_index(None), 0);
+        assert_eq!(r.pick_index(None), 1);
     }
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -188,11 +188,13 @@ pub struct ScrapeRequest {
     pub proxy: Option<String>,
     /// Per-request proxy pool to rotate among (BYOP). Takes precedence over
     /// `proxy` and over the server's configured pool. Empty = use server config.
-    #[serde(default)]
+    /// Accepts the snake_case `proxy_list` alias (the managed layer injects it)
+    /// in addition to the camelCase `proxyList`.
+    #[serde(default, alias = "proxy_list")]
     pub proxy_list: Vec<String>,
     /// Rotation strategy for `proxy_list` (`round_robin`, `random`,
     /// `sticky_per_host`). `None` = server default (`sticky_per_host`).
-    #[serde(default)]
+    #[serde(default, alias = "proxy_rotation")]
     pub proxy_rotation: Option<crate::proxy::ProxyRotation>,
     /// 2-letter ISO 3166-1 alpha-2 country code (e.g. "us", "gb") for the
     /// residential-proxy chrome tier's egress. When the server has
@@ -680,12 +682,12 @@ pub struct CrawlRequest {
     pub country: Option<String>,
     /// Per-crawl proxy pool to rotate among (BYOP). Takes precedence over the
     /// server's configured pool. Empty = use server config. Rotation is applied
-    /// per page (see `proxy_rotation`).
-    #[serde(default)]
+    /// per page (see `proxy_rotation`). Accepts the snake_case `proxy_list` alias.
+    #[serde(default, alias = "proxy_list")]
     pub proxy_list: Vec<String>,
     /// Rotation strategy for `proxy_list` (`round_robin`, `random`,
     /// `sticky_per_host`). `None` = server default (`sticky_per_host`).
-    #[serde(default)]
+    #[serde(default, alias = "proxy_rotation")]
     pub proxy_rotation: Option<crate::proxy::ProxyRotation>,
 }
 

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -186,6 +186,14 @@ pub struct ScrapeRequest {
     /// (e.g. "http://proxy:8080" or "socks5://user:pass@proxy:1080").
     #[serde(default)]
     pub proxy: Option<String>,
+    /// Per-request proxy pool to rotate among (BYOP). Takes precedence over
+    /// `proxy` and over the server's configured pool. Empty = use server config.
+    #[serde(default)]
+    pub proxy_list: Vec<String>,
+    /// Rotation strategy for `proxy_list` (`round_robin`, `random`,
+    /// `sticky_per_host`). `None` = server default (`sticky_per_host`).
+    #[serde(default)]
+    pub proxy_rotation: Option<crate::proxy::ProxyRotation>,
     /// 2-letter ISO 3166-1 alpha-2 country code (e.g. "us", "gb") for the
     /// residential-proxy chrome tier's egress. When the server has
     /// DataImpulse credentials configured, the engine composes
@@ -376,6 +384,8 @@ impl Default for ScrapeRequest {
             filter_mode: None,
             top_k: None,
             proxy: None,
+            proxy_list: Vec::new(),
+            proxy_rotation: None,
             country: None,
             stealth: None,
             actions: None,
@@ -668,6 +678,15 @@ pub struct CrawlRequest {
     /// every page fetched in this crawl. See `ScrapeRequest::country`.
     #[serde(default)]
     pub country: Option<String>,
+    /// Per-crawl proxy pool to rotate among (BYOP). Takes precedence over the
+    /// server's configured pool. Empty = use server config. Rotation is applied
+    /// per page (see `proxy_rotation`).
+    #[serde(default)]
+    pub proxy_list: Vec<String>,
+    /// Rotation strategy for `proxy_list` (`round_robin`, `random`,
+    /// `sticky_per_host`). `None` = server default (`sticky_per_host`).
+    #[serde(default)]
+    pub proxy_rotation: Option<crate::proxy::ProxyRotation>,
 }
 
 /// Resolve the effective `render_js` decision from a per-request value and the

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -119,6 +119,21 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
     let max_depth = req.max_depth.unwrap_or(2).min(10);
     let max_pages = req.max_pages.unwrap_or(100).min(1000) as usize;
 
+    // Per-crawl BYOP proxy pool (req.proxy_list, req.proxy_rotation). Takes
+    // precedence over the server-config rotator. A malformed entry fails the
+    // whole job — never a silent direct connection (real-IP leak).
+    let byop_rotator = match crw_core::ProxyRotator::build(
+        &req.proxy_list,
+        None,
+        req.proxy_rotation.unwrap_or_default(),
+    ) {
+        Ok(r) => r.map(std::sync::Arc::new),
+        Err(e) => {
+            send_failed(id, &state_tx, format!("invalid proxy_list: {e}"));
+            return;
+        }
+    };
+
     // Apply "pinned implies JS" once per crawl, mirroring single.rs.
     let pinned_renderer = resolve_pinned_renderer(req.renderer);
     let effective_render_js = if req.renderer.is_some()
@@ -216,8 +231,17 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         let page_deadline = crw_core::Deadline::from_request_ms(deadline_ms_per_page);
         // Per-page proxy selection (sticky-per-host by default) so each crawled
         // host egresses through its assigned proxy across both the HTTP and
-        // JS/CDP paths. Scoped per page since hosts vary across the crawl.
-        let resolved_proxy = renderer.pick_proxy_for_url(&url);
+        // JS/CDP paths. BYOP pool (if supplied) takes precedence over config.
+        // Scoped per page since hosts vary across the crawl.
+        let resolved_proxy = match &byop_rotator {
+            Some(b) => {
+                let host = url::Url::parse(&url)
+                    .ok()
+                    .and_then(|u| u.host_str().map(str::to_string));
+                Some(std::sync::Arc::new(b.pick(host.as_deref()).clone()))
+            }
+            None => renderer.pick_proxy_for_url(&url),
+        };
         let empty_headers: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         let fetch_fut = renderer.fetch(

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -5,7 +5,7 @@ use crw_core::types::{
 };
 use crw_extract::readability::extract_links;
 use crw_renderer::FallbackRenderer;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use uuid::Uuid;
@@ -528,19 +528,29 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
     }
     let origin = parsed.origin().ascii_serialization();
 
+    // robots/sitemap egress must match page egress: prefer the config rotator
+    // (proxy_list), then the legacy single `proxy`. Fail closed on a bad proxy —
+    // never a silent direct connection (real-IP leak).
+    let discover_proxy: Option<String> = renderer
+        .pick_proxy_for_url(&origin)
+        .map(|e| e.raw().to_string())
+        .or_else(|| proxy.clone());
     let mut discover_client_builder = reqwest::Client::builder()
         .user_agent(user_agent)
         .timeout(std::time::Duration::from_secs(15))
         .connect_timeout(std::time::Duration::from_secs(5))
         .redirect(crw_core::url_safety::safe_redirect_policy());
-    if let Some(ref proxy_url) = proxy
-        && let Ok(p) = reqwest::Proxy::all(proxy_url)
-    {
+    if let Some(ref proxy_url) = discover_proxy {
+        let p = reqwest::Proxy::all(proxy_url).map_err(|e| {
+            crw_core::error::CrwError::InvalidRequest(format!(
+                "invalid proxy URL '{proxy_url}': {e}"
+            ))
+        })?;
         discover_client_builder = discover_client_builder.proxy(p);
     }
     let client = discover_client_builder
         .build()
-        .expect("reqwest client build should not fail");
+        .map_err(|e| crw_core::error::CrwError::Internal(format!("http client build: {e}")))?;
 
     let mut all_urls: HashSet<String> = HashSet::new();
 
@@ -670,15 +680,20 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         }
 
         let discover_deadline = crw_core::Deadline::from_request_ms(deadline_ms_per_page);
-        let fetch = renderer
-            .fetch(
-                &url,
-                &Default::default(),
-                Some(false),
-                None,
-                None,
-                discover_deadline,
-            )
+        // Honor the config rotator so discovery page fetches egress through the
+        // proxy (sticky-per-host), not direct. Resolved once into REQUEST_PROXY.
+        let resolved_proxy = renderer.pick_proxy_for_url(&url);
+        let empty_headers: HashMap<String, String> = HashMap::new();
+        let fetch_fut = renderer.fetch(
+            &url,
+            &empty_headers,
+            Some(false),
+            None,
+            None,
+            discover_deadline,
+        );
+        let fetch = crw_renderer::REQUEST_PROXY
+            .scope(resolved_proxy, fetch_fut)
             .await;
 
         if let Ok(result) = fetch {

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -167,14 +167,30 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         }
     };
 
+    // Robots/sitemap egress must match the page egress: prefer the per-crawl
+    // BYOP pool, then the config rotator, then the legacy single `proxy`. Never
+    // a silent direct connection when a proxy is configured (real-IP leak).
+    let robots_proxy: Option<String> = match &byop_rotator {
+        Some(b) => Some(b.pick(base_url.host_str()).raw().to_string()),
+        None => renderer
+            .pick_proxy_for_url(&origin)
+            .map(|e| e.raw().to_string())
+            .or_else(|| proxy.clone()),
+    };
     let mut client_builder = reqwest::Client::builder()
         .user_agent(user_agent)
         .redirect(crw_core::url_safety::safe_redirect_policy());
-    if let Some(ref proxy_url) = proxy {
-        if let Ok(p) = reqwest::Proxy::all(proxy_url) {
-            client_builder = client_builder.proxy(p);
-        } else {
-            tracing::warn!("Invalid crawl proxy URL: {proxy_url}");
+    if let Some(ref proxy_url) = robots_proxy {
+        match reqwest::Proxy::all(proxy_url) {
+            Ok(p) => client_builder = client_builder.proxy(p),
+            Err(e) => {
+                send_failed(
+                    id,
+                    &state_tx,
+                    format!("invalid crawl proxy URL '{proxy_url}': {e}"),
+                );
+                return;
+            }
         }
     }
     let client = client_builder

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -214,15 +214,22 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         // the renderer's acquire when per_host_max_concurrent = 1.
 
         let page_deadline = crw_core::Deadline::from_request_ms(deadline_ms_per_page);
-        let mut fetch_result = match renderer
-            .fetch(
-                &url,
-                &Default::default(),
-                effective_render_js,
-                req.wait_for,
-                pinned_renderer,
-                page_deadline,
-            )
+        // Per-page proxy selection (sticky-per-host by default) so each crawled
+        // host egresses through its assigned proxy across both the HTTP and
+        // JS/CDP paths. Scoped per page since hosts vary across the crawl.
+        let resolved_proxy = renderer.pick_proxy_for_url(&url);
+        let empty_headers: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let fetch_fut = renderer.fetch(
+            &url,
+            &empty_headers,
+            effective_render_js,
+            req.wait_for,
+            pinned_renderer,
+            page_deadline,
+        );
+        let mut fetch_result = match crw_renderer::REQUEST_PROXY
+            .scope(resolved_proxy, fetch_fut)
             .await
         {
             Ok(r) => r,

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -6,9 +6,35 @@ use crw_core::types::{
     resolve_pinned_renderer, resolve_render_js,
 };
 use crw_renderer::FallbackRenderer;
-use crw_renderer::http_only::{HttpFetcher, RotatingHttpFetcher};
+use crw_renderer::http_only::HttpFetcher;
 use crw_renderer::traits::PageFetcher;
 use std::sync::{Arc, Mutex};
+
+/// Resolve the effective proxy for a request, honoring precedence
+/// `req.proxy_list > req.proxy > server config`. The single resolved entry is
+/// scoped into `REQUEST_PROXY` so BOTH the HTTP and JS/CDP paths egress through
+/// it (no second pick, no path-specific resolution). A malformed BYOP proxy is
+/// an `InvalidRequest` error — never a silent direct connection.
+fn resolve_request_proxy(
+    req: &ScrapeRequest,
+    renderer: &FallbackRenderer,
+) -> CrwResult<Option<Arc<crw_core::ProxyEntry>>> {
+    if !req.proxy_list.is_empty() || req.proxy.is_some() {
+        let byop = crw_core::ProxyRotator::build(
+            &req.proxy_list,
+            req.proxy.as_deref(),
+            req.proxy_rotation.unwrap_or_default(),
+        )
+        .map_err(crw_core::error::CrwError::InvalidRequest)?;
+        if let Some(byop) = byop {
+            let host = url::Url::parse(&req.url)
+                .ok()
+                .and_then(|u| u.host_str().map(str::to_string));
+            return Ok(Some(Arc::new(byop.pick(host.as_deref()).clone())));
+        }
+    }
+    Ok(renderer.pick_proxy_for_url(&req.url))
+}
 
 /// Scrape a single URL: fetch → extract → (optional) LLM structured extraction.
 ///
@@ -28,13 +54,11 @@ pub async fn scrape_url(
     render_js_default: Option<bool>,
     deadline: Deadline,
 ) -> CrwResult<ScrapeData> {
-    // Propagate per-request country + resolved proxy into the renderer stack
-    // via task-locals. `REQUEST_COUNTRY` drives DataImpulse credential country;
-    // `REQUEST_PROXY` carries the rotator-picked proxy so the JS/CDP path
-    // egresses through it (HTTP-only BYOP is handled separately in the inner fn
-    // via a temp RotatingHttpFetcher). The proxy is resolved from the configured
-    // rotator here; per-request BYOP applies to the HTTP path.
-    let resolved_proxy = renderer.pick_proxy_for_url(&req.url);
+    // Propagate per-request country + the single resolved proxy into the
+    // renderer stack via task-locals. `REQUEST_COUNTRY` drives DataImpulse
+    // credential country; `REQUEST_PROXY` carries the resolved proxy (BYOP >
+    // config) so BOTH the HTTP and JS/CDP paths egress through the same entry.
+    let resolved_proxy = resolve_request_proxy(req, renderer)?;
     crw_renderer::REQUEST_COUNTRY
         .scope(req.country.clone(), async move {
             crw_renderer::REQUEST_PROXY
@@ -109,27 +133,12 @@ async fn scrape_url_inner(
         }
     }
 
-    // Per-request proxy override (BYOP). A non-empty `proxy_list` or a single
-    // `proxy` builds a fresh rotator that takes precedence over server config.
-    // An invalid URL is a 400 (InvalidRequest), never a silent direct fetch.
-    let req_rotator: Option<Arc<crw_core::ProxyRotator>> =
-        if !req.proxy_list.is_empty() || req.proxy.is_some() {
-            crw_core::ProxyRotator::build(
-                &req.proxy_list,
-                req.proxy.as_deref(),
-                req.proxy_rotation.unwrap_or_default(),
-            )
-            .map_err(crw_core::error::CrwError::InvalidRequest)?
-            .map(Arc::new)
-        } else {
-            None
-        };
-
-    // Use a temporary fetcher when:
-    // (a) a per-request proxy/proxy_list overrides global proxy, OR
-    // (b) per-request stealth differs from what the shared renderer was built with.
-    let needs_temp_fetcher =
-        req_rotator.is_some() || req.stealth.is_some_and(|s| s != default_stealth);
+    // Use a temporary fetcher ONLY when per-request stealth differs from the
+    // shared renderer's config. Proxy egress (config rotation + BYOP) is carried
+    // by the REQUEST_PROXY task-local (resolved once in `scrape_url`) and is
+    // honored by the shared renderer's HTTP and CDP paths, so it does not need a
+    // temp fetcher.
+    let needs_temp_fetcher = req.stealth.is_some_and(|s| s != default_stealth);
 
     let mut fetch_result = if needs_temp_fetcher {
         // Rotate UA from built-in pool when stealth is active, so the request
@@ -141,19 +150,25 @@ async fn scrape_url_inner(
         };
 
         if effective_render_js == Some(false) {
-            // HTTP-only: safe to use a temp fetcher with custom proxy/stealth.
-            // With a per-request rotator, rotate across the pool; otherwise a
-            // plain direct fetcher (stealth-only override).
-            if let Some(rot) = &req_rotator {
-                let temp = RotatingHttpFetcher::new(rot.clone(), &effective_ua, inject_stealth)?;
-                temp.fetch(&req.url, &req.headers, req.wait_for, deadline)
-                    .await?
-            } else {
-                let temp_http = HttpFetcher::new(&effective_ua, None, inject_stealth);
-                temp_http
-                    .fetch(&req.url, &req.headers, req.wait_for, deadline)
-                    .await?
-            }
+            // HTTP-only temp fetcher with per-request stealth. Honor REQUEST_PROXY
+            // so a stealth-override request still egresses through the resolved
+            // proxy — fail-closed, a set proxy is never bypassed.
+            let temp_http = match crw_renderer::REQUEST_PROXY
+                .try_with(|p| p.clone())
+                .ok()
+                .flatten()
+            {
+                Some(entry) => HttpFetcher::with_proxy(
+                    &effective_ua,
+                    entry.raw(),
+                    inject_stealth,
+                    std::time::Duration::from_secs(30),
+                )?,
+                None => HttpFetcher::new(&effective_ua, None, inject_stealth),
+            };
+            temp_http
+                .fetch(&req.url, &req.headers, req.wait_for, deadline)
+                .await?
         } else {
             // JS rendering needed (or auto-detect): use the shared renderer which
             // has CDP backends configured. Inject stealth headers via custom headers

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -6,7 +6,7 @@ use crw_core::types::{
     resolve_pinned_renderer, resolve_render_js,
 };
 use crw_renderer::FallbackRenderer;
-use crw_renderer::http_only::HttpFetcher;
+use crw_renderer::http_only::{HttpFetcher, RotatingHttpFetcher};
 use crw_renderer::traits::PageFetcher;
 use std::sync::{Arc, Mutex};
 
@@ -101,14 +101,29 @@ async fn scrape_url_inner(
         }
     }
 
-    // Use a temporary HttpFetcher when:
-    // (a) per-request proxy overrides global proxy, OR
+    // Per-request proxy override (BYOP). A non-empty `proxy_list` or a single
+    // `proxy` builds a fresh rotator that takes precedence over server config.
+    // An invalid URL is a 400 (InvalidRequest), never a silent direct fetch.
+    let req_rotator: Option<Arc<crw_core::ProxyRotator>> =
+        if !req.proxy_list.is_empty() || req.proxy.is_some() {
+            crw_core::ProxyRotator::build(
+                &req.proxy_list,
+                req.proxy.as_deref(),
+                req.proxy_rotation.unwrap_or_default(),
+            )
+            .map_err(crw_core::error::CrwError::InvalidRequest)?
+            .map(Arc::new)
+        } else {
+            None
+        };
+
+    // Use a temporary fetcher when:
+    // (a) a per-request proxy/proxy_list overrides global proxy, OR
     // (b) per-request stealth differs from what the shared renderer was built with.
     let needs_temp_fetcher =
-        req.proxy.is_some() || req.stealth.is_some_and(|s| s != default_stealth);
+        req_rotator.is_some() || req.stealth.is_some_and(|s| s != default_stealth);
 
     let mut fetch_result = if needs_temp_fetcher {
-        let proxy = req.proxy.as_deref();
         // Rotate UA from built-in pool when stealth is active, so the request
         // looks like a real browser even for per-request stealth overrides.
         let effective_ua = if inject_stealth {
@@ -118,11 +133,19 @@ async fn scrape_url_inner(
         };
 
         if effective_render_js == Some(false) {
-            // HTTP-only: safe to use a temp HttpFetcher with custom proxy/stealth.
-            let temp_http = HttpFetcher::new(&effective_ua, proxy, inject_stealth);
-            temp_http
-                .fetch(&req.url, &req.headers, req.wait_for, deadline)
-                .await?
+            // HTTP-only: safe to use a temp fetcher with custom proxy/stealth.
+            // With a per-request rotator, rotate across the pool; otherwise a
+            // plain direct fetcher (stealth-only override).
+            if let Some(rot) = &req_rotator {
+                let temp = RotatingHttpFetcher::new(rot.clone(), &effective_ua, inject_stealth)?;
+                temp.fetch(&req.url, &req.headers, req.wait_for, deadline)
+                    .await?
+            } else {
+                let temp_http = HttpFetcher::new(&effective_ua, None, inject_stealth);
+                temp_http
+                    .fetch(&req.url, &req.headers, req.wait_for, deadline)
+                    .await?
+            }
         } else {
             // JS rendering needed (or auto-detect): use the shared renderer which
             // has CDP backends configured. Inject stealth headers via custom headers

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -28,22 +28,30 @@ pub async fn scrape_url(
     render_js_default: Option<bool>,
     deadline: Deadline,
 ) -> CrwResult<ScrapeData> {
-    // Propagate per-request country into the renderer stack via task-local.
-    // Read by `crw-renderer::cdp` when composing DataImpulse credentials for
-    // the chrome_proxy tier. None = use `proxy_default_country` fallback.
+    // Propagate per-request country + resolved proxy into the renderer stack
+    // via task-locals. `REQUEST_COUNTRY` drives DataImpulse credential country;
+    // `REQUEST_PROXY` carries the rotator-picked proxy so the JS/CDP path
+    // egresses through it (HTTP-only BYOP is handled separately in the inner fn
+    // via a temp RotatingHttpFetcher). The proxy is resolved from the configured
+    // rotator here; per-request BYOP applies to the HTTP path.
+    let resolved_proxy = renderer.pick_proxy_for_url(&req.url);
     crw_renderer::REQUEST_COUNTRY
         .scope(req.country.clone(), async move {
-            scrape_url_inner(
-                req,
-                renderer,
-                llm_config,
-                extraction_cfg,
-                user_agent,
-                default_stealth,
-                render_js_default,
-                deadline,
-            )
-            .await
+            crw_renderer::REQUEST_PROXY
+                .scope(resolved_proxy, async move {
+                    scrape_url_inner(
+                        req,
+                        renderer,
+                        llm_config,
+                        extraction_cfg,
+                        user_agent,
+                        default_stealth,
+                        render_js_default,
+                        deadline,
+                    )
+                    .await
+                })
+                .await
         })
         .await
 }

--- a/crates/crw-monitor/src/runner.rs
+++ b/crates/crw-monitor/src/runner.rs
@@ -284,6 +284,8 @@ impl EngineSource {
             filter_mode: None,
             top_k: None,
             proxy: None,
+            proxy_list: Vec::new(),
+            proxy_rotation: None,
             country: None,
             stealth: None,
             actions: None,
@@ -377,6 +379,8 @@ impl EngineSource {
             wait_for: None,
             renderer: None,
             country: None,
+            proxy_list: Vec::new(),
+            proxy_rotation: None,
         };
         let initial = CrawlState {
             id: uuid::Uuid::new_v4(),

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1201,8 +1201,15 @@ impl PageFetcher for CdpRenderer {
             ));
         }
 
+        // When a per-request proxy is active, bypass the context pool: each
+        // proxied request needs a fresh browser context created with its own
+        // `proxyServer`, which `fetch_with_ws` builds and disposes. The pool is
+        // reserved for the (common) no-proxy path where contexts are reused.
+        let proxy_active = crate::REQUEST_PROXY
+            .try_with(|p| p.is_some())
+            .unwrap_or(false);
         let fut = async {
-            if let Some(pool) = self.pool.as_ref() {
+            if let Some(pool) = self.pool.as_ref().filter(|_| !proxy_active) {
                 self.fetch_with_pool(pool, url, wait_for_ms, deadline).await
             } else {
                 self.fetch_with_ws(url, wait_for_ms, deadline).await
@@ -1392,6 +1399,38 @@ impl CdpRenderer {
 
         let conn = self.connect_with_retry().await?;
 
+        // Per-request proxy: create a dedicated browser context whose egress is
+        // routed through `proxyServer` (credentials, if any, are supplied by the
+        // `Fetch.authRequired` pump in `fetch_inner`). Disposed after the target
+        // closes. `None` keeps the prior browser-level behaviour unchanged.
+        let proxy_ctx: Option<String> =
+            match crate::REQUEST_PROXY.try_with(|p| p.clone()).ok().flatten() {
+                Some(entry) => {
+                    let v = conn
+                        .send_recv(
+                            "Target.createBrowserContext",
+                            serde_json::json!({
+                                "proxyServer": entry.chrome_proxy_server(),
+                                "proxyBypassList": "<-loopback>",
+                            }),
+                            None,
+                            Duration::from_secs(2),
+                        )
+                        .await?;
+                    let ctx = v
+                        .get("browserContextId")
+                        .and_then(|x| x.as_str())
+                        .ok_or_else(|| {
+                            CrwError::RendererError(
+                                "createBrowserContext: missing browserContextId".into(),
+                            )
+                        })?
+                        .to_string();
+                    Some(ctx)
+                }
+                None => None,
+            };
+
         // Legacy path: `tid_slot` is the SOLE authoritative source for target
         // close on both Ok and Err branches. fetch_inner no longer closes
         // targets itself — we own that here. `Arc<Mutex<...>>` (not `Cell`)
@@ -1403,7 +1442,14 @@ impl CdpRenderer {
             *tid_slot_rec.lock().unwrap() = Some(tid.to_string());
         };
         let result = self
-            .fetch_inner(&conn, None, &recorder, url, wait_for_ms, deadline)
+            .fetch_inner(
+                &conn,
+                proxy_ctx.as_deref(),
+                &recorder,
+                url,
+                wait_for_ms,
+                deadline,
+            )
             .await;
 
         // B2 gate metric: pre-navigation overhead (connect + createTarget +
@@ -1415,6 +1461,19 @@ impl CdpRenderer {
         let captured_tid = tid_slot.lock().unwrap().take();
         if let Some(tid) = captured_tid {
             close_target(&conn, &tid, &self.name).await;
+        }
+
+        // Dispose the per-request proxy context (best-effort) before closing the
+        // connection, so a proxied request doesn't leak browser contexts.
+        if let Some(ctx) = &proxy_ctx {
+            let _ = conn
+                .send_recv(
+                    "Target.disposeBrowserContext",
+                    serde_json::json!({ "browserContextId": ctx }),
+                    None,
+                    Duration::from_secs(1),
+                )
+                .await;
         }
 
         conn.close().await;
@@ -1850,10 +1909,17 @@ impl CdpRenderer {
         // Subscribe to events BEFORE navigating so we don't miss loadEventFired.
         let events_rx = conn.subscribe();
 
-        // Compose per-call DataImpulse credentials for the chrome_proxy tier.
-        // Country priority: per-request (task-local) → renderer default → none.
-        // Two-letter lowercase ASCII guard mirrors `RendererConfig::effective_proxy_credentials`.
-        let effective_creds: Option<(String, String)> =
+        // Credentials for the `Fetch.authRequired` pump. Priority:
+        //   1. The per-request rotated proxy's own embedded `user:pass`
+        //      (REQUEST_PROXY) — takes precedence so a BYOP/rotated proxy
+        //      authenticates correctly.
+        //   2. Otherwise the chrome_proxy tier's DataImpulse base creds, with
+        //      the country suffix composed from REQUEST_COUNTRY → default → none.
+        let request_proxy_auth: Option<(String, String)> = crate::REQUEST_PROXY
+            .try_with(|p| p.as_ref().and_then(|e| e.auth().cloned()))
+            .ok()
+            .flatten();
+        let effective_creds: Option<(String, String)> = request_proxy_auth.or_else(|| {
             self.proxy_auth_base.as_ref().map(|(base_user, base_pass)| {
                 let req_country = crate::REQUEST_COUNTRY
                     .try_with(|c| c.clone())
@@ -1868,7 +1934,8 @@ impl CdpRenderer {
                     Some(cc) => (format!("{base_user}__cr.{cc}"), base_pass.clone()),
                     None => (base_user.clone(), base_pass.clone()),
                 }
-            });
+            })
+        });
         let auth_active = effective_creds.is_some();
 
         // Optionally enable request interception. Must be done before

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1406,13 +1406,23 @@ impl CdpRenderer {
         let proxy_ctx: Option<String> =
             match crate::REQUEST_PROXY.try_with(|p| p.clone()).ok().flatten() {
                 Some(entry) => {
+                    // Chrome cannot authenticate SOCKS proxies (no Fetch.authRequired
+                    // for SOCKS). Reject socks+auth on the CDP path with a clear error
+                    // rather than hanging the auth pump on an event that never fires.
+                    if !entry.supports_cdp_auth() {
+                        return Err(CrwError::RendererError(
+                            "SOCKS5 proxy authentication is not supported on the \
+                             Chrome/JS renderer; use an HTTP/HTTPS proxy for JS rendering \
+                             or a credential-less SOCKS proxy"
+                                .into(),
+                        ));
+                    }
                     let v = conn
                         .send_recv(
                             "Target.createBrowserContext",
-                            serde_json::json!({
-                                "proxyServer": entry.chrome_proxy_server(),
-                                "proxyBypassList": "<-loopback>",
-                            }),
+                            // No proxyBypassList: Chrome bypasses loopback by default,
+                            // which is what we want (don't route localhost via proxy).
+                            serde_json::json!({ "proxyServer": entry.chrome_proxy_server() }),
                             None,
                             Duration::from_secs(2),
                         )

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
 use crw_core::Deadline;
+use crw_core::ProxyRotator;
 use crw_core::error::{CrwError, CrwResult};
 use crw_core::types::FetchResult;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::traits::PageFetcher;
@@ -49,6 +51,34 @@ const STEALTH_ACCEPT: &str =
 const STEALTH_SEC_CH_UA: &str =
     r#""Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24""#;
 
+/// Build a configured reqwest client, optionally routed through `proxy`.
+///
+/// **Strict**: a malformed proxy URL or a client build failure is a hard error
+/// — we never silently fall back to a direct (no-proxy) client, which would
+/// leak the host's real IP. Used by the rotating fetcher, whose entries are
+/// already validated upstream so the error path is effectively unreachable.
+fn build_client(
+    user_agent: &str,
+    proxy: Option<&str>,
+    request_timeout: std::time::Duration,
+) -> CrwResult<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .user_agent(user_agent)
+        .connect_timeout(HTTP_CONNECT_TIMEOUT)
+        .timeout(request_timeout)
+        .redirect(crw_core::url_safety::safe_redirect_policy());
+
+    if let Some(proxy_url) = proxy {
+        let p = reqwest::Proxy::all(proxy_url)
+            .map_err(|e| CrwError::ConfigError(format!("invalid proxy URL '{proxy_url}': {e}")))?;
+        builder = builder.proxy(p);
+    }
+
+    builder
+        .build()
+        .map_err(|e| CrwError::ConfigError(format!("failed to build HTTP client: {e}")))
+}
+
 /// Simple HTTP fetcher using reqwest. No JS rendering.
 pub struct HttpFetcher {
     client: reqwest::Client,
@@ -67,36 +97,99 @@ impl HttpFetcher {
 
     /// Same as [`Self::new`] but with a caller-supplied request timeout.
     /// Used by `FallbackRenderer` to honor `RendererConfig::http_timeout()`.
+    ///
+    /// Infallible for backward compatibility: an invalid proxy URL logs and
+    /// falls back to a default client. The strict, leak-safe path is
+    /// [`RotatingHttpFetcher`] (used whenever a proxy pool/rotator is active).
     pub fn with_timeout(
         user_agent: &str,
         proxy: Option<&str>,
         inject_stealth_headers: bool,
         request_timeout: std::time::Duration,
     ) -> Self {
-        let mut builder = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .connect_timeout(HTTP_CONNECT_TIMEOUT)
-            .timeout(request_timeout)
-            .redirect(crw_core::url_safety::safe_redirect_policy());
-
-        if let Some(proxy_url) = proxy {
-            match reqwest::Proxy::all(proxy_url) {
-                Ok(p) => builder = builder.proxy(p),
-                Err(e) => tracing::warn!("Invalid proxy URL '{}': {}", proxy_url, e),
-            }
-        }
-
-        let client = match builder.build() {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!("Failed to build HTTP client: {e}, using default");
-                reqwest::Client::new()
-            }
-        };
+        let client = build_client(user_agent, proxy, request_timeout).unwrap_or_else(|e| {
+            tracing::error!("{e}, using default client");
+            reqwest::Client::new()
+        });
         Self {
             client,
             inject_stealth_headers,
         }
+    }
+}
+
+/// HTTP fetcher that rotates across a pool of proxies. One pre-built
+/// [`HttpFetcher`] (warm `reqwest::Client`, no per-request client churn) per
+/// proxy entry; the [`ProxyRotator`] picks the fetcher per request by host.
+pub struct RotatingHttpFetcher {
+    fetchers: Vec<HttpFetcher>,
+    rotator: Arc<ProxyRotator>,
+}
+
+impl RotatingHttpFetcher {
+    /// Build one fetcher per validated proxy entry with the default request
+    /// timeout. Used by the per-request BYOP path.
+    pub fn new(
+        rotator: Arc<ProxyRotator>,
+        user_agent: &str,
+        inject_stealth_headers: bool,
+    ) -> CrwResult<Self> {
+        Self::with_timeout(
+            rotator,
+            user_agent,
+            inject_stealth_headers,
+            HTTP_REQUEST_TIMEOUT,
+        )
+    }
+
+    /// Build one fetcher per validated proxy entry. Hard-fails (no silent
+    /// direct-connection fallback) if any client cannot be built.
+    pub fn with_timeout(
+        rotator: Arc<ProxyRotator>,
+        user_agent: &str,
+        inject_stealth_headers: bool,
+        request_timeout: std::time::Duration,
+    ) -> CrwResult<Self> {
+        let mut fetchers = Vec::with_capacity(rotator.len());
+        for entry in rotator.entries() {
+            let client = build_client(user_agent, Some(entry.raw()), request_timeout)?;
+            fetchers.push(HttpFetcher {
+                client,
+                inject_stealth_headers,
+            });
+        }
+        Ok(Self { fetchers, rotator })
+    }
+}
+
+#[async_trait]
+impl PageFetcher for RotatingHttpFetcher {
+    async fn fetch(
+        &self,
+        url: &str,
+        headers: &HashMap<String, String>,
+        wait_for_ms: Option<u64>,
+        deadline: Deadline,
+    ) -> CrwResult<FetchResult> {
+        let host_key = url::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(crate::preference::normalize_host));
+        let idx = self.rotator.pick_index(host_key.as_deref());
+        self.fetchers[idx]
+            .fetch(url, headers, wait_for_ms, deadline)
+            .await
+    }
+
+    fn name(&self) -> &str {
+        "http"
+    }
+
+    fn supports_js(&self) -> bool {
+        false
+    }
+
+    async fn is_available(&self) -> bool {
+        true
     }
 }
 

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -1,10 +1,8 @@
 use async_trait::async_trait;
 use crw_core::Deadline;
-use crw_core::ProxyRotator;
 use crw_core::error::{CrwError, CrwResult};
 use crw_core::types::FetchResult;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Instant;
 
 use crate::traits::PageFetcher;
@@ -98,9 +96,9 @@ impl HttpFetcher {
     /// Same as [`Self::new`] but with a caller-supplied request timeout.
     /// Used by `FallbackRenderer` to honor `RendererConfig::http_timeout()`.
     ///
-    /// Infallible for backward compatibility: an invalid proxy URL logs and
-    /// falls back to a default client. The strict, leak-safe path is
-    /// [`RotatingHttpFetcher`] (used whenever a proxy pool/rotator is active).
+    /// Infallible: callers that pass a `proxy` must pre-validate it (the renderer
+    /// does, via `ProxyEntry::parse`, so this never silently falls back for a
+    /// configured proxy). The strict per-request path is [`Self::with_proxy`].
     pub fn with_timeout(
         user_agent: &str,
         proxy: Option<&str>,
@@ -116,80 +114,22 @@ impl HttpFetcher {
             inject_stealth_headers,
         }
     }
-}
 
-/// HTTP fetcher that rotates across a pool of proxies. One pre-built
-/// [`HttpFetcher`] (warm `reqwest::Client`, no per-request client churn) per
-/// proxy entry; the [`ProxyRotator`] picks the fetcher per request by host.
-pub struct RotatingHttpFetcher {
-    fetchers: Vec<HttpFetcher>,
-    rotator: Arc<ProxyRotator>,
-}
-
-impl RotatingHttpFetcher {
-    /// Build one fetcher per validated proxy entry with the default request
-    /// timeout. Used by the per-request BYOP path.
-    pub fn new(
-        rotator: Arc<ProxyRotator>,
+    /// Build a fetcher bound to a specific proxy. **Fail-closed**: a bad proxy
+    /// URL or client build failure is a hard error — never a silent direct
+    /// (no-proxy) client. Used for per-request proxy egress (config rotation +
+    /// BYOP) so the HTTP path provably uses the selected proxy.
+    pub fn with_proxy(
         user_agent: &str,
-        inject_stealth_headers: bool,
-    ) -> CrwResult<Self> {
-        Self::with_timeout(
-            rotator,
-            user_agent,
-            inject_stealth_headers,
-            HTTP_REQUEST_TIMEOUT,
-        )
-    }
-
-    /// Build one fetcher per validated proxy entry. Hard-fails (no silent
-    /// direct-connection fallback) if any client cannot be built.
-    pub fn with_timeout(
-        rotator: Arc<ProxyRotator>,
-        user_agent: &str,
+        proxy_url: &str,
         inject_stealth_headers: bool,
         request_timeout: std::time::Duration,
     ) -> CrwResult<Self> {
-        let mut fetchers = Vec::with_capacity(rotator.len());
-        for entry in rotator.entries() {
-            let client = build_client(user_agent, Some(entry.raw()), request_timeout)?;
-            fetchers.push(HttpFetcher {
-                client,
-                inject_stealth_headers,
-            });
-        }
-        Ok(Self { fetchers, rotator })
-    }
-}
-
-#[async_trait]
-impl PageFetcher for RotatingHttpFetcher {
-    async fn fetch(
-        &self,
-        url: &str,
-        headers: &HashMap<String, String>,
-        wait_for_ms: Option<u64>,
-        deadline: Deadline,
-    ) -> CrwResult<FetchResult> {
-        let host_key = url::Url::parse(url)
-            .ok()
-            .and_then(|u| u.host_str().map(crate::preference::normalize_host));
-        let idx = self.rotator.pick_index(host_key.as_deref());
-        self.fetchers[idx]
-            .fetch(url, headers, wait_for_ms, deadline)
-            .await
-    }
-
-    fn name(&self) -> &str {
-        "http"
-    }
-
-    fn supports_js(&self) -> bool {
-        false
-    }
-
-    async fn is_available(&self) -> bool {
-        true
+        let client = build_client(user_agent, Some(proxy_url), request_timeout)?;
+        Ok(Self {
+            client,
+            inject_stealth_headers,
+        })
     }
 }
 

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -52,9 +52,10 @@ const STEALTH_SEC_CH_UA: &str =
 /// Build a configured reqwest client, optionally routed through `proxy`.
 ///
 /// **Strict**: a malformed proxy URL or a client build failure is a hard error
-/// — we never silently fall back to a direct (no-proxy) client, which would
-/// leak the host's real IP. Used by the rotating fetcher, whose entries are
-/// already validated upstream so the error path is effectively unreachable.
+/// — we never silently fall back to a direct (no-proxy) client, which would leak
+/// the host's real IP. Reached via [`HttpFetcher::with_timeout`] (infallible —
+/// callers pre-validate) and [`HttpFetcher::with_proxy`] (fail-closed per-request
+/// path for config rotation + BYOP, where the error path IS reachable).
 fn build_client(
     user_agent: &str,
     proxy: Option<&str>,

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -325,3 +325,33 @@ impl PageFetcher for HttpFetcher {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_proxy_is_fail_closed_on_bad_url() {
+        // A malformed proxy is a hard error — never a silent direct client.
+        assert!(
+            HttpFetcher::with_proxy("ua", "", false, std::time::Duration::from_secs(5)).is_err()
+        );
+        assert!(
+            HttpFetcher::with_proxy("ua", "not a url", false, std::time::Duration::from_secs(5))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn with_proxy_accepts_valid_url() {
+        assert!(
+            HttpFetcher::with_proxy(
+                "ua",
+                "http://user:pass@host:8080",
+                false,
+                std::time::Duration::from_secs(5),
+            )
+            .is_ok()
+        );
+    }
+}

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -214,6 +214,10 @@ pub struct FallbackRenderer {
     /// decides whether a 200-status block page is a soft failure (escalate
     /// toward `chrome_proxy`) or a genuine success.
     antibot: crw_core::config::AntibotConfig,
+    /// Active proxy rotator. Drives the HTTP fetcher pool and (with the `cdp`
+    /// feature) per-request CDP `proxyServer` selection. `None` = no proxy
+    /// configured → direct connections, byte-identical to prior behavior.
+    proxy_rotator: Option<Arc<crw_core::ProxyRotator>>,
     /// Chrome browser-context pool handle for graceful drain on shutdown.
     /// `None` when the pool is disabled or the chrome tier isn't configured.
     #[cfg(feature = "cdp")]
@@ -288,6 +292,7 @@ impl FallbackRenderer {
                 requests_per_second: 0.0,
                 per_host_max_concurrent: 1,
                 antibot: config.antibot.clone(),
+                proxy_rotator: None,
                 #[cfg(feature = "cdp")]
                 chrome_pool: None,
             });
@@ -477,9 +482,36 @@ impl FallbackRenderer {
             requests_per_second: 0.0,
             per_host_max_concurrent: 1,
             antibot: config.antibot.clone(),
+            proxy_rotator: None,
             #[cfg(feature = "cdp")]
             chrome_pool,
         })
+    }
+
+    /// Attach a proxy rotator built from config (or per request). When `Some`,
+    /// the HTTP fetcher is rebuilt as a [`http_only::RotatingHttpFetcher`] over
+    /// the pool, and the rotator is retained for per-request CDP `proxyServer`
+    /// selection. `None` is a no-op (keeps the direct/single-proxy fetcher from
+    /// [`Self::new`]). Builder-style so `new()`'s signature stays stable.
+    pub fn with_proxy_rotator(
+        mut self,
+        rotator: Option<Arc<crw_core::ProxyRotator>>,
+        user_agent: &str,
+        stealth: &StealthConfig,
+        http_timeout_ms: u64,
+    ) -> CrwResult<Self> {
+        if let Some(rotator) = rotator {
+            let effective_ua = pick_ua(user_agent, stealth);
+            let inject_headers = stealth.enabled && stealth.inject_headers;
+            self.http = Arc::new(http_only::RotatingHttpFetcher::with_timeout(
+                rotator.clone(),
+                &effective_ua,
+                inject_headers,
+                std::time::Duration::from_millis(http_timeout_ms),
+            )?) as Arc<dyn PageFetcher>;
+            self.proxy_rotator = Some(rotator);
+        }
+        Ok(self)
     }
 
     /// Drain the chrome browser-context pool. Idempotent and a no-op when

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -227,6 +227,11 @@ pub struct FallbackRenderer {
     /// feature) per-request CDP `proxyServer` selection. `None` = no proxy
     /// configured → direct connections, byte-identical to prior behavior.
     proxy_rotator: Option<Arc<crw_core::ProxyRotator>>,
+    /// Saved HTTP-fetcher construction inputs so a per-request proxied client
+    /// can be built on demand (when `REQUEST_PROXY` is set) without re-picking.
+    http_ua: String,
+    http_inject_stealth: bool,
+    http_timeout_ms: u64,
     /// Chrome browser-context pool handle for graceful drain on shutdown.
     /// `None` when the pool is disabled or the chrome tier isn't configured.
     #[cfg(feature = "cdp")]
@@ -259,11 +264,17 @@ impl FallbackRenderer {
     ) -> CrwResult<Self> {
         let effective_ua = pick_ua(user_agent, stealth);
         let inject_headers = stealth.enabled && stealth.inject_headers;
+        let http_timeout_ms = config.http_timeout();
+        // Fail closed: a malformed single `proxy` (e.g. CLI `--proxy htp://...`)
+        // is a hard error, never a silent direct connection (real-IP leak).
+        if let Some(p) = proxy {
+            crw_core::ProxyEntry::parse(p).map_err(CrwError::ConfigError)?;
+        }
         let http = Arc::new(http_only::HttpFetcher::with_timeout(
             &effective_ua,
             proxy,
             inject_headers,
-            std::time::Duration::from_millis(config.http_timeout()),
+            std::time::Duration::from_millis(http_timeout_ms),
         )) as Arc<dyn PageFetcher>;
 
         // A pinned backend (Lightpanda/Chrome/Playwright) must have CDP compiled in
@@ -302,6 +313,9 @@ impl FallbackRenderer {
                 per_host_max_concurrent: 1,
                 antibot: config.antibot.clone(),
                 proxy_rotator: None,
+                http_ua: effective_ua.clone(),
+                http_inject_stealth: inject_headers,
+                http_timeout_ms,
                 #[cfg(feature = "cdp")]
                 chrome_pool: None,
             });
@@ -492,35 +506,43 @@ impl FallbackRenderer {
             per_host_max_concurrent: 1,
             antibot: config.antibot.clone(),
             proxy_rotator: None,
+            http_ua: effective_ua.clone(),
+            http_inject_stealth: inject_headers,
+            http_timeout_ms,
             #[cfg(feature = "cdp")]
             chrome_pool,
         })
     }
 
-    /// Attach a proxy rotator built from config (or per request). When `Some`,
-    /// the HTTP fetcher is rebuilt as a [`http_only::RotatingHttpFetcher`] over
-    /// the pool, and the rotator is retained for per-request CDP `proxyServer`
-    /// selection. `None` is a no-op (keeps the direct/single-proxy fetcher from
-    /// [`Self::new`]). Builder-style so `new()`'s signature stays stable.
+    /// Attach the config proxy rotator. Retained so scrape/crawl entry points
+    /// can resolve a per-request proxy (via [`Self::pick_proxy_for_url`]) into
+    /// the [`REQUEST_PROXY`] task-local; the HTTP and CDP paths then both consume
+    /// that single resolved entry — no second pick. `None` is a no-op. Builder
+    /// style so `new()`'s signature stays stable.
     pub fn with_proxy_rotator(
         mut self,
         rotator: Option<Arc<crw_core::ProxyRotator>>,
-        user_agent: &str,
-        stealth: &StealthConfig,
-        http_timeout_ms: u64,
     ) -> CrwResult<Self> {
-        if let Some(rotator) = rotator {
-            let effective_ua = pick_ua(user_agent, stealth);
-            let inject_headers = stealth.enabled && stealth.inject_headers;
-            self.http = Arc::new(http_only::RotatingHttpFetcher::with_timeout(
-                rotator.clone(),
-                &effective_ua,
-                inject_headers,
-                std::time::Duration::from_millis(http_timeout_ms),
-            )?) as Arc<dyn PageFetcher>;
-            self.proxy_rotator = Some(rotator);
-        }
+        self.proxy_rotator = rotator;
         Ok(self)
+    }
+
+    /// The HTTP fetcher to use for the current request. When `REQUEST_PROXY` is
+    /// set (resolved once by the caller, honoring BYOP > config precedence),
+    /// build a client bound to THAT exact proxy so the HTTP path egresses
+    /// through the same proxy the CDP path uses. Hard-fails on a bad proxy
+    /// (never a silent direct connection). When unset, use the shared
+    /// (no-proxy or single-proxy) fetcher from `new()`.
+    fn http_fetcher_for_request(&self) -> CrwResult<Arc<dyn PageFetcher>> {
+        match REQUEST_PROXY.try_with(|p| p.clone()).ok().flatten() {
+            Some(entry) => Ok(Arc::new(http_only::HttpFetcher::with_proxy(
+                &self.http_ua,
+                entry.raw(),
+                self.http_inject_stealth,
+                std::time::Duration::from_millis(self.http_timeout_ms),
+            )?) as Arc<dyn PageFetcher>),
+            None => Ok(self.http.clone()),
+        }
     }
 
     /// Pick a proxy from the configured rotator for `host` (honoring the
@@ -664,13 +686,19 @@ impl FallbackRenderer {
         let is_hard_pinned = matches!(requested_renderer, Some(name) if name != "auto");
         match effective {
             Some(false) => {
-                let mut r = self.http.fetch(url, headers, None, deadline).await?;
+                let mut r = self
+                    .http_fetcher_for_request()?
+                    .fetch(url, headers, None, deadline)
+                    .await?;
                 stamp_http_decision(&mut r, requested_renderer);
                 Ok(r)
             }
             Some(true) => {
                 // Fetch via HTTP first to check content type — PDFs can't be JS-rendered.
-                let mut http_result = self.http.fetch(url, headers, None, deadline).await?;
+                let mut http_result = self
+                    .http_fetcher_for_request()?
+                    .fetch(url, headers, None, deadline)
+                    .await?;
                 if http_result.content_type.as_deref() == Some("application/pdf") {
                     stamp_http_decision(&mut http_result, requested_renderer);
                     return Ok(http_result);
@@ -702,7 +730,11 @@ impl FallbackRenderer {
                 // sites that reject reqwest's TLS/UA fingerprint succeed via a
                 // real Chromium navigation. Bench analysis: 10/147 false
                 // "unreachable" + 5/147 "http_502" map to this branch.
-                let mut result = match self.http.fetch(url, headers, None, deadline).await {
+                let mut result = match self
+                    .http_fetcher_for_request()?
+                    .fetch(url, headers, None, deadline)
+                    .await
+                {
                     Ok(r) => r,
                     Err(e) if !self.js_renderers.is_empty() => {
                         tracing::info!(
@@ -871,17 +903,20 @@ impl FallbackRenderer {
 
         // LightPanda has no upstream-proxy support: when a proxy is active for
         // this request, drop it so the rotated/sticky egress IP is honored
-        // (vanilla Chrome applies it via a per-context `proxyServer`). Only
-        // filter when at least one other renderer remains.
+        // (vanilla Chrome applies it via a per-context `proxyServer`). Fail
+        // CLOSED — if filtering leaves no proxy-capable JS renderer, return a
+        // hard error rather than silently navigating direct through LightPanda
+        // and leaking the host's real IP.
         let proxy_active = REQUEST_PROXY.try_with(|p| p.is_some()).unwrap_or(false);
         if proxy_active {
-            let filtered: Vec<&Arc<dyn PageFetcher>> = renderers
-                .iter()
-                .filter(|r| r.name() != "lightpanda")
-                .copied()
-                .collect();
-            if !filtered.is_empty() {
-                renderers = filtered;
+            renderers.retain(|r| r.name() != "lightpanda");
+            if renderers.is_empty() {
+                return Err(CrwError::RendererError(
+                    "a proxy is required for this request but the only available JS \
+                     renderer (lightpanda) cannot route through a proxy; configure a \
+                     chrome/chrome_proxy tier to use proxies with JS rendering"
+                        .into(),
+                ));
             }
         }
 

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -232,6 +232,11 @@ pub struct FallbackRenderer {
     http_ua: String,
     http_inject_stealth: bool,
     http_timeout_ms: u64,
+    /// Warm per-proxy HTTP fetchers keyed by `ProxyEntry::raw()`, so repeated
+    /// requests to the same proxy reuse a connection pool instead of rebuilding
+    /// a client each time. Bounded — cleared past a cap to avoid unbounded
+    /// growth under arbitrary BYOP proxies.
+    proxy_client_cache: std::sync::Mutex<std::collections::HashMap<String, Arc<dyn PageFetcher>>>,
     /// Chrome browser-context pool handle for graceful drain on shutdown.
     /// `None` when the pool is disabled or the chrome tier isn't configured.
     #[cfg(feature = "cdp")]
@@ -316,6 +321,7 @@ impl FallbackRenderer {
                 http_ua: effective_ua.clone(),
                 http_inject_stealth: inject_headers,
                 http_timeout_ms,
+                proxy_client_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
                 #[cfg(feature = "cdp")]
                 chrome_pool: None,
             });
@@ -509,6 +515,7 @@ impl FallbackRenderer {
             http_ua: effective_ua.clone(),
             http_inject_stealth: inject_headers,
             http_timeout_ms,
+            proxy_client_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
             #[cfg(feature = "cdp")]
             chrome_pool,
         })
@@ -534,15 +541,35 @@ impl FallbackRenderer {
     /// (never a silent direct connection). When unset, use the shared
     /// (no-proxy or single-proxy) fetcher from `new()`.
     fn http_fetcher_for_request(&self) -> CrwResult<Arc<dyn PageFetcher>> {
-        match REQUEST_PROXY.try_with(|p| p.clone()).ok().flatten() {
-            Some(entry) => Ok(Arc::new(http_only::HttpFetcher::with_proxy(
-                &self.http_ua,
-                entry.raw(),
-                self.http_inject_stealth,
-                std::time::Duration::from_millis(self.http_timeout_ms),
-            )?) as Arc<dyn PageFetcher>),
-            None => Ok(self.http.clone()),
+        let Some(entry) = REQUEST_PROXY.try_with(|p| p.clone()).ok().flatten() else {
+            return Ok(self.http.clone());
+        };
+        // Reuse a warm per-proxy client if we've built one before.
+        if let Some(f) = self
+            .proxy_client_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(entry.raw())
+            .cloned()
+        {
+            return Ok(f);
         }
+        let fetcher: Arc<dyn PageFetcher> = Arc::new(http_only::HttpFetcher::with_proxy(
+            &self.http_ua,
+            entry.raw(),
+            self.http_inject_stealth,
+            std::time::Duration::from_millis(self.http_timeout_ms),
+        )?);
+        let mut cache = self
+            .proxy_client_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Bound growth under arbitrary BYOP proxies (config pools are small).
+        if cache.len() >= 512 {
+            cache.clear();
+        }
+        cache.insert(entry.raw().to_string(), fetcher.clone());
+        Ok(fetcher)
     }
 
     /// Pick a proxy from the configured rotator for `host` (honoring the
@@ -1726,6 +1753,66 @@ mod tests {
             FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap();
         r.js_renderers = mocks;
         r
+    }
+
+    #[tokio::test]
+    async fn proxy_active_lightpanda_only_fails_closed() {
+        // When a proxy is active but the only JS renderer is lightpanda (which
+        // cannot proxy), fetch_with_js must hard-error, never egress direct.
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(rich_html("LP-")),
+        }) as Arc<dyn PageFetcher>;
+        let r = make_renderer_with_mocks(vec![lp]);
+        let entry = Arc::new(crw_core::ProxyEntry::parse("http://p:8080").unwrap());
+        // Call fetch_with_js directly to isolate the lightpanda guard from the
+        // HTTP pre-fetch (which would otherwise fail against the fake proxy).
+        let res = REQUEST_PROXY
+            .scope(Some(entry), async {
+                r.fetch_with_js(
+                    "https://example.com",
+                    &HashMap::new(),
+                    None,
+                    None,
+                    crw_core::Deadline::from_request_ms(5000),
+                )
+                .await
+            })
+            .await;
+        assert!(
+            res.is_err(),
+            "lightpanda-only + proxy active must fail closed, got {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_active_prefers_chrome_over_lightpanda() {
+        // With a proxy active, lightpanda is skipped and chrome (proxy-capable)
+        // serves the request.
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(rich_html("LP-")),
+        }) as Arc<dyn PageFetcher>;
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Ok(rich_html("CHROME-")),
+        }) as Arc<dyn PageFetcher>;
+        let r = make_renderer_with_mocks(vec![lp, chrome]);
+        let entry = Arc::new(crw_core::ProxyEntry::parse("http://p:8080").unwrap());
+        let res = REQUEST_PROXY
+            .scope(Some(entry), async {
+                r.fetch_with_js(
+                    "https://example.com",
+                    &HashMap::new(),
+                    None,
+                    None,
+                    crw_core::Deadline::from_request_ms(5000),
+                )
+                .await
+            })
+            .await
+            .unwrap();
+        assert_eq!(res.rendered_with.as_deref(), Some("chrome"));
     }
 
     #[tokio::test]

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -75,6 +75,15 @@ tokio::task_local! {
     pub static REQUEST_COUNTRY: Option<String>;
 }
 
+tokio::task_local! {
+    /// Resolved proxy entry for the current request, picked from the active
+    /// rotator by host. Set by the scrape/crawl entry points (via
+    /// [`FallbackRenderer::pick_proxy`]); read in `cdp.rs` to drive the
+    /// per-request Chrome `proxyServer` (a fresh proxied browser context) and
+    /// the `Fetch.authRequired` pump. `None` = no proxy → existing behaviour.
+    pub static REQUEST_PROXY: Option<Arc<crw_core::ProxyEntry>>;
+}
+
 /// Map a renderer's name string to the closed `RendererKind` enum.
 /// Returns `None` for unknown names (e.g. "playwright" — treated as a
 /// JS renderer but not tracked in metrics/preferences).
@@ -514,6 +523,27 @@ impl FallbackRenderer {
         Ok(self)
     }
 
+    /// Pick a proxy from the configured rotator for `host` (honoring the
+    /// rotation strategy). `None` when no proxy is configured. Scrape/crawl
+    /// entry points call this and scope the result into the [`REQUEST_PROXY`]
+    /// task-local so the CDP/JS path egresses through the chosen proxy.
+    pub fn pick_proxy(&self, host: Option<&str>) -> Option<Arc<crw_core::ProxyEntry>> {
+        self.proxy_rotator
+            .as_ref()
+            .map(|r| Arc::new(r.pick(host).clone()))
+    }
+
+    /// Like [`Self::pick_proxy`] but derives the host key from a URL using the
+    /// same normalization the HTTP fetcher and host limiter use — so the CDP
+    /// `proxyServer` and the HTTP client land on the SAME sticky proxy.
+    pub fn pick_proxy_for_url(&self, url: &str) -> Option<Arc<crw_core::ProxyEntry>> {
+        self.proxy_rotator.as_ref()?;
+        let host = url::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(crate::preference::normalize_host));
+        self.pick_proxy(host.as_deref())
+    }
+
     /// Drain the chrome browser-context pool. Idempotent and a no-op when
     /// the pool is disabled. Call from the server's SIGTERM handler after
     /// the HTTP server has finished serving in-flight requests.
@@ -838,6 +868,22 @@ impl FallbackRenderer {
                 .collect(),
             _ => self.js_renderers.iter().collect(),
         };
+
+        // LightPanda has no upstream-proxy support: when a proxy is active for
+        // this request, drop it so the rotated/sticky egress IP is honored
+        // (vanilla Chrome applies it via a per-context `proxyServer`). Only
+        // filter when at least one other renderer remains.
+        let proxy_active = REQUEST_PROXY.try_with(|p| p.is_some()).unwrap_or(false);
+        if proxy_active {
+            let filtered: Vec<&Arc<dyn PageFetcher>> = renderers
+                .iter()
+                .filter(|r| r.name() != "lightpanda")
+                .copied()
+                .collect();
+            if !filtered.is_empty() {
+                renderers = filtered;
+            }
+        }
 
         // Auto mode: if this host has been promoted, try Chrome first.
         if !is_user_pinned

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -1084,6 +1084,8 @@ async fn enrich_with_scrape(
                 filter_mode: None,
                 top_k: None,
                 proxy: None,
+                proxy_list: Vec::new(),
+                proxy_rotation: None,
                 country: None,
                 stealth: None,
                 actions: None,

--- a/crates/crw-server/src/routes/v2/crawl.rs
+++ b/crates/crw-server/src/routes/v2/crawl.rs
@@ -49,6 +49,12 @@ pub struct V2CrawlRequest {
     pub renderer: Option<RequestedRenderer>,
     #[serde(default)]
     pub country: Option<String>,
+    /// BYOP proxy pool (crw extension), rotated per `proxy_rotation`. Accepts the
+    /// snake_case `proxy_list` alias (what the managed layer injects).
+    #[serde(default, alias = "proxy_list")]
+    pub proxy_list: Vec<String>,
+    #[serde(default, alias = "proxy_rotation")]
+    pub proxy_rotation: Option<crw_core::proxy::ProxyRotation>,
 }
 
 #[derive(Debug, Serialize)]
@@ -125,8 +131,8 @@ pub async fn start_crawl(
         wait_for: opts.wait_for,
         renderer: v2.renderer,
         country: v2.country,
-        proxy_list: Vec::new(),
-        proxy_rotation: None,
+        proxy_list: v2.proxy_list,
+        proxy_rotation: v2.proxy_rotation,
     };
     validate_crawl_renderer(&req, &state)?;
 

--- a/crates/crw-server/src/routes/v2/crawl.rs
+++ b/crates/crw-server/src/routes/v2/crawl.rs
@@ -125,6 +125,8 @@ pub async fn start_crawl(
         wait_for: opts.wait_for,
         renderer: v2.renderer,
         country: v2.country,
+        proxy_list: Vec::new(),
+        proxy_rotation: None,
     };
     validate_crawl_renderer(&req, &state)?;
 

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -229,3 +229,47 @@ pub async fn get_scrape_job(
          use POST /v2/scrape and read the response directly"
     ))))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v2_scrape_accepts_snake_case_proxy_alias_and_threads_to_internal() {
+        // The managed layer injects snake_case proxy_list/proxy_rotation; the v2
+        // wire is camelCase, so the alias must accept both and to_internal must
+        // thread them into the engine ScrapeRequest (not drop via Default).
+        let body = serde_json::json!({
+            "url": "http://example.com",
+            "proxy_list": ["http://u:p@1.2.3.4:8080"],
+            "proxy_rotation": "round_robin",
+        });
+        let v2: V2ScrapeRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(v2.proxy_list, vec!["http://u:p@1.2.3.4:8080"]);
+        assert_eq!(
+            v2.proxy_rotation,
+            Some(crw_core::proxy::ProxyRotation::RoundRobin)
+        );
+        let (req, _, _) = to_internal(v2).unwrap();
+        assert_eq!(req.proxy_list, vec!["http://u:p@1.2.3.4:8080"]);
+        assert_eq!(
+            req.proxy_rotation,
+            Some(crw_core::proxy::ProxyRotation::RoundRobin)
+        );
+    }
+
+    #[test]
+    fn v2_scrape_camelcase_proxy_list_also_works_and_mode_is_separate() {
+        let body = serde_json::json!({
+            "url": "http://example.com",
+            "proxyList": ["http://1.2.3.4:8080"],
+            "proxy": "stealth",
+        });
+        let v2: V2ScrapeRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(v2.proxy_list, vec!["http://1.2.3.4:8080"]);
+        // `proxy` MODE is independent of the proxy_list BYOP URLs.
+        assert_eq!(v2.proxy, "stealth");
+        let (req, _, _) = to_internal(v2).unwrap();
+        assert_eq!(req.proxy_list.len(), 1);
+    }
+}

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -46,6 +46,13 @@ pub struct V2ScrapeRequest {
     /// residential chrome tier; everything else is reported as "basic".
     #[serde(default = "default_proxy")]
     pub proxy: String,
+    /// BYOP proxy pool (crw extension) rotated per `proxy_rotation`. Distinct
+    /// from the `proxy` MODE above — these are actual proxy URLs. Accepts the
+    /// snake_case `proxy_list` alias (what the managed layer injects).
+    #[serde(default, alias = "proxy_list")]
+    pub proxy_list: Vec<String>,
+    #[serde(default, alias = "proxy_rotation")]
+    pub proxy_rotation: Option<crw_core::proxy::ProxyRotation>,
     /// v2 `timeout` (ms) → engine `deadline_ms`.
     #[serde(default)]
     pub timeout: Option<u64>,
@@ -146,6 +153,8 @@ pub(crate) fn to_internal(
         summary_prompt: v2.summary_prompt,
         renderer,
         parsers: v2.parsers,
+        proxy_list: v2.proxy_list,
+        proxy_rotation: v2.proxy_rotation,
         ..Default::default()
     };
     Ok((req, decomposed, tier))

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -152,12 +152,7 @@ impl AppState {
             None,
             &config.crawler.stealth,
         )?
-        .with_proxy_rotator(
-            proxy_rotator,
-            &config.crawler.user_agent,
-            &config.crawler.stealth,
-            config.renderer.http_timeout(),
-        )?
+        .with_proxy_rotator(proxy_rotator)?
         .with_host_limits(
             config.crawler.requests_per_second,
             config.crawler.per_host_max_concurrent,

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -134,12 +134,29 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(config: AppConfig) -> CrwResult<Self> {
-        let proxy = config.crawler.proxy.as_deref();
+        // Build the proxy rotator from config (list takes precedence over the
+        // single `proxy`). When present, it owns ALL proxy routing (HTTP pool +
+        // per-request CDP proxyServer), so `new()` gets `proxy = None` and the
+        // rotator is attached via `with_proxy_rotator`. An invalid proxy URL is
+        // a hard startup error — never a silent direct-connection fallback.
+        let proxy_rotator = crw_core::ProxyRotator::build(
+            &config.crawler.proxy_list,
+            config.crawler.proxy.as_deref(),
+            config.crawler.proxy_rotation,
+        )
+        .map_err(CrwError::ConfigError)?
+        .map(Arc::new);
         let renderer = FallbackRenderer::new(
             &config.renderer,
             &config.crawler.user_agent,
-            proxy,
+            None,
             &config.crawler.stealth,
+        )?
+        .with_proxy_rotator(
+            proxy_rotator,
+            &config.crawler.user_agent,
+            &config.crawler.stealth,
+            config.renderer.http_timeout(),
         )?
         .with_host_limits(
             config.crawler.requests_per_second,

--- a/scripts/verify-proxy-rotation.sh
+++ b/scripts/verify-proxy-rotation.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Verify proxy-list rotation end-to-end against a running crw-server.
+#
+# Proves: (1) HTTP-path requests rotate across the pool, (2) JS/Chrome requests
+# egress through the per-request proxy (needs a real Chrome/CDP backend),
+# (3) a bad proxy fails closed (no direct egress).
+#
+# Requires two logging proxies. Easiest: mitmproxy (`pip install mitmproxy`),
+# which this script drives via `mitmdump`. Any forward proxy that logs requests
+# works — point PROXY_A_LOG / PROXY_B_LOG at their access logs instead.
+#
+# Usage:
+#   ./scripts/verify-proxy-rotation.sh                 # HTTP-path checks
+#   WITH_CHROME=1 ./scripts/verify-proxy-rotation.sh   # also drive a JS render
+#
+# Notes:
+#   - Start your CDP backend separately for WITH_CHROME (see docs/self-hosting).
+#   - This drives the server you point CRW_URL at; it does NOT start crw-server.
+set -euo pipefail
+
+CRW_URL="${CRW_URL:-http://localhost:3000}"
+PORT_A="${PORT_A:-8091}"
+PORT_B="${PORT_B:-8092}"
+TARGET="${TARGET:-https://example.com}"
+N="${N:-6}"
+
+if ! command -v mitmdump >/dev/null 2>&1; then
+  echo "mitmdump not found. Install with: pip install mitmproxy" >&2
+  echo "(or run two forward proxies on :$PORT_A and :$PORT_B and tail their logs)" >&2
+  exit 2
+fi
+
+tmp="$(mktemp -d)"
+log_a="$tmp/a.log"; log_b="$tmp/b.log"
+echo "logs: $log_a $log_b"
+
+# Start two logging forward proxies. `-w` writes a flow dump; we just need the
+# request lines, so use the addon stdout captured to a file.
+mitmdump --listen-port "$PORT_A" -q --set flow_detail=1 >"$log_a" 2>&1 &
+pid_a=$!
+mitmdump --listen-port "$PORT_B" -q --set flow_detail=1 >"$log_b" 2>&1 &
+pid_b=$!
+cleanup() { kill "$pid_a" "$pid_b" 2>/dev/null || true; }
+trap cleanup EXIT
+sleep 1
+
+echo "==> Configure crw-server with:"
+echo "    CRW_CRAWLER__PROXY_LIST=http://localhost:$PORT_A,http://localhost:$PORT_B"
+echo "    CRW_CRAWLER__PROXY_ROTATION=round_robin"
+echo "    (restart the server, then press enter)"
+read -r _
+
+echo "==> Firing $N HTTP-only scrapes ($TARGET)"
+for _ in $(seq "$N"); do
+  curl -s "$CRW_URL/v1/scrape" -H 'content-type: application/json' \
+    -d "{\"url\":\"$TARGET\",\"render_js\":false}" >/dev/null || true
+done
+
+hits_a=$(grep -c "CONNECT\|GET\|$TARGET" "$log_a" || true)
+hits_b=$(grep -c "CONNECT\|GET\|$TARGET" "$log_b" || true)
+echo "proxy A hits: $hits_a | proxy B hits: $hits_b"
+if [ "$hits_a" -gt 0 ] && [ "$hits_b" -gt 0 ]; then
+  echo "PASS: HTTP traffic rotated across BOTH proxies (round_robin)."
+else
+  echo "FAIL: traffic did not hit both proxies — rotation not working." >&2
+  exit 1
+fi
+
+if [ "${WITH_CHROME:-0}" = "1" ]; then
+  echo "==> Firing $N JS scrapes (render_js:true) — requires a CDP backend"
+  before_a=$hits_a; before_b=$hits_b
+  for _ in $(seq "$N"); do
+    curl -s "$CRW_URL/v1/scrape" -H 'content-type: application/json' \
+      -d "{\"url\":\"$TARGET\",\"render_js\":true}" >/dev/null || true
+  done
+  ja=$(grep -c "CONNECT\|$TARGET" "$log_a" || true)
+  jb=$(grep -c "CONNECT\|$TARGET" "$log_b" || true)
+  echo "after JS — proxy A: $ja (was $before_a) | proxy B: $jb (was $before_b)"
+  if [ "$ja" -gt "$before_a" ] || [ "$jb" -gt "$before_b" ]; then
+    echo "PASS: JS/Chrome traffic egressed through the proxy pool."
+  else
+    echo "WARN: no new proxy hits from JS path — confirm a CDP backend is running" >&2
+  fi
+fi
+
+echo
+echo "==> Leak-safety: a malformed proxy must fail closed (manual)."
+echo "    Restart with CRW_CRAWLER__PROXY_LIST=not-a-url and confirm the server"
+echo "    REFUSES TO START (ConfigError) instead of connecting directly."
+echo "DONE."


### PR DESCRIPTION
Closes #139.

Adds first-class **proxy list + rotation** so self-hosters can bring their own pool and have crw rotate across it — across the **HTTP and JS/Chrome (CDP) paths**, for **scrape, crawl, and map**, on both **/v1 and /v2**, plus the CLI.

## What
- `crawler.proxy_list` + `crawler.proxy_rotation` (`round_robin` / `random` / **`sticky_per_host`** default) — also per-request BYOP via `proxy_list`/`proxy_rotation` on scrape/crawl.
- HTTP path: warm per-proxy client pool, picked per request by host.
- JS/Chrome path: per-request `Target.createBrowserContext { proxyServer }` (Chrome 74+), driven by a `REQUEST_PROXY` task-local; the `Fetch.authRequired` pump uses the rotated proxy's credentials. LightPanda can't proxy, so it's **skipped (fail-closed)** when a proxy is active.
- **No real-IP leak**: a bad proxy is a hard error everywhere (config, CLI, crawl), never a silent direct connection.
- SOCKS5: HTTP path supported; `socks5h`→`socks5` for Chrome; SOCKS+auth rejected on the CDP path (Chrome can't auth SOCKS).

## Quality
- Reviewed across 5 adversarial multi-agent rounds (converged at 0 blocker/high). Findings + rationale in `REVIEW-FIXES.md`.
- `cargo clippy` clean (default + `cdp`); full test suite + new proxy unit/security tests green.
- Docs (`README`, `config.default.toml`) state real coverage honestly; `scripts/verify-proxy-rotation.sh` for end-to-end checks.

## Note for reviewer
JS/Chrome behavior was unit-tested with a fake CDP; **please run `scripts/verify-proxy-rotation.sh` against a real Chrome backend** to confirm live egress before relying on the JS path in production.