### PR TITLE
chore: coalesce author identities in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,8 +2,11 @@
 # contributors graph onto the maintainer's canonical identity. This is applied
 # at display time only — no commit is rewritten and no history changes.
 #
-# Format: <canonical> <alias-to-fold-in>
-us <22618852+us@users.noreply.github.com> us <rahmetsaritekin@gmail.com>
+# Format (email-only RHS = match ANY name with that email):
+#   <canonical-name> <canonical-email> <alias-email-to-fold-in>
+us <22618852+us@users.noreply.github.com> <rahmetsaritekin@gmail.com>
 us <22618852+us@users.noreply.github.com> <noreply@anthropic.com>
 us <22618852+us@users.noreply.github.com> <github-actions[bot]@users.noreply.github.com>
 us <22618852+us@users.noreply.github.com> <41898282+github-actions[bot]@users.noreply.github.com>
+us <22618852+us@users.noreply.github.com> <39339951+permissiontest@users.noreply.github.com>
+us <22618852+us@users.noreply.github.com> Recep S <22618852+us@users.noreply.github.com>


### PR DESCRIPTION
Fold every maintainer commit email (incl. the address linked to the permissiontest account, the Anthropic co-author address, and github-actions) onto the canonical `us` identity using email-only mappings, so the GitHub contributors graph shows a single author. Display-only; no history rewritten.