### PR TITLE
feat(renderer): add opt-in Camoufox stealth renderer tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "base64",
  "clap",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1016,11 +1016,12 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
+ "wiremock",
 ]
 
 [[package]]
 name = "crw-search"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1037,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ docker compose -f docker-compose.yml \
   -f docker-compose.stealth.yml --profile stealth up -d      # browserless stealth tier
 ```
 
+There's also an **optional [Camoufox](https://github.com/daijro/camoufox)
+stealth tier** (REST sidecar, opt-in) for fingerprint-blocked targets the CDP
+renderers can't pass — off by default and never touches the `auto` chain unless
+you turn it on. Build with `--features camoufox`; see [JS rendering →
+Camoufox](https://docs.fastcrw.com/#js-rendering).
+
 See the [self-hosting guide](https://docs.fastcrw.com/#self-hosting) for
 production hardening, auth, reverse proxy, and resource tuning.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,6 +197,8 @@ docker run -p 3000:3000 ghcr.io/us/crw:latest
 docker compose up
 ```
 
+还有一个**可选的 [Camoufox](https://github.com/daijro/camoufox) 隐身渲染层**（REST 边车，需手动启用），用于绕过 CDP 渲染器无法通过的指纹 / 反爬封锁——默认关闭，除非显式开启，否则绝不会进入 `auto` 链。需使用 `--features camoufox` 构建；详见 [JS 渲染 → Camoufox](https://docs.fastcrw.com/#js-渲染)。
+
 **抓取网页：**
 
 ```bash

--- a/blog/camoufox-stealth-tier.md
+++ b/blog/camoufox-stealth-tier.md
@@ -1,0 +1,95 @@
+# When Chrome Gets a 403: CRW's Opt-In Camoufox Stealth Tier
+
+> Some sites block headless Chrome on its fingerprint, not its IP. CRW now has an optional Camoufox stealth renderer for exactly those targets — off by default, opt-in per request, and it never slows down the fast path.
+
+**Published:** 2026-06-18  
+**Canonical:** https://fastcrw.com/blog/camoufox-stealth-tier
+
+---
+
+## The problem: a clean IP that still gets blocked
+
+CRW's renderer chain is built for speed. A request starts as plain HTTP, escalates to LightPanda (a lightweight browser engine) if the page needs JavaScript, and falls through to Chrome for the heavy SPAs. For IP-flagged targets there's an optional residential-proxy Chrome tier on top of that.
+
+That chain handles the vast majority of the web. But every so often you hit a site that returns a `403` even though your IP is fine, your proxy is residential, and Chrome rendered the page perfectly in your own browser. The block isn't about *where* the request came from — it's about *what* the browser looks like. Modern anti-bot systems fingerprint the browser itself: navigator properties, screen metrics, WebGL and canvas readbacks, font lists, timing quirks. Headless Chrome has tells, and some WAFs key on them.
+
+You can't proxy your way out of a fingerprint block. You need a browser that doesn't look like headless Chrome.
+
+## Why not just swap the whole renderer?
+
+The obvious move is "use a stealth browser for everything." We didn't do that, on purpose.
+
+CRW's identity is *fast and small* — a single Rust binary, low RAM, HTTP-first. A full Firefox-class stealth browser is the opposite of that: it's a heavier launch, more memory per instance, and an extra process to run. Paying that cost on every request — including the 95%+ that a plain HTTP fetch or LightPanda already handles — would throw away the thing that makes CRW worth using.
+
+So the design goal was narrower: **add stealth as a tool you reach for, without touching the fast path or changing anything for people who don't need it.**
+
+## The design: opt-in, and it means it
+
+The new tier is [Camoufox](https://github.com/daijro/camoufox) — a Firefox-based, anti-fingerprint browser — driven through the [`camofox-browser`](https://github.com/jo-inc/camofox-browser) REST sidecar. Three things keep it from leaking into anyone's setup:
+
+1. **It's a compile-time feature.** The default build doesn't include it at all. You opt in with `--features camoufox`. A normal build is byte-for-byte unchanged.
+2. **A configured endpoint does not join `auto`.** This is the part people expect to be a lie, and it isn't. Even after you point CRW at a running sidecar, it stays *out* of the automatic failover chain. You have to ask for it.
+3. **REST, not CDP.** Camoufox doesn't expose the Chrome DevTools Protocol surface CRW uses for proxy auth and resource interception, so it's reached over a small HTTP API instead — it lives entirely outside the CDP code path.
+
+There are exactly three ways to actually use it:
+
+| How | What it does |
+|-----|--------------|
+| `"renderer": "camoufox"` on a request | Hard-pin a single request to the stealth tier. |
+| `mode = "camoufox"` in config | Pin every request to it. |
+| `include_in_auto = true` | Add it as the **last** tier of the `auto` chain — tried only after the cheaper renderers fail. |
+
+If you set none of them, Camoufox never runs. That's the whole point.
+
+## Turning it on
+
+First, run the sidecar (default port `9377`):
+
+```bash
+docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser
+```
+
+Then point CRW at it in `config.toml`:
+
+```toml
+[renderer.camoufox]
+base_url = "http://127.0.0.1:9377"
+# api_key = "..."             # sent as `Authorization: Bearer` — only if you
+#                             # put the sidecar behind your own auth proxy
+# include_in_auto = false     # default: stays out of the auto chain
+# camoufox_timeout_ms = 60000 # per-request REST budget (default 60s)
+```
+
+Build with the feature on, and pin it per request:
+
+```bash
+curl -X POST http://localhost:3000/v1/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com", "renderer": "camoufox"}'
+```
+
+If the sidecar isn't reachable, CRW health-probes it and skips the tier rather than failing every request.
+
+## What happens under the hood
+
+The renderer is a small REST client, not a CDP connection. Per request it:
+
+1. `POST /tabs` — opens a fresh, isolated session and navigates to the URL.
+2. `POST /tabs/{id}/evaluate` — runs `document.documentElement.outerHTML` to pull the fully JS-rendered DOM back as a string.
+3. `DELETE /sessions/{id}` — always tears the session down, even on error, so nothing leaks server-side.
+
+That HTML string then flows through the *same* post-render pipeline as every other tier — `onlyMainContent`, include/exclude tags, markdown conversion. Nothing downstream knows or cares that the bytes came from a stealth browser, so your output shape is identical. Each request gets its own session with no cookie carry-over, and if the page comes back as a challenge wall, the tier raises a retryable error so the chain can move on instead of handing you a "Just a moment..." page.
+
+## The honest trade-offs
+
+This tier is not free, which is exactly why it's opt-in:
+
+- **It's slower and heavier.** A Firefox-class render plus a REST round-trip costs more than LightPanda or Chrome, and CRW prices it as the most expensive renderer internally. You only pay it on the requests you choose.
+- **It's another process.** Running the sidecar breaks the clean single-binary story for deployments that enable it — that's a real operational cost to weigh.
+- **You lose CDP resource blocking on this tier.** The sidecar loads the page itself, so the `Fetch`-based blocking the Chrome path uses doesn't apply here.
+
+## When to reach for it
+
+Keep `auto` as your default. Pin `camoufox` on the specific hosts where Chrome keeps coming back blocked on its fingerprint — and leave everything else on the fast path. That's the whole idea: stealth on demand, speed by default, and nothing changes for anyone who never turns it on.
+
+CRW is open source. If you want to see how the tier slots into the renderer chain without disturbing the rest, the code lives in [`crates/crw-renderer`](https://github.com/us/crw/tree/main/crates/crw-renderer), and the docs are at [JS rendering → Camoufox](https://docs.fastcrw.com/#js-rendering).

--- a/config.default.toml
+++ b/config.default.toml
@@ -19,7 +19,7 @@ rate_limit_rps = 10              # Max requests/second (global). 0 = unlimited.
 #   is small. Set to false to enforce a strict SLO regardless of tier sizing.
 
 [renderer]
-mode = "auto"                     # auto | lightpanda | playwright | chrome | none
+mode = "auto"                     # auto | lightpanda | playwright | chrome | camoufox | none
 page_timeout_ms = 30000
 pool_size = 4
 # render_js_default = true        # alias: force_js = true
@@ -45,6 +45,21 @@ ws_url = "ws://127.0.0.1:9222/"
 
 # [renderer.playwright]
 # ws_url = "ws://playwright:9222"
+
+# Opt-in Camoufox stealth tier (REST, not CDP). Requires a build with
+# `--features camoufox` AND a running camofox-browser server. Covers
+# fingerprint / bot-challenge blocks (e.g. Cloudflare 403) the CDP tiers miss.
+#
+# Opt-in semantics: a configured endpoint does NOT join the default `auto`
+# ladder. Reach it by one of:
+#   - per-request   renderer = "camoufox"   (always works once configured)
+#   - config        mode = "camoufox"       (pins every request to it)
+#   - include_in_auto = true                (joins the auto failover chain)
+# [renderer.camoufox]
+# base_url = "http://127.0.0.1:9377"
+# api_key = ""                 # optional bearer token if the sidecar is protected
+# include_in_auto = false      # default: stay out of the auto ladder
+# camoufox_timeout_ms = 60000  # optional per-request REST budget override
 
 [crawler]
 max_concurrency = 10

--- a/crates/crw-cli/Cargo.toml
+++ b/crates/crw-cli/Cargo.toml
@@ -25,6 +25,12 @@ mcp-embedded = ["dep:crw-server"]
 # Enable browse subcommand (browser automation MCP)
 browse = ["dep:crw-browse", "dep:rmcp", "dep:anyhow"]
 
+# Opt-in Camoufox stealth renderer tier (REST). Default OFF so the shipped
+# `crw` binary stays lean. Build with `--features camoufox` to enable. Forwards
+# to crw-renderer/camoufox and, when the embedded server is present, to
+# crw-server/camoufox.
+camoufox = ["crw-renderer/camoufox", "crw-server?/camoufox"]
+
 [dependencies]
 # Core crates
 crw-core = { workspace = true }

--- a/crates/crw-core/Cargo.toml
+++ b/crates/crw-core/Cargo.toml
@@ -17,6 +17,12 @@ description = "Core types, config, and error handling for the CRW web scraper"
 # CDP-less builds keep their strict `deadline_ms_default`. The workspace
 # binary enables this transitively via `crw-renderer/cdp`.
 cdp = []
+# Opt-in Camoufox stealth renderer tier (REST, not CDP). When the downstream
+# binary is built without this feature the tier is never constructable and the
+# config-level `camoufox_in_ladder()` predicate always returns false, so the
+# auto ladder and deadline math stay byte-identical to a lean build. The
+# workspace binary enables this transitively via `crw-renderer/camoufox`.
+camoufox = []
 
 [dependencies]
 crw-mcp-proto = { workspace = true }

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -179,6 +179,16 @@ pub const CDP_TIER_OVERHEAD_MS: u64 = 28_000;
 /// `types.rs::ScrapeRequest::wait_for`.
 pub const MAX_WAIT_FOR_MS: u64 = 60_000;
 
+/// Default Camoufox REST per-request budget (ms). Covers the full REST
+/// round-trip (create tab → evaluate `outerHTML` → destroy session) plus
+/// Camoufox's anti-bot navigation. 60s mirrors the established camofox-browser
+/// client navigate budget. Used by [`RendererConfig::camoufox_timeout`].
+///
+/// There is intentionally no `CAMOUFOX_*_OVERHEAD_MS` analogue to
+/// [`CDP_TIER_OVERHEAD_MS`]: Camoufox is a single REST tier, not a CDP tier,
+/// and must never be charged CDP overhead.
+pub const CAMOUFOX_DEFAULT_TIMEOUT_MS: u64 = 60_000;
+
 /// Configuration for the `/v1/search` endpoint and its SearXNG backend.
 ///
 /// When `searxng_url` is unset the endpoint returns HTTP 503 with
@@ -491,6 +501,11 @@ pub enum RendererMode {
     Lightpanda,
     Chrome,
     Playwright,
+    /// Opt-in Camoufox stealth tier (REST, not CDP). Pinning `mode = "camoufox"`
+    /// uses only this tier. See [`CamoufoxEndpoint`]. Requires the `camoufox`
+    /// build feature; a build without it rejects this mode at renderer
+    /// construction time.
+    Camoufox,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -545,6 +560,17 @@ pub struct RendererConfig {
     /// fallback tier needs more headroom than direct Chrome.
     #[serde(default)]
     pub chrome_proxy_timeout_ms: Option<u64>,
+    /// Opt-in Camoufox stealth REST endpoint. See [`CamoufoxEndpoint`].
+    /// `None` = not configured (default). Orthogonal to the CDP tiers: a
+    /// configured endpoint with the default `include_in_auto = false` does NOT
+    /// change the existing auto ladder — it is reachable only via an explicit
+    /// per-request `renderer = "camoufox"` pin or `mode = "camoufox"`.
+    #[serde(default)]
+    pub camoufox: Option<CamoufoxEndpoint>,
+    /// Per-request Camoufox REST budget override (ms). Falls back to
+    /// [`CAMOUFOX_DEFAULT_TIMEOUT_MS`] when unset.
+    #[serde(default)]
+    pub camoufox_timeout_ms: Option<u64>,
     /// Enable Chrome resource interception (`Fetch.enable` blocking of media,
     /// fonts, trackers). Default `false`; flipped after the CDP-fake suite
     /// validates pump + cleanup behaviour. See plan Phase 2.
@@ -772,6 +798,8 @@ impl Default for RendererConfig {
             chrome: None,
             chrome_proxy: None,
             chrome_proxy_timeout_ms: None,
+            camoufox: None,
+            camoufox_timeout_ms: None,
             chrome_intercept_resources: false,
             chrome_intercept_stylesheets: false,
             chrome_host_intercept_disable: Vec::new(),
@@ -814,6 +842,52 @@ impl RendererConfig {
     pub fn chrome_proxy_timeout(&self) -> u64 {
         self.chrome_proxy_timeout_ms
             .unwrap_or_else(|| self.chrome_timeout().saturating_add(15_000))
+    }
+    pub fn camoufox_timeout(&self) -> u64 {
+        self.camoufox_timeout_ms
+            .unwrap_or(CAMOUFOX_DEFAULT_TIMEOUT_MS)
+    }
+
+    /// True when the Camoufox REST tier participates in the *auto* ladder for
+    /// the current mode — i.e. it would be tried for a non-pinned request.
+    /// Distinct from merely "configured": a configured endpoint with
+    /// `include_in_auto = false` returns `false` here unless `mode == Camoufox`.
+    ///
+    /// | mode                              | result                          |
+    /// |-----------------------------------|---------------------------------|
+    /// | `None`                            | `false` (no renderers at all)   |
+    /// | `Camoufox`                        | `true` when configured (pinned) |
+    /// | `Auto` + `include_in_auto = true` | `true`                          |
+    /// | `Auto` + `include_in_auto = false`| `false` (opt-in default)        |
+    /// | `Lightpanda`/`Chrome`/`Playwright`| `false`                         |
+    ///
+    /// This method is intentionally NOT `#[cfg(feature = "camoufox")]`: callers
+    /// in the deadline math (`min_deadline_for_full_ladder_ms`,
+    /// `effective_deadline_ms`) reference it unconditionally. The leading
+    /// `cfg!(feature = "camoufox")` runtime check (compiled to a constant and
+    /// dead-code-eliminated by LLVM in the lean build) makes it always return
+    /// `false` without the feature, so HTTP-only builds stay byte-identical.
+    /// Do not remove that early return thinking it is redundant — it is what
+    /// keeps `RendererMode::Camoufox` (an unconditional enum variant) inert in
+    /// lean builds.
+    pub fn camoufox_in_ladder(&self) -> bool {
+        if !cfg!(feature = "camoufox") || matches!(self.mode, RendererMode::None) {
+            return false;
+        }
+        // Mirror the construction filter in `FallbackRenderer::new`, which only
+        // builds the tier when `base_url` is non-empty. Without this guard a
+        // degenerate config (blank `base_url` + `include_in_auto = true`) would
+        // claim ladder membership for a tier that is never constructed, leaking
+        // a phantom +camoufox_timeout into the deadline budget.
+        let configured = |c: &CamoufoxEndpoint| !c.base_url.trim().is_empty();
+        match self.mode {
+            RendererMode::Camoufox => self.camoufox.as_ref().is_some_and(configured),
+            RendererMode::Auto => self
+                .camoufox
+                .as_ref()
+                .is_some_and(|c| c.include_in_auto && configured(c)),
+            _ => false,
+        }
     }
 
     /// Compose the DataImpulse-style proxy credentials for a single request.
@@ -885,6 +959,16 @@ impl RendererConfig {
             sum = sum.saturating_add(self.http_timeout());
         }
 
+        // Camoufox REST contribution. Added BEFORE the cdp early-return below so
+        // an HTTP-only + camoufox-enabled build still extends the deadline.
+        // Camoufox is a single REST tier: it is never counted in
+        // `cdp_tier_count` and never charged `CDP_TIER_OVERHEAD_MS`.
+        // `camoufox_in_ladder()` is always `false` in the lean build, so this
+        // line is inert there.
+        if self.camoufox_in_ladder() {
+            sum = sum.saturating_add(self.camoufox_timeout());
+        }
+
         // CDP tiers only contribute when the binary was built with the `cdp`
         // feature; otherwise no JS renderer is constructable at runtime and
         // including their budgets would over-extend the deadline.
@@ -915,6 +999,26 @@ fn default_pool_size() -> usize {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CdpEndpoint {
     pub ws_url: String,
+}
+
+/// Opt-in Camoufox stealth renderer endpoint (REST, not CDP). When present it
+/// is selectable via `mode = "camoufox"` or a per-request `renderer =
+/// "camoufox"` pin, and additionally joins the Auto ladder ONLY when
+/// `include_in_auto = true`. A configured endpoint with the default
+/// `include_in_auto = false` does NOT change the existing auto ladder.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct CamoufoxEndpoint {
+    /// Base URL of the camofox-browser REST server, e.g. `http://localhost:9377`.
+    pub base_url: String,
+    /// Optional bearer token sent as `Authorization: Bearer <key>`. Empty string
+    /// (the default) means no auth header is added.
+    #[serde(default)]
+    pub api_key: String,
+    /// Whether this tier joins the Auto fallback ladder. Default `false`:
+    /// configured-but-not-in-auto, reachable only via an explicit pin or
+    /// `mode = "camoufox"`.
+    #[serde(default)]
+    pub include_in_auto: bool,
 }
 
 /// Stealth mode configuration for evading bot detection.
@@ -1344,7 +1448,13 @@ impl AppConfig {
         // extra fetch/challenge/stability overhead). Skip the extension when
         // no CDP tiers are configured so HTTP-only users keep the strict
         // operator-configured default.
-        if self.renderer.cdp_tier_count() == 0 {
+        //
+        // The opt-in Camoufox REST tier also warrants the extension when it is
+        // in the ladder (e.g. a camoufox-only, no-CDP deployment) — otherwise
+        // its 60s budget would be clamped to the strict default and starved.
+        // `camoufox_in_ladder()` is always `false` in the lean build, so
+        // HTTP-only deployments keep byte-identical behaviour here.
+        if self.renderer.cdp_tier_count() == 0 && !self.renderer.camoufox_in_ladder() {
             return default_ms;
         }
         let ladder_min = self.renderer.min_deadline_for_full_ladder_ms();
@@ -1428,6 +1538,9 @@ mod tests {
             "CRW_RENDERER__FORCE_JS",
             "CRW_RENDERER__RENDER_JS_DEFAULT",
             "CRW_RENDERER__LIGHTPANDA__WS_URL",
+            "CRW_RENDERER__CAMOUFOX__BASE_URL",
+            "CRW_RENDERER__CAMOUFOX__API_KEY",
+            "CRW_RENDERER__CAMOUFOX__INCLUDE_IN_AUTO",
             "CRW_SERVER__PORT",
         ] {
             unsafe { std::env::remove_var(k) };
@@ -1446,6 +1559,7 @@ mod tests {
             ("mode = \"lightpanda\"", RendererMode::Lightpanda),
             ("mode = \"chrome\"", RendererMode::Chrome),
             ("mode = \"playwright\"", RendererMode::Playwright),
+            ("mode = \"camoufox\"", RendererMode::Camoufox),
         ];
         for (toml_str, expected) in cases {
             let w: Wrap = toml::from_str(toml_str).unwrap();
@@ -1469,6 +1583,123 @@ mod tests {
         let cfg = RendererConfig::default();
         assert_eq!(cfg.mode, RendererMode::Auto);
         assert_eq!(cfg.render_js_default, None);
+    }
+
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_in_ladder_semantics() {
+        let ep = || CamoufoxEndpoint {
+            base_url: "http://localhost:9377".into(),
+            api_key: String::new(),
+            include_in_auto: false,
+        };
+        // (1) configured + Auto + include_in_auto=false -> NOT in auto ladder.
+        let c = RendererConfig {
+            mode: RendererMode::Auto,
+            camoufox: Some(ep()),
+            ..Default::default()
+        };
+        assert!(
+            !c.camoufox_in_ladder(),
+            "opt-in default must stay out of auto"
+        );
+        // (2) Auto + include_in_auto=true -> in ladder.
+        let c = RendererConfig {
+            mode: RendererMode::Auto,
+            camoufox: Some(CamoufoxEndpoint {
+                include_in_auto: true,
+                ..ep()
+            }),
+            ..Default::default()
+        };
+        assert!(c.camoufox_in_ladder());
+        // (3) mode=Camoufox pin + include_in_auto=false -> in ladder (pinned).
+        let c = RendererConfig {
+            mode: RendererMode::Camoufox,
+            camoufox: Some(ep()),
+            ..Default::default()
+        };
+        assert!(c.camoufox_in_ladder());
+        // (4) mode=None -> never.
+        let c = RendererConfig {
+            mode: RendererMode::None,
+            camoufox: Some(ep()),
+            ..Default::default()
+        };
+        assert!(!c.camoufox_in_ladder());
+        // (5) other CDP-pinned modes -> never.
+        let c = RendererConfig {
+            mode: RendererMode::Chrome,
+            camoufox: Some(CamoufoxEndpoint {
+                include_in_auto: true,
+                ..ep()
+            }),
+            ..Default::default()
+        };
+        assert!(!c.camoufox_in_ladder());
+        // (6) blank base_url must NOT count as in-ladder even with the flag set
+        // (mirrors the construction filter — no phantom deadline extension).
+        let c = RendererConfig {
+            mode: RendererMode::Auto,
+            camoufox: Some(CamoufoxEndpoint {
+                base_url: "   ".into(),
+                include_in_auto: true,
+                ..ep()
+            }),
+            ..Default::default()
+        };
+        assert!(!c.camoufox_in_ladder());
+        // (7) blank base_url + mode=camoufox pin -> also not in ladder.
+        let c = RendererConfig {
+            mode: RendererMode::Camoufox,
+            camoufox: Some(CamoufoxEndpoint {
+                base_url: String::new(),
+                ..ep()
+            }),
+            ..Default::default()
+        };
+        assert!(!c.camoufox_in_ladder());
+    }
+
+    #[cfg(not(feature = "camoufox"))]
+    #[test]
+    fn camoufox_in_ladder_always_false_without_feature() {
+        // Without the feature the tier can never join the ladder, even if a
+        // (deserialized) endpoint is present and mode is pinned to camoufox.
+        let c = RendererConfig {
+            mode: RendererMode::Camoufox,
+            camoufox: Some(CamoufoxEndpoint {
+                base_url: "http://localhost:9377".into(),
+                api_key: String::new(),
+                include_in_auto: true,
+            }),
+            ..Default::default()
+        };
+        assert!(!c.camoufox_in_ladder());
+    }
+
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_only_no_cdp_deadline_not_starved() {
+        // A camoufox-only deployment (no CDP tiers) with auto-extend on must
+        // get a deadline of at least http_timeout + camoufox_timeout, never
+        // clamped to the strict default.
+        let mut app = AppConfig::default();
+        app.request.auto_extend_deadline_for_ladder = true;
+        app.renderer.mode = RendererMode::Auto;
+        app.renderer.camoufox = Some(CamoufoxEndpoint {
+            base_url: "http://localhost:9377".into(),
+            api_key: String::new(),
+            include_in_auto: true,
+        });
+        let d = app.effective_deadline_ms(None, None);
+        let floor = app.renderer.http_timeout() + app.renderer.camoufox_timeout();
+        assert!(
+            d >= floor,
+            "camoufox-only deadline {d} starved below {floor}"
+        );
+        // cdp_tier_count must remain 0 — camoufox is REST, never a CDP tier.
+        assert_eq!(app.renderer.cdp_tier_count(), 0);
     }
 
     #[test]

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -116,6 +116,10 @@ pub enum RequestedRenderer {
     #[serde(rename = "chrome_proxy")]
     ChromeProxy,
     Playwright,
+    /// Opt-in Camoufox stealth tier. `rename_all = "lowercase"` already yields
+    /// `"camoufox"`, matching the internal renderer name and
+    /// `RendererKind::Camoufox`.
+    Camoufox,
 }
 
 impl RequestedRenderer {
@@ -128,6 +132,7 @@ impl RequestedRenderer {
             RequestedRenderer::Chrome => Some("chrome"),
             RequestedRenderer::ChromeProxy => Some("chrome_proxy"),
             RequestedRenderer::Playwright => Some("playwright"),
+            RequestedRenderer::Camoufox => Some("camoufox"),
         }
     }
 }
@@ -780,10 +785,24 @@ mod tests {
             ("\"lightpanda\"", RequestedRenderer::Lightpanda),
             ("\"chrome\"", RequestedRenderer::Chrome),
             ("\"playwright\"", RequestedRenderer::Playwright),
+            ("\"camoufox\"", RequestedRenderer::Camoufox),
         ] {
             let parsed: RequestedRenderer = serde_json::from_str(s).unwrap();
             assert_eq!(parsed, expected, "input {s} should parse to {expected:?}");
         }
+    }
+
+    #[test]
+    fn requested_renderer_camoufox_round_trip() {
+        let parsed: RequestedRenderer = serde_json::from_str("\"camoufox\"").unwrap();
+        assert_eq!(parsed, RequestedRenderer::Camoufox);
+        let json = serde_json::to_string(&RequestedRenderer::Camoufox).unwrap();
+        assert_eq!(json, "\"camoufox\"");
+        assert_eq!(
+            resolve_pinned_renderer(Some(RequestedRenderer::Camoufox)),
+            Some("camoufox")
+        );
+        assert_eq!(RendererKind::Camoufox.as_str(), "camoufox");
     }
 
     #[test]
@@ -1338,6 +1357,11 @@ pub enum RendererKind {
     Chrome,
     #[serde(rename = "chrome_proxy")]
     ChromeProxy,
+    /// Opt-in Camoufox stealth tier (REST). `rename_all = "lowercase"` yields
+    /// `"camoufox"`. Unconditional (not feature-gated) like every other kind —
+    /// the variant is inert in lean builds since no camoufox renderer is ever
+    /// constructed there.
+    Camoufox,
 }
 
 impl RendererKind {
@@ -1347,6 +1371,7 @@ impl RendererKind {
             RendererKind::Lightpanda => "lightpanda",
             RendererKind::Chrome => "chrome",
             RendererKind::ChromeProxy => "chrome_proxy",
+            RendererKind::Camoufox => "camoufox",
         }
     }
 }

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -118,8 +118,8 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                     },
                     "renderer": {
                         "type": "string",
-                        "enum": ["auto", "lightpanda", "chrome", "playwright"],
-                        "description": "Pin renderer; non-auto hard-pins and implies renderJs:true (default auto)"
+                        "enum": ["auto", "lightpanda", "chrome", "playwright", "camoufox"],
+                        "description": "Pin renderer; non-auto hard-pins and implies renderJs:true (default auto). 'camoufox' requires the server's opt-in camoufox tier to be configured."
                     }
                 },
                 "required": ["url"]
@@ -166,8 +166,8 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                     },
                     "renderer": {
                         "type": "string",
-                        "enum": ["auto", "lightpanda", "chrome", "playwright"],
-                        "description": "Pin renderer; non-auto hard-pins and implies renderJs:true (default auto)"
+                        "enum": ["auto", "lightpanda", "chrome", "playwright", "camoufox"],
+                        "description": "Pin renderer; non-auto hard-pins and implies renderJs:true (default auto). 'camoufox' requires the server's opt-in camoufox tier to be configured."
                     }
                 },
                 "required": ["url"]
@@ -820,6 +820,7 @@ mod tests {
                 json!("lightpanda"),
                 json!("chrome"),
                 json!("playwright"),
+                json!("camoufox"),
             ]
         );
     }
@@ -843,11 +844,12 @@ mod tests {
         let enum_vals = props["renderer"]["enum"]
             .as_array()
             .expect("renderer.enum must be an array");
-        assert_eq!(enum_vals.len(), 4);
+        assert_eq!(enum_vals.len(), 5);
         assert!(enum_vals.iter().any(|v| v == "chrome"));
         assert!(enum_vals.iter().any(|v| v == "lightpanda"));
         assert!(enum_vals.iter().any(|v| v == "auto"));
         assert!(enum_vals.iter().any(|v| v == "playwright"));
+        assert!(enum_vals.iter().any(|v| v == "camoufox"));
     }
 
     #[test]

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -13,6 +13,11 @@ description = "HTTP and CDP browser rendering engine for the CRW web scraper"
 default = []
 cdp = ["tokio-tungstenite", "crw-core/cdp"]
 auto-browser = ["dep:dirs"]
+# Opt-in Camoufox stealth renderer tier (REST, not CDP). Gates the `camoufox`
+# module and its construction in `FallbackRenderer::new`. Default off so the
+# lean build is byte-identical. Forwards to `crw-core/camoufox` for the
+# config-level predicate and deadline math.
+camoufox = ["crw-core/camoufox"]
 
 [dependencies]
 crw-core = { workspace = true }
@@ -41,3 +46,4 @@ axum = { workspace = true }
 tokio = { workspace = true }
 flate2 = "1"
 brotli = "8"
+wiremock = { workspace = true }

--- a/crates/crw-renderer/src/breaker.rs
+++ b/crates/crw-renderer/src/breaker.rs
@@ -494,7 +494,7 @@ const REGISTRY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 #[derive(Clone)]
 pub struct BreakerRegistry {
     config: BreakerConfig,
-    global: Arc<[(RendererKind, Arc<CircuitBreaker>); 4]>,
+    global: Arc<[(RendererKind, Arc<CircuitBreaker>); 5]>,
     host: Cache<(String, RendererKind), Arc<CircuitBreaker>>,
 }
 
@@ -509,6 +509,13 @@ impl BreakerRegistry {
             (RendererKind::Chrome, Arc::new(CircuitBreaker::new(config))),
             (
                 RendererKind::ChromeProxy,
+                Arc::new(CircuitBreaker::new(config)),
+            ),
+            // Unconditional (like every other kind). Harmless dead capacity in
+            // lean builds — gating the fixed-size array on a feature would
+            // complicate its type for no behavioural gain.
+            (
+                RendererKind::Camoufox,
                 Arc::new(CircuitBreaker::new(config)),
             ),
         ]);
@@ -537,7 +544,7 @@ impl BreakerRegistry {
                 return Arc::clone(breaker);
             }
         }
-        unreachable!("RendererKind is closed: Http | Lightpanda | Chrome | ChromeProxy")
+        unreachable!("RendererKind is closed: Http | Lightpanda | Chrome | ChromeProxy | Camoufox")
     }
 
     pub async fn host_for(&self, host: &str, renderer: RendererKind) -> Arc<CircuitBreaker> {
@@ -1082,7 +1089,14 @@ mod tests {
     #[test]
     fn registry_has_breaker_for_chrome_proxy() {
         let reg = BreakerRegistry::with_defaults();
-        // Must not panic: global_for iterates a fixed 4-element array now.
+        // Must not panic: global_for iterates a fixed 5-element array now.
         let _ = reg.global_for(RendererKind::ChromeProxy);
+    }
+
+    #[test]
+    fn registry_has_breaker_for_camoufox() {
+        let reg = BreakerRegistry::with_defaults();
+        // Must not panic: the camoufox kind is a registered (5th) global tier.
+        let _ = reg.global_for(RendererKind::Camoufox);
     }
 }

--- a/crates/crw-renderer/src/camoufox.rs
+++ b/crates/crw-renderer/src/camoufox.rs
@@ -1,0 +1,662 @@
+//! Camoufox stealth renderer tier (opt-in, REST — not CDP).
+//!
+//! Backed by a [`camofox-browser`](https://github.com/jo-inc/camofox-browser)
+//! REST sidecar (default port `9377`) which drives a Camoufox (Firefox-fork)
+//! browser with C++-level fingerprint spoofing. This tier covers
+//! fingerprint/bot-challenge blocks (e.g. Cloudflare 403) that the CDP tiers
+//! cannot pass.
+//!
+//! ## Why REST, not CDP
+//! Camoufox does not expose a usable Chromium-CDP `Fetch.*` surface, so it is
+//! reached over the sidecar's HTTP API instead of the [`crate::cdp`] path. The
+//! renderer is a plain [`reqwest::Client`] — it never touches `cdp.rs`.
+//!
+//! ## Sequence (per request, fresh session — no cookie carry-over)
+//! 1. `POST {base}/tabs` `{userId, sessionKey, url}` → `{tabId, url}` (the
+//!    `url` body navigates the new tab as it is created).
+//! 2. `POST {base}/tabs/{tabId}/evaluate` `{userId, expression}` with
+//!    `expression = "document.documentElement.outerHTML"` → `{ok, result}`.
+//!    `result` is the fully JS-rendered DOM string — exactly what CRW's
+//!    post-render pipeline (`only_main_content`, tag filters, markdown) needs.
+//! 3. `DELETE {base}/sessions/{userId}` — ALWAYS, even on error, so the sidecar
+//!    never leaks a server-side session.
+//!
+//! The endpoint contract above is from the camofox-browser `openapi.json`.
+
+use async_trait::async_trait;
+use crw_core::Deadline;
+use crw_core::error::{CrwError, CrwResult};
+use crw_core::types::FetchResult;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::traits::PageFetcher;
+
+/// JS expression evaluated to retrieve the post-render DOM.
+const OUTER_HTML_EXPR: &str = "document.documentElement.outerHTML";
+/// Fixed budget for the best-effort session cleanup. Deliberately NOT derived
+/// from the request deadline: a hung cleanup must never consume the caller's
+/// remaining budget.
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+/// Budget for the `is_available` health probe.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Opt-in Camoufox stealth renderer. Construct via [`CamoufoxRenderer::new`].
+pub struct CamoufoxRenderer {
+    name: String,
+    /// Trimmed base URL, no trailing slash (e.g. `http://localhost:9377`).
+    base_url: String,
+    /// Bearer token; empty string means no `Authorization` header is sent.
+    api_key: String,
+    /// Overall per-request REST budget (`config.camoufox_timeout()`).
+    timeout: Duration,
+    client: reqwest::Client,
+}
+
+impl CamoufoxRenderer {
+    pub fn new(name: &str, base_url: &str, api_key: &str, timeout_ms: u64) -> Self {
+        Self {
+            name: name.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            timeout: Duration::from_millis(timeout_ms),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Attach the bearer header when an API key is configured.
+    fn auth(&self, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if self.api_key.is_empty() {
+            rb
+        } else {
+            rb.bearer_auth(&self.api_key)
+        }
+    }
+
+    /// Random opaque identifier (`<prefix>` + 32 hex chars). Fresh per request
+    /// so sessions never share cookies — safer for stealth.
+    fn rand_id(prefix: &str) -> String {
+        let n: u128 = rand::random();
+        format!("{prefix}{n:032x}")
+    }
+
+    /// Remaining budget for the next REST call: the smaller of the request
+    /// deadline's remaining time and the configured camoufox timeout. This is
+    /// the single source of the clamp formula — every REST call uses it.
+    fn call_budget(&self, deadline: &Deadline) -> Duration {
+        deadline.remaining().min(self.timeout)
+    }
+
+    /// Send a JSON POST, honoring the deadline, and parse a JSON response.
+    /// Maps transport/timeout/non-2xx into the appropriate [`CrwError`].
+    async fn post_json(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+        deadline: &Deadline,
+    ) -> CrwResult<serde_json::Value> {
+        let budget = self.call_budget(deadline);
+        if budget.is_zero() {
+            return Err(CrwError::Timeout(
+                deadline.overrun().as_millis().max(1) as u64
+            ));
+        }
+        let url = format!("{}{}", self.base_url, path);
+        let fut = self.auth(self.client.post(&url).json(body)).send();
+        let resp = tokio::time::timeout(budget, fut)
+            .await
+            .map_err(|_| CrwError::Timeout(budget.as_millis() as u64))?
+            .map_err(|e| CrwError::RendererError(format!("camoufox POST {path}: {e}")))?;
+        let status = resp.status();
+        let value: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| CrwError::RendererError(format!("camoufox POST {path} body: {e}")))?;
+        if !status.is_success() {
+            let msg = value
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or("unknown error");
+            return Err(CrwError::RendererError(format!(
+                "camoufox POST {path} -> HTTP {}: {msg}",
+                status.as_u16()
+            )));
+        }
+        Ok(value)
+    }
+
+    /// Create a fresh tab navigated to `url`. Returns its `tabId`. Some sidecar
+    /// builds intermittently omit `tabId` under proxy-IP races on the first
+    /// attempt, so we retry exactly once before failing.
+    async fn create_tab(
+        &self,
+        url: &str,
+        user_id: &str,
+        session_key: &str,
+        deadline: &Deadline,
+    ) -> CrwResult<String> {
+        let body = serde_json::json!({
+            "userId": user_id,
+            "sessionKey": session_key,
+            "url": url,
+        });
+        for attempt in 0..2u8 {
+            let value = self.post_json("/tabs", &body, deadline).await?;
+            if let Some(tab_id) = value.get("tabId").and_then(|t| t.as_str()) {
+                return Ok(tab_id.to_string());
+            }
+            tracing::debug!(
+                renderer = %self.name,
+                attempt,
+                "camoufox create tab returned no tabId, retrying"
+            );
+        }
+        Err(CrwError::RendererError(
+            "camoufox: create tab returned no tabId after retry".into(),
+        ))
+    }
+
+    /// Evaluate `document.documentElement.outerHTML` and return the DOM string.
+    async fn evaluate_outer_html(
+        &self,
+        tab_id: &str,
+        user_id: &str,
+        deadline: &Deadline,
+    ) -> CrwResult<String> {
+        let body = serde_json::json!({
+            "userId": user_id,
+            "expression": OUTER_HTML_EXPR,
+        });
+        let value = self
+            .post_json(&format!("/tabs/{tab_id}/evaluate"), &body, deadline)
+            .await?;
+        // Shape: { ok: bool, result: <any> }. For outerHTML, result is a string.
+        if value.get("ok").and_then(|o| o.as_bool()) == Some(false) {
+            return Err(CrwError::RendererError(
+                "camoufox: evaluate returned ok=false".into(),
+            ));
+        }
+        match value.get("result").and_then(|r| r.as_str()) {
+            Some(html) => Ok(html.to_string()),
+            None => Err(CrwError::RendererError(
+                "camoufox: evaluate result was not an HTML string".into(),
+            )),
+        }
+    }
+
+    /// Best-effort session teardown. Uses [`CLEANUP_TIMEOUT`] (NOT the request
+    /// deadline) and swallows every error — a failed cleanup is logged, never
+    /// propagated.
+    async fn destroy_session(&self, user_id: &str) {
+        let url = format!("{}/sessions/{}", self.base_url, user_id);
+        let fut = self.auth(self.client.delete(&url)).send();
+        match tokio::time::timeout(CLEANUP_TIMEOUT, fut).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => tracing::warn!(
+                renderer = %self.name, user_id, "camoufox session cleanup failed: {e}"
+            ),
+            Err(_) => tracing::warn!(
+                renderer = %self.name,
+                user_id,
+                "camoufox session cleanup timed out after {}s (leaked server-side session)",
+                CLEANUP_TIMEOUT.as_secs()
+            ),
+        }
+    }
+
+    /// Full create → evaluate sequence with GUARANTEED cleanup. The inner
+    /// result is bound first, then `destroy_session` runs at statement level so
+    /// it fires on both the Ok and Err paths, and only afterward is the result
+    /// returned.
+    async fn run_sequence(
+        &self,
+        url: &str,
+        user_id: &str,
+        session_key: &str,
+        deadline: &Deadline,
+    ) -> CrwResult<(u16, String)> {
+        let inner = self
+            .run_sequence_inner(url, user_id, session_key, deadline)
+            .await;
+        self.destroy_session(user_id).await;
+        inner
+    }
+
+    async fn run_sequence_inner(
+        &self,
+        url: &str,
+        user_id: &str,
+        session_key: &str,
+        deadline: &Deadline,
+    ) -> CrwResult<(u16, String)> {
+        let tab_id = self.create_tab(url, user_id, session_key, deadline).await?;
+        let html = self.evaluate_outer_html(&tab_id, user_id, deadline).await?;
+        // A bot wall or an empty body is a failure for THIS tier — surface it as
+        // a retryable RendererError so the fallback loop / breaker can react.
+        if html.trim().is_empty() {
+            return Err(CrwError::RendererError(
+                "camoufox: evaluate returned empty HTML".into(),
+            ));
+        }
+        if let Some(kind) = looks_like_wall(&html) {
+            return Err(CrwError::RendererError(format!(
+                "camoufox: bot {kind} detected in rendered HTML"
+            )));
+        }
+        // The /evaluate path does not surface the page's HTTP status; the
+        // navigation in `create_tab` already succeeded server-side, so 200.
+        Ok((200, html))
+    }
+}
+
+/// Heuristic detection of a bot wall / challenge interstitial in rendered HTML.
+/// Returns the wall kind when matched. These markers are CRW-specific (the
+/// stock camofox-browser client does not classify walls); they let the tier
+/// report a retryable failure instead of returning a useless challenge page.
+fn looks_like_wall(html: &str) -> Option<&'static str> {
+    let h = html.to_ascii_lowercase();
+    const NEEDLES: &[(&str, &str)] = &[
+        ("just a moment", "challenge"),
+        ("verifying you are human", "challenge"),
+        ("checking your browser before", "challenge"),
+        ("cf-challenge", "challenge"),
+        ("/cdn-cgi/challenge-platform", "challenge"),
+        ("attention required! | cloudflare", "wall"),
+        ("enable javascript and cookies to continue", "wall"),
+    ];
+    NEEDLES
+        .iter()
+        .find(|(needle, _)| h.contains(needle))
+        .map(|(_, kind)| *kind)
+}
+
+#[async_trait]
+impl PageFetcher for CamoufoxRenderer {
+    async fn fetch(
+        &self,
+        url: &str,
+        _headers: &HashMap<String, String>,
+        _wait_for_ms: Option<u64>,
+        deadline: Deadline,
+    ) -> CrwResult<FetchResult> {
+        if deadline.expired() {
+            return Err(CrwError::Timeout(
+                deadline.overrun().as_millis().max(1) as u64
+            ));
+        }
+        let start = Instant::now();
+        let user_id = Self::rand_id("crw_");
+        let session_key = Self::rand_id("task_");
+        let (status, html) = self
+            .run_sequence(url, &user_id, &session_key, &deadline)
+            .await?;
+
+        Ok(FetchResult {
+            url: url.to_string(),
+            final_url: None,
+            status_code: status,
+            html,
+            content_type: None,
+            raw_bytes: None,
+            rendered_with: Some(self.name.clone()),
+            elapsed_ms: start.elapsed().as_millis() as u64,
+            warning: None,
+            render_decision: None,
+            credit_cost: 0,
+            warnings: Vec::new(),
+            truncated: false,
+            deadline_exceeded: deadline.remaining().is_zero(),
+            captured_responses: Vec::new(),
+        })
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn supports_js(&self) -> bool {
+        true
+    }
+
+    /// Health probe against `GET {base}/health`. Mirrors the camofox-browser
+    /// client's availability check. Cheap (~5s cap) so the FallbackRenderer can
+    /// skip a down sidecar instead of paying the full per-request budget.
+    async fn is_available(&self) -> bool {
+        let url = format!("{}/health", self.base_url);
+        let fut = self.auth(self.client.get(&url)).send();
+        matches!(
+            tokio::time::timeout(PROBE_TIMEOUT, fut).await,
+            Ok(Ok(r)) if r.status().is_success()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn renderer(base_url: &str) -> CamoufoxRenderer {
+        CamoufoxRenderer::new("camoufox", base_url, "", 30_000)
+    }
+
+    fn deadline() -> Deadline {
+        Deadline::from_request_ms(30_000)
+    }
+
+    async fn mount_delete_session(server: &MockServer) {
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/sessions/.+"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true, "closed": 1
+            })))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_html_and_cleans_up() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "tabId": "t1", "url": "https://example.com"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs/t1/evaluate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": "<html><body>real content well over the empty threshold here</body></html>"
+            })))
+            .mount(&server)
+            .await;
+        // Expect cleanup to fire exactly once.
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/sessions/.+"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let r = renderer(&server.uri());
+        let res = r
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect("fetch should succeed");
+        assert_eq!(res.rendered_with.as_deref(), Some("camoufox"));
+        assert_eq!(res.status_code, 200);
+        assert!(res.html.contains("real content"));
+        // server drop verifies the expect(1) on the DELETE mock
+    }
+
+    #[tokio::test]
+    async fn cleanup_fires_on_evaluate_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"tabId": "t1"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs/t1/evaluate"))
+            .respond_with(
+                ResponseTemplate::new(500).set_body_json(serde_json::json!({"error": "boom"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/sessions/.+"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .expect(1) // cleanup MUST fire even though evaluate failed
+            .mount(&server)
+            .await;
+
+        let r = renderer(&server.uri());
+        let err = r
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect_err("evaluate 500 should error");
+        assert!(matches!(err, CrwError::RendererError(_)));
+    }
+
+    /// Helper: mock create-tab OK + evaluate returning `eval_body`, with a
+    /// cleanup mock that MUST fire once. Returns the started server.
+    async fn server_with_evaluate(eval_body: serde_json::Value) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"tabId": "t1"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs/t1/evaluate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(eval_body))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/sessions/.+"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .expect(1) // cleanup must fire on every error path below
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn empty_html_errors_and_cleans_up() {
+        let server = server_with_evaluate(serde_json::json!({"ok": true, "result": "   "})).await;
+        let err = renderer(&server.uri())
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect_err("empty HTML should error");
+        match err {
+            CrwError::RendererError(m) => assert!(m.contains("empty HTML")),
+            other => panic!("expected RendererError, got {other:?}"),
+        }
+        // server drop verifies cleanup expect(1)
+    }
+
+    #[tokio::test]
+    async fn evaluate_ok_false_errors_and_cleans_up() {
+        let server = server_with_evaluate(serde_json::json!({"ok": false})).await;
+        let err = renderer(&server.uri())
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect_err("ok=false should error");
+        match err {
+            CrwError::RendererError(m) => assert!(m.contains("ok=false")),
+            other => panic!("expected RendererError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn evaluate_non_string_result_errors_and_cleans_up() {
+        // result is a number, not the expected HTML string.
+        let server = server_with_evaluate(serde_json::json!({"ok": true, "result": 42})).await;
+        let err = renderer(&server.uri())
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect_err("non-string result should error");
+        match err {
+            CrwError::RendererError(m) => assert!(m.contains("not an HTML string")),
+            other => panic!("expected RendererError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_tab_id_retries_once_then_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(2) // first attempt + one retry
+            .mount(&server)
+            .await;
+        mount_delete_session(&server).await;
+
+        let r = renderer(&server.uri());
+        let err = r
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect_err("missing tabId should error");
+        match err {
+            CrwError::RendererError(m) => assert!(m.contains("no tabId")),
+            other => panic!("expected RendererError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn wall_detection_returns_retryable_renderer_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"tabId": "t1"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tabs/t1/evaluate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": "<html><head><title>Just a moment...</title></head><body>verifying you are human</body></html>"
+            })))
+            .mount(&server)
+            .await;
+        mount_delete_session(&server).await;
+
+        let r = renderer(&server.uri());
+        let err = r
+            .fetch("https://example.com", &HashMap::new(), None, deadline())
+            .await
+            .expect_err("wall should error");
+        match err {
+            CrwError::RendererError(m) => assert!(m.contains("challenge")),
+            other => panic!("expected RendererError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_deadline_short_circuits_without_http() {
+        // No mocks mounted: if any HTTP call were made it would 404 and the
+        // error message would differ from a Timeout.
+        let server = MockServer::start().await;
+        let r = renderer(&server.uri());
+        let err = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(0),
+            )
+            .await
+            .expect_err("expired deadline should error immediately");
+        assert!(matches!(err, CrwError::Timeout(_)));
+    }
+
+    #[tokio::test]
+    async fn is_available_true_when_health_ok() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+        assert!(renderer(&server.uri()).is_available().await);
+    }
+
+    #[tokio::test]
+    async fn is_available_false_when_health_503() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/health"))
+            .respond_with(
+                ResponseTemplate::new(503).set_body_json(serde_json::json!({"ok": false})),
+            )
+            .mount(&server)
+            .await;
+        assert!(!renderer(&server.uri()).is_available().await);
+    }
+
+    #[test]
+    fn wall_needles_match_and_clean_html_passes() {
+        assert_eq!(looks_like_wall("Just a moment..."), Some("challenge"));
+        assert_eq!(
+            looks_like_wall("<script src=/cdn-cgi/challenge-platform/x>"),
+            Some("challenge")
+        );
+        assert_eq!(
+            looks_like_wall("<div class=cf-challenge>"),
+            Some("challenge")
+        );
+        assert_eq!(
+            looks_like_wall("Verifying you are human"),
+            Some("challenge")
+        );
+        assert_eq!(
+            looks_like_wall("Checking your browser before access"),
+            Some("challenge")
+        );
+        assert_eq!(
+            looks_like_wall("<h1>Attention Required! | Cloudflare</h1>"),
+            Some("wall")
+        );
+        assert_eq!(
+            looks_like_wall("Please enable JavaScript and cookies to continue"),
+            Some("wall")
+        );
+        assert_eq!(
+            looks_like_wall("<html><body>normal page</body></html>"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_uses_fixed_timeout_not_request_deadline() {
+        // A near-exhausted request deadline must NOT prevent cleanup from
+        // running: cleanup has its own fixed budget. We give a tiny deadline so
+        // the fetch fails fast (budget exhausted mid-sequence), then assert the
+        // DELETE cleanup still fired exactly once.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tabs"))
+            .respond_with(
+                // Large delay (2s) vs the 5ms deadline gives a ~400x margin, so
+                // the create-tab call deterministically times out before its
+                // response arrives even under heavy CI load — no flakiness.
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(2))
+                    .set_body_json(serde_json::json!({"tabId": "t1"})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/sessions/.+"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let r = renderer(&server.uri());
+        // 5ms deadline << 2s create-tab delay -> create_tab times out, but
+        // cleanup (fixed 5s budget) must still fire.
+        let err = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(5),
+            )
+            .await
+            .expect_err("tiny deadline should error");
+        assert!(matches!(err, CrwError::Timeout(_)));
+        // server drop verifies cleanup expect(1) despite the exhausted deadline
+    }
+}

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -39,6 +39,8 @@ pub mod breaker;
 pub mod browser;
 #[cfg(feature = "cdp")]
 pub mod browser_pool;
+#[cfg(feature = "camoufox")]
+pub mod camoufox;
 #[cfg(feature = "cdp")]
 pub mod cdp;
 #[cfg(feature = "cdp")]
@@ -93,6 +95,7 @@ fn renderer_kind_for(name: &str) -> Option<RendererKind> {
         "lightpanda" => Some(RendererKind::Lightpanda),
         "chrome" => Some(RendererKind::Chrome),
         "chrome_proxy" => Some(RendererKind::ChromeProxy),
+        "camoufox" => Some(RendererKind::Camoufox),
         _ => None,
     }
 }
@@ -140,6 +143,14 @@ fn tier_timeouts_from(
         RendererKind::ChromeProxy,
         std::time::Duration::from_millis(config.chrome_proxy_timeout()),
     );
+    // Unconditional: `camoufox_timeout()` exists regardless of feature. The map
+    // entry is consulted only when a camoufox renderer is actually in the pool,
+    // so an unused entry in lean builds is harmless and keeps this function
+    // feature-free.
+    m.insert(
+        RendererKind::Camoufox,
+        std::time::Duration::from_millis(config.camoufox_timeout()),
+    );
     m
 }
 
@@ -153,6 +164,12 @@ fn credit_for(kind: RendererKind) -> u32 {
         // Engine-internal cost only. SaaS billing reads request-body
         // `renderer` string and still charges 1 credit per scrape regardless.
         RendererKind::ChromeProxy => 2,
+        // Camoufox stealth: a full real-browser render (≈Chrome=2) plus the
+        // REST create-tab/evaluate/destroy-session round-trip and anti-bot
+        // warm-up, ≈1.5× Chrome rounded up. Engine-internal cost only (the same
+        // SaaS-billing note as ChromeProxy applies). Revisit to 2 if operational
+        // metrics show parity with Chrome.
+        RendererKind::Camoufox => 3,
     }
 }
 
@@ -241,6 +258,12 @@ pub struct FallbackRenderer {
     /// `None` when the pool is disabled or the chrome tier isn't configured.
     #[cfg(feature = "cdp")]
     chrome_pool: Option<Arc<browser_pool::BrowserContextPool<cdp_conn::CdpConnection>>>,
+    /// Whether the (constructed) camoufox tier participates in the auto ladder
+    /// for this instance's mode. Drives the non-pinned pool filter in
+    /// `fetch_with_js`: when false, a configured camoufox renderer is reachable
+    /// only by an explicit `renderer = "camoufox"` pin, never the auto chain.
+    #[cfg(feature = "camoufox")]
+    camoufox_in_auto: bool,
 }
 
 impl std::fmt::Debug for FallbackRenderer {
@@ -297,6 +320,19 @@ impl FallbackRenderer {
             )));
         }
 
+        // Camoufox is REST, not CDP — it requires the `camoufox` feature
+        // independently of `cdp`. Separate top-level guard (never nested in the
+        // cdp block above) so a camoufox-less build rejects the pin cleanly.
+        #[cfg(not(feature = "camoufox"))]
+        if matches!(config.mode, RendererMode::Camoufox) {
+            return Err(CrwError::ConfigError(
+                "renderer.mode = \"camoufox\" requires the 'camoufox' feature, but this build \
+                 was compiled without it. Rebuild with --features camoufox or set mode = \
+                 \"auto\"/\"none\"."
+                    .into(),
+            ));
+        }
+
         #[allow(unused_mut)]
         let mut js_renderers: Vec<Arc<dyn PageFetcher>> = Vec::new();
 
@@ -324,6 +360,10 @@ impl FallbackRenderer {
                 proxy_client_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
                 #[cfg(feature = "cdp")]
                 chrome_pool: None,
+                // mode=none constructs no renderers, so camoufox is never in
+                // the (empty) ladder.
+                #[cfg(feature = "camoufox")]
+                camoufox_in_auto: false,
             });
         }
 
@@ -488,6 +528,39 @@ impl FallbackRenderer {
             }
         }
 
+        // Camoufox REST tier — a TOP-LEVEL block, NOT nested in the cdp guard
+        // above (camoufox is REST, not CDP). The renderer is constructed
+        // whenever an endpoint is configured, so an explicit per-request
+        // `renderer = "camoufox"` pin can always reach it. Whether it
+        // participates in the *auto* (non-pinned) chain is decided at request
+        // time in `fetch_with_js` via `camoufox_in_auto` — a configured
+        // endpoint with `include_in_auto = false` stays out of the auto ladder.
+        #[cfg(feature = "camoufox")]
+        {
+            if let Some(cf) = config
+                .camoufox
+                .as_ref()
+                .filter(|c| !c.base_url.trim().is_empty())
+            {
+                js_renderers.push(Arc::new(camoufox::CamoufoxRenderer::new(
+                    "camoufox",
+                    &cf.base_url,
+                    &cf.api_key,
+                    config.camoufox_timeout(),
+                )) as Arc<dyn PageFetcher>);
+                tracing::info!(
+                    base_url = %cf.base_url,
+                    include_in_auto = cf.include_in_auto,
+                    "camoufox tier enabled"
+                );
+            } else if matches!(config.mode, RendererMode::Camoufox) {
+                return Err(CrwError::ConfigError(
+                    "renderer.mode = \"camoufox\" but [renderer.camoufox] base_url is not configured"
+                        .into(),
+                ));
+            }
+        }
+
         // Spawn the process-wide CDP telemetry sampler. Idempotent —
         // OnceLock guarantees a single task across all FallbackRenderer
         // instances. No-op on the `mode = none` early-return path above.
@@ -518,6 +591,11 @@ impl FallbackRenderer {
             proxy_client_cache: std::sync::Mutex::new(std::collections::HashMap::new()),
             #[cfg(feature = "cdp")]
             chrome_pool,
+            // Single source of truth for the opt-in policy: true only when
+            // mode=camoufox (pinned) or mode=auto + include_in_auto. A
+            // configured-but-not-opted-in endpoint stays out of the auto chain.
+            #[cfg(feature = "camoufox")]
+            camoufox_in_auto: config.camoufox_in_ladder(),
         })
     }
 
@@ -919,13 +997,32 @@ impl FallbackRenderer {
 
         // Filter the JS pool down to a hard-pinned renderer when one was named.
         // "auto" or `None` means "use the configured chain".
+        //
+        // A pinned request (`Some(name)` where name != "auto") is matched by
+        // exact name and BYPASSES the camoufox auto-exclusion — an explicit
+        // `renderer = "camoufox"` pin always reaches the (constructed) tier even
+        // when `include_in_auto = false`. The exclusion applies ONLY to the
+        // non-pinned auto chain.
         let mut renderers: Vec<&Arc<dyn PageFetcher>> = match requested_renderer {
             Some(name) if name != "auto" => self
                 .js_renderers
                 .iter()
                 .filter(|r| r.name() == name)
                 .collect(),
-            _ => self.js_renderers.iter().collect(),
+            _ => {
+                #[cfg(feature = "camoufox")]
+                {
+                    let in_auto = self.camoufox_in_auto;
+                    self.js_renderers
+                        .iter()
+                        .filter(|r| in_auto || r.name() != "camoufox")
+                        .collect()
+                }
+                #[cfg(not(feature = "camoufox"))]
+                {
+                    self.js_renderers.iter().collect()
+                }
+            }
         };
 
         // LightPanda has no upstream-proxy support: when a proxy is active for
@@ -1532,6 +1629,8 @@ fn html_body_text_len(html: &str) -> usize {
 mod tests {
     use super::*;
     use crate::breaker::BreakerConfig;
+    #[cfg(feature = "camoufox")]
+    use crw_core::config::CamoufoxEndpoint;
     #[cfg(feature = "cdp")]
     use crw_core::config::CdpEndpoint;
     use std::time::Duration;
@@ -1668,6 +1767,79 @@ mod tests {
             FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap_err();
         let msg = err.to_string().to_lowercase();
         assert!(msg.contains("cdp"), "expected cdp in error: {msg}");
+    }
+
+    #[cfg(feature = "camoufox")]
+    fn camoufox_cfg(mode: RendererMode, include_in_auto: bool) -> RendererConfig {
+        RendererConfig {
+            mode,
+            camoufox: Some(CamoufoxEndpoint {
+                base_url: "http://127.0.0.1:9377".into(),
+                api_key: String::new(),
+                include_in_auto,
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Opt-in default: a configured endpoint is CONSTRUCTED (so an explicit
+    /// `renderer = "camoufox"` pin can reach it) but does NOT join the auto
+    /// ladder when `include_in_auto = false`.
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_constructed_for_pin_but_excluded_from_auto() {
+        let cfg = camoufox_cfg(RendererMode::Auto, false);
+        let r = FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap();
+        assert!(
+            r.js_renderer_names().contains(&"camoufox"),
+            "configured camoufox must be constructed for pin-reachability"
+        );
+        assert!(
+            !r.camoufox_in_auto,
+            "include_in_auto=false must keep camoufox out of the auto ladder"
+        );
+    }
+
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_joins_auto_when_include_in_auto_true() {
+        let cfg = camoufox_cfg(RendererMode::Auto, true);
+        let r = FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap();
+        assert!(r.js_renderer_names().contains(&"camoufox"));
+        assert!(r.camoufox_in_auto);
+    }
+
+    /// `mode = "camoufox"` pins to ONLY camoufox, and must mark it in-auto so a
+    /// non-pinned request is not left with zero renderers.
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_pinned_mode_uses_only_camoufox() {
+        let cfg = camoufox_cfg(RendererMode::Camoufox, false);
+        let r = FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap();
+        assert_eq!(r.js_renderer_names(), vec!["camoufox"]);
+        assert!(r.camoufox_in_auto);
+    }
+
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_pinned_mode_without_base_url_errors() {
+        let cfg = RendererConfig {
+            mode: RendererMode::Camoufox,
+            camoufox: Some(CamoufoxEndpoint::default()), // empty base_url
+            ..Default::default()
+        };
+        let err =
+            FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("camoufox"));
+    }
+
+    #[cfg(feature = "camoufox")]
+    #[test]
+    fn camoufox_absent_when_not_configured() {
+        let cfg = base_cfg(RendererMode::Auto);
+        let r = FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap();
+        assert!(!r.js_renderer_names().contains(&"camoufox"));
+        assert!(!r.camoufox_in_auto);
     }
 
     #[test]

--- a/crates/crw-server/Cargo.toml
+++ b/crates/crw-server/Cargo.toml
@@ -12,6 +12,9 @@ description = "Firecrawl-compatible API server for the CRW web scraper"
 [features]
 default = []
 cdp = ["crw-renderer/cdp"]
+# Opt-in Camoufox stealth renderer tier (REST). Default OFF — the lean build is
+# byte-identical. Forwards to crw-renderer/camoufox (→ crw-core/camoufox).
+camoufox = ["crw-renderer/camoufox"]
 test-utils = []
 # Optional self-host monitor mode. Default OFF. Activating it links the
 # `crw-monitor` crate (and only then its SQLite/HMAC stack). The open-core

--- a/crates/crw-server/tests/mcp.rs
+++ b/crates/crw-server/tests/mcp.rs
@@ -261,8 +261,8 @@ async fn mcp_crw_scrape_advertises_renderer_in_tools_list() {
     let renderer = &scrape["inputSchema"]["properties"]["renderer"];
     assert_eq!(renderer["type"], "string");
     let enum_vals = renderer["enum"].as_array().expect("renderer.enum");
-    assert_eq!(enum_vals.len(), 4);
-    for v in ["auto", "lightpanda", "chrome", "playwright"] {
+    assert_eq!(enum_vals.len(), 5);
+    for v in ["auto", "lightpanda", "chrome", "playwright", "camoufox"] {
         assert!(
             enum_vals.iter().any(|e| e == v),
             "renderer enum missing {v}"

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -20,7 +20,7 @@ request_timeout_secs = 120
 rate_limit_rps = 10              # Max requests/second (global). 0 = unlimited.
 
 [renderer]
-mode = "auto"               # auto | lightpanda | playwright | chrome | none
+mode = "auto"               # auto | lightpanda | playwright | chrome | camoufox | none
 page_timeout_ms = 30000
 pool_size = 4
 # render_js_default = true  # alias: force_js = true
@@ -202,6 +202,7 @@ Use the `CRW_` prefix with `__` as a nesting separator:
 | `lightpanda` | Always use LightPanda via CDP |
 | `playwright` | Always use Playwright via CDP |
 | `chrome` | Always use Chrome via CDP |
+| `camoufox` | Opt-in Camoufox stealth tier (REST). Requires `--features camoufox` + a `[renderer.camoufox]` endpoint |
 | `none` | HTTP only, no JS rendering |
 
 The server `mode` controls **availability** of renderers in the pool. Per-request `renderer` selects from what's available — see [JS rendering](#js-rendering). A request that pins an unavailable renderer returns HTTP 400 with the configured pool listed.

--- a/docs/docs/crawling.md
+++ b/docs/docs/crawling.md
@@ -158,7 +158,7 @@ Poll response:
 | `jsonSchema` | object | -- | Optional schema for structured extraction per page |
 | `renderJs` | boolean or null | `null` | `true` forces JS on every page, `false` skips JS, `null` uses auto-detect or the server's `render_js_default` |
 | `waitFor` | number | -- | Milliseconds to wait after JS rendering on each page |
-| `renderer` | string | `auto` | Pin every crawled page to a specific renderer: `auto`, `lightpanda`, `chrome`, or `playwright`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set. Validation runs once at crawl start — invalid combinations return HTTP 400 before the job is queued. Per-page failures of a pinned renderer are logged and skipped, so failed pages may be missing from results — see [JS rendering](#js-rendering) for the resilience tradeoff |
+| `renderer` | string | `auto` | Pin every crawled page to a specific renderer: `auto`, `lightpanda`, `chrome`, `chrome_proxy`, `playwright`, or `camoufox`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set. Validation runs once at crawl start — invalid combinations return HTTP 400 before the job is queued. Per-page failures of a pinned renderer are logged and skipped, so failed pages may be missing from results — see [JS rendering](#js-rendering) for the resilience tradeoff |
 | `country` | string | -- | 2-letter ISO 3166-1 alpha-2 country code (lowercase, e.g. `us`, `gb`, `de`). Routes every page in the crawl through the named residential pool when the `chrome_proxy` renderer tier is configured. Ignored if no proxy tier is set up |
 
 ## Scrape options and extraction

--- a/docs/docs/js-rendering.md
+++ b/docs/docs/js-rendering.md
@@ -204,6 +204,80 @@ ws_url = "ws://chrome:9222"
 5. Execute `Runtime.evaluate("document.documentElement.outerHTML")` to get rendered HTML
 6. Close the tab via `Target.closeTarget`
 
+## Camoufox stealth tier (opt-in)
+
+Camoufox is an **optional** stealth renderer for targets that block the CDP
+tiers on **fingerprint / bot-challenge** grounds (e.g. a Cloudflare `403` that
+Chrome can't get past). It is a [Camoufox](https://github.com/daijro/camoufox)
+(Firefox-based, anti-fingerprint) browser driven through the
+[`camofox-browser`](https://github.com/jo-inc/camofox-browser) REST sidecar —
+**not** CDP.
+
+It is **off by default and changes nothing** unless you opt in. Even a
+configured endpoint stays out of the `auto` failover chain until you ask for it.
+
+### Requirements
+
+1. A build with the feature compiled in: `--features camoufox` (the default
+   build does not include it).
+2. A running camofox-browser sidecar (default port `9377`):
+
+   ```bash
+   docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser
+   ```
+
+3. The endpoint in your config:
+
+   ```toml
+   [renderer.camoufox]
+   base_url = "http://127.0.0.1:9377"
+   # api_key = "..."             # sent as `Authorization: Bearer` — only needed
+   #                             # if you front the sidecar with an auth proxy
+   # include_in_auto = false     # default: stay OUT of the auto ladder
+   # camoufox_timeout_ms = 60000 # per-request REST budget (default 60s)
+   ```
+
+### Three ways to use it
+
+| How | What it does |
+|-----|--------------|
+| Per-request `"renderer": "camoufox"` | Hard-pin a single request to Camoufox. Works as soon as the endpoint is configured. |
+| Config `mode = "camoufox"` | Pin **every** request to Camoufox. |
+| `include_in_auto = true` | Add Camoufox as the **last** tier of the `auto` failover chain (tried only after the cheaper tiers fail). |
+
+With the default `include_in_auto = false`, a configured endpoint is **only**
+reachable via an explicit pin (`renderer = "camoufox"`) or `mode = "camoufox"` —
+it never silently joins `auto`.
+
+### How it works
+
+The renderer talks to the sidecar over HTTP, not CDP:
+
+1. `POST /tabs` — create a fresh, isolated session and navigate to the URL.
+2. `POST /tabs/{id}/evaluate` — run `document.documentElement.outerHTML` to get
+   the fully JS-rendered DOM.
+3. `DELETE /sessions/{id}` — always tear the session down (even on error), so
+   no server-side session leaks.
+
+The returned HTML flows through the **same** post-render pipeline as every other
+tier (`only_main_content`, tag filters, markdown), so your output shape is
+unchanged. Each request gets a fresh session (no cookie carry-over). If the page
+comes back as a bot wall / challenge, the tier reports a retryable error so the
+chain can react.
+
+### Trade-offs
+
+- **Cost:** a full Firefox-class render plus a REST round-trip — heavier and
+  slower than the CDP tiers, and it counts as the most expensive renderer
+  internally. You only pay this on the requests you opt in.
+- **Ops:** it's a separate (Node) process to run and monitor — it breaks the
+  pure single-binary story for deployments that enable it.
+- **Resilience:** the `Fetch`-based resource blocking the CDP path uses does not
+  apply on this tier (the sidecar loads the page itself).
+
+If the sidecar is unreachable, the tier reports unavailable (health-probed) and
+is skipped rather than failing every request.
+
 ## Cloud vs Self-hosted
 
 - **Cloud**: JS rendering is always available. The managed infrastructure runs a LightPanda sidecar alongside the engine. Available on [fastcrw.com](https://fastcrw.com) (cloud).

--- a/docs/docs/js-rendering.md
+++ b/docs/docs/js-rendering.md
@@ -19,6 +19,7 @@ pool_size = 4
 | `lightpanda` | Always use LightPanda for JS rendering |
 | `playwright` | Always use Playwright for JS rendering |
 | `chrome` | Always use Chrome for JS rendering |
+| `camoufox` | Opt-in stealth tier (REST). Requires `--features camoufox` + a configured `[renderer.camoufox]` endpoint |
 | `none` | HTTP only, never render JS |
 
 ## Per-request control
@@ -77,6 +78,7 @@ When `mode = "auto"` and you have multiple renderers configured (e.g., LightPand
 | `chrome` | Hard-pin to Chrome — no fallback |
 | `chrome_proxy` | Hard-pin to residential-proxy Chrome tier — no fallback |
 | `playwright` | Hard-pin to Playwright — no fallback |
+| `camoufox` | Hard-pin to the opt-in Camoufox stealth tier (REST) — no fallback. Requires a build with `--features camoufox` and a configured `[renderer.camoufox]` endpoint |
 
 ### Pinned implies JS
 

--- a/docs/docs/scraping.md
+++ b/docs/docs/scraping.md
@@ -132,7 +132,7 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `onlyMainContent` | boolean | `true` | Remove nav, footer, and boilerplate before conversion |
 | `renderJs` | boolean or null | `null` | `null` auto-detects, `true` forces browser rendering, `false` stays HTTP-only |
 | `waitFor` | number | -- | Milliseconds to wait after JS rendering |
-| `renderer` | string | `auto` | Pin to a specific renderer: `auto`, `lightpanda`, `chrome`, `chrome_proxy`, or `playwright`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set explicitly. See [JS rendering](#js-rendering) |
+| `renderer` | string | `auto` | Pin to a specific renderer: `auto`, `lightpanda`, `chrome`, `chrome_proxy`, `playwright`, or `camoufox`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set explicitly. See [JS rendering](#js-rendering) |
 | `includeTags` | string[] | `[]` | CSS selectors to keep |
 | `excludeTags` | string[] | `[]` | CSS selectors to remove |
 | `headers` | object | `{}` | Custom HTTP headers |

--- a/docs/docs/self-hosting.md
+++ b/docs/docs/self-hosting.md
@@ -48,6 +48,29 @@ Three deployment paths cover most self-hosted use cases. Choose based on how muc
 4. add auth, TLS, and edge controls before broader access
 5. add JS rendering only when targets actually need it
 
+## Optional: Camoufox stealth sidecar
+
+For targets that block the CDP renderers on fingerprint / bot-challenge grounds
+(e.g. a Cloudflare `403`), you can run an optional [Camoufox](https://github.com/daijro/camoufox)
+stealth tier. It is a REST sidecar — separate from the CDP browsers — and is
+**off by default**: it requires a `--features camoufox` build and never joins
+the `auto` chain unless you opt in.
+
+```bash
+# 1. run the camofox-browser sidecar (default port 9377)
+docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser
+
+# 2. point CRW at it (config.toml)
+#    [renderer.camoufox]
+#    base_url = "http://127.0.0.1:9377"
+#    # include_in_auto = true   # optional: add as the last auto-failover tier
+```
+
+Reach it per request with `"renderer": "camoufox"`, pin every request with
+`mode = "camoufox"`, or set `include_in_auto = true`. It is a heavier
+(Firefox-class) render than the CDP tiers, so enable it only for the requests
+that need it. Full details: [JS rendering → Camoufox](#js-rendering).
+
 ## When Self-Hosting Is The Right Choice
 
 Choose self-hosting when you want:


### PR DESCRIPTION
## Summary

Adds **Camoufox** as an **opt-in stealth renderer tier** for fingerprint/bot-challenge–blocked targets (e.g. Cloudflare 403) that the existing CDP tiers can't pass. It is reached **only when explicitly requested** — it does **not** join the default `auto` failover ladder unless you turn it on. Existing deployments are unaffected.

This is the "Option C" design from the earlier feasibility evaluation: *supported + selectable + not-in-default-auto + breaks nothing.*

## How a user opts in

Three explicit paths (in increasing scope):

1. **Per-request pin** — `renderer: "camoufox"` on a scrape/crawl request.
2. **Config pin** — `mode = "camoufox"` pins every request to it.
3. **Auto-chain opt-in** — `[renderer.camoufox] include_in_auto = true` adds it as the last-resort tier in the `auto` chain.

```toml
[renderer.camoufox]
base_url = "http://127.0.0.1:9377"
# api_key = ""               # optional bearer token
# include_in_auto = false    # default: stay OUT of the auto ladder
# camoufox_timeout_ms = 60000
```

A configured endpoint with the default `include_in_auto = false` is **constructed** (so a per-request pin can reach it) but stays **out** of the auto chain — so simply configuring an endpoint changes nothing for existing `auto`-mode traffic.

## Breaks nothing

- **Default-off `camoufox` cargo feature** threaded `crw-core → crw-renderer → crw-server → crw-cli`. The lean build is byte-identical; `cargo build` with no extra features pulls no new deps.
- **REST, not CDP.** Camoufox is never counted in `cdp_tier_count`, never charged `CDP_TIER_OVERHEAD_MS`, and gets its own deadline-budget branch *outside* the cdp gate (so a camoufox-only deployment isn't deadline-starved).
- `RendererMode::Camoufox` is excluded from the `cfg(not(feature = "cdp"))` rejection (it needs no CDP), and rejected cleanly when built without the `camoufox` feature.
- The only changed existing assertions are two MCP-schema renderer-enum counts (4 → 5), correct because the schema advertises `camoufox` unconditionally (like `playwright`).

## Implementation

- **Config** (`crw-core`): `RendererMode::Camoufox`, `CamoufoxEndpoint { base_url, api_key, include_in_auto }`, `camoufox_timeout()`, and a single-source-of-truth `camoufox_in_ladder()` predicate driving the opt-in policy + deadline math.
- **Kinds/metrics** (`crw-core`/`crw-renderer`): `RendererKind::Camoufox` + `RequestedRenderer::Camoufox` (both → `"camoufox"`), `credit_for = 3`, `tier_timeouts`, and a 5th `BreakerRegistry` entry.
- **Renderer** (`crw-renderer/src/camoufox.rs`): a `reqwest`-based `PageFetcher` driving the camofox-browser REST contract — create tab → `evaluate(document.documentElement.outerHTML)` → **always** destroy session (even on error). Per-request fresh session (no cookie carry-over), missing-`tabId` retry-once, bot-wall/empty-HTML → retryable error, deadline-clamped per call, health-probe `is_available()`.
- **Wiring** (`crw-renderer`): independent construction block (not nested in the cdp guard); auto-exclusion applied at request time in `fetch_with_js` while pins bypass it.
- **Surface**: MCP tool schema advertises `camoufox`; `validate_renderer_pin` accepts it generically; documented in `config.default.toml`.

## REST contract

Verified against the camofox-browser `openapi.json`:

| Call | Endpoint |
|---|---|
| create tab (navigates) | `POST /tabs` `{userId, sessionKey, url}` → `{tabId}` |
| get DOM | `POST /tabs/{tabId}/evaluate` `{userId, expression}` → `{ok, result}` |
| cleanup | `DELETE /sessions/{userId}` |
| health | `GET /health` |

## Tests & verification

- New: 12 renderer unit tests (happy path + cleanup-on-error + missing-tabId retry + wall/empty/ok=false/non-string-result + deadline short-circuit + cleanup-timeout isolation + `is_available`), opt-in construction/ladder tests, config `camoufox_in_ladder` truth-table + camoufox-only deadline test, MCP schema + breaker tests.
- Gate: **lean workspace 1044 tests pass / 0 fail**; `camoufox`, `cdp,camoufox`, and lean builds all compile and test green; `clippy` + `fmt` clean.

## Operating note

Requires a build with `--features camoufox` **and** a running camofox-browser sidecar. The tier auto-skips (via `is_available()` health probe) when the sidecar is unreachable, so it degrades gracefully rather than erroring every request.
