### PR TITLE
docs: fix X handle to @fast_crw

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Built in Rust because every millisecond of agent latency compounds.
 </p>
 
 <p align="center">
-  <a href="https://twitter.com/fastcrw"><img src="https://img.shields.io/badge/Follow%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
+  <a href="https://x.com/fast_crw"><img src="https://img.shields.io/badge/Follow%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
   <a href="https://www.linkedin.com/company/fastcrw"><img src="https://img.shields.io/badge/Follow%20on%20LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" /></a>
   <a href="https://discord.gg/kkFh2SC8"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" /></a>
 </p>
@@ -490,7 +490,7 @@ on request — write to **hello@fastcrw.com**.
 - **Benchmarks:** [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks)
 - **Marketing site:** [fastcrw.com](https://fastcrw.com)
 - **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
-- **X / Twitter:** [@fastcrw](https://twitter.com/fastcrw)
+- **X / Twitter:** [@fast_crw](https://x.com/fast_crw)
 - **LinkedIn:** [fastcrw](https://www.linkedin.com/company/fastcrw)
 - **Discord:** [discord.gg/kkFh2SC8](https://discord.gg/kkFh2SC8)
 - **MCP Registry:** [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=crw)


### PR DESCRIPTION
Corrects the X/Twitter handle from @fastcrw to the real handle @fast_crw in the follow badge and contact section.