### PR TITLE
perf(search): research concurrency 4->8, cache cap 20k->3k

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -2095,7 +2095,11 @@ mod tests {
 
         // (3) whitespace-only -> None.
         unsafe { std::env::set_var("CRW_CRAWLER__PROXY", "   ") };
-        assert_eq!(load(), None, "whitespace proxy env should normalize to None");
+        assert_eq!(
+            load(),
+            None,
+            "whitespace proxy env should normalize to None"
+        );
 
         // (4) a real value -> Some (trimmed).
         unsafe { std::env::set_var("CRW_CRAWLER__PROXY", "  http://proxy:8080  ") };

--- a/crates/crw-search/src/research.rs
+++ b/crates/crw-search/src/research.rs
@@ -27,9 +27,12 @@ use tokio::sync::Semaphore;
 
 const UA: &str = "crw-opencore/0.x (https://fastcrw.com; contact@fastcrw.com) reqwest";
 const TIMEOUT: Duration = Duration::from_secs(20);
-const MAX_CONCURRENCY: usize = 4;
+const MAX_CONCURRENCY: usize = 8;
 const CACHE_TTL: Duration = Duration::from_secs(24 * 3600);
-const CACHE_CAP: u64 = 20_000;
+// Entries hold full OpenAlex/SS JSON responses (~10-50KB each). 20k entries
+// could pin 200MB-1GB and OOM-restart crw-api under research load; 3k keeps the
+// cache useful while bounding it to ~50-150MB. ponytail: cap, not a byte-weigher.
+const CACHE_CAP: u64 = 3_000;
 
 /// Per-call credentials, borrowed from the route's `AppConfig`.
 #[derive(Clone, Copy, Default)]


### PR DESCRIPTION
Bump OpenAlex/SS semaphore 4->8 (more headroom under concurrent research load; SS 1rps still the hard ceiling). Drop moka cache cap 20k->3k to stop crw-api OOM-restarts (each entry holds a full API-response JSON). Verified live earlier; this addresses the latency/restart behavior seen during the hosted benchmark.