### PR TITLE
feat(scrape): add screenshot output format via CDP capture

### DIFF
--- a/crates/crw-cli/src/commands/scrape.rs
+++ b/crates/crw-cli/src/commands/scrape.rs
@@ -783,5 +783,6 @@ fn build_request(
         goal: None,
         judge_enabled: None,
         parsers: None,
+        screenshot_full_page: false,
     }
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -17,6 +17,7 @@ pub enum OutputFormat {
     Json,
     Summary,
     ChangeTracking,
+    Screenshot,
 }
 
 impl OutputFormat {
@@ -36,6 +37,11 @@ impl OutputFormat {
             "json" | "extract" | "llm-extract" => Ok(OutputFormat::Json),
             "summary" => Ok(OutputFormat::Summary),
             "changeTracking" | "change-tracking" => Ok(OutputFormat::ChangeTracking),
+            // `screenshot@fullPage` parses to the same fieldless variant; the
+            // `fullPage` bit is carried out-of-band via
+            // `ScrapeRequest.screenshot_full_page` (v2 extracts it in
+            // `routes/v2/formats.rs`; v1 always treats it as false — see D7).
+            "screenshot" | "screenshot@fullPage" => Ok(OutputFormat::Screenshot),
             other => Err(format!(
                 "Unknown format '{other}'. Valid formats: markdown, html, rawHtml, plainText, links, json, summary, changeTracking \
                  (aliases: extract, llm-extract, change-tracking). Use formats: [\"json\"] with jsonSchema for structured extraction."
@@ -291,6 +297,13 @@ pub struct ScrapeRequest {
     ///   capped via `maxPages`).
     #[serde(default)]
     pub parsers: Option<Vec<ParserSpec>>,
+    /// Whether a requested `screenshot` format should capture the full page
+    /// (`screenshot@fullPage` / `{type:"screenshot", fullPage:true}`) instead of
+    /// just the viewport. Carried out-of-band rather than on the (`Copy`/`Hash`)
+    /// `OutputFormat` enum so `formats.contains(&Screenshot)` stays cheap. v1
+    /// always leaves this false (see D7); v2 sets it in `routes/v2/formats.rs`.
+    #[serde(default, alias = "screenshot_full_page")]
+    pub screenshot_full_page: bool,
 }
 
 /// A document parser directive (Firecrawl `parsers` entry). Accepts either the
@@ -410,6 +423,7 @@ impl Default for ScrapeRequest {
             goal: None,
             judge_enabled: None,
             parsers: None,
+            screenshot_full_page: false,
         }
     }
 }
@@ -572,6 +586,11 @@ pub struct ScrapeData {
     /// the orchestration layer ran the judge).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub change_tracking: Option<ChangeTrackingResult>,
+    /// Page screenshot as a `data:image/png;base64,<...>` URL; populated only
+    /// when `formats` includes `"screenshot"`. The `data:` prefix is wrapped
+    /// once in `single.rs` (`FetchResult.screenshot` stays raw base64).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub screenshot: Option<String>,
 }
 
 /// Per-request extraction debug trace. One entry per extract() call
@@ -1506,6 +1525,11 @@ pub struct FetchResult {
     /// renderer ran with network capture enabled. Used by extraction as a
     /// fallback content source when DOM-based extraction is low quality.
     pub captured_responses: Vec<CapturedNetworkResponse>,
+    /// Raw base64 PNG captured via CDP `Page.captureScreenshot` when the
+    /// request asked for the `screenshot` format. `None` for the HTTP /
+    /// camoufox / lightpanda paths (they never capture). The `data:` URL
+    /// prefix is added in `single.rs`, not here.
+    pub screenshot: Option<String>,
 }
 
 /// A single XHR/fetch response captured via CDP Network domain.

--- a/crates/crw-core/tests/types_tests.rs
+++ b/crates/crw-core/tests/types_tests.rs
@@ -177,6 +177,7 @@ fn scrape_data_skip_serializing_none() {
         debug_extraction: None,
         content_type: None,
         change_tracking: None,
+        screenshot: None,
     };
 
     let json = serde_json::to_value(&data).unwrap();
@@ -288,6 +289,7 @@ fn scrape_data_serializes_debug_extraction_as_camel_case() {
         debug_extraction: None,
         content_type: None,
         change_tracking: None,
+        screenshot: None,
     };
     let v = serde_json::to_value(&data).unwrap();
     assert!(v.get("debugExtraction").is_none(), "absent when None");

--- a/crates/crw-crawl/src/pdf.rs
+++ b/crates/crw-crawl/src/pdf.rs
@@ -555,6 +555,8 @@ fn build_scrape_data(
         debug_extraction: None,
         content_type: Some("application/pdf".to_string()),
         change_tracking: None,
+        // PDFs are never screenshotted (binary doc path).
+        screenshot: None,
     }
 }
 

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -59,21 +59,34 @@ pub async fn scrape_url(
     // credential country; `REQUEST_PROXY` carries the resolved proxy (BYOP >
     // config) so BOTH the HTTP and JS/CDP paths egress through the same entry.
     let resolved_proxy = resolve_request_proxy(req, renderer)?;
+    // `REQUEST_SCREENSHOT` carries the (out-of-band) screenshot params into the
+    // renderer stack so the CDP path can capture without trait-signature churn
+    // (mirrors REQUEST_PROXY). `Some` only when `formats` asked for it.
+    let screenshot_req =
+        req.formats
+            .contains(&OutputFormat::Screenshot)
+            .then_some(crw_renderer::ScreenshotReq {
+                full_page: req.screenshot_full_page,
+            });
     crw_renderer::REQUEST_COUNTRY
         .scope(req.country.clone(), async move {
             crw_renderer::REQUEST_PROXY
                 .scope(resolved_proxy, async move {
-                    scrape_url_inner(
-                        req,
-                        renderer,
-                        llm_config,
-                        extraction_cfg,
-                        user_agent,
-                        default_stealth,
-                        render_js_default,
-                        deadline,
-                    )
-                    .await
+                    crw_renderer::REQUEST_SCREENSHOT
+                        .scope(screenshot_req, async move {
+                            scrape_url_inner(
+                                req,
+                                renderer,
+                                llm_config,
+                                extraction_cfg,
+                                user_agent,
+                                default_stealth,
+                                render_js_default,
+                                deadline,
+                            )
+                            .await
+                        })
+                        .await
                 })
                 .await
         })
@@ -116,6 +129,18 @@ async fn scrape_url_inner(
     // render_js_default=true and a per-request proxy still reaches the JS renderer.
     let effective_render_js = resolve_render_js(effective_render_js_request, render_js_default);
 
+    // A screenshot is captured via CDP and cannot be produced on the HTTP-only
+    // path. An explicit `renderJs:false` + `screenshot` is contradictory — reject
+    // it rather than silently return a null screenshot. For the default/auto case
+    // the renderer forces the CDP path (see FallbackRenderer::fetch), and the
+    // temp HTTP fetcher below is skipped so the screenshot is never dropped.
+    let wants_screenshot = req.formats.contains(&OutputFormat::Screenshot);
+    if wants_screenshot && req.render_js == Some(false) {
+        return Err(crw_core::error::CrwError::InvalidRequest(
+            "screenshot format requires JS rendering; remove renderJs:false (or omit it)".into(),
+        ));
+    }
+
     // Validate pinned renderer is available — fail fast with a 400 instead of
     // letting the request reach the dispatcher with a hard-pin to a missing pool.
     // Skip validation when renderJs:false is honored (HTTP-only ignores the pin).
@@ -149,7 +174,7 @@ async fn scrape_url_inner(
             user_agent.to_string()
         };
 
-        if effective_render_js == Some(false) {
+        if effective_render_js == Some(false) && !wants_screenshot {
             // HTTP-only temp fetcher with per-request stealth. Honor REQUEST_PROXY
             // so a stealth-override request still egresses through the resolved
             // proxy — fail-closed, a set proxy is never bypassed.
@@ -397,7 +422,7 @@ async fn scrape_url_inner(
                 )
                 .await
             {
-                Ok(js_fetch) => {
+                Ok(mut js_fetch) => {
                     // Accept JS result even if status >= 400, as long as it produced
                     // real content. Anti-bot/UA-detection sites frequently return a
                     // 4xx code while still serving the actual page body — the status
@@ -428,6 +453,10 @@ async fn scrape_url_inner(
                             js_md_len >= retry_threshold && (http_was_thin || quality_improved);
                         if accept {
                             data = js_data;
+                            // The escalation re-rendered via CDP, so a screenshot (if
+                            // requested) lives on `js_fetch`, not the original low-tier
+                            // `fetch_result`. Carry it over so it isn't dropped.
+                            fetch_result.screenshot = js_fetch.screenshot.take();
                             // Replace the original "Target returned 4xx" with the JS
                             // fetch's warning (which is None for a clean 2xx render),
                             // so a successful escalation doesn't leak the original
@@ -579,6 +608,14 @@ async fn scrape_url_inner(
     // Surface the fetched content type so change-tracking (here and on the
     // crawl path) can hash binary/non-text content rather than diff it.
     data.content_type = fetch_result.content_type.clone();
+
+    // Wrap the raw base64 screenshot in a `data:image/png;base64,` URL exactly
+    // once, here, so both v1 and v2 responses are identical (D8). FetchResult
+    // keeps the raw b64.
+    data.screenshot = fetch_result
+        .screenshot
+        .as_ref()
+        .map(|b| format!("data:image/png;base64,{b}"));
 
     // ── Change tracking (monitor) ──────────────────────────────────────────
     // Activated by the `"changeTracking"` format string; options ride on the
@@ -896,7 +933,25 @@ mod tests {
             truncated: false,
             deadline_exceeded: false,
             captured_responses: Vec::new(),
+            screenshot: None,
         }
+    }
+
+    /// The raw base64 in `FetchResult.screenshot` is wrapped into a
+    /// `data:image/png;base64,` URL exactly once when building `ScrapeData`.
+    #[test]
+    fn screenshot_wrapped_as_data_url() {
+        let mut fetch = sample_fetch(200, "<html><body>hi</body></html>");
+        fetch.screenshot = Some("AAAQ".to_string());
+        let wrapped = fetch
+            .screenshot
+            .as_ref()
+            .map(|b| format!("data:image/png;base64,{b}"));
+        assert_eq!(
+            wrapped.as_deref(),
+            Some("data:image/png;base64,AAAQ"),
+            "raw b64 must be prefixed with the data URL scheme exactly once"
+        );
     }
 
     #[test]

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -810,9 +810,10 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         },
         debug_extraction: None,
         // Populated post-extract by the caller (single.rs / crawl.rs) from
-        // FetchResult.content_type; change_tracking is computed there too.
+        // FetchResult.content_type; change_tracking + screenshot are set there too.
         content_type: None,
         change_tracking: None,
+        screenshot: None,
     })
 }
 

--- a/crates/crw-monitor/src/runner.rs
+++ b/crates/crw-monitor/src/runner.rs
@@ -303,6 +303,7 @@ impl EngineSource {
             goal: None,
             judge_enabled: None,
             parsers: None,
+            screenshot_full_page: false,
         }
     }
 }

--- a/crates/crw-renderer/src/camoufox.rs
+++ b/crates/crw-renderer/src/camoufox.rs
@@ -307,6 +307,8 @@ impl PageFetcher for CamoufoxRenderer {
             truncated: false,
             deadline_exceeded: deadline.remaining().is_zero(),
             captured_responses: Vec::new(),
+            // Camoufox is an HTTP sidecar (no CDP) — it never captures.
+            screenshot: None,
         })
     }
 

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1339,7 +1339,7 @@ impl CdpRenderer {
             tracing::warn!(error = %e, "pool: release returned error (slot recycled as Dead)");
         }
 
-        let (html, status_code, truncated, final_href, captured_responses, _tid) = res?;
+        let (html, status_code, truncated, final_href, captured_responses, screenshot, _tid) = res?;
 
         if html.is_empty() {
             return Err(CrwError::RendererError(
@@ -1377,6 +1377,7 @@ impl CdpRenderer {
             truncated,
             deadline_exceeded: deadline.remaining().is_zero(),
             captured_responses,
+            screenshot,
         })
     }
 
@@ -1488,7 +1489,15 @@ impl CdpRenderer {
 
         conn.close().await;
 
-        let (html, status_code, truncated, final_href, captured_responses, _tid_ignored) = result?;
+        let (
+            html,
+            status_code,
+            truncated,
+            final_href,
+            captured_responses,
+            screenshot,
+            _tid_ignored,
+        ) = result?;
 
         if html.is_empty() {
             return Err(CrwError::RendererError(
@@ -1528,6 +1537,7 @@ impl CdpRenderer {
             truncated,
             deadline_exceeded: deadline.remaining().is_zero(),
             captured_responses,
+            screenshot,
         })
     }
 
@@ -1840,6 +1850,7 @@ impl CdpRenderer {
         bool,
         Option<String>,
         Vec<CapturedNetworkResponse>,
+        Option<String>,
         String,
     )> {
         // 1. Create a blank target so navigation events can be observed reliably.
@@ -2014,8 +2025,9 @@ impl CdpRenderer {
             // we attempt a partial-DOM snapshot and return `truncated = true`;
             // `single.rs` decides success on md length.
             let phase = self.post_navigate_phase(conn, &session_id, url, wait_for_ms, &net_tracker);
-            let (html, truncated) = match tokio::time::timeout(nav_budget, phase).await {
-                Ok(Ok(html)) => (html, false),
+            let (html, screenshot, truncated) = match tokio::time::timeout(nav_budget, phase).await
+            {
+                Ok(Ok((html, screenshot))) => (html, screenshot, false),
                 Ok(Err(err)) => return Err(err),
                 Err(_) => {
                     tracing::info!(
@@ -2038,10 +2050,11 @@ impl CdpRenderer {
                         .chrome_budget_truncated_total
                         .with_label_values(&[if html.is_empty() { "empty" } else { "ok" }])
                         .inc();
-                    (html, true)
+                    // Best-effort: no screenshot when the budget elapsed.
+                    (html, None, true)
                 }
             };
-            Ok::<_, CrwError>((html, status_code, truncated))
+            Ok::<_, CrwError>((html, status_code, truncated, screenshot))
         };
 
         // Always-on XHR/fetch capture. Cheap when no JSON XHRs fire (events
@@ -2150,7 +2163,7 @@ impl CdpRenderer {
         // it via the recorded target_id; legacy fetch_with_ws closes after
         // fetch_inner returns via its Cell-captured id).
 
-        let (html, status_code, truncated) = outcome?;
+        let (html, status_code, truncated, screenshot) = outcome?;
 
         if html.is_empty() && truncated {
             return Err(CrwError::Timeout(nav_budget.as_millis() as u64));
@@ -2170,6 +2183,7 @@ impl CdpRenderer {
             truncated,
             final_href,
             captured_drained,
+            screenshot,
             target_id,
         ))
     }
@@ -2184,7 +2198,7 @@ impl CdpRenderer {
         url: &str,
         wait_for_ms: Option<u64>,
         net: &NetworkActivityTracker,
-    ) -> CrwResult<String> {
+    ) -> CrwResult<(String, Option<String>)> {
         // 2.5. Best-effort consent / CMP dismissal. Cookie banners can both
         // hide content behind an overlay and inflate `body.innerText` past
         // the SPA-readiness threshold prematurely (the banner copy alone
@@ -2297,7 +2311,39 @@ impl CdpRenderer {
             }
         }
 
-        Ok(html)
+        // 6. Screenshot capture (CDP `Page.captureScreenshot`). Runs after the
+        // full wait/scroll/reveal window so the PNG reflects the final rendered
+        // DOM. Only when a screenshot was requested via the task-local. Keeps
+        // the raw base64 (no decode); `single.rs` wraps the `data:` prefix.
+        // Capture failure is non-fatal — the page content still returns.
+        let screenshot = if let Some(req) = crate::current_screenshot_req() {
+            match conn
+                .send_recv(
+                    "Page.captureScreenshot",
+                    serde_json::json!({
+                        "format": "png",
+                        "captureBeyondViewport": req.full_page,
+                        "fromSurface": true,
+                    }),
+                    Some(session_id),
+                    self.page_timeout,
+                )
+                .await
+            {
+                Ok(resp) => resp
+                    .get("data")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                Err(e) => {
+                    tracing::warn!(url, "Page.captureScreenshot failed: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok((html, screenshot))
     }
 }
 

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -310,6 +310,8 @@ impl PageFetcher for HttpFetcher {
             truncated: false,
             deadline_exceeded: false,
             captured_responses: Vec::new(),
+            // HTTP-only path never renders or captures a screenshot.
+            screenshot: None,
         })
     }
 

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -86,6 +86,39 @@ tokio::task_local! {
     pub static REQUEST_PROXY: Option<Arc<crw_core::ProxyEntry>>;
 }
 
+/// Per-request screenshot capture parameters. Carried via a task-local rather
+/// than the `PageFetcher::fetch` signature (mirrors [`REQUEST_PROXY`]) so the
+/// trait + its ~30 call sites stay untouched. `Some` ⇒ capture a PNG via CDP
+/// `Page.captureScreenshot` after the wait window; `None` ⇒ no screenshot.
+#[derive(Debug, Clone, Copy)]
+pub struct ScreenshotReq {
+    /// Capture the full scrollable page (`captureBeyondViewport`) vs. just the
+    /// current viewport.
+    pub full_page: bool,
+}
+
+tokio::task_local! {
+    /// Resolved screenshot request for the current scrape. Set by the
+    /// scrape/crawl entry point ([`crw_crawl::single::scrape_url`]) when
+    /// `formats` contains `Screenshot`; read in `cdp.rs` to drive
+    /// `Page.captureScreenshot` and in [`FallbackRenderer::fetch`] to force the
+    /// vanilla-Chrome CDP path. `None` = no screenshot → existing behaviour.
+    pub static REQUEST_SCREENSHOT: Option<ScreenshotReq>;
+}
+
+/// Whether a screenshot was requested for the current task (reads the
+/// [`REQUEST_SCREENSHOT`] task-local). `false` when unset / outside a scope.
+pub fn screenshot_requested() -> bool {
+    REQUEST_SCREENSHOT
+        .try_with(|s| s.is_some())
+        .unwrap_or(false)
+}
+
+/// The resolved screenshot params for the current task, if any.
+pub fn current_screenshot_req() -> Option<ScreenshotReq> {
+    REQUEST_SCREENSHOT.try_with(|s| *s).ok().flatten()
+}
+
 /// Map a renderer's name string to the closed `RendererKind` enum.
 /// Returns `None` for unknown names (e.g. "playwright" — treated as a
 /// JS renderer but not tracked in metrics/preferences).
@@ -778,7 +811,15 @@ impl FallbackRenderer {
             None
         };
 
-        let effective = resolve_render_js(render_js, self.render_js_default);
+        let mut effective = resolve_render_js(render_js, self.render_js_default);
+        // A screenshot is captured via CDP — it can only happen on the JS/CDP
+        // path. Force `render_js = Some(true)` so the `Some(false)` / auto
+        // (`None`) branches below don't return an HTTP-only result that never
+        // reaches `fetch_with_js` (where the capture occurs). The HTTP-only,
+        // camoufox and lightpanda renderers are also filtered out downstream.
+        if effective != Some(true) && screenshot_requested() {
+            effective = Some(true);
+        }
         tracing::debug!(
             url,
             request_render_js = ?render_js,
@@ -805,11 +846,25 @@ impl FallbackRenderer {
                     .fetch(url, headers, None, deadline)
                     .await?;
                 if http_result.content_type.as_deref() == Some("application/pdf") {
+                    // A PDF has no rendered DOM to capture. A screenshot request
+                    // on a PDF returns the parsed document with no `screenshot`
+                    // field (ponytail: honest null — PDFs genuinely can't be
+                    // screenshotted; not worth a warning the PDF parse path drops).
                     stamp_http_decision(&mut http_result, requested_renderer);
                     return Ok(http_result);
                 }
 
                 if self.js_renderers.is_empty() {
+                    // A screenshot needs CDP — there is no HTTP fallback that can
+                    // satisfy it. Fail closed rather than return a 200 with a null
+                    // screenshot the caller explicitly asked for.
+                    if screenshot_requested() {
+                        return Err(CrwError::RendererError(
+                            "a screenshot was requested but no JS renderer is available; \
+                             configure a chrome/chrome_proxy tier"
+                                .into(),
+                        ));
+                    }
                     tracing::warn!(
                         url,
                         "JS rendering requested but no renderer available — falling back to HTTP"
@@ -1039,6 +1094,25 @@ impl FallbackRenderer {
                     "a proxy is required for this request but the only available JS \
                      renderer (lightpanda) cannot route through a proxy; configure a \
                      chrome/chrome_proxy tier to use proxies with JS rendering"
+                        .into(),
+                ));
+            }
+        }
+
+        // Screenshot capture is CDP `Page.captureScreenshot` on vanilla Chrome.
+        // LightPanda's CdpRenderer returns a ~30-byte stub and Camoufox is an
+        // HTTP sidecar that doesn't speak CDP — neither can capture. Drop both
+        // and fail CLOSED if that empties the chain, rather than returning a
+        // screenshot-less result the caller asked for (mirrors the proxy retain
+        // above). Applies even to a hard pin: pinning camoufox/lightpanda +
+        // requesting a screenshot is unsatisfiable.
+        if screenshot_requested() {
+            renderers.retain(|r| r.name() != "lightpanda" && r.name() != "camoufox");
+            if renderers.is_empty() {
+                return Err(CrwError::RendererError(
+                    "a screenshot was requested but no CDP-capable Chrome renderer is \
+                     available; lightpanda and camoufox cannot capture screenshots — \
+                     configure a chrome/chrome_proxy tier"
                         .into(),
                 ));
             }
@@ -1896,6 +1970,7 @@ mod tests {
                 truncated: false,
                 deadline_exceeded: false,
                 captured_responses: Vec::new(),
+                screenshot: None,
             })
         }
 

--- a/crates/crw-renderer/tests/browser_pool_real_chrome.rs
+++ b/crates/crw-renderer/tests/browser_pool_real_chrome.rs
@@ -493,3 +493,115 @@ async fn t7_permit_accounting_under_shutdown() {
 
     assert_eq!(pool.inflight(), 0);
 }
+
+// ---------------------------------------------------------------------------
+// SS — screenshot capture smoke: `Page.captureScreenshot` returns a PNG.
+//
+// Mirrors the engine's capture path in `cdp.rs::post_navigate_phase`
+// (format:"png", captureBeyondViewport, fromSurface) reading the raw base64
+// `data` field. Chrome-gated like the rest of this file. A PNG's 8-byte magic
+// header (`\x89PNG\r\n\x1a\n`) base64-encodes to the constant prefix
+// `iVBORw0KGgo`, so we can assert it without pulling a base64 dep.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+#[ignore]
+async fn ss_capture_screenshot_returns_png() {
+    let Some(base) = require_real_chrome() else {
+        return;
+    };
+    let ws = resolve_ws(&base).await;
+    let pool = build_pool(ws, 1);
+
+    let guard = pool.acquire().await.expect("acquire");
+    let create = guard
+        .conn
+        .send_recv(
+            "Target.createTarget",
+            json!({ "url": "about:blank", "browserContextId": guard.ctx_id }),
+            None,
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("createTarget");
+    let target_id = create
+        .get("targetId")
+        .and_then(|v| v.as_str())
+        .expect("targetId")
+        .to_string();
+    guard.record_target(target_id.clone());
+
+    let attach = guard
+        .conn
+        .send_recv(
+            "Target.attachToTarget",
+            json!({ "targetId": target_id, "flatten": true }),
+            None,
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("attachToTarget");
+    let sid = attach
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .expect("sessionId")
+        .to_string();
+
+    guard
+        .conn
+        .send_recv("Page.enable", json!({}), Some(&sid), CDP_TIMEOUT)
+        .await
+        .expect("Page.enable");
+    let events_rx = guard.conn.subscribe();
+    guard
+        .conn
+        .send_recv(
+            "Page.navigate",
+            json!({ "url": "https://example.com/" }),
+            Some(&sid),
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("Page.navigate");
+
+    let mut rx = events_rx;
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            panic!("loadEventFired timeout");
+        }
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Err(_) => panic!("loadEventFired timeout"),
+            Ok(Err(_)) => continue,
+            Ok(Ok(ev)) => {
+                if ev.method == "Page.loadEventFired" && ev.session_id.as_deref() == Some(&sid) {
+                    break;
+                }
+            }
+        }
+    }
+
+    let resp = guard
+        .conn
+        .send_recv(
+            "Page.captureScreenshot",
+            json!({ "format": "png", "captureBeyondViewport": false, "fromSurface": true }),
+            Some(&sid),
+            CDP_TIMEOUT,
+        )
+        .await
+        .expect("Page.captureScreenshot");
+    let b64 = resp
+        .get("data")
+        .and_then(|v| v.as_str())
+        .expect("captureScreenshot returned `data`");
+    assert!(!b64.is_empty(), "screenshot base64 must be non-empty");
+    assert!(
+        b64.starts_with("iVBORw0KGgo"),
+        "screenshot must be a PNG (base64 PNG magic prefix), got {:?}",
+        &b64[..b64.len().min(16)]
+    );
+
+    guard.release().await.expect("release");
+    pool.shutdown(Duration::from_secs(5)).await;
+}

--- a/crates/crw-server/src/routes/scrape.rs
+++ b/crates/crw-server/src/routes/scrape.rs
@@ -128,7 +128,16 @@ pub async fn scrape(
         } else {
             crw_extract::antibot::AntibotResult::none()
         };
-        if typed.signal.is_blocked() || warning_blocked {
+        // A successful screenshot is real content even when no text was requested
+        // (screenshot-only scrape has empty markdown by design). It may ONLY
+        // suppress the generic near-empty `StructuralFailure` heuristic — never a
+        // positive vendor block (Cloudflare/Datadome/GenericBlock/…), which is a
+        // real block that must still fail (and drive anti_bot credit refunds)
+        // even when we captured a screenshot of the challenge page.
+        let suppressed_by_screenshot = data.screenshot.is_some()
+            && !warning_blocked
+            && typed.signal == crw_extract::antibot::AntibotSignal::StructuralFailure;
+        if (typed.signal.is_blocked() || warning_blocked) && !suppressed_by_screenshot {
             let error_msg = if typed.signal.is_blocked() {
                 format!(
                     "Blocked by anti-bot ({}): {}",

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -1103,6 +1103,7 @@ async fn enrich_with_scrape(
                 goal: None,
                 judge_enabled: None,
                 parsers: None,
+                screenshot_full_page: false,
             };
             let deadline = Deadline::from_request_ms(deadline_ms);
             let result = scrape_url(

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -33,6 +33,10 @@ pub struct V2Document {
     pub summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub change_tracking: Option<ChangeTrackingResult>,
+    /// Page screenshot as a `data:image/png;base64,<...>` URL (Firecrawl-compat
+    /// `screenshot` field). Present only when the `screenshot` format was asked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub screenshot: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
     pub metadata: V2Metadata,
@@ -107,6 +111,7 @@ pub fn to_v2_document(data: ScrapeData, proxy_used: &str, scrape_id: String) -> 
         json: data.json,
         summary: data.summary,
         change_tracking: data.change_tracking,
+        screenshot: data.screenshot,
         warning: data.warning,
         metadata,
     }
@@ -306,6 +311,7 @@ mod tests {
             debug_extraction: None,
             content_type: Some("text/html".into()),
             change_tracking: None,
+            screenshot: None,
         }
     }
 

--- a/crates/crw-server/src/routes/v2/formats.rs
+++ b/crates/crw-server/src/routes/v2/formats.rs
@@ -59,12 +59,16 @@ pub struct DecomposedFormats {
     pub json_schema: Option<Value>,
     /// `ScrapeRequest.change_tracking` (from a `{"type":"changeTracking",...}` entry).
     pub change_tracking: Option<ChangeTrackingOptions>,
-    /// A `screenshot` format was requested. crw does not yet capture screenshots
-    /// (Tier-3), so this is recorded for the response `warning` rather than
-    /// silently dropped — the request still succeeds with the other formats.
+    /// A `screenshot` format was requested. The format is now produced via CDP
+    /// `Page.captureScreenshot`; this flag is retained for callers that want to
+    /// branch on it (e.g. credit pricing).
     pub screenshot_requested: bool,
+    /// Whether the requested screenshot should be full-page (`screenshot@fullPage`
+    /// or `{type:"screenshot", fullPage:true}`) rather than viewport-only.
+    /// Copied into `ScrapeRequest.screenshot_full_page` by `to_internal`.
+    pub screenshot_full_page: bool,
     /// v2-only formats crw cannot yet produce (`images`, `attributes`,
-    /// `branding`, `audio`, `query`, `screenshot`). Surfaced as a warning.
+    /// `branding`, `audio`, `query`). Surfaced as a warning.
     pub unsupported: Vec<String>,
 }
 
@@ -110,13 +114,25 @@ fn handle_token(
     screenshot_seen: &mut bool,
 ) -> Result<(), String> {
     match ty {
-        "screenshot" => {
+        "screenshot" | "screenshot@fullPage" => {
             if *screenshot_seen {
                 return Err("only one screenshot format allowed per request".to_string());
             }
             *screenshot_seen = true;
             out.screenshot_requested = true;
-            out.unsupported.push("screenshot".to_string());
+            // fullPage from the string suffix (`screenshot@fullPage`) or the
+            // object's `fullPage` key. `quality` / `viewport` keys are
+            // accepted-and-ignored for drop-in compatibility (D6).
+            // ponytail: quality + custom viewport deferred to v2 follow-up.
+            let full_page = ty == "screenshot@fullPage"
+                || obj
+                    .and_then(|m| m.get("fullPage"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+            out.screenshot_full_page = full_page;
+            if !out.formats.contains(&OutputFormat::Screenshot) {
+                out.formats.push(OutputFormat::Screenshot);
+            }
             Ok(())
         }
         "images" | "attributes" | "branding" | "audio" | "query" => {
@@ -251,13 +267,56 @@ mod tests {
     #[test]
     fn unsupported_formats_collected_not_fatal() {
         let d = decompose(&specs(
-            json!(["markdown", {"type": "images"}, {"type": "screenshot"}]),
+            json!(["markdown", {"type": "images"}, {"type": "audio"}]),
         ))
         .unwrap();
         assert!(d.formats.contains(&OutputFormat::Markdown));
         assert!(d.unsupported.contains(&"images".to_string()));
-        assert!(d.unsupported.contains(&"screenshot".to_string()));
+        assert!(d.unsupported.contains(&"audio".to_string()));
         assert!(unsupported_warning(&d.unsupported).is_some());
+    }
+
+    #[test]
+    fn screenshot_string_parses() {
+        let d = decompose(&specs(json!(["screenshot"]))).unwrap();
+        assert!(d.formats.contains(&OutputFormat::Screenshot));
+        assert!(!d.screenshot_full_page);
+        assert!(d.screenshot_requested);
+        // not surfaced as unsupported anymore — it's produced.
+        assert!(!d.unsupported.contains(&"screenshot".to_string()));
+    }
+
+    #[test]
+    fn screenshot_full_page_string_sets_flag() {
+        let d = decompose(&specs(json!(["screenshot@fullPage"]))).unwrap();
+        assert!(d.formats.contains(&OutputFormat::Screenshot));
+        assert!(d.screenshot_full_page);
+    }
+
+    #[test]
+    fn screenshot_object_full_page_sets_flag() {
+        let d = decompose(&specs(json!([{"type": "screenshot", "fullPage": true}]))).unwrap();
+        assert!(d.formats.contains(&OutputFormat::Screenshot));
+        assert!(d.screenshot_full_page);
+    }
+
+    #[test]
+    fn screenshot_object_ignores_quality_and_viewport() {
+        // Forgiving over erroring (D6): unknown sub-keys are accepted, not 400'd.
+        let d = decompose(&specs(json!([
+            {"type": "screenshot", "fullPage": false, "quality": 80,
+             "viewport": {"width": 1280, "height": 720}}
+        ])))
+        .unwrap();
+        assert!(d.formats.contains(&OutputFormat::Screenshot));
+        assert!(!d.screenshot_full_page);
+    }
+
+    #[test]
+    fn screenshot_only_does_not_force_markdown() {
+        let d = decompose(&specs(json!(["screenshot"]))).unwrap();
+        assert_eq!(d.formats, vec![OutputFormat::Screenshot]);
+        assert!(!d.formats.contains(&OutputFormat::Markdown));
     }
 
     #[test]

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -144,6 +144,7 @@ pub(crate) fn to_internal(
         headers: v2.headers,
         json_schema: decomposed.json_schema.clone(),
         change_tracking: decomposed.change_tracking.clone(),
+        screenshot_full_page: decomposed.screenshot_full_page,
         country,
         deadline_ms: v2.timeout,
         llm_api_key: v2.llm_api_key,

--- a/docs/docs/output-formats.md
+++ b/docs/docs/output-formats.md
@@ -1,6 +1,6 @@
 # Output Formats
 
-crw supports 8 output formats. Request multiple formats in a single scrape call.
+crw supports 9 output formats. Request multiple formats in a single scrape call.
 
 ## Formats
 
@@ -14,6 +14,7 @@ crw supports 8 output formats. Request multiple formats in a single scrape call.
 | JSON | `json` | LLM structured extraction with JSON schema validation |
 | Summary | `summary` | LLM-generated prose summary of the page |
 | Change Tracking | `changeTracking` | Diff-based change detection against a prior snapshot |
+| Screenshot | `screenshot` | PNG screenshot via Chrome/CDP, returned as a `data:image/png;base64,…` URL (use `screenshot@fullPage` for the full page) |
 | Extract | `extract` | Alias for `json` — accepted for Firecrawl compatibility |
 
 ## Which Format Should You Choose?


### PR DESCRIPTION
Closes #161

## What

Adds a `screenshot` output format to the scrape API. A page screenshot is captured during the scrape session via CDP `Page.captureScreenshot` and returned as a `data:image/png;base64,…` URL in `data.screenshot`.

Supported request forms (Firecrawl-compatible wire shape):
- `formats: ["screenshot"]` → viewport screenshot
- `formats: ["screenshot@fullPage"]` → full-page (string token; v1 + v2)
- `formats: [{ "type": "screenshot", "fullPage": true }]` → object form (v2)

Works on both `/v1/scrape` and `/v2/scrape`.

## How

- Capture is **Chrome/CDP only**. A screenshot request forces the JS/CDP path and filters out **lightpanda** (returns a ~30-byte stub) and **camoufox** (HTTP sidecar, no CDP). If no CDP-capable renderer is available it **fails closed** with a clear error instead of returning a null screenshot on a 200.
- `renderJs:false` + `screenshot` is rejected as contradictory (400).
- Screenshot-only requests no longer trip the v1 empty-content anti-bot gate: only the generic `StructuralFailure` (near-empty) heuristic is suppressed when a screenshot was captured — a real vendor block (Cloudflare/Datadome/…) still fails and still drives anti-bot handling.
- Opts flow via a `REQUEST_SCREENSHOT` task-local (mirrors the existing `REQUEST_PROXY`), so the renderer trait signature and its ~30 call sites are untouched.
- The `data:` prefix is wrapped once at the `ScrapeData` boundary so v1 and v2 responses are identical.

## Tested

- Unit tests for format parsing (string/`@fullPage`/object, screenshot-only does not force markdown, dedupe), the data-URL wrap, and a Chrome-gated capture smoke test (`#[ignore]`).
- End-to-end against a real headless Chrome + live server: viewport (756×469) and full-page (756×10653) PNGs; markdown+screenshot together; v1 + v2 screenshot-only `success:true`; `renderJs:false` rejected (400); normal scrape unaffected.
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo build`, `cargo test` all green.

## Deferred (follow-ups)

`quality` param · custom viewport · JPEG/WebP · hosted-URL storage · CLI `--format screenshot` · MCP advertised screenshot.