### PR TITLE
fix(map): render SPA shells during URL discovery

### DIFF
--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -695,14 +695,12 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         // proxy (sticky-per-host), not direct. Resolved once into REQUEST_PROXY.
         let resolved_proxy = renderer.pick_proxy_for_url(&url);
         let empty_headers: HashMap<String, String> = HashMap::new();
-        let fetch_fut = renderer.fetch(
-            &url,
-            &empty_headers,
-            Some(false),
-            None,
-            None,
-            discover_deadline,
-        );
+        // render_js = None (auto), not Some(false): SPAs (Angular/React/Vue)
+        // serve an empty app shell over plain HTTP, so HTTP-only discovery finds
+        // zero navigational links and /map returns only the seed URL (issue #166).
+        // Auto mode lets the renderer escalate thin/SPA shells to a JS render
+        // (it stays HTTP-only for static sites), matching /scrape and /crawl.
+        let fetch_fut = renderer.fetch(&url, &empty_headers, None, None, None, discover_deadline);
         let fetch = crw_renderer::REQUEST_PROXY
             .scope(resolved_proxy, fetch_fut)
             .await;


### PR DESCRIPTION
Fixes #166.

## Problem
`/v1/map` returned only the seed URL for single-page apps. The example from the issue ([loyalty-tap.buildwithimran.online](https://loyalty-tap.buildwithimran.online/)) is an Angular SPA: the homepage and even `/sitemap.xml` return the empty app shell over plain HTTP, and the route links only exist after JS runs.

## Root cause
`discover_urls`' BFS phase fetched every page with `render_js = Some(false)` (HTTP-only). For SPAs that shell has no navigational links → `extract_links` finds nothing → map returns just the seed.

## Fix
Pass `render_js = None` (auto) instead. The renderer escalates thin/SPA shells to a JS render while staying HTTP-only for static sites — same behavior `/scrape` and `/crawl` already use.

## Verified in production
| Site | Before | After |
|------|--------|-------|
| loyalty-tap.buildwithimran.online (Angular SPA) | 1 link | **14 links** (auth, faq, blogs + nested posts, policies) |
| example.com (static) | fast | fast, HTTP-only |
| books.toscrape.com (large static) | HTTP-only | HTTP-only (no render regression) |

Static sites stay on the HTTP path (`autoDefault → http`), so there's no added latency or cost for non-SPA targets.