### PR TITLE
chore(release): track openapi.json info.version in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -130,6 +130,16 @@
           "type": "json",
           "path": "sdks/typescript/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "docs/openapi.json",
+          "jsonpath": "$.info.version"
+        },
+        {
+          "type": "json",
+          "path": "crates/crw-server/openapi/openapi.json",
+          "jsonpath": "$.info.version"
         }
       ]
     }


### PR DESCRIPTION
The two OpenAPI specs (`docs/openapi.json` + `crates/crw-server/openapi/openapi.json`) were missing from release-please `extra-files`, so their `info.version` was never bumped on release. Result: the OpenAPI drift guard fails on every release PR (e.g. #147: Cargo.toml=0.17.0 vs openapi.json=0.16.0).

Register both files so release-please bumps `info.version` together with Cargo.toml/SDK versions. Fixes the recurring drift failure for #147 and all future releases.