### PR TITLE
feat(extract): optional reasoning_effort config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Built in Rust because every millisecond of agent latency compounds.
 </p>
 
 <p align="center">
-  <a href="https://twitter.com/fastcrw"><img src="https://img.shields.io/badge/Follow%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
+  <a href="https://x.com/fast_crw"><img src="https://img.shields.io/badge/Follow%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
   <a href="https://www.linkedin.com/company/fastcrw"><img src="https://img.shields.io/badge/Follow%20on%20LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" /></a>
   <a href="https://discord.gg/kkFh2SC8"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" /></a>
 </p>
@@ -490,7 +490,7 @@ on request — write to **hello@fastcrw.com**.
 - **Benchmarks:** [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks)
 - **Marketing site:** [fastcrw.com](https://fastcrw.com)
 - **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
-- **X / Twitter:** [@fastcrw](https://twitter.com/fastcrw)
+- **X / Twitter:** [@fast_crw](https://x.com/fast_crw)
 - **LinkedIn:** [fastcrw](https://www.linkedin.com/company/fastcrw)
 - **Discord:** [discord.gg/kkFh2SC8](https://discord.gg/kkFh2SC8)
 - **MCP Registry:** [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=crw)

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1276,6 +1276,11 @@ pub struct LlmConfig {
     /// proven not to raise abstention.
     #[serde(default)]
     pub temperature: Option<f32>,
+    /// Optional reasoning-effort hint forwarded to OpenAI-compatible providers
+    /// that support it. `None` (default) and the empty string send no key,
+    /// preserving each provider's default behavior.
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
 }
 
 impl Default for LlmConfig {
@@ -1291,6 +1296,7 @@ impl Default for LlmConfig {
             max_html_bytes: default_llm_max_html_bytes(),
             require_byok_header: None,
             temperature: None,
+            reasoning_effort: None,
         }
     }
 }

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -14,6 +14,7 @@ use crate::pricing;
 use crw_core::config::LlmConfig;
 use crw_core::error::{CrwError, CrwResult};
 use crw_core::types::LlmUsage;
+use rand::Rng;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -86,6 +87,7 @@ pub async fn extract_via_llm(
         max_tokens,
         azure_api_version,
         None, // extraction path: keep provider-default temperature
+        None, // extraction path: no reasoning_effort
         EXTRACTION_SYSTEM_PROMPT,
         &user_msg,
     )
@@ -117,6 +119,7 @@ pub async fn chat(
         cfg.max_tokens,
         cfg.azure_api_version.as_deref(),
         cfg.temperature,
+        cfg.reasoning_effort.as_deref(),
         system_prompt,
         user_msg,
     )
@@ -233,6 +236,7 @@ async fn dispatch(
     max_tokens: u32,
     azure_api_version: Option<&str>,
     temperature: Option<f32>,
+    reasoning_effort: Option<&str>,
     system_prompt: &str,
     user_msg: &str,
 ) -> CrwResult<LlmCallResult> {
@@ -263,6 +267,7 @@ async fn dispatch(
                 base_url,
                 max_tokens,
                 temperature,
+                reasoning_effort,
                 system_prompt,
                 user_msg,
                 provider_tag,
@@ -370,6 +375,7 @@ async fn call_openai(
     base_url: Option<&str>,
     max_tokens: u32,
     temperature: Option<f32>,
+    reasoning_effort: Option<&str>,
     system_prompt: &str,
     user_msg: &str,
     provider: &str,
@@ -401,20 +407,50 @@ async fn call_openai(
         body["temperature"] = serde_json::json!(t);
         body["seed"] = serde_json::json!(42);
     }
-    let resp = client
-        .post(url)
-        .bearer_auth(api_key)
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
+    // Only forward a present, non-empty value. A configured-but-empty value
+    // deserializes to `Some("")` and would be rejected (HTTP 400) by providers
+    // that validate the field, so treat it as unset.
+    if let Some(effort) = reasoning_effort.filter(|s| !s.is_empty()) {
+        body["reasoning_effort"] = serde_json::json!(effort);
+    }
+    // Fixed self-limiting retry on transient server throttling (HTTP 429/503)
+    // only. The shared client carries a 30s per-attempt timeout and the
+    // caller's request deadline is not threaded in here, so the budget stays
+    // small and fixed (a few short jittered sleeps). 429/503 are fast server
+    // rejects, so the worst case stays well under the request deadline. All
+    // other non-2xx responses (and transport/timeout errors) keep the original
+    // single-POST contract: hard-error on the first response.
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut attempt: u32 = 0;
+    let (status, text) = loop {
+        attempt += 1;
+        let resp = client
+            .post(url)
+            .bearer_auth(api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
 
-    let status = resp.status();
-    let text = resp
-        .text()
-        .await
-        .map_err(|e| CrwError::Internal(format!("LLM response read failed: {e}")))?;
+        let status = resp.status();
+        let is_retryable = status == reqwest::StatusCode::TOO_MANY_REQUESTS
+            || status == reqwest::StatusCode::SERVICE_UNAVAILABLE;
+        if is_retryable && attempt < MAX_ATTEMPTS {
+            // Exponential backoff with jitter: ~0.5s, ~1s base + up to ~1s
+            // jitter. Drop the response body unread — the status is enough.
+            let base_ms = 500u64 * (1u64 << (attempt - 1));
+            let jitter_ms = rand::rng().random_range(0..1000);
+            tokio::time::sleep(Duration::from_millis(base_ms + jitter_ms)).await;
+            continue;
+        }
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| CrwError::Internal(format!("LLM response read failed: {e}")))?;
+        break (status, text);
+    };
     if !status.is_success() {
         return Err(CrwError::Internal(format!("LLM HTTP {status} from openai")));
     }

--- a/crates/crw-extract/tests/reasoning_effort_tests.rs
+++ b/crates/crw-extract/tests/reasoning_effort_tests.rs
@@ -1,0 +1,200 @@
+//! Wiremock-backed tests for the optional `reasoning_effort` field and the
+//! 429/503 transient-throttle retry on the OpenAI-compatible chat path.
+//!
+//! The field is forwarded into the request body only when set to a present,
+//! non-empty value; a configured-but-empty value (`Some("")`) is treated as
+//! unset to avoid provider 400s.
+
+use crw_core::config::LlmConfig;
+use crw_extract::llm::chat;
+use serde_json::json;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+fn mock_llm(base_url: String) -> LlmConfig {
+    LlmConfig {
+        provider: "deepseek".into(),
+        api_key: "test-key".into(),
+        model: "test-model".into(),
+        base_url: Some(base_url),
+        ..Default::default()
+    }
+}
+
+fn chat_response() -> serde_json::Value {
+    json!({
+        "choices": [{ "message": { "content": "hello world" } }],
+        "usage": { "prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15 }
+    })
+}
+
+#[tokio::test]
+async fn reasoning_effort_forwarded_when_set() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(chat_response()))
+        .mount(&server)
+        .await;
+
+    let mut llm = mock_llm(format!("{}/v1", server.uri()));
+    llm.reasoning_effort = Some("none".into());
+    let res = chat(&llm, "sys", "user").await.expect("chat succeeds");
+    assert_eq!(res.content, "hello world");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(
+        body.get("reasoning_effort").and_then(|v| v.as_str()),
+        Some("none")
+    );
+}
+
+#[tokio::test]
+async fn reasoning_effort_absent_when_none() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(chat_response()))
+        .mount(&server)
+        .await;
+
+    let llm = mock_llm(format!("{}/v1", server.uri())); // reasoning_effort defaults to None
+    let _ = chat(&llm, "sys", "user").await.expect("chat succeeds");
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert!(body.get("reasoning_effort").is_none());
+}
+
+#[tokio::test]
+async fn reasoning_effort_absent_when_empty_string() {
+    // A configured-but-empty value deserializes to `Some("")` and must NOT be
+    // forwarded (providers that validate the field would 400).
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(chat_response()))
+        .mount(&server)
+        .await;
+
+    let mut llm = mock_llm(format!("{}/v1", server.uri()));
+    llm.reasoning_effort = Some(String::new());
+    let _ = chat(&llm, "sys", "user").await.expect("chat succeeds");
+
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert!(body.get("reasoning_effort").is_none());
+}
+
+/// Responder that returns a transient throttle status for the first N calls,
+/// then a 200 success. Lets us prove the retry loop recovers without sleeping
+/// the test for long (the loop's own jittered backoff stays sub-second early).
+struct ThrottleThenOk {
+    fails: usize,
+    seen: Arc<AtomicUsize>,
+    status: u16,
+}
+
+impl Respond for ThrottleThenOk {
+    fn respond(&self, _: &Request) -> ResponseTemplate {
+        let n = self.seen.fetch_add(1, Ordering::SeqCst);
+        if n < self.fails {
+            ResponseTemplate::new(self.status)
+        } else {
+            ResponseTemplate::new(200).set_body_json(chat_response())
+        }
+    }
+}
+
+#[tokio::test]
+async fn retries_on_429_then_succeeds() {
+    let server = MockServer::start().await;
+    let seen = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ThrottleThenOk {
+            fails: 1,
+            seen: seen.clone(),
+            status: 429,
+        })
+        .mount(&server)
+        .await;
+
+    let llm = mock_llm(format!("{}/v1", server.uri()));
+    let res = chat(&llm, "sys", "user")
+        .await
+        .expect("chat recovers after 429");
+    assert_eq!(res.content, "hello world");
+    // One 429 + one 200 = exactly two server hits.
+    assert_eq!(seen.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn retries_on_503_then_succeeds() {
+    let server = MockServer::start().await;
+    let seen = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ThrottleThenOk {
+            fails: 1,
+            seen: seen.clone(),
+            status: 503,
+        })
+        .mount(&server)
+        .await;
+
+    let llm = mock_llm(format!("{}/v1", server.uri()));
+    let res = chat(&llm, "sys", "user")
+        .await
+        .expect("chat recovers after 503");
+    assert_eq!(res.content, "hello world");
+    assert_eq!(seen.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn retry_budget_is_bounded_and_errors_when_exhausted() {
+    // Persistent 429 must stop after the fixed attempt budget and hard-error,
+    // not loop forever.
+    let server = MockServer::start().await;
+    let seen = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ThrottleThenOk {
+            fails: usize::MAX,
+            seen: seen.clone(),
+            status: 429,
+        })
+        .mount(&server)
+        .await;
+
+    let llm = mock_llm(format!("{}/v1", server.uri()));
+    let res = chat(&llm, "sys", "user").await;
+    assert!(res.is_err(), "exhausted retry budget must hard-error");
+    // Fixed budget of 3 attempts total.
+    assert_eq!(seen.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn non_retryable_status_errors_on_first_response() {
+    // A 400 must keep the original single-POST contract: hard-error, no retry.
+    let server = MockServer::start().await;
+    let seen = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ThrottleThenOk {
+            fails: usize::MAX,
+            seen: seen.clone(),
+            status: 400,
+        })
+        .mount(&server)
+        .await;
+
+    let llm = mock_llm(format!("{}/v1", server.uri()));
+    let res = chat(&llm, "sys", "user").await;
+    assert!(res.is_err());
+    assert_eq!(seen.load(Ordering::SeqCst), 1, "400 must not be retried");
+}

--- a/crates/crw-server/src/main.rs
+++ b/crates/crw-server/src/main.rs
@@ -114,13 +114,23 @@ async fn run_server() {
         std::process::exit(1);
     }
 
-    // Boot guard: the configured LLM model must live in this project's own
-    // `crw-` namespace. This catches a misconfigured deploy before any request
-    // is served. Skipped when no LLM is configured (non-LLM deploys are fine).
-    if let Some(llm) = config.extraction.llm.as_ref()
-        && !llm.model.starts_with("crw-")
-    {
-        tracing::error!("[extraction.llm].model must use the `crw-` namespace (refusing to boot).");
+    // Optional boot guard (off by default): when `CRW_REQUIRE_MANAGED_MODEL_PREFIX`
+    // is set, the configured LLM model must live in this project's own `crw-`
+    // namespace. SaaS-fronted deploys enable it to catch a misconfigured model
+    // before any request is served. Self-hosters leave it unset and can use any
+    // model. Skipped when no LLM is configured.
+    let require_managed_prefix = std::env::var("CRW_REQUIRE_MANAGED_MODEL_PREFIX")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if !managed_model_prefix_ok(
+        require_managed_prefix,
+        config.extraction.llm.as_ref().map(|c| c.model.as_str()),
+    ) {
+        tracing::error!(
+            "[extraction.llm].model must use the `crw-` namespace when \
+             CRW_REQUIRE_MANAGED_MODEL_PREFIX is set (check CRW_EXTRACTION__LLM__MODEL); \
+             refusing to boot."
+        );
         std::process::exit(1);
     }
 
@@ -261,5 +271,46 @@ async fn shutdown_signal() {
     tokio::select! {
         _ = ctrl_c => tracing::info!("Received Ctrl+C, shutting down..."),
         _ = terminate => tracing::info!("Received SIGTERM, shutting down..."),
+    }
+}
+
+/// Decide whether the configured LLM model satisfies the optional managed-prefix
+/// guard. Returns `true` (boot allowed) when the guard is off, when no LLM is
+/// configured, or when the model uses the `crw-` namespace. Returns `false`
+/// (refuse boot) only when the guard is on AND a non-`crw-` model is configured.
+fn managed_model_prefix_ok(require: bool, model: Option<&str>) -> bool {
+    if !require {
+        return true;
+    }
+    match model {
+        None => true,
+        Some(m) => m.starts_with("crw-"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::managed_model_prefix_ok;
+
+    #[test]
+    fn guard_off_allows_any_model() {
+        assert!(managed_model_prefix_ok(false, Some("gpt-4o")));
+        assert!(managed_model_prefix_ok(false, Some("crw-managed")));
+        assert!(managed_model_prefix_ok(false, None));
+    }
+
+    #[test]
+    fn guard_on_allows_crw_prefixed_model() {
+        assert!(managed_model_prefix_ok(true, Some("crw-managed")));
+    }
+
+    #[test]
+    fn guard_on_rejects_non_crw_model() {
+        assert!(!managed_model_prefix_ok(true, Some("gpt-4o")));
+    }
+
+    #[test]
+    fn guard_on_skips_when_no_model_configured() {
+        assert!(managed_model_prefix_ok(true, None));
     }
 }

--- a/crates/crw-server/src/main.rs
+++ b/crates/crw-server/src/main.rs
@@ -114,6 +114,16 @@ async fn run_server() {
         std::process::exit(1);
     }
 
+    // Boot guard: the configured LLM model must live in this project's own
+    // `crw-` namespace. This catches a misconfigured deploy before any request
+    // is served. Skipped when no LLM is configured (non-LLM deploys are fine).
+    if let Some(llm) = config.extraction.llm.as_ref()
+        && !llm.model.starts_with("crw-")
+    {
+        tracing::error!("[extraction.llm].model must use the `crw-` namespace (refusing to boot).");
+        std::process::exit(1);
+    }
+
     let state = match AppState::new(config) {
         Ok(s) => s,
         Err(e) => {

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -885,6 +885,9 @@ fn build_byok_search_llm_config(
     if let Some(b) = &req.base_url {
         cfg.base_url = Some(b.clone());
     }
+    // Never inherit the server's reasoning_effort into a BYOK request — the
+    // customer's endpoint must receive only what they explicitly configure.
+    cfg.reasoning_effort = None;
     Some(cfg)
 }
 
@@ -1285,6 +1288,32 @@ mod tests {
             }
             other => panic!("expected TargetUnreachable, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn byok_config_clears_reasoning_effort() {
+        // A BYOK request must never inherit the server's reasoning_effort.
+        let server_cfg = LlmConfig {
+            reasoning_effort: Some("none".into()),
+            ..Default::default()
+        };
+        let mut r = req("hello");
+        r.llm_api_key = Some("byok-key".into());
+        let byok = build_byok_search_llm_config(&r, Some(&server_cfg))
+            .expect("byok config built when llm_api_key present");
+        assert_eq!(byok.reasoning_effort, None);
+        assert_eq!(byok.api_key, "byok-key");
+    }
+
+    #[test]
+    fn byok_config_none_without_api_key() {
+        let server_cfg = LlmConfig {
+            reasoning_effort: Some("none".into()),
+            ..Default::default()
+        };
+        // No llm_api_key => not a BYOK request.
+        let byok = build_byok_search_llm_config(&req("hello"), Some(&server_cfg));
+        assert!(byok.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Adds an optional reasoning_effort config field on LlmConfig, forwarded to OpenAI-compatible providers that support it. Off by default: unset or empty sends nothing (BYOK and self-host unaffected). Cleared for BYOK search requests. Adds a bounded 429/503 exponential-backoff retry to the LLM HTTP call. Adds an opt-in boot guard (CRW_REQUIRE_MANAGED_MODEL_PREFIX, default off) that enforces a crw- model namespace only when set. All additive; cargo build/test/clippy green.