### PR TITLE
fix(mcp): static musl linux binaries + correct claude mcp add docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,11 +137,18 @@ jobs:
             os: macos-latest
             platform: darwin
             arch_label: arm64
-          - target: x86_64-unknown-linux-gnu
+          # Linux ships static musl builds so the binaries run on ANY glibc
+          # (old Debian/Ubuntu, Alpine, etc.). A glibc-linked build requires the
+          # builder's glibc (≥2.38) and crashes on older hosts with
+          # "GLIBC_2.xx not found". Safe here: TLS is rustls+ring (no native
+          # openssl), so musl links cleanly. Asset/npm names (linux-x64/arm64)
+          # are unchanged; both built via cross (musl toolchain in its image).
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             platform: linux
             arch_label: x64
-          - target: aarch64-unknown-linux-gnu
+            cross: true
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             platform: linux
             arch_label: arm64

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ the `crw-mcp` Node binary both shell to the same Rust core.
 ```bash
 npm install -g crw-mcp          # MCP server (Node wrapper)
 pip install crw                 # Python SDK (auto-downloads binary)
-claude mcp add crw -- npx crw-mcp                                          # Claude Code, embedded
-claude mcp add -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=… \
-  crw -- npx crw-mcp                                                       # Claude Code, managed
+claude mcp add crw -- npx -y crw-mcp                                       # Claude Code, embedded
+claude mcp add crw \
+  -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=… \
+  -- npx -y crw-mcp                                                        # Claude Code, managed
 ```
 
 Per-client config recipes (Claude Desktop, Cursor, Windsurf, Cline,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,7 +147,7 @@ CRW 提供 Firecrawl 的 API，但资源占用极低。无运行时依赖，无 
 **MCP（AI 代理 — 推荐）：**
 
 ```bash
-claude mcp add crw -- npx crw-mcp
+claude mcp add crw -- npx -y crw-mcp
 ```
 
 > 完成。Claude Code 现在拥有 `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file` 工具（`crw_search` 在配置 SearXNG 后端后自动出现）。Cursor、Windsurf、Cline 等 MCP 客户端请参见 [MCP 服务器](#mcp-服务器)。
@@ -302,7 +302,7 @@ docker run -i ghcr.io/us/crw crw-mcp
 **Claude Code：**
 
 ```bash
-claude mcp add crw -- npx crw-mcp
+claude mcp add crw -- npx -y crw-mcp
 ```
 
 **其他 MCP 客户端配置：**

--- a/crates/crw-mcp/README.md
+++ b/crates/crw-mcp/README.md
@@ -32,6 +32,11 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 ## Installation
 
 ```bash
+# npm — prebuilt binary (Linux builds are static musl, so they run on any
+# distro/glibc; macOS and Windows included)
+npm install -g crw-mcp
+
+# or build from source (Rust)
 cargo install crw-mcp
 ```
 
@@ -43,11 +48,13 @@ No server to run. Just add `crw-mcp` to your AI client:
 # Claude Code
 claude mcp add crw -- crw-mcp
 
-# With custom config via env vars
-claude mcp add \
+# With custom config via env vars.
+# NOTE: the server name (crw) MUST come BEFORE the -e flags — `-e` is variadic
+# and will otherwise swallow the name ("Invalid environment variable: crw").
+claude mcp add crw \
   -e CRW_CRAWLER__MAX_CONCURRENCY=5 \
   -e CRW_RENDERER__LIGHTPANDA__WS_URL=ws://127.0.0.1:9222 \
-  crw -- crw-mcp
+  -- crw-mcp
 ```
 
 ## Proxy Mode (Remote Server)
@@ -55,16 +62,16 @@ claude mcp add \
 Connect to [fastcrw.com](https://fastcrw.com) or any remote CRW instance:
 
 ```bash
-# Cloud server
-claude mcp add \
+# Cloud server (name `crw` comes BEFORE -e, command after `--`)
+claude mcp add crw \
   -e CRW_API_URL=https://api.fastcrw.com \
   -e CRW_API_KEY=crw_live_xxx \
-  crw -- crw-mcp
+  -- crw-mcp
 
 # Local crw-server on custom port
-claude mcp add \
+claude mcp add crw \
   -e CRW_API_URL=http://localhost:4000 \
-  crw -- crw-mcp
+  -- crw-mcp
 ```
 
 Or use the HTTP transport directly (no `crw-mcp` binary needed):

--- a/docs/docs/mcp-clients.md
+++ b/docs/docs/mcp-clients.md
@@ -58,16 +58,16 @@ If you only remember one rule, remember this one: local embedded mode is the eas
 ### Local embedded
 
 ```bash
-claude mcp add crw -- npx crw-mcp
+claude mcp add crw -- npx -y crw-mcp
 ```
 
 ### fastcrw.com cloud
 
 ```bash
-claude mcp add \
+claude mcp add crw \
   -e CRW_API_URL=https://api.fastcrw.com \
   -e CRW_API_KEY=YOUR_API_KEY \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 ```
 
 ### Local HTTP transport
@@ -461,9 +461,9 @@ Local embedded mode uses the same config chain as `crw-server`:
 If you need JavaScript rendering in local MCP mode, pass a renderer URL:
 
 ```bash
-claude mcp add \
+claude mcp add crw \
   -e CRW_RENDERER__LIGHTPANDA__WS_URL=ws://127.0.0.1:9222 \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 ```
 
 Without a configured renderer, CRW still works in HTTP-only mode.

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -54,7 +54,7 @@ Add to your MCP client:
 
 ```bash
 # Claude Code:
-claude mcp add crw -- npx crw-mcp
+claude mcp add crw -- npx -y crw-mcp
 
 # OpenAI Codex CLI:
 codex mcp add crw -- npx crw-mcp
@@ -69,9 +69,9 @@ If you want host-by-host config files instead of one-liners, jump to [MCP Client
 If you have a CDP-compatible browser, pass it via env vars:
 
 ```bash
-claude mcp add \
+claude mcp add crw \
   -e CRW_RENDERER__LIGHTPANDA__WS_URL=ws://127.0.0.1:9222 \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 ```
 
 Without a CDP browser, `crw-mcp` uses its HTTP-only renderer (no JavaScript rendering).
@@ -92,15 +92,15 @@ Connect to [fastcrw.com](https://fastcrw.com) or any remote CRW instance:
 
 ```bash
 # Cloud server
-claude mcp add \
+claude mcp add crw \
   -e CRW_API_URL=https://api.fastcrw.com \
   -e CRW_API_KEY=YOUR_API_KEY \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 
 # Local crw-server on custom port
-claude mcp add \
+claude mcp add crw \
   -e CRW_API_URL=http://localhost:4000 \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 ```
 
 The same `CRW_API_URL` + `CRW_API_KEY` env block also works in Codex, Claude Desktop, Cursor, Windsurf, Cline, and Continue. See [MCP Client Setup](#mcp-clients) for ready-to-paste config files.
@@ -109,7 +109,7 @@ The same `CRW_API_URL` + `CRW_API_KEY` env block also works in Codex, Claude Des
 
 | Transport | Setup | Requires |
 |-----------|-------|----------|
-| **Stdio embedded** (recommended) | `claude mcp add crw -- npx crw-mcp` | Nothing |
+| **Stdio embedded** (recommended) | `claude mcp add crw -- npx -y crw-mcp` | Nothing |
 | **Stdio proxy** | `CRW_API_URL=... npx crw-mcp` | Remote CRW server |
 | **HTTP** | `claude mcp add --transport http crw http://localhost:3000/mcp` | `crw-server` running |
 
@@ -187,13 +187,13 @@ Wire it into your client the same way you do `crw-mcp` — it uses stdio transpo
 
 ```bash
 # Local embedded
-claude mcp add crw -- npx crw-mcp
+claude mcp add crw -- npx -y crw-mcp
 
 # fastcrw.com cloud
-claude mcp add \
+claude mcp add crw \
   -e CRW_API_URL=https://api.fastcrw.com \
   -e CRW_API_KEY=YOUR_API_KEY \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 ```
 
 ### OpenAI Codex CLI

--- a/docs/docs/recipe-mcp-5min.md
+++ b/docs/docs/recipe-mcp-5min.md
@@ -15,7 +15,7 @@ This recipe walks from zero to a working Claude Code agent that can search the w
 The MCP binary contains a full scraping engine. No server, no account needed.
 
 ```bash
-claude mcp add crw -- npx crw-mcp
+claude mcp add crw -- npx -y crw-mcp
 ```
 
 Claude Code writes this into your project `.claude/mcp.json` automatically. You are done. Start a new Claude Code session and the tools are available.
@@ -27,10 +27,10 @@ Claude Code writes this into your project `.claude/mcp.json` automatically. You 
 Get a free API key at [fastcrw.com](https://fastcrw.com) — 500 one-time lifetime credits, no monthly reset.
 
 ```bash
-claude mcp add \
+claude mcp add crw \
   -e CRW_API_URL=https://api.fastcrw.com \
   -e CRW_API_KEY=crw_live_xxxxxxxxxxxx \
-  crw -- npx crw-mcp
+  -- npx -y crw-mcp
 ```
 
 This registers the same `crw-mcp` binary in proxy mode. Tool calls are forwarded to `api.fastcrw.com`. All 6 tools are advertised, including `crw_search`.

--- a/skills/crw-self-host/SKILL.md
+++ b/skills/crw-self-host/SKILL.md
@@ -274,7 +274,7 @@ sandbox = false            # set true in Docker (untrusted uploads)
 MCP process. No separate server needed. ~6 MB RAM. Zero setup.
 ```bash
 npx crw-mcp                            # embedded
-claude mcp add crw -- npx crw-mcp     # Claude Code, embedded
+claude mcp add crw -- npx -y crw-mcp  # Claude Code, embedded
 ```
 
 **Proxy mode** (`CRW_API_URL` set): MCP forwards all calls to the REST endpoint.
@@ -284,8 +284,9 @@ point at `api.fastcrw.com`.
 CRW_API_URL=https://api.fastcrw.com CRW_API_KEY=crw_live_... npx crw-mcp
 
 # Claude Code:
-claude mcp add -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=crw_live_... \
-  crw -- npx crw-mcp
+claude mcp add crw \
+  -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=crw_live_... \
+  -- npx -y crw-mcp
 ```
 
 ## Verify the setup


### PR DESCRIPTION
## Problem
crw-mcp's linux release binaries are **glibc-linked** (built on a runner with glibc ≥2.38), so on older hosts they crash with `GLIBC_2.38/2.39 not found` and Claude Code reports `MCP error -32000: Connection closed`. Reported on a Debian/Ubuntu server.

## Fix
- **Linux → static musl** (`x86_64/aarch64-unknown-linux-musl` via cross) in `release.yml`. TLS is `rustls`+`ring` (no native openssl), so musl links cleanly. Asset & npm package names (`linux-x64`/`linux-arm64`) are unchanged → asset-gate, npm publish, apt/brew all unaffected. Result: binaries run on **any** glibc (old Debian/Ubuntu, Alpine…).
- **Docs**: every `claude mcp add` example that put the server name *after* the `-e` flags was broken — `-e` is variadic and swallows the name → `Invalid environment variable: crw`. Fixed 9 commands across README(.zh-CN), crw-mcp README, docs/mcp(.md/-clients/recipe), and the self-host skill to put the name first + command after `--`, and added `npx -y` so first-run install doesn't hang on a prompt.

## Note
musl build runs on the next tagged release; asset-gate (18 binaries) guards a bad build from shipping.