### PR TITLE
fix(stealth): bump UA + Sec-Ch-Ua from Chrome 131 to 150

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1134,11 +1134,11 @@ fn default_jitter() -> f64 {
 
 /// Built-in realistic user-agent pool used when stealth is enabled.
 pub const BUILTIN_UA_POOL: &[&str] = &[
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15",
 ];
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1227,7 +1227,7 @@ fn default_ua() -> String {
     // (opencorporates, killeenisd, wsj) returning 403/404. Kept in sync with the
     // Sec-Ch-Ua client hint in `crw-renderer/src/http_only.rs`.
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
-     (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+     (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
         .into()
 }
 fn default_depth() -> u32 {

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -45,9 +45,9 @@ fn is_retriable_status(status: u16) -> bool {
 /// These mimic a real browser's default request headers.
 const STEALTH_ACCEPT: &str =
     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
-/// Chrome 131 client hint — kept in sync with the UA strings in BUILTIN_UA_POOL.
+/// Chrome 150 client hint — kept in sync with the UA strings in BUILTIN_UA_POOL.
 const STEALTH_SEC_CH_UA: &str =
-    r#""Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24""#;
+    r#""Google Chrome";v="150", "Chromium";v="150", "Not_A Brand";v="24""#;
 
 /// Build a configured reqwest client, optionally routed through `proxy`.
 ///


### PR DESCRIPTION
## Problem
Users (incl. `brew install crw`) hit **"Your browser is outdated"** on sites that gate by UA major version. crw's default UA was **Chrome 131** (late 2024) — ~19 majors behind current stable (**Chrome 150**, Jun 2026).

## Fix
- `BUILTIN_UA_POOL` → Chrome 150, Firefox 140, Safari 18.5 (+ current OS versions).
- `default_ua()` → Chrome 150.
- `STEALTH_SEC_CH_UA` client hint → `v="150"`, kept in sync with the UA (a UA / Sec-Ch-Ua major mismatch is itself a bot signal).

Ships in the next release. Pre-commit fmt/clippy/build/test green.