### PR TITLE
feat(install): auto-launch crw setup after install + conversion copy

### DIFF
--- a/crates/crw-cli/src/commands/setup/wizard.rs
+++ b/crates/crw-cli/src/commands/setup/wizard.rs
@@ -25,12 +25,12 @@ pub async fn run_wizard() -> Result<(), SetupError> {
 
 /// Prompt user to select Cloud or Local setup.
 fn select_setup_mode() -> Result<SetupMode, SetupError> {
-    println!("  How would you like to use CRW?");
+    println!("  How do you want to run CRW?  (you can switch anytime with `crw setup`)");
     println!();
 
     let items = vec![
-        "☁️  Cloud (Recommended for getting started)\n        • 500 free one-time credits, no payment needed\n        • Zero setup, works instantly\n        • Managed infrastructure, always up-to-date",
-        "🏠 Local (Self-hosted)\n        • Unlimited usage, completely free\n        • Full control over your data\n        • Requires: Docker (~1.5GB for images)",
+        "☁️  Cloud — ready in 30 seconds                      ⭐ Recommended\n        • 500 free credits — no card, nothing to pay\n        • No Docker, nothing to run — works instantly\n        • Managed & always up to date\n        • Sign up with GitHub/Google, paste your key, done",
+        "🏠 Local — self-hosted, unlimited & free\n        • Runs fully on your machine — your data never leaves\n        • No limits, no account\n        • Needs Docker (~1.5GB) + a minute to boot the search backend",
     ];
 
     let selection = Select::with_theme(&ui::select_style())

--- a/crates/crw-cli/src/commands/setup/wizard.rs
+++ b/crates/crw-cli/src/commands/setup/wizard.rs
@@ -30,7 +30,7 @@ fn select_setup_mode() -> Result<SetupMode, SetupError> {
 
     let items = vec![
         "☁️  Cloud — ready in 30 seconds                      ⭐ Recommended\n        • 500 free credits — no card, nothing to pay\n        • No Docker, nothing to run — works instantly\n        • Managed & always up to date\n        • Sign up with GitHub/Google, paste your key, done",
-        "🏠 Local — self-hosted, unlimited & free\n        • Runs fully on your machine — your data never leaves\n        • No limits, no account\n        • Needs Docker (~1.5GB) + a minute to boot the search backend",
+        "🏠 Local — self-hosted, unlimited & free\n        • Runs fully on your machine — your data never leaves\n        • No limits, no account\n        • Needs Docker + a minute to boot the search backend",
     ];
 
     let selection = Select::with_theme(&ui::select_style())

--- a/install.sh
+++ b/install.sh
@@ -207,7 +207,7 @@ install() {
         || info "Setup skipped — run 'crw setup' whenever you're ready."
     else
       echo ""
-      echo "  Next:  crw setup        # cloud (free credits) or local self-host"
+      echo "  Next:  crw setup        # cloud (500 free credits) or local self-host"
       echo "  Help:  crw --help"
       echo ""
     fi

--- a/install.sh
+++ b/install.sh
@@ -183,8 +183,6 @@ install() {
 
   success "CRW ${VERSION} installed to ${INSTALL_DIR}/${BINARY}"
   echo ""
-  echo "  Run:  ${BINARY} --help"
-  echo ""
 
   # Check if install dir is in PATH
   case ":$PATH:" in
@@ -193,6 +191,31 @@ install() {
        echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
        echo "" ;;
   esac
+
+  # First-run onboarding (crw CLI only). `crw setup` is interactive — cloud
+  # (sign up, free credits) vs local (self-host). `curl | sh` feeds THIS script
+  # over stdin, so we bind setup to /dev/tty and only auto-launch in a real
+  # interactive terminal ([ -t 1 ] + readable /dev/tty). Non-interactive runs
+  # (CI, logged pipe) just print the next step. Opt out with CRW_NO_SETUP=1.
+  if [ "$BINARY" = "crw" ]; then
+    if [ "${CRW_NO_SETUP:-}" != "1" ] && [ -t 1 ] && [ -e /dev/tty ]; then
+      echo ""
+      info "One step left — let's get you scraping."
+      info "Cloud gives you 500 free credits in ~30s (no card, no Docker), or self-host local:"
+      echo ""
+      "${INSTALL_DIR}/${BINARY}" setup </dev/tty \
+        || info "Setup skipped — run 'crw setup' whenever you're ready."
+    else
+      echo ""
+      echo "  Next:  crw setup        # cloud (free credits) or local self-host"
+      echo "  Help:  crw --help"
+      echo ""
+    fi
+  else
+    echo ""
+    echo "  Run:  ${BINARY} --help"
+    echo ""
+  fi
 }
 
 # --- run --------------------------------------------------------------------


### PR DESCRIPTION
After `curl … | sh`, drop the user into onboarding instead of leaving them to hit a 404 on first scrape.

- **install.sh**: when installing the crw CLI in an interactive terminal, auto-runs `crw setup` bound to `/dev/tty` (curl|sh pipes the script over stdin). CI / non-tty prints the next step instead. Opt out: `CRW_NO_SETUP=1`.
- **wizard.rs**: conversion-tuned cloud/local copy — cloud leads with "ready in 30s · 500 free credits · no card · no Docker"; local honest ("needs Docker", no GB figure); header notes you can switch anytime. Default stays Cloud.

brew/apt stay non-interactive by design — they'll show a "run crw setup" caveat/postinst message (their own repos), not auto-launch.