### PR TITLE
chore(docs): use branded fastcrw.com/install URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64",
  "clap",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npx crw-mcp                           # zero install — runs the embedded engin
 pip install crw                        # Python SDK (auto-downloads binary)
 brew install us/crw/crw                # Homebrew
 cargo install crw-cli                  # Cargo
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 ```
 
 ---
@@ -239,7 +239,7 @@ cargo build --profile release-small --no-default-features -p crw-mcp
 brew install us/crw/crw
 
 # One-line install (auto-detects OS & arch):
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | CRW_BINARY=crw sh
+curl -fsSL https://fastcrw.com/install | CRW_BINARY=crw sh
 
 # APT (Debian/Ubuntu):
 curl -fsSL https://apt.fastcrw.com/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/crw.gpg
@@ -259,7 +259,7 @@ shared microservice.
 brew install us/crw/crw-server
 
 # One-line install:
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | CRW_BINARY=crw-server sh
+curl -fsSL https://fastcrw.com/install | CRW_BINARY=crw-server sh
 
 # Docker:
 docker run -p 3000:3000 ghcr.io/us/crw

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@ CRW 是为 AI 代理打造的开源网页抓取工具。内置 MCP 服务器（s
 
 ```bash
 # 一键安装（自动检测操作系统和架构）：
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 
 # npm（零安装）：
 npx crw-mcp
@@ -284,7 +284,7 @@ CRW 可作为 Claude Code 和 Claude Desktop 的 MCP 工具服务器，支持两
 
 ```bash
 # 一键安装（自动检测操作系统和架构）：
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 
 # npm（零安装）：
 npx crw-mcp

--- a/blog/browser-automation-ai-agents.md
+++ b/blog/browser-automation-ai-agents.md
@@ -401,7 +401,7 @@ That's it. Your agent now has the same page-reading capability as a full browser
 If you want zero ongoing API costs and full control, CRW ships as a single small static binary that runs on any Linux server:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | bash
+curl -fsSL https://fastcrw.com/install | bash
 crw  # starts on http://localhost:3000
 ```
 

--- a/blog/crw-vs-crawl4ai.md
+++ b/blog/crw-vs-crawl4ai.md
@@ -422,7 +422,7 @@ Or install the binary directly — CRW ships as a single statically-linked binar
 
 ```
 # Linux / macOS — download and inspect first
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh -o install.sh
+curl -fsSL https://fastcrw.com/install -o install.sh
 cat install.sh          # review before running
 sh install.sh
 

--- a/blog/langchain-crw-rag-tutorial.md
+++ b/blog/langchain-crw-rag-tutorial.md
@@ -34,7 +34,7 @@ Pick one:
 
 ```
 # Install and start CRW
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | bash
+curl -fsSL https://fastcrw.com/install | bash
 crw  # runs on http://localhost:3000
 
 # Or Docker

--- a/blog/openclaw-web-scraping-crw.md
+++ b/blog/openclaw-web-scraping-crw.md
@@ -43,7 +43,7 @@ That's it — cloud is the default. No server to run.
 ### Option B: Self-hosted with binary (free, no limits)
 
 ```
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | bash
+curl -fsSL https://fastcrw.com/install | bash
 crw  # starts on http://localhost:3000
 ```
 

--- a/blog/web-search-api-for-ai-agents.md
+++ b/blog/web-search-api-for-ai-agents.md
@@ -271,7 +271,7 @@ That's it. The API is now running at `http://localhost:3000`. All the endpoints 
 
 ```
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | bash
+curl -fsSL https://fastcrw.com/install | bash
 
 # Start the server
 crw

--- a/crates/crw-cli/src/main.rs
+++ b/crates/crw-cli/src/main.rs
@@ -45,7 +45,7 @@ use teardown::{CmdError, finish, install_signal_teardown};
     after_help = "INSTALL:\n  \
         brew install us/crw/crw                                         # macOS / Linux\n  \
         cargo install crw-cli                                           # Any Rust toolchain\n  \
-        curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh\n\n\
+        curl -fsSL https://fastcrw.com/install | sh\n\n\
         DOCS:    https://docs.fastcrw.com  ·  https://github.com/us/crw\n\
         CLOUD:   https://fastcrw.com (500 free credits, no monthly reset)\n\
         SEARCH:  `crw setup --local` boots a JSON-enabled SearXNG on 127.0.0.1:8080.\n\

--- a/docs/agent-onboarding/index.html
+++ b/docs/agent-onboarding/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/authentication/index.html
+++ b/docs/authentication/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/capabilities/index.html
+++ b/docs/capabilities/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/choose-endpoint/index.html
+++ b/docs/choose-endpoint/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/compatibility/index.html
+++ b/docs/compatibility/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/configuration/index.html
+++ b/docs/configuration/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/crates/index.html
+++ b/docs/crates/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/crawling/index.html
+++ b/docs/crawling/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/credit-costs/index.html
+++ b/docs/credit-costs/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/crw-browse/index.html
+++ b/docs/crw-browse/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/docker/index.html
+++ b/docs/docker/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -17,20 +17,20 @@ curl -X POST https://api.fastcrw.com/v1/scrape \
 The install script auto-detects your OS and architecture, downloads the latest binary, and installs it:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 ```
 
 Or with `wget`:
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+wget -qO- https://fastcrw.com/install | sh
 ```
 
 **Options:**
 
 ```bash
 # Install to a custom directory:
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | CRW_INSTALL_DIR=~/.local/bin sh
+curl -fsSL https://fastcrw.com/install | CRW_INSTALL_DIR=~/.local/bin sh
 ```
 
 Supported platforms: macOS (Intel & Apple Silicon), Linux (x64 & ARM64), Windows (via MSYS2/Git Bash).

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -35,7 +35,7 @@ No server to start, no setup. Install and add `crw-mcp`:
 
 ```bash
 # One-line install (auto-detects OS & arch):
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 
 # npm (zero install):
 npx crw-mcp

--- a/docs/error-codes/index.html
+++ b/docs/error-codes/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/extract/index.html
+++ b/docs/extract/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -192,7 +192,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 
@@ -292,12 +292,12 @@ Same Firecrawl-compatible endpoints, zero infrastructure.</p>
   -d '{&quot;url&quot;: &quot;https://example.com&quot;}'</code></pre>
 <h2 id="one-line-install-recommended">One-Line Install (Recommended)</h2>
 <p>The install script auto-detects your OS and architecture, downloads the latest binary, and installs it:</p>
-<pre data-lang="bash"><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code></pre>
+<pre data-lang="bash"><code class="language-bash">curl -fsSL https://fastcrw.com/install | sh</code></pre>
 <p>Or with <code>wget</code>:</p>
-<pre data-lang="bash"><code class="language-bash">wget -qO- https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code></pre>
+<pre data-lang="bash"><code class="language-bash">wget -qO- https://fastcrw.com/install | sh</code></pre>
 <p><strong>Options:</strong></p>
 <pre data-lang="bash"><code class="language-bash"># Install to a custom directory:
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | CRW_INSTALL_DIR=~/.local/bin sh</code></pre>
+curl -fsSL https://fastcrw.com/install | CRW_INSTALL_DIR=~/.local/bin sh</code></pre>
 <p>Supported platforms: macOS (Intel &amp; Apple Silicon), Linux (x64 &amp; ARM64), Windows (via MSYS2/Git Bash).</p>
 <h2 id="from-cratesio">From crates.io</h2>
 <pre data-lang="bash"><code class="language-bash"># CLI tool (no server required)

--- a/docs/integrations/index.html
+++ b/docs/integrations/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/introduction/index.html
+++ b/docs/introduction/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/js-rendering/index.html
+++ b/docs/js-rendering/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -859,7 +859,7 @@ PyPI (crw):         https://pypi.org/project/crw/
 npm (crw-sdk):      https://www.npmjs.com/package/crw-sdk
 npm (crw-mcp):      https://www.npmjs.com/package/crw-mcp
 
-Install crw binary: curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+Install crw binary: curl -fsSL https://fastcrw.com/install | sh
 Install crw-mcp:    npx crw-mcp  (zero-install) or cargo install crw-mcp
 Install crw-browse: cargo install crw-browse
 

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/mcp-clients/index.html
+++ b/docs/mcp-clients/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 
@@ -328,7 +328,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
 <h2 id="quick-start-embedded-mode">Quick Start (Embedded Mode)</h2>
 <p>No server to start, no setup. Install and add <code>crw-mcp</code>:</p>
 <pre data-lang="bash"><code class="language-bash"># One-line install (auto-detects OS &amp; arch):
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 
 # npm (zero install):
 npx crw-mcp

--- a/docs/migrate-from-firecrawl/index.html
+++ b/docs/migrate-from-firecrawl/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/monitoring/index.html
+++ b/docs/monitoring/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/output-formats/index.html
+++ b/docs/output-formats/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/pdf-parsing/index.html
+++ b/docs/pdf-parsing/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/proxies/index.html
+++ b/docs/proxies/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/quick-start/index.html
+++ b/docs/quick-start/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/rate-limits/index.html
+++ b/docs/rate-limits/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-batch/index.html
+++ b/docs/recipe-batch/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-js-spa/index.html
+++ b/docs/recipe-js-spa/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-mcp-5min/index.html
+++ b/docs/recipe-mcp-5min/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-monitoring/index.html
+++ b/docs/recipe-monitoring/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-pdf/index.html
+++ b/docs/recipe-pdf/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-product-catalog/index.html
+++ b/docs/recipe-product-catalog/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/recipe-rag/index.html
+++ b/docs/recipe-rag/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/research-api/index.html
+++ b/docs/research-api/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/response-shapes/index.html
+++ b/docs/response-shapes/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/rest-api/index.html
+++ b/docs/rest-api/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/scraping/index.html
+++ b/docs/scraping/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/sdk-examples/index.html
+++ b/docs/sdk-examples/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/sdk-reference/index.html
+++ b/docs/sdk-reference/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/self-hosting-hardening/index.html
+++ b/docs/self-hosting-hardening/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/self-hosting/index.html
+++ b/docs/self-hosting/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/troubleshooting/index.html
+++ b/docs/troubleshooting/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/docs/v2-api/index.html
+++ b/docs/v2-api/index.html
@@ -190,7 +190,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
       <code>pip install crw</code> ·
       <code>npx crw-mcp</code> ·
       <code>brew install us/crw/crw</code> ·
-      <code>curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh</code> ·
+      <code>curl -fsSL https://fastcrw.com/install | sh</code> ·
       <code>docker run -p 3000:3000 ghcr.io/us/crw:latest</code>
     </p>
 

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # CRW installer — downloads the latest release binary for your platform.
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
-#   wget -qO- https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+#   curl -fsSL https://fastcrw.com/install | sh
+#   wget -qO- https://fastcrw.com/install | sh
 #
 # Options (environment variables):
 #   CRW_VERSION=v0.3.0    Install a specific version instead of latest

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -6,7 +6,7 @@ Python SDK for [CRW](https://github.com/us/crw) — the open-source web scraper 
 
 ```bash
 # One-line install (auto-detects OS & arch):
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | sh
+curl -fsSL https://fastcrw.com/install | sh
 
 # npm (zero install):
 npx crw-mcp

--- a/skills/crw-self-host/SKILL.md
+++ b/skills/crw-self-host/SKILL.md
@@ -50,7 +50,7 @@ cargo build --profile release-small --no-default-features -p crw-mcp
 
 ```bash
 brew install us/crw/crw
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | CRW_BINARY=crw sh
+curl -fsSL https://fastcrw.com/install | CRW_BINARY=crw sh
 cargo install crw-cli
 
 # APT (Debian/Ubuntu):
@@ -67,7 +67,7 @@ microservice.
 
 ```bash
 brew install us/crw/crw-server
-curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | CRW_BINARY=crw-server sh
+curl -fsSL https://fastcrw.com/install | CRW_BINARY=crw-server sh
 docker run -p 3000:3000 ghcr.io/us/crw
 ```
 


### PR DESCRIPTION
Replace \`https://raw.githubusercontent.com/us/crw/main/install.sh\` with \`https://fastcrw.com/install\` across all docs and source files.

## Files changed
- README.md, README.zh-CN.md
- blog/*.md (5 posts)
- docs/**/*.html (50+ rendered pages)
- docs/docs/installation.md, docs/docs/mcp.md
- docs/llms-full.txt
- install.sh (header usage comments only)
- crates/crw-cli/src/main.rs (hint/message string)
- sdks/python/README.md
- skills/crw-self-host/SKILL.md

## Notes
- install.sh binary download logic (github.com/.../releases/download/... on line 139) is unaffected — only the two header comment lines were updated.
- cargo check -p crw-cli passes; sh -n install.sh syntax check passes.