### PR TITLE
fix(mcp): clarify crawl/parse jsonSchema arg for MCP clients

### DIFF
--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -154,7 +154,8 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                     },
                     "jsonSchema": {
                         "type": "object",
-                        "description": "JSON schema for LLM extraction per page"
+                        "additionalProperties": true,
+                        "description": "Optional. A JSON Schema (draft 2020-12) describing fields to extract from each page via an LLM, e.g. {\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\"}}}. Free-form object. Omit to crawl without structured extraction."
                     },
                     "renderJs": {
                         "type": "boolean",
@@ -360,7 +361,8 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                 },
                 "jsonSchema": {
                     "type": "object",
-                    "description": "JSON schema for LLM extraction (when formats has json)"
+                    "additionalProperties": true,
+                    "description": "Optional. A JSON Schema (draft 2020-12) describing fields to extract when formats includes \"json\", e.g. {\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\"}}}. Free-form object."
                 },
                 "parsers": {
                     "type": "array",


### PR DESCRIPTION
## What
`crw_crawl`'s `jsonSchema` input was a bare `{"type":"object"}` with no shape or guidance. ChatGPT's connector analyzer flagged it: *"jsonSchema is a required-shape object but unspecified … likely to be called incorrectly without guidance."*

Fix: add `additionalProperties: true` (signals it is intentionally free-form) and expand the description with the JSON Schema draft + a concrete example. Same fix applied to `crw_parse_file`'s `jsonSchema`.

## Scope
- `crates/crw-mcp-proto/src/lib.rs` only — the schema source of truth for both the stdio binary and the `crw-server` `POST /mcp` transport (so the hosted `fastcrw.com/mcp` connector picks it up after deploy).

## Verification
- `cargo test -p crw-mcp-proto` → 32 passed (incl. `tools_list_token_budget` — additions stay within budget).
- `cargo fmt --check`, `cargo clippy -p crw-mcp-proto -- -D warnings` clean.
- Pre-commit hook ran the full workspace test suite → all passed.
- No snapshot/test pins the changed description; the one schema-validator test targets `crw_search` outputSchema (unrelated).