### PR TITLE
ci(release): Cross.toml — cmake/perl for aws-lc-sys on musl

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,15 @@
+# cross-rs build configuration.
+#
+# The official `cross` musl images are minimal and don't ship cmake/perl, which
+# `aws-lc-sys` (rustls' crypto provider, pulled transitively via reqwest) needs
+# to build for the musl targets. Install them before the build so the static
+# musl release binaries link cleanly.
+#
+# Verified locally (messense/rust-musl-cross): aws-lc-sys 0.38 builds fine as
+# static-musl once the toolchain is present — no source changes / no ring swap.
+
+[target.x86_64-unknown-linux-musl]
+pre-build = ["apt-get update && apt-get install --yes --no-install-recommends cmake perl"]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = ["apt-get update && apt-get install --yes --no-install-recommends cmake perl"]


### PR DESCRIPTION
musl release binaries (#173) link aws-lc-sys (rustls crypto via reqwest). Verified locally it builds fine as **static-musl** — but needs cmake/perl, which the minimal cross-rs musl images don't ship. This adds a pre-build step to install them for both musl targets. No source change, no ring swap; musl stays (any libc incl. Alpine).