### PR TITLE
fix(npm): ship install.js + agents.js in crw-mcp package

### DIFF
--- a/mcp/crw-mcp/package.json
+++ b/mcp/crw-mcp/package.json
@@ -27,6 +27,8 @@
   "files": [
     "bin/crw-mcp.js",
     "bin/init.js",
+    "bin/install.js",
+    "bin/agents.js",
     "skills/SKILL.md"
   ],
   "optionalDependencies": {


### PR DESCRIPTION
`crw-mcp install` failed with "Cannot find module './install.js'" — install.js and agents.js weren't in the package `files` allowlist (only init.js was). Adds them. Verified via `npm pack --dry-run`. Ships in v0.18.1.