### PR TITLE
perf(engine): offload HTML extraction off the async reactor

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1263,6 +1263,13 @@ pub struct ExtractionConfig {
     /// returns SPA husks of 90–500B that pass HTML-shape checks).
     #[serde(default = "default_lightpanda_retry_threshold")]
     pub lightpanda_retry_threshold_bytes: usize,
+    /// Process-wide cap on concurrent HTML → markdown extractions (html5ever +
+    /// htmd). Extraction is CPU-bound and runs on the blocking pool; this bound
+    /// keeps a burst of concurrent scrapes from oversubscribing the cores and
+    /// starving the async reactor. Defaults to ~2/3 of available cores (≈8 on a
+    /// 12-vCPU host), floored at 2.
+    #[serde(default = "default_max_concurrent_extracts")]
+    pub max_concurrent_extracts: usize,
 }
 
 fn default_http_retry_threshold() -> usize {
@@ -1271,6 +1278,13 @@ fn default_http_retry_threshold() -> usize {
 
 fn default_lightpanda_retry_threshold() -> usize {
     2000
+}
+
+fn default_max_concurrent_extracts() -> usize {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    (cpus * 2 / 3).max(2)
 }
 
 impl Default for ExtractionConfig {
@@ -1283,6 +1297,7 @@ impl Default for ExtractionConfig {
             llm_fallback: LlmFallbackConfig::default(),
             http_retry_threshold_bytes: default_http_retry_threshold(),
             lightpanda_retry_threshold_bytes: default_lightpanda_retry_threshold(),
+            max_concurrent_extracts: default_max_concurrent_extracts(),
         }
     }
 }

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -324,19 +324,23 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
                 }
             }
         } else {
-            match crw_extract::extract(crw_extract::ExtractOptions {
-                raw_html: &fetch_result.html,
-                source_url: &fetch_result.url,
+            // Off-reactor, parallelism-bounded extraction (see
+            // `crate::extract_pool`). The owned input lets the CPU-bound
+            // `extract()` run on the blocking pool without starving the crawl's
+            // async fan-out.
+            match crate::extract_pool::extract_offloaded(crw_extract::OwnedExtractInput {
+                raw_html: fetch_result.html.clone(),
+                source_url: fetch_result.url.clone(),
                 status_code: fetch_result.status_code,
                 rendered_with: fetch_result.rendered_with.clone(),
                 elapsed_ms: fetch_result.elapsed_ms,
                 render_decision: fetch_result.render_decision.clone(),
                 credit_cost: fetch_result.credit_cost,
                 warnings: fetch_result.warnings.clone(),
-                formats: &req.formats,
+                formats: req.formats.clone(),
                 only_main_content: req.only_main_content,
-                include_tags: &[],
-                exclude_tags: &[],
+                include_tags: Vec::new(),
+                exclude_tags: Vec::new(),
                 css_selector: None,
                 xpath: None,
                 chunk_strategy: None,
@@ -344,11 +348,12 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
                 filter_mode: None,
                 top_k: None,
                 domain_selectors: None,
-                captured_responses: &fetch_result.captured_responses,
-                llm_fallback: None,
+                captured_responses: fetch_result.captured_responses.clone(),
                 debug: false,
                 debug_sink: None,
-            }) {
+            })
+            .await
+            {
                 Ok(data) => data,
                 Err(err) => {
                     tracing::warn!(url, error = %err, "Crawl: extraction failed");

--- a/crates/crw-crawl/src/extract_pool.rs
+++ b/crates/crw-crawl/src/extract_pool.rs
@@ -1,0 +1,70 @@
+//! Off-reactor, parallelism-bounded HTML → markdown extraction.
+//!
+//! `crw_extract::extract` (html5ever + htmd) is CPU-bound and synchronous.
+//! Running it inline on the tokio worker threads starves the async reactor
+//! under high scrape concurrency (~600 concurrent scrapes), collapsing
+//! throughput. This module moves each extraction onto the blocking pool via
+//! [`tokio::task::spawn_blocking`] and bounds the number of concurrent
+//! extractions with a process-wide [`Semaphore`] so the CPU work can't
+//! oversubscribe the cores. The runtime builder is left untouched
+//! (`worker_threads`/`max_blocking_threads` at their defaults) — this semaphore
+//! is the real bound. Mirrors the PDF parse gate in [`crate::pdf`].
+
+use std::sync::{Arc, OnceLock};
+
+use tokio::sync::Semaphore;
+
+use crw_core::error::{CrwError, CrwResult};
+use crw_core::types::ScrapeData;
+use crw_extract::OwnedExtractInput;
+
+/// Process-wide cap on concurrent HTML extractions. Installed once at startup
+/// via [`configure_extract_limit`]; surfaces that never configure (CLI, tests)
+/// fall back to [`default_extract_limit`].
+static EXTRACT_SEM: OnceLock<Arc<Semaphore>> = OnceLock::new();
+
+/// Fallback bound when [`configure_extract_limit`] is never called: ~2/3 of the
+/// available cores, floored at 2. Leaves headroom for the async reactor and
+/// renderer threads instead of letting extraction claim every core.
+fn default_extract_limit() -> usize {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    (cpus * 2 / 3).max(2)
+}
+
+/// Install the concurrent-extraction cap. Idempotent — the first call wins
+/// (subsequent calls are ignored), so call it once at boot. Mirrors
+/// [`crate::pdf::configure_limits`].
+pub fn configure_extract_limit(n: usize) {
+    let _ = EXTRACT_SEM.set(Arc::new(Semaphore::new(n.max(1))));
+}
+
+fn sem() -> &'static Arc<Semaphore> {
+    EXTRACT_SEM.get_or_init(|| Arc::new(Semaphore::new(default_extract_limit())))
+}
+
+/// Run one HTML → markdown extraction off the async reactor.
+///
+/// Acquires a concurrency permit (held for the whole CPU job, even if the
+/// caller is dropped early), then runs [`crw_extract::extract`] on the blocking
+/// pool. This keeps the reactor responsive and bounds peak CPU parallelism to
+/// the configured limit so a burst of concurrent scrapes can't stall the
+/// runtime.
+pub async fn extract_offloaded(input: OwnedExtractInput) -> CrwResult<ScrapeData> {
+    // Acquire BEFORE spawning and move the permit into the closure so it is held
+    // for the full duration of the blocking parse — keeping the semaphore an
+    // honest bound on real concurrent CPU work.
+    let permit = sem()
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| CrwError::ExtractionError("extract semaphore closed".to_string()))?;
+
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        crw_extract::extract(input.as_opts())
+    })
+    .await
+    .map_err(|e| CrwError::ExtractionError(format!("extract task failed: {e}")))?
+}

--- a/crates/crw-crawl/src/lib.rs
+++ b/crates/crw-crawl/src/lib.rs
@@ -19,6 +19,7 @@
 //! ```
 
 pub mod crawl;
+pub mod extract_pool;
 pub mod pdf;
 pub mod robots;
 pub mod single;

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -237,35 +237,39 @@ async fn scrape_url_inner(
     } else {
         None
     };
-    fn build_extract_opts<'a>(
-        fr: &'a FetchResult,
-        req: &'a ScrapeRequest,
-        extraction_cfg: &'a ExtractionConfig,
+    // Build the OWNED extraction input so the CPU-bound `extract()` can run off
+    // the async reactor via `extract_pool::extract_offloaded` (spawn_blocking
+    // needs `'static`, so the borrowed `ExtractOptions` can't cross the
+    // boundary). `domain_selectors` is wrapped in an `Arc` to avoid deep-copying
+    // the host→selector map on every request.
+    fn build_owned_extract_input(
+        fr: &FetchResult,
+        req: &ScrapeRequest,
+        extraction_cfg: &ExtractionConfig,
         debug: bool,
         sink: Option<Arc<Mutex<crw_extract::DebugCollector>>>,
-    ) -> crw_extract::ExtractOptions<'a> {
-        crw_extract::ExtractOptions {
-            raw_html: &fr.html,
-            source_url: &fr.url,
+    ) -> crw_extract::OwnedExtractInput {
+        crw_extract::OwnedExtractInput {
+            raw_html: fr.html.clone(),
+            source_url: fr.url.clone(),
             status_code: fr.status_code,
             rendered_with: fr.rendered_with.clone(),
             elapsed_ms: fr.elapsed_ms,
             render_decision: fr.render_decision.clone(),
             credit_cost: fr.credit_cost,
             warnings: fr.warnings.clone(),
-            formats: &req.formats,
+            formats: req.formats.clone(),
             only_main_content: req.only_main_content,
-            include_tags: &req.include_tags,
-            exclude_tags: &req.exclude_tags,
-            css_selector: req.css_selector.as_deref(),
-            xpath: req.xpath.as_deref(),
-            chunk_strategy: req.chunk_strategy.as_ref(),
-            query: req.query.as_deref(),
-            filter_mode: req.filter_mode.as_ref(),
+            include_tags: req.include_tags.clone(),
+            exclude_tags: req.exclude_tags.clone(),
+            css_selector: req.css_selector.clone(),
+            xpath: req.xpath.clone(),
+            chunk_strategy: req.chunk_strategy.clone(),
+            query: req.query.clone(),
+            filter_mode: req.filter_mode.clone(),
             top_k: req.top_k,
-            domain_selectors: Some(&extraction_cfg.domain_selectors),
-            captured_responses: &fr.captured_responses,
-            llm_fallback: None,
+            domain_selectors: Some(Arc::new(extraction_cfg.domain_selectors.clone())),
+            captured_responses: fr.captured_responses.clone(),
             debug,
             debug_sink: sink,
         }
@@ -296,13 +300,14 @@ async fn scrape_url_inner(
         };
         crate::pdf::convert_pdf_bytes(bytes, req, source).await?
     } else {
-        let mut data = crw_extract::extract(build_extract_opts(
+        let mut data = crate::extract_pool::extract_offloaded(build_owned_extract_input(
             &fetch_result,
             req,
             extraction_cfg,
             debug_enabled,
             debug_sink.clone(),
-        ))?;
+        ))
+        .await?;
         // LLM-assisted re-extraction when DOM result is low-quality and the
         // operator opted in via [extraction.llm_fallback]. Failure paths inside
         // the helper preserve the original markdown.
@@ -429,13 +434,16 @@ async fn scrape_url_inner(
                     // is a soft signal, not a content gate.
                     let js_status = js_fetch.status_code;
                     let js_warning = derive_target_warning(&js_fetch);
-                    if let Ok(js_data) = crw_extract::extract(build_extract_opts(
-                        &js_fetch,
-                        req,
-                        extraction_cfg,
-                        debug_enabled,
-                        debug_sink.clone(),
-                    )) {
+                    if let Ok(js_data) =
+                        crate::extract_pool::extract_offloaded(build_owned_extract_input(
+                            &js_fetch,
+                            req,
+                            extraction_cfg,
+                            debug_enabled,
+                            debug_sink.clone(),
+                        ))
+                        .await
+                    {
                         let js_md_len = js_data
                             .markdown
                             .as_deref()

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -140,6 +140,77 @@ pub struct ExtractOptions<'a> {
     pub debug_sink: Option<Arc<Mutex<DebugCollector>>>,
 }
 
+/// Owned counterpart to [`ExtractOptions`], used to ship an extraction job
+/// across the `'static` `spawn_blocking` boundary — the borrowed
+/// [`ExtractOptions`] can't cross it. Build it from the same inputs as a
+/// `build_extract_opts` call site, move it onto the blocking pool, then
+/// reconstruct the borrowed view inside the closure with [`Self::as_opts`].
+///
+/// [`ExtractOptions`] and [`extract`] are intentionally left unchanged so every
+/// existing borrow-caller keeps compiling; this is purely additive.
+pub struct OwnedExtractInput {
+    pub raw_html: String,
+    pub source_url: String,
+    pub status_code: u16,
+    pub rendered_with: Option<String>,
+    pub elapsed_ms: u64,
+    pub render_decision: Option<RenderDecision>,
+    pub credit_cost: u32,
+    pub warnings: Vec<String>,
+    pub formats: Vec<OutputFormat>,
+    pub only_main_content: bool,
+    pub include_tags: Vec<String>,
+    pub exclude_tags: Vec<String>,
+    pub css_selector: Option<String>,
+    pub xpath: Option<String>,
+    pub chunk_strategy: Option<ChunkStrategy>,
+    pub query: Option<String>,
+    pub filter_mode: Option<FilterMode>,
+    pub top_k: Option<usize>,
+    /// Shared host→selector overrides. Held behind an `Arc` so callers can clone
+    /// the (potentially large) map by refcount instead of deep-copying it per
+    /// request.
+    pub domain_selectors: Option<Arc<HashMap<String, String>>>,
+    pub captured_responses: Vec<CapturedNetworkResponse>,
+    pub debug: bool,
+    pub debug_sink: Option<Arc<Mutex<DebugCollector>>>,
+}
+
+impl OwnedExtractInput {
+    /// Reconstruct the borrowed [`ExtractOptions`] view over this owned input.
+    ///
+    /// `llm_fallback` is always `None`: [`extract`] ignores that field (the LLM
+    /// fallback runs as a separate async stage in `crw-crawl`), and no offloaded
+    /// caller sets it — so it does not need to survive the offload boundary.
+    pub fn as_opts(&self) -> ExtractOptions<'_> {
+        ExtractOptions {
+            raw_html: &self.raw_html,
+            source_url: &self.source_url,
+            status_code: self.status_code,
+            rendered_with: self.rendered_with.clone(),
+            elapsed_ms: self.elapsed_ms,
+            render_decision: self.render_decision.clone(),
+            credit_cost: self.credit_cost,
+            warnings: self.warnings.clone(),
+            formats: &self.formats,
+            only_main_content: self.only_main_content,
+            include_tags: &self.include_tags,
+            exclude_tags: &self.exclude_tags,
+            css_selector: self.css_selector.as_deref(),
+            xpath: self.xpath.as_deref(),
+            chunk_strategy: self.chunk_strategy.as_ref(),
+            query: self.query.as_deref(),
+            filter_mode: self.filter_mode.as_ref(),
+            top_k: self.top_k,
+            domain_selectors: self.domain_selectors.as_deref(),
+            captured_responses: &self.captured_responses,
+            llm_fallback: None,
+            debug: self.debug,
+            debug_sink: self.debug_sink.clone(),
+        }
+    }
+}
+
 /// Parameters for the LLM-assisted extraction fallback. See
 /// [`LlmFallbackConfig`](crw_core::config::LlmFallbackConfig).
 #[derive(Debug, Clone)]

--- a/crates/crw-server/src/main.rs
+++ b/crates/crw-server/src/main.rs
@@ -58,6 +58,13 @@ async fn run_server() {
     // cap) from [document] config before any request can trigger a parse.
     crw_crawl::pdf::configure_limits(&config.document);
 
+    // Bound concurrent HTML extraction (html5ever + htmd). Extraction is moved
+    // off the async reactor onto the blocking pool; this semaphore caps its
+    // parallelism so a burst of concurrent scrapes can't oversubscribe the
+    // cores and stall the runtime. The tokio runtime builder is left at its
+    // defaults — this is the real capacity bound.
+    crw_crawl::extract_pool::configure_extract_limit(config.extraction.max_concurrent_extracts);
+
     let addr = format!("{}:{}", config.server.host, config.server.port);
     tracing::info!("Starting CRW on {addr}");
     tracing::info!("Renderer mode: {:?}", config.renderer.mode);


### PR DESCRIPTION
Move CPU-bound extract() onto the blocking pool via spawn_blocking, bounded by a process-wide Semaphore (extraction.max_concurrent_extracts ~2/3 cores). Fixes the throughput collapse under high scrape concurrency (C=200→600 dropped 100→60 RPS = reactor starvation). extract()/ExtractOptions unchanged; new owned OwnedExtractInput mirrors the PDF parse gate. Enables the box to hold ~1000 concurrent without collapse.