### PR TITLE
fix(billing): flat 1-credit cost, extraction = base + LLM token, retire BYOK term

### DIFF
--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -187,23 +187,13 @@ fn tier_timeouts_from(
     m
 }
 
-/// Per-renderer credit cost. Exposed so the routing layer can populate
-/// `FetchResult.credit_cost` and `/v1/scrape` charge accurately.
-fn credit_for(kind: RendererKind) -> u32 {
-    match kind {
-        RendererKind::Http => 1,
-        RendererKind::Lightpanda => 1,
-        RendererKind::Chrome => 2,
-        // Engine-internal cost only. SaaS billing reads request-body
-        // `renderer` string and still charges 1 credit per scrape regardless.
-        RendererKind::ChromeProxy => 2,
-        // Camoufox stealth: a full real-browser render (≈Chrome=2) plus the
-        // REST create-tab/evaluate/destroy-session round-trip and anti-bot
-        // warm-up, ≈1.5× Chrome rounded up. Engine-internal cost only (the same
-        // SaaS-billing note as ChromeProxy applies). Revisit to 2 if operational
-        // metrics show parity with Chrome.
-        RendererKind::Camoufox => 3,
-    }
+/// Credit cost per fetched page. Flat 1 for every renderer: the SaaS bills 1
+/// credit per scrape regardless of renderer, and `data.credit_cost` is the
+/// field docs tell users to audit their charge against — so it must equal that
+/// charge. ponytail: per-renderer pricing removed; re-add a `match kind` here
+/// (e.g. `Chrome => 2`) if a renderer ever needs to cost more than the base.
+fn credit_for(_kind: RendererKind) -> u32 {
+    1
 }
 
 /// Stamp `render_decision` and `credit_cost` for an HTTP-only result.
@@ -2861,7 +2851,7 @@ mod tests {
             "promoted host should hit chrome first, got: {}",
             &result.html[..80.min(result.html.len())]
         );
-        assert_eq!(result.credit_cost, 2, "chrome costs 2 credits");
+        assert_eq!(result.credit_cost, 1, "every renderer costs 1 credit");
         assert!(matches!(
             result.render_decision,
             Some(RenderDecision::AutoPromoted {
@@ -2997,7 +2987,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(result.credit_cost, 2);
+        assert_eq!(result.credit_cost, 1);
         assert!(matches!(
             result.render_decision,
             Some(RenderDecision::UserPinned {

--- a/docs/docs/capabilities.md
+++ b/docs/docs/capabilities.md
@@ -60,7 +60,7 @@ All keys use camelCase.
 |-------|------|-------------|
 | `providers` | `string[]` | LLM provider tags the server's dispatch layer supports. Always `["anthropic", "openai", "deepseek", "openai-compatible", "azure"]` — these are compile-time constants. |
 | `supportsBaseUrl` | `boolean` | Always `true`. Any provider can be redirected to a custom base URL per request. |
-| `serverKeyConfigured` | `boolean` | `true` when a server-side `[extraction.llm]` API key is configured. `false` means the instance has no server LLM key and requires callers to supply `llmApiKey` in the request body. Hosted SaaS sets this to `false` and relies on per-request BYOK. |
+| `serverKeyConfigured` | `boolean` | `true` when a server-side `[extraction.llm]` API key is configured. `false` means the instance has no server LLM key and requires callers to supply `llmApiKey` in the request body. Hosted SaaS sets this to `false` and relies on per-request keys. |
 | `maxConcurrency` | `number` | Server-side fan-out cap for LLM calls. `0` when no server LLM config is present. |
 | `requireByokHeader` | `string?` | Present only when the server requires a specific request header on LLM-touching calls. Absent when no header guard is configured. |
 
@@ -97,7 +97,7 @@ The `search` object does not expose whether a SearXNG backend is reachable. A li
 
 On `api.fastcrw.com` you can expect:
 
-- `llm.serverKeyConfigured` — `false` (SaaS relies on per-request BYOK)
+- `llm.serverKeyConfigured` — `false` (SaaS relies on per-request keys)
 - `documents.parsers` — `["pdf"]` (PDF support is enabled)
 - `documents.fileUpload.maxBytes` — `52428800` (50 MiB)
 - `formats.supported` — all 8 formats
@@ -125,7 +125,7 @@ caps = httpx.get(
 if caps["llm"]["serverKeyConfigured"]:
     llm_key_in_body = None          # server has a key
 else:
-    llm_key_in_body = "sk-..."      # caller must supply BYOK
+    llm_key_in_body = "sk-..."      # caller must supply a per-request key
 
 pdf_ok = caps["documents"]["fileUpload"]["supported"]
 ```

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -192,7 +192,7 @@ Use the `CRW_` prefix with `__` as a nesting separator:
 | `extraction.llm.max_html_bytes` | `CRW_EXTRACTION__LLM__MAX_HTML_BYTES` |
 | `extraction.llm.max_concurrency` | `CRW_EXTRACTION__LLM__MAX_CONCURRENCY` |
 | `extraction.llm.require_byok_header` | `CRW_EXTRACTION__LLM__REQUIRE_BYOK_HEADER` |
-| _(boot guard)_ | `CRW_DISABLE_SERVER_LLM_KEY` — when set to `1`, refuses to boot if `[extraction.llm].api_key` is also configured. Use behind a SaaS BYOK proxy. |
+| _(boot guard)_ | `CRW_DISABLE_SERVER_LLM_KEY` — when set to `1`, refuses to boot if `[extraction.llm].api_key` is also configured. Use behind a SaaS proxy that injects per-request LLM keys. |
 
 ## Renderer modes
 

--- a/docs/docs/credit-costs.md
+++ b/docs/docs/credit-costs.md
@@ -10,7 +10,7 @@ Cloud only (fastcrw.com) -- self-hosted instances do not have credit-based billi
 | --- | --- |
 | `scrape` (any render — HTTP, lightpanda, chrome, or `chrome_proxy`) | 1 credit |
 | `scrape` with `playwright` render | SaaS billing only; engine `data.creditCost` is omitted (0) |
-| `scrape` with structured extraction (`formats: ["json"]` / `summary`) | 1 credit + managed-LLM token cost (see note below) |
+| `scrape` with structured extraction (`formats: ["json"]` / `summary`) | 1 credit + LLM token cost |
 | `map` | 1 credit |
 | `crawl` start | 1 credit |
 | `crawl` polling | New pages discovered since the previous poll |
@@ -19,10 +19,10 @@ Cloud only (fastcrw.com) -- self-hosted instances do not have credit-based billi
 | `browse` session | 1 credit (planned cloud rate; the self-hosted `crw-browse` binary is free) |
 
 Every renderer costs 1 credit per page — the engine's `credit_for` returns a flat 1 (`crw-renderer/src/lib.rs`), and `data.creditCost` matches the charge regardless of which renderer (HTTP, lightpanda, Chrome, chrome_proxy) actually served the page.
-LLM-backed extraction (`json`/`summary` formats) is **not** a flat fee. It costs the 1-credit base render plus the actual managed-LLM token cost (3× provider markup, capped 8 000 — see the note below; BYOK pays only a flat infra fee, no token markup). The open-source engine itself adds no surcharge beyond the 1-credit render cost — the LLM portion is applied entirely by the managed cloud billing layer and tracked separately in `creditsUsed`.
+LLM-backed extraction (`json`/`summary` formats) is **not** a flat fee. It costs the 1-credit base render plus the LLM token cost. The open-source engine itself adds no surcharge beyond the 1-credit render cost — the LLM portion is applied by the managed cloud billing layer and tracked separately in `creditsUsed`.
 
 :::note
-**Managed-LLM markup (fastcrw.com cloud only)** — this is a SaaS billing policy enforced by the cloud platform, not by the open-source engine. When you use `answer`, `summarizeResults`, or other managed LLM features on fastcrw.com, token usage is billed at a 3× markup over the provider price, capped at 8 000 credits per request. BYOK requests pay only a flat infra fee with no token markup. Self-hosted deployments have no billing layer and are unaffected.
+**Managed-LLM billing (fastcrw.com cloud only)** — token usage for managed LLM features (`json`/`summary` extraction, `answer`, `summarizeResults`) is billed on top of the base credit by the cloud platform, not by the open-source engine. Self-hosted deployments have no billing layer and are unaffected.
 :::
 
 ## Why crawl billing looks different

--- a/docs/docs/credit-costs.md
+++ b/docs/docs/credit-costs.md
@@ -10,7 +10,7 @@ Cloud only (fastcrw.com) -- self-hosted instances do not have credit-based billi
 | --- | --- |
 | `scrape` (any render — HTTP, lightpanda, chrome, or `chrome_proxy`) | 1 credit |
 | `scrape` with `playwright` render | SaaS billing only; engine `data.creditCost` is omitted (0) |
-| `scrape` with structured extraction / `formats: ["json"]` | 5 credits |
+| `scrape` with structured extraction (`formats: ["json"]` / `summary`) | 1 credit + managed-LLM token cost (see note below) |
 | `map` | 1 credit |
 | `crawl` start | 1 credit |
 | `crawl` polling | New pages discovered since the previous poll |
@@ -19,7 +19,7 @@ Cloud only (fastcrw.com) -- self-hosted instances do not have credit-based billi
 | `browse` session | 1 credit (planned cloud rate; the self-hosted `crw-browse` binary is free) |
 
 Every renderer costs 1 credit per page — the engine's `credit_for` returns a flat 1 (`crw-renderer/src/lib.rs`), and `data.creditCost` matches the charge regardless of which renderer (HTTP, lightpanda, Chrome, chrome_proxy) actually served the page.
-The 5-credit cost for LLM-backed extraction (`json`/`summary` formats) is applied by the managed cloud billing layer; the open-source engine itself does not add an extra surcharge beyond the render cost.
+LLM-backed extraction (`json`/`summary` formats) is **not** a flat fee. It costs the 1-credit base render plus the actual managed-LLM token cost (3× provider markup, capped 8 000 — see the note below; BYOK pays only a flat infra fee, no token markup). The open-source engine itself adds no surcharge beyond the 1-credit render cost — the LLM portion is applied entirely by the managed cloud billing layer and tracked separately in `creditsUsed`.
 
 :::note
 **Managed-LLM markup (fastcrw.com cloud only)** — this is a SaaS billing policy enforced by the cloud platform, not by the open-source engine. When you use `answer`, `summarizeResults`, or other managed LLM features on fastcrw.com, token usage is billed at a 3× markup over the provider price, capped at 8 000 credits per request. BYOK requests pay only a flat infra fee with no token markup. Self-hosted deployments have no billing layer and are unaffected.

--- a/docs/docs/credit-costs.md
+++ b/docs/docs/credit-costs.md
@@ -8,9 +8,7 @@ Cloud only (fastcrw.com) -- self-hosted instances do not have credit-based billi
 
 | Operation | Credit cost |
 | --- | --- |
-| `scrape` (HTTP or lightpanda render) | 1 credit |
-| `scrape` with Chrome render (`renderer: "chrome"`) | 2 credits |
-| `scrape` with `chrome_proxy` render | 1 credit (SaaS) — engine `data.creditCost` reports 2 (matches `credit_for(ChromeProxy)`) |
+| `scrape` (any render — HTTP, lightpanda, chrome, or `chrome_proxy`) | 1 credit |
 | `scrape` with `playwright` render | SaaS billing only; engine `data.creditCost` is omitted (0) |
 | `scrape` with structured extraction / `formats: ["json"]` | 5 credits |
 | `map` | 1 credit |
@@ -20,7 +18,7 @@ Cloud only (fastcrw.com) -- self-hosted instances do not have credit-based billi
 | `search` + scrape | 1 credit + 1 per scraped result |
 | `browse` session | 1 credit (planned cloud rate; the self-hosted `crw-browse` binary is free) |
 
-Chrome's 2-credit cost is applied by the engine renderer (`crw-renderer/src/lib.rs: credit_for(RendererKind::Chrome) = 2`).
+Every renderer costs 1 credit per page — the engine's `credit_for` returns a flat 1 (`crw-renderer/src/lib.rs`), and `data.creditCost` matches the charge regardless of which renderer (HTTP, lightpanda, Chrome, chrome_proxy) actually served the page.
 The 5-credit cost for LLM-backed extraction (`json`/`summary` formats) is applied by the managed cloud billing layer; the open-source engine itself does not add an extra surcharge beyond the render cost.
 
 :::note
@@ -62,12 +60,12 @@ Every successful scrape response (v1 `/v1/scrape`) includes a `creditCost` field
   "data": {
     "markdown": "...",
     "metadata": { ... },
-    "creditCost": 2
+    "creditCost": 1
   }
 }
 ```
 
-The value reflects the renderer cost only (1 for HTTP/lightpanda, 2 for Chrome). On the managed cloud the SaaS billing layer may charge additional credits for LLM features (extraction, summary), which are tracked separately in `creditsUsed` on v2 responses and in your account billing dashboard.
+The value reflects the renderer cost only (a flat 1 credit for every renderer). On the managed cloud the SaaS billing layer may charge additional credits for LLM features (extraction, summary), which are tracked separately in `creditsUsed` on v2 responses and in your account billing dashboard.
 
 The field is omitted when its value would be 0 (internal paths that have not yet been priced).
 

--- a/docs/docs/error-codes.md
+++ b/docs/docs/error-codes.md
@@ -52,7 +52,7 @@ You need both to debug real scraping failures.
 | Invalid JSON schema | Schema provided for extraction is malformed |
 | Extraction failure | LLM extraction failed (no LLM configured, or LLM returned an error) |
 | `summary` format requires LLM config | `formats: ["summary"]` sent without a server-side `[extraction.llm]` block and without per-request `llmApiKey` |
-| BYOK header required | Server is in BYOK-only mode (`require_byok_header`) and the request lacks both the header and `llmApiKey` |
+| Key header required | Server is in key-required mode (`require_byok_header`) and the request lacks both the header and `llmApiKey` |
 | No JS renderer available | `renderJs: true` but no CDP browser is configured |
 
 ## Common warnings

--- a/docs/docs/extract.md
+++ b/docs/docs/extract.md
@@ -160,7 +160,7 @@ curl -X POST https://api.fastcrw.com/v1/scrape \
 | `formats` | string[] | required | Use `["json"]` for the canonical extraction path |
 | `jsonSchema` | object | required | JSON schema describing the fields you want back |
 | `extract` | object | -- | Firecrawl-compatible wrapper; `extract.schema` is accepted |
-| `llmApiKey` | string | -- | Per-request BYOK credential |
+| `llmApiKey` | string | -- | Per-request LLM API key |
 | `llmProvider` | string | server default | `anthropic`, `openai`, `deepseek`, `azure`, or `openai-compatible` |
 | `llmModel` | string | server default | Extraction model override |
 | `baseUrl` | string | -- | OpenAI-compatible endpoint base, e.g. `https://api.deepseek.com/v1` (also used by Azure). crw appends `/chat/completions` automatically if you omit it. |
@@ -197,16 +197,16 @@ Use this workflow:
 
 If the underlying page scrape is weak, the JSON extraction will also be weak.
 
-## BYOK and provider control
+## Self-hosted LLM and provider control
 
-**Self-hosted / BYOK:** set `[extraction.llm]` in `config.toml` for a server-wide default, or pass `llmApiKey` + `llmProvider` + `llmModel` per request to override it. Supported providers: `anthropic`, `openai`, `deepseek`, `azure`, and `openai-compatible`. Use `baseUrl` for any OpenAI-compatible endpoint (DeepSeek, Azure, local models).
+**Self-hosted:** set `[extraction.llm]` in `config.toml` for a server-wide default, or pass `llmApiKey` + `llmProvider` + `llmModel` per request to override it. Supported providers: `anthropic`, `openai`, `deepseek`, `azure`, and `openai-compatible`. Use `baseUrl` for any OpenAI-compatible endpoint (DeepSeek, Azure, local models).
 
 ## Common production patterns
 
 - Validate the target with markdown first, then add extraction.
 - Keep the schema as small as possible on the first pass.
 - Narrow the page with `cssSelector` only when the default extraction is too noisy.
-- Use BYOK only when you need per-request provider separation.
+- Use a per-request `llmApiKey` only when you need per-request provider separation.
 
 ## Common mistakes
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -36,7 +36,7 @@ Chrome DevTools Protocol is the WebSocket-based protocol that lets external prog
 
 ## credit
 
-A credit is the billing unit for the hosted cloud at `fastcrw.com`. One plain scrape costs 1 credit; a Chrome-rendered scrape costs 2; LLM-backed extraction via `POST /v2/extract` costs 5 credits (legacy). When using `formats: ["json"]` on a scrape request, see the [Credit Costs](/docs/credit-costs) table for current billing. Map and search start-calls each cost 1 credit, and crawl jobs charge 1 credit at start plus one additional credit per page as pages are discovered during polling. Self-hosted deployments have no billing layer and are unaffected by credit costs. Check your balance with `GET /api/v1/account/balance` on the SaaS control-plane. See [Credit Costs](/docs/credit-costs) for the full table.
+A credit is the billing unit for the hosted cloud at `fastcrw.com`. Every scrape costs 1 credit regardless of renderer (HTTP, lightpanda, or Chrome); LLM-backed extraction (`formats: ["json"]` / `summary`) costs that 1-credit base render plus the managed-LLM token cost. See the [Credit Costs](/docs/credit-costs) table for current billing. Map and search start-calls each cost 1 credit, and crawl jobs charge 1 credit at start plus one additional credit per page as pages are discovered during polling. Self-hosted deployments have no billing layer and are unaffected by credit costs. Check your balance with `GET /api/v1/account/balance` on the SaaS control-plane. See [Credit Costs](/docs/credit-costs) for the full table.
 
 ---
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -10,12 +10,6 @@ Breadth-first search is the traversal strategy fastCRW uses for the [`/v1/crawl`
 
 ---
 
-## BYOK (Bring Your Own Key)
-
-BYOK means supplying your own LLM provider API key per request instead of relying on a server-configured default. Pass `llmApiKey`, `llmProvider`, and `llmModel` in the request body when calling `formats: ["json"]` or `formats: ["summary"]` to have fastCRW bill your LLM account directly rather than the server's. On self-hosted deployments, supplying your own key is the only option unless you configure `[extraction.llm]` in `config.toml`. See [Output Formats](/docs/output-formats) and [Extract](/docs/extract) for usage.
-
----
-
 ## CDP (Chrome DevTools Protocol)
 
 Chrome DevTools Protocol is the WebSocket-based protocol that lets external programs control a running Chromium browser — navigating pages, waiting for JavaScript to finish, clicking elements, and reading the final DOM. fastCRW uses CDP (via `tokio-tungstenite`) to power its `chrome` and `chrome_proxy` rendering modes. When a page cannot be scraped cleanly by an HTTP request alone, the engine can fall back to CDP to obtain the fully rendered HTML. See [JS Rendering](/docs/js-rendering) for the rendering modes and per-request `renderer` field.
@@ -48,7 +42,7 @@ A credit is the billing unit for the hosted cloud at `fastcrw.com`. Every scrape
 
 ## llmProvider
 
-`llmProvider` is a request field that selects which LLM provider fastCRW routes extraction or summarization calls to. Accepted values are `"anthropic"`, `"openai"`, `"deepseek"`, `"azure"`, and `"openai-compatible"`. Use it together with `llmApiKey` and `llmModel` (BYOK mode) to pin a specific provider per request, or set the server-wide default in `config.toml` under `[extraction.llm]`. When using Azure or a custom OpenAI-compatible endpoint, also supply `baseUrl`. See [Extract](/docs/extract) and [Output Formats](/docs/output-formats) for full field references.
+`llmProvider` is a request field that selects which LLM provider fastCRW routes extraction or summarization calls to. Accepted values are `"anthropic"`, `"openai"`, `"deepseek"`, `"azure"`, and `"openai-compatible"`. Use it together with `llmApiKey` and `llmModel` to pin a specific provider per request, or set the server-wide default in `config.toml` under `[extraction.llm]`. When using Azure or a custom OpenAI-compatible endpoint, also supply `baseUrl`. See [Extract](/docs/extract) and [Output Formats](/docs/output-formats) for full field references.
 
 ---
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -12,7 +12,7 @@ Breadth-first search is the traversal strategy fastCRW uses for the [`/v1/crawl`
 
 ## BYOK (Bring Your Own Key)
 
-BYOK means supplying your own LLM provider API key per request instead of relying on a server-configured default. Pass `llmApiKey`, `llmProvider`, and `llmModel` in the request body when calling `formats: ["json"]` or `formats: ["summary"]` to have fastCRW bill your LLM account directly rather than the server's. On the hosted cloud, BYOK requests pay only a flat infrastructure fee with no token markup. On self-hosted deployments, BYOK is the only option unless you configure `[extraction.llm]` in `config.toml`. See [Output Formats](/docs/output-formats) and [Extract](/docs/extract) for usage.
+BYOK means supplying your own LLM provider API key per request instead of relying on a server-configured default. Pass `llmApiKey`, `llmProvider`, and `llmModel` in the request body when calling `formats: ["json"]` or `formats: ["summary"]` to have fastCRW bill your LLM account directly rather than the server's. On self-hosted deployments, supplying your own key is the only option unless you configure `[extraction.llm]` in `config.toml`. See [Output Formats](/docs/output-formats) and [Extract](/docs/extract) for usage.
 
 ---
 

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -258,7 +258,7 @@ curl -s -X POST "http://localhost:3000/v1/change-tracking/diff" \
 ```
 
 :::note
-The `monitor` feature pulls in SQLite/HMAC dependencies only when enabled — the default engine build stays dependency-light. Self-host monitoring uses UTC schedules and your own LLM key (BYOK) for judging.
+The `monitor` feature pulls in SQLite/HMAC dependencies only when enabled — the default engine build stays dependency-light. Self-host monitoring uses UTC schedules and your own LLM key for judging.
 :::
 
 ## Change Tracking

--- a/docs/docs/output-formats.md
+++ b/docs/docs/output-formats.md
@@ -117,7 +117,7 @@ When the content is truncated, the response's `data.warnings` array carries a `c
 
 ### Where the key comes from
 
-- Per-request BYOK: send `llmApiKey` / `llmProvider` / `llmModel` / `baseUrl` in the body.
+- Per-request key: send `llmApiKey` / `llmProvider` / `llmModel` / `baseUrl` in the body.
 - Server default: configure `[extraction.llm]` in `config.toml` (see [Configuration](configuration)).
 
 If neither is set, requesting `formats: ["summary"]` returns a 422.

--- a/docs/docs/scraping.md
+++ b/docs/docs/scraping.md
@@ -147,7 +147,7 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `stealth` | boolean | -- | Override global stealth setting |
 | `jsonSchema` | object | -- | Schema for structured extraction |
 | `extract` | object | -- | Firecrawl-compatible alias wrapper for extraction schema |
-| `llmApiKey` | string | -- | Per-request LLM API key (BYOK) |
+| `llmApiKey` | string | -- | Per-request LLM API key |
 | `llmProvider` | string | server default | `anthropic`, `openai`, `deepseek`, `azure`, or `openai-compatible` |
 | `llmModel` | string | server default | Model override (extraction and summary) |
 | `baseUrl` | string | -- | OpenAI-compatible endpoint base, e.g. `https://api.deepseek.com/v1` (also used by Azure). crw appends `/chat/completions` automatically if you omit it. |
@@ -165,7 +165,7 @@ Use the smallest output shape that solves the job:
 - `markdown` is the default and best first request for most pipelines.
 - `html` or `rawHtml` is useful when downstream systems need original structure.
 - `links` is useful when you want lightweight discovery without page bodies.
-- `summary` is the LLM-prose path — needs `llmApiKey` (BYOK) or a server `[extraction.llm]` config. Optional `summaryPrompt` lets the caller pick language/tone without weakening the safety wrapper.
+- `summary` is the LLM-prose path — needs `llmApiKey` or a server `[extraction.llm]` config. Optional `summaryPrompt` lets the caller pick language/tone without weakening the safety wrapper.
 - `json` is the extraction path and should be paired with `jsonSchema`.
 
 If you ask for multiple formats, only those formats are populated in the response.

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -142,7 +142,7 @@ That is the flat response shape used when `sources` is not set.
 | `sources` | string[] | -- | Result groups such as `"web"`, `"news"`, `"images"` |
 | `categories` | string[] | -- | Curated filters (`"github"`, `"research"`, `"pdf"`) **plus** any native SearXNG category (`"science"`, `"it"`, `"news"`, `"files"`, …) passed straight through. Max 5 entries. See [Curated vs. passthrough categories](#curated-vs-passthrough-categories) |
 | `scrapeOptions` | object | -- | Scrape each result URL after search |
-| `summarizeResults` | boolean | `false` | When `true`, each scraped result is summarized by the LLM and the digest appears in `result.summary`. Needs LLM config (BYOK or server). Fan-out is bounded by `[extraction.llm].max_concurrency`. |
+| `summarizeResults` | boolean | `false` | When `true`, each scraped result is summarized by the LLM and the digest appears in `result.summary`. Needs LLM config (per-request key or server). Fan-out is bounded by `[extraction.llm].max_concurrency`. |
 | `answer` | boolean | `false` | When `true`, after scraping the top results crw synthesizes a single answer over them. The answer + `citations` land on the response wrapper. |
 | `answerTopN` | number | `5` (max `10`) | Number of top-scoring results to feed into the answer pipeline |
 | `maxCharsPerSource` | number | `8192` | Per-source byte cap on markdown fed into the answer prompt. Clamped to 32 KB server-side. |
@@ -153,7 +153,7 @@ That is the flat response shape used when `sources` is not set.
 | `queryExpandVariants` | number | server config | Number of diverse query rewrites fetched and unioned when query expansion is enabled. Overrides `[search].query_expand_variants` for this request. |
 | `multiRound` | boolean | server config | When `true`, fires an adaptive evidence-scout round if the first-round answer abstains. Overrides `[search].multi_round` for this request. |
 | `answerListFormat` | boolean | server config | When `true` (and the query has list intent such as "best/top X"), renders the answer as a ranked list instead of prose. `false` forces prose. Overrides `[search].answer_list_format`. |
-| `llmApiKey` | string | -- | Per-request LLM API key (BYOK) |
+| `llmApiKey` | string | -- | Per-request LLM API key |
 | `llmProvider` | string | server default | `anthropic`, `openai`, `deepseek`, `azure`, or `openai-compatible` |
 | `llmModel` | string | server default | Model override |
 | `baseUrl` | string | -- | OpenAI-compatible endpoint base (e.g. DeepSeek, Azure) |
@@ -288,7 +288,7 @@ If the answer call fails (rate limit, network error, etc.), `answer` is `null`, 
 
 ### Where the key comes from
 
-Same BYOK pattern as `/v1/scrape`: send `llmApiKey` / `llmProvider` / `llmModel` / `baseUrl` in the request body, or configure `[extraction.llm]` in `config.toml`.
+Same per-request key pattern as `/v1/scrape`: send `llmApiKey` / `llmProvider` / `llmModel` / `baseUrl` in the request body, or configure `[extraction.llm]` in `config.toml`.
 
 ## Freshness, sources, and categories
 

--- a/docs/docs/self-hosting-hardening.md
+++ b/docs/docs/self-hosting-hardening.md
@@ -129,7 +129,7 @@ model    = "gpt-4o-mini"
 
 Anyone who can reach your opencore can spend on that key. Front it with auth, network policy, or a private network.
 
-**SaaS / multi-tenant (BYOK, per-request keys):**
+**SaaS / multi-tenant (per-request keys):**
 
 - Set `CRW_DISABLE_SERVER_LLM_KEY=1` in opencore's environment. With this env var set, opencore refuses to boot if `[extraction.llm].api_key` is also configured — the most common operator mistake.
 - Set `[extraction.llm].require_byok_header = "X-CRW-Tenant"` (or similar). CRW rejects LLM-touching requests that lack that header AND do not pass a per-request `llmApiKey`. Your SaaS layer adds the header on every forwarded request; direct public callers cannot.

--- a/docs/docs/v2-api.md
+++ b/docs/docs/v2-api.md
@@ -84,9 +84,9 @@ Scrape one URL synchronously. Returns immediately with a `V2Document`.
 | `timeout` | `number` | server default | Request deadline in milliseconds |
 | `renderer` | `"auto" \| "lightpanda" \| "chrome" \| "chrome_proxy" \| "playwright"` | — | Pin a renderer tier |
 | `parsers` | `ParserSpec[]` | — | Document parser directives (e.g. `["pdf"]`) |
-| `llmApiKey` | `string` | — | BYOK LLM API key (required for `summary` / `json` if no server key) |
-| `llmProvider` | `"anthropic" \| "openai" \| "deepseek" \| "azure" \| "openai-compatible"` | — | BYOK LLM provider |
-| `llmModel` | `string` | — | BYOK LLM model name |
+| `llmApiKey` | `string` | — | Per-request LLM API key (required for `summary` / `json` if no server key) |
+| `llmProvider` | `"anthropic" \| "openai" \| "deepseek" \| "azure" \| "openai-compatible"` | — | Per-request LLM provider |
+| `llmModel` | `string` | — | Per-request LLM model name |
 | `summaryPrompt` | `string` | — | Custom prompt for the `summary` format |
 
 ### Response


### PR DESCRIPTION
Billing-model + docs cleanup. Three related changes:

## 1. Flat 1-credit render cost
`credit_for` returns a flat **1 credit** for every renderer (was `Chrome=2`, `ChromeProxy=2`, `Camoufox=3`). The SaaS bills 1 credit per scrape regardless of renderer, and `data.creditCost` is the field docs tell users to audit against — so the engine must report that same charge. Mirrors the SaaS-side flattening (crw-saas #211) on the engine.

## 2. Extraction priced as `1 base credit + LLM token cost`
Structured extraction (`json`/`summary`) is no longer documented as a flat 5 credits. It costs the 1-credit base render plus the LLM token cost (a SaaS billing concern; the engine adds no surcharge). Resolves the old "5 credits" vs token-cost contradiction.

## 3. Retire "BYOK" as a product term
"BYOK" / "Bring Your Own Key" is dropped as a branded concept across the docs (glossary entry, headings, labels) → plain "per-request LLM API key" wording. **The engine capability is unchanged**: per-request `llmApiKey`/`llmProvider`/`llmModel` and the `require_byok_header` config field stay verbatim (real, live opencore identifiers — not renamed). The retired cloud BYOK billing tier ("flat infra fee / no markup") is removed. Changelog history left intact.

## Changes
- `crates/crw-renderer/src/lib.rs` — `credit_for` → flat `1`; two unit-test assertions updated.
- `docs/docs/credit-costs.md`, `glossary.md` — credit table/prose/example + BYOK billing language.
- `docs/docs/{capabilities,configuration,error-codes,extract,monitoring,output-formats,scraping,search,self-hosting-hardening,v2-api}.md` — BYOK term → plain wording.

## Not affected
- Engine LLM-key code (`single.rs` `build_byok_llm_config`, `req.llm_api_key`, `require_byok_header`) — opencore self-hosters keep bring-your-own-key.
- PDF per-page billing (`pdf.rs`: `credit_cost = page_count`) — stays per-page; `pdf_tests.rs` passes.

## Verification
- `cargo test -p crw-renderer --lib` → 115 passed · `cargo test -p crw-crawl` → green (incl. pdf_tests) · fmt + clippy clean.
- `grep -i byok docs/docs/*.md` → only literal `require_byok_header`/`requireByokHeader` identifiers + changelog history remain.

Static doc HTML is regenerated by the `google-indexing` workflow on push to main.