### PR TITLE
fix(map): URL discovery on hard sites — www/http sitemaps, big/nested indexes, auth-proxy & anti-bot escalation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "base64",
  "clap",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.17.0"
+version = "0.19.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-cli/src/commands/map.rs
+++ b/crates/crw-cli/src/commands/map.rs
@@ -36,6 +36,10 @@ pub struct MapArgs {
     #[arg(long)]
     pub sitemap_only: bool,
 
+    /// Max URLs to discover (up to 5,000,000). Raise it to dump large sitemaps.
+    #[arg(long, default_value_t = crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS)]
+    pub limit: usize,
+
     /// Enable JavaScript rendering
     #[arg(long)]
     pub js: bool,
@@ -143,6 +147,7 @@ pub async fn run(mut args: MapArgs) -> Result<(), CmdError> {
         deadline_ms_per_page: args.timeout,
         per_host_max_concurrent: 2,
         url_filter: None,
+        max_urls: args.limit,
     };
 
     let result = match discover_urls(opts).await {

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -997,6 +997,11 @@ pub struct MapRequest {
     /// Max 64 keys; over-cap → 422.
     #[serde(default)]
     pub preserve_params: Option<Vec<String>>,
+    /// Max URLs to discover. Firecrawl-compatible. Defaults to
+    /// `DEFAULT_MAX_DISCOVERED_URLS`; the engine clamps to its hard ceiling.
+    /// Raise it to dump large/nested sitemaps (e.g. songsterr's ~4.3M URLs).
+    #[serde(default)]
+    pub limit: Option<usize>,
 }
 
 /// POST /v1/map response data — the discovered links plus filter stats.

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -13,8 +13,12 @@ use uuid::Uuid;
 use crate::robots::RobotsTxt;
 use crate::single::derive_target_warning;
 
-/// Maximum URL discovery limit to prevent memory exhaustion.
-const MAX_DISCOVERED_URLS: usize = 5000;
+/// Default URL discovery limit when a caller doesn't specify one.
+pub const DEFAULT_MAX_DISCOVERED_URLS: usize = 5000;
+/// Hard ceiling on `DiscoverOptions::max_urls` — caps memory even when a caller
+/// asks for "everything" (a site like songsterr.com exposes ~4.3M sitemap URLs;
+/// holding them all is a few hundred MB, which is the most we allow per call).
+pub const MAX_DISCOVERED_URLS_CEILING: usize = 5_000_000;
 
 /// Options for running a BFS crawl job.
 pub struct CrawlOptions<'a> {
@@ -435,6 +439,9 @@ pub struct DiscoverOptions<'a> {
     /// Optional /map URL filter (Tier A drop + Tier B strip). When `None`,
     /// behaviour is the legacy `normalize_url` pass-through.
     pub url_filter: Option<Arc<crate::url_filter::UrlFilterCfg>>,
+    /// Max URLs to discover. Clamped to `[1, MAX_DISCOVERED_URLS_CEILING]`.
+    /// Use `DEFAULT_MAX_DISCOVERED_URLS` for the historical behaviour.
+    pub max_urls: usize,
 }
 
 /// Result of [`discover_urls`]. URLs in `urls` have already passed the
@@ -454,9 +461,10 @@ pub struct DiscoverResult {
 const SITEMAP_SUFFICIENT_THRESHOLD: usize = 50;
 /// Hard ceiling on the BFS crawl phase when sitemap was sufficient.
 const BFS_SHORT_BUDGET_SECS: u64 = 30;
-/// Recursion depth + count caps for the sitemap tree fetch.
+/// Recursion depth for the sitemap tree fetch. The per-call fetch *count* is
+/// derived from `max_urls` (`sitemap_max_fetches`) so a large `<sitemapindex>`
+/// (e.g. ultimate-guitar.com: 84 children; songsterr.com: 854) isn't truncated.
 const SITEMAP_MAX_DEPTH: u32 = 3;
-const SITEMAP_MAX_FETCHES: usize = 25;
 
 /// Discover URLs from a site (map endpoint).
 pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResult> {
@@ -473,7 +481,19 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         deadline_ms_per_page,
         per_host_max_concurrent,
         url_filter,
+        max_urls,
     } = opts;
+    // `0` is the documented "unbounded" sentinel (MCP/Firecrawl) → the ceiling.
+    let max_urls = if max_urls == 0 {
+        MAX_DISCOVERED_URLS_CEILING
+    } else {
+        max_urls.clamp(1, MAX_DISCOVERED_URLS_CEILING)
+    };
+    // Each leaf sitemap holds up to ~50k URLs (spec) but commonly ~5k. To reach
+    // a large `max_urls` the tree walk must be allowed to fetch enough children:
+    // a 4.3M-URL site (songsterr) needs ~900 leaf fetches. Scale the fetch budget
+    // with the requested limit, with a small floor so the default stays cheap.
+    let sitemap_max_fetches = (max_urls / 1000).clamp(200, 50_000);
     let mut dropped_action_count: usize = 0;
     let mut stripped_tracking_count: usize = 0;
     // Helper closures around the optional filter — None ⇒ legacy pass-through
@@ -621,13 +641,13 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
             &parsed,
             &client,
             SITEMAP_MAX_DEPTH,
-            SITEMAP_MAX_FETCHES,
-            MAX_DISCOVERED_URLS,
+            sitemap_max_fetches,
+            max_urls,
             per_host_max_concurrent as usize,
         )
         .await;
         for u in sitemap_urls {
-            if all_urls.len() >= MAX_DISCOVERED_URLS {
+            if all_urls.len() >= max_urls {
                 break;
             }
             if let Some(n) = filter_raw(&u, &mut dropped_action_count, &mut stripped_tracking_count)
@@ -672,7 +692,7 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
     visited.insert(normalize_url(base_url));
 
     while let Some((url, depth)) = queue.pop_front() {
-        if visited.len() > MAX_DISCOVERED_URLS {
+        if visited.len() > max_urls {
             break;
         }
         if let Some(deadline) = bfs_deadline_at

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -465,6 +465,17 @@ const BFS_SHORT_BUDGET_SECS: u64 = 30;
 /// derived from `max_urls` (`sitemap_max_fetches`) so a large `<sitemapindex>`
 /// (e.g. ultimate-guitar.com: 84 children; songsterr.com: 854) isn't truncated.
 const SITEMAP_MAX_DEPTH: u32 = 3;
+/// Per-render deadline for the sitemap anti-bot escalation arm. A Cloudflare
+/// managed challenge needs a few seconds of JS execution to clear.
+const SITEMAP_ESCALATE_DEADLINE_MS: u64 = 30_000;
+/// Hard cap on renderer escalations per map call. Chrome renders cost ~100× a
+/// plain GET, so a fully-gated site (every child sitemap behind Cloudflare)
+/// can't fan out unbounded; we recover the first N sections within the timeout.
+const SITEMAP_ESCALATE_BUDGET: usize = 64;
+/// Wall-clock budget for the sitemap phase when escalation is active. Bounds the
+/// total time spent solving challenges so the map returns partial results within
+/// the caller's request timeout instead of being killed with nothing.
+const SITEMAP_PHASE_BUDGET_SECS: u64 = 75;
 
 /// Discover URLs from a site (map endpoint).
 pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResult> {
@@ -636,6 +647,42 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         // is still N requests against the SAME host, and respecting the
         // configured per-host limit is what an operator who set it expects.
         // `fetch_sitemap_tree` clamps to a small ceiling internally.
+        // Anti-bot escalation arm: a sitemap behind a Cloudflare/JS challenge
+        // is re-fetched through the renderer (which executes the challenge and
+        // returns the real XML). Only wired when a JS renderer is available —
+        // otherwise a re-fetch would just hit the same wall. Egress (proxy) is
+        // resolved per-URL, identical to the BFS page-fetch path below.
+        let escalate_render = move |u: String| -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Option<String>> + Send>,
+        > {
+            let renderer = renderer.clone();
+            Box::pin(async move {
+                let empty: HashMap<String, String> = HashMap::new();
+                let deadline = crw_core::Deadline::from_request_ms(SITEMAP_ESCALATE_DEADLINE_MS);
+                let resolved_proxy = renderer.pick_proxy_for_url(&u);
+                let fut = renderer.fetch(&u, &empty, Some(true), None, None, deadline);
+                match crw_renderer::REQUEST_PROXY.scope(resolved_proxy, fut).await {
+                    Ok(r) => Some(r.html),
+                    Err(e) => {
+                        tracing::debug!("sitemap escalation render failed for {u}: {e}");
+                        None
+                    }
+                }
+            })
+        };
+        let escalator = renderer.js_capable().then(|| {
+            crate::sitemap::SitemapEscalator::new(&escalate_render, SITEMAP_ESCALATE_BUDGET)
+        });
+        // Wall-clock budget for the sitemap phase — only meaningful when the
+        // escalation arm is live (plain-HTTP sitemaps finish in well under it).
+        // Without it a fully-gated multi-child index (e.g. UG's 84 children, each
+        // behind its own Cloudflare solve) would grind every child to the outer
+        // request timeout and return nothing; with it the walk stops and returns
+        // whatever it recovered.
+        let sitemap_deadline = escalator.as_ref().map(|_| {
+            std::time::Instant::now() + std::time::Duration::from_secs(SITEMAP_PHASE_BUDGET_SECS)
+        });
+
         let sitemap_urls = crate::sitemap::fetch_sitemap_tree(
             seeds,
             &parsed,
@@ -644,6 +691,8 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
             sitemap_max_fetches,
             max_urls,
             per_host_max_concurrent as usize,
+            escalator.as_ref(),
+            sitemap_deadline,
         )
         .await;
         for u in sitemap_urls {

--- a/crates/crw-crawl/src/sitemap.rs
+++ b/crates/crw-crawl/src/sitemap.rs
@@ -1,5 +1,8 @@
 use crw_core::error::CrwResult;
 use scraper::{Html, Selector};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Hard cap on a single sitemap response body. The sitemap spec (sitemaps.org,
 /// 2017 revision) raised the per-file limit to 50 MB uncompressed / 50,000
@@ -47,11 +50,30 @@ impl SitemapResult {
 /// Errors are logged but not surfaced — callers iterate over multiple seeds
 /// and a single bad sitemap should not abort discovery.
 pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<SitemapResult> {
+    Ok(match fetch_sitemap_raw(url, client).await {
+        SitemapOutcome::Parsed(r) => r,
+        SitemapOutcome::Challenged | SitemapOutcome::Empty => SitemapResult::default(),
+    })
+}
+
+/// Outcome of a single plain-HTTP sitemap fetch. `Challenged` is the signal the
+/// tree walk uses to decide whether a JS-renderer escalation is worth trying.
+enum SitemapOutcome {
+    Parsed(SitemapResult),
+    /// Anti-bot interstitial (Cloudflare "Just a moment", `cf-mitigated`, or a
+    /// 403/503/429). A JS renderer that executes the challenge may recover it.
+    Challenged,
+    /// Nothing usable and not a recoverable block (404, timeout, off-site,
+    /// HTML soft-404, genuinely empty). Escalation would not help.
+    Empty,
+}
+
+async fn fetch_sitemap_raw(url: &str, client: &reqwest::Client) -> SitemapOutcome {
     let requested_site = match url::Url::parse(url).ok().as_ref().and_then(site_key) {
         Some(k) => k,
         None => {
             tracing::debug!("sitemap fetch skipped: cannot parse origin for {url}");
-            return Ok(SitemapResult::default());
+            return SitemapOutcome::Empty;
         }
     };
 
@@ -64,7 +86,7 @@ pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<Sit
         Ok(r) => r,
         Err(e) => {
             tracing::debug!("sitemap fetch error for {url}: {e}");
-            return Ok(SitemapResult::default());
+            return SitemapOutcome::Empty;
         }
     };
 
@@ -76,19 +98,27 @@ pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<Sit
         Some(ref k) if *k == requested_site => {}
         _ => {
             tracing::warn!("sitemap {url} redirected off-site to {final_url}, dropping");
-            return Ok(SitemapResult::default());
+            return SitemapOutcome::Empty;
         }
     }
-    if !resp.status().is_success() {
-        tracing::debug!("sitemap {url} returned {}", resp.status());
-        return Ok(SitemapResult::default());
+    let status = resp.status();
+    if !status.is_success() {
+        tracing::debug!("sitemap {url} returned {status}");
+        // 403/503/429 from an edge WAF is the classic "blocked" signal — let the
+        // caller try a JS renderer. Other non-2xx (404, 5xx app errors) are not
+        // recoverable that way.
+        return if matches!(status.as_u16(), 403 | 429 | 503) {
+            SitemapOutcome::Challenged
+        } else {
+            SitemapOutcome::Empty
+        };
     }
 
     let bytes = match read_body_capped(resp, MAX_SITEMAP_BYTES).await {
         Ok(b) => b,
         Err(e) => {
             tracing::warn!("sitemap body read failed for {url}: {e}");
-            return Ok(SitemapResult::default());
+            return SitemapOutcome::Empty;
         }
     };
 
@@ -104,7 +134,7 @@ pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<Sit
             Ok(d) => d,
             Err(e) => {
                 tracing::warn!("sitemap gzip decode failed for {url}: {e}");
-                return Ok(SitemapResult::default());
+                return SitemapOutcome::Empty;
             }
         }
     } else {
@@ -112,7 +142,18 @@ pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<Sit
     };
 
     let text = String::from_utf8_lossy(&xml_bytes);
-    Ok(parse_sitemap_with_sniff(&text))
+    let head = sniff_head(&text);
+    if has_challenge_markers(&head) {
+        // 200 with a Cloudflare interstitial body (managed challenge served as
+        // HTTP 200) — recoverable via a JS renderer.
+        tracing::warn!("sitemap {url} body is an anti-bot challenge; may escalate");
+        return SitemapOutcome::Challenged;
+    }
+    if looks_like_html(&head) {
+        tracing::warn!("sitemap {url} body looks like HTML, not XML; ignoring");
+        return SitemapOutcome::Empty;
+    }
+    SitemapOutcome::Parsed(parse_sitemap(&text))
 }
 
 /// Issue a HEAD request — used by the discover layer to skip body GETs on
@@ -163,28 +204,42 @@ fn decode_gzip_capped(data: &[u8], max: usize) -> Result<Vec<u8>, String> {
     Ok(out)
 }
 
-/// Detect HTML masquerading as sitemap (Cloudflare challenge, soft 404 pages
-/// served with HTTP 200). Returns empty if detected, else parses normally.
-fn parse_sitemap_with_sniff(xml: &str) -> SitemapResult {
+/// Lowercased first ≤2048 bytes, split on a UTF-8 char boundary so a multi-byte
+/// sequence straddling the 2048th byte can't panic.
+fn sniff_head(xml: &str) -> String {
     let trimmed = xml.trim_start();
-    // Walk back to the nearest UTF-8 char boundary so a 2048th-byte split in
-    // the middle of a multi-byte sequence doesn't panic. `is_char_boundary`
-    // is true at index 0 and at index `len`, so this loop always terminates.
     let mut head_len = trimmed.len().min(2048);
     while !trimmed.is_char_boundary(head_len) {
         head_len -= 1;
     }
-    let head = trimmed[..head_len].to_lowercase();
-    if head.starts_with("<!doctype html")
-        || head.starts_with("<html")
-        || head.contains("just a moment")
+    trimmed[..head_len].to_lowercase()
+}
+
+/// Anti-bot interstitial markers (Cloudflare managed challenge / JS challenge).
+fn has_challenge_markers(head: &str) -> bool {
+    head.contains("just a moment")
         || head.contains("cf-mitigated")
         || head.contains("cf-chl-")
-    {
-        tracing::warn!("sitemap response looks like HTML, not XML; ignoring");
+        || head.contains("attention required")
+        || head.contains("/cdn-cgi/challenge-platform")
+}
+
+/// HTML masquerading as a sitemap (soft-404 pages served with HTTP 200).
+fn looks_like_html(head: &str) -> bool {
+    head.starts_with("<!doctype html") || head.starts_with("<html")
+}
+
+/// Parse a sitemap that a JS renderer fetched (challenge already solved). Chrome
+/// wraps XML in `<div id="webkit-xml-viewer-source-xml">…</div>`, but the
+/// `<url><loc>` / `<sitemap><loc>` nodes are real DOM elements so the normal
+/// selectors still match. Unlike the plain path we must NOT reject on the
+/// `<html>` prefix (the rendered document is legitimately HTML-wrapped); only a
+/// still-present challenge marker means the renderer failed to clear the wall.
+fn parse_rendered_sitemap(html: &str) -> SitemapResult {
+    if has_challenge_markers(&sniff_head(html)) {
         return SitemapResult::default();
     }
-    parse_sitemap(xml)
+    parse_sitemap(html)
 }
 
 /// Parse sitemap XML and split entries by kind.
@@ -233,6 +288,57 @@ pub fn parse_sitemap(xml: &str) -> SitemapResult {
     result
 }
 
+/// Renders a challenged sitemap URL through a JS renderer (executing a
+/// Cloudflare/JS challenge) and returns the rendered HTML, or `None` if the
+/// render failed. The caller (`discover_urls`) constructs this so this module
+/// stays renderer-agnostic and unit-testable.
+pub type SitemapRenderFn<'a> =
+    dyn Fn(String) -> Pin<Box<dyn Future<Output = Option<String>> + Send>> + Send + Sync + 'a;
+
+/// Escalation arm for anti-bot-gated sitemaps. A `SitemapOutcome::Challenged`
+/// fetch is retried through `render`, bounded by a shared `budget` (chrome
+/// renders cost ~100× a plain GET, so a deeply-gated site can't fan out
+/// unbounded).
+pub struct SitemapEscalator<'a> {
+    render: &'a SitemapRenderFn<'a>,
+    budget: AtomicUsize,
+}
+
+impl<'a> SitemapEscalator<'a> {
+    pub fn new(render: &'a SitemapRenderFn<'a>, budget: usize) -> Self {
+        Self {
+            render,
+            budget: AtomicUsize::new(budget),
+        }
+    }
+
+    /// Claim a budget slot and render. Returns empty if the budget is exhausted,
+    /// the render failed, or the rendered page is still a challenge.
+    async fn try_render(&self, url: &str) -> SitemapResult {
+        // Atomically claim one slot; bail when the budget is spent.
+        let mut cur = self.budget.load(Ordering::Relaxed);
+        loop {
+            if cur == 0 {
+                return SitemapResult::default();
+            }
+            match self.budget.compare_exchange_weak(
+                cur,
+                cur - 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(observed) => cur = observed,
+            }
+        }
+        tracing::info!("escalating challenged sitemap via renderer: {url}");
+        match (self.render)(url.to_string()).await {
+            Some(html) => parse_rendered_sitemap(&html),
+            None => SitemapResult::default(),
+        }
+    }
+}
+
 /// BFS over a sitemap tree. Same-origin filter applies to both child sitemaps
 /// and page URLs to prevent the engine from being abused as a sitemap-fetch
 /// proxy (a crafted index could otherwise point us at arbitrary public hosts).
@@ -242,6 +348,7 @@ pub fn parse_sitemap(xml: &str) -> SitemapResult {
 /// roughly 9× latency to discovery, but unbounded `join_all` would also burst
 /// up to `max_sitemaps` concurrent same-host requests, ignoring the operator's
 /// politeness setting.
+#[allow(clippy::too_many_arguments)] // cohesive tuning knobs; a struct adds noise
 pub async fn fetch_sitemap_tree(
     seeds: Vec<String>,
     target_origin: &url::Url,
@@ -250,9 +357,13 @@ pub async fn fetch_sitemap_tree(
     max_sitemaps: usize,
     max_urls: usize,
     max_concurrency: usize,
+    escalator: Option<&SitemapEscalator<'_>>,
+    deadline: Option<std::time::Instant>,
 ) -> Vec<String> {
     use futures::stream::{self, StreamExt};
     use std::collections::HashSet;
+
+    let past_deadline = || deadline.is_some_and(|d| std::time::Instant::now() >= d);
 
     let target_key = match site_key(target_origin) {
         Some(k) => k,
@@ -274,6 +385,10 @@ pub async fn fetch_sitemap_tree(
     let mut total_fetched: usize = 0;
 
     while !current.is_empty() && depth <= max_depth && total_fetched < max_sitemaps {
+        if past_deadline() {
+            tracing::info!("sitemap_tree wall-clock budget spent; returning partial results");
+            break;
+        }
         let remaining_budget = max_sitemaps.saturating_sub(total_fetched);
         let batch: Vec<String> = current
             .drain(..)
@@ -290,7 +405,21 @@ pub async fn fetch_sitemap_tree(
             .map(|u| {
                 let client = client.clone();
                 async move {
-                    let res = fetch_sitemap(&u, &client).await.unwrap_or_default();
+                    let res = match fetch_sitemap_raw(&u, &client).await {
+                        SitemapOutcome::Parsed(r) => r,
+                        // Anti-bot wall: retry through the JS renderer if one was
+                        // supplied (solves Cloudflare and yields the real XML).
+                        // Skip the (expensive) render once the budget is spent so
+                        // a deeply-gated index finishes fast with partial results
+                        // instead of grinding every child to the timeout.
+                        SitemapOutcome::Challenged => match escalator {
+                            Some(esc) if deadline.is_none_or(|d| std::time::Instant::now() < d) => {
+                                esc.try_render(&u).await
+                            }
+                            _ => SitemapResult::default(),
+                        },
+                        SitemapOutcome::Empty => SitemapResult::default(),
+                    };
                     (u, res)
                 }
             })
@@ -421,18 +550,19 @@ mod tests {
     }
 
     #[test]
-    fn html_pretending_to_be_sitemap_returns_empty() {
+    fn html_pretending_to_be_sitemap_is_flagged() {
+        // Soft-404 HTML on the plain path → looks_like_html (not a challenge).
         let html = "<!DOCTYPE html><html><body>Not Found</body></html>";
-        let r = parse_sitemap_with_sniff(html);
-        assert!(r.is_empty());
+        let head = sniff_head(html);
+        assert!(looks_like_html(&head));
+        assert!(!has_challenge_markers(&head));
     }
 
     #[test]
-    fn cloudflare_challenge_returns_empty() {
+    fn cloudflare_challenge_is_flagged_as_challenge() {
         let challenge =
             r#"<html><head><title>Just a moment...</title></head><body>cf-mitigated</body></html>"#;
-        let r = parse_sitemap_with_sniff(challenge);
-        assert!(r.is_empty());
+        assert!(has_challenge_markers(&sniff_head(challenge)));
     }
 
     #[test]
@@ -444,10 +574,11 @@ mod tests {
         s.push_str(&"a".repeat(2047));
         s.push('é');
         s.push_str("<urlset><url><loc>https://x.com/p</loc></url></urlset>");
-        // Should not panic, and should not be flagged as HTML.
-        let r = parse_sitemap_with_sniff(&s);
+        let head = sniff_head(&s); // must not panic
+        assert!(!looks_like_html(&head) && !has_challenge_markers(&head));
         // The body has a urlset deeper than the sniff window, so the parser
-        // still picks up the URL once we get past sniffing.
+        // still picks up the URL.
+        let r = parse_sitemap(&s);
         assert!(r.page_urls.iter().any(|u| u.contains("/p")));
     }
 
@@ -615,6 +746,8 @@ mod tests {
             25,
             5000,
             8,
+            None,
+            None,
         )
         .await;
 
@@ -663,6 +796,8 @@ mod tests {
             25,
             5000,
             8,
+            None,
+            None,
         )
         .await;
 
@@ -707,9 +842,88 @@ mod tests {
             25,
             5000,
             8,
+            None,
+            None,
         )
         .await;
         assert!(urls.is_empty());
+    }
+
+    #[test]
+    fn parse_rendered_sitemap_handles_chrome_xml_viewer_wrapper() {
+        // Exactly the shape Chrome returns for an XML URL once Cloudflare clears:
+        // the real `<sitemap><loc>` nodes live inside a viewer wrapper div.
+        let html = r#"<html><head></head><body>
+            <div id="webkit-xml-viewer-source-xml"><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+              <sitemap><loc>https://www.ultimate-guitar.com/sitemap1.xml</loc></sitemap>
+              <sitemap><loc>https://www.ultimate-guitar.com/sitemap2.xml</loc></sitemap>
+            </sitemapindex></div></body></html>"#;
+        let r = parse_rendered_sitemap(html);
+        assert_eq!(r.child_sitemaps.len(), 2);
+        assert!(r.page_urls.is_empty());
+    }
+
+    #[test]
+    fn parse_rendered_sitemap_rejects_unsolved_challenge() {
+        // Renderer failed to clear the wall — markers still present.
+        let html = r#"<html><head><title>Just a moment...</title></head>
+            <body>cf-mitigated</body></html>"#;
+        assert!(parse_rendered_sitemap(html).is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_sitemap_tree_escalates_challenged_sitemap() {
+        // /sitemap.xml is served as a 403 wall; the escalator (standing in for a
+        // JS renderer that solved the challenge) returns the real XML.
+        let mock = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::path("/sitemap.xml"))
+            .respond_with(wiremock::ResponseTemplate::new(403).set_body_string("Just a moment..."))
+            .mount(&mock)
+            .await;
+
+        let host = mock.uri();
+        let solved = format!(
+            r#"<html><body><div id="webkit-xml-viewer-source-xml"><urlset>
+              <url><loc>{host}/page-a</loc></url>
+              <url><loc>{host}/page-b</loc></url>
+            </urlset></div></body></html>"#
+        );
+        let render: Box<SitemapRenderFn> = Box::new(move |_u| {
+            let solved = solved.clone();
+            Box::pin(async move { Some(solved) })
+        });
+        let escalator = SitemapEscalator::new(&*render, 8);
+
+        let target = url::Url::parse(&mock.uri()).unwrap();
+        let client = reqwest::Client::new();
+        let seeds = vec![format!("{}/sitemap.xml", mock.uri())];
+
+        // Without an escalator the challenge is dropped → empty.
+        let none =
+            fetch_sitemap_tree(seeds.clone(), &target, &client, 3, 25, 5000, 8, None, None).await;
+        assert!(
+            none.is_empty(),
+            "challenge must be dropped without escalator"
+        );
+
+        // With the escalator the solved XML's page URLs come through.
+        let mut got = fetch_sitemap_tree(
+            seeds,
+            &target,
+            &client,
+            3,
+            25,
+            5000,
+            8,
+            Some(&escalator),
+            None,
+        )
+        .await;
+        got.sort();
+        assert_eq!(
+            got,
+            vec![format!("{host}/page-a"), format!("{host}/page-b")]
+        );
     }
 
     #[tokio::test]

--- a/crates/crw-crawl/src/sitemap.rs
+++ b/crates/crw-crawl/src/sitemap.rs
@@ -47,7 +47,7 @@ impl SitemapResult {
 /// Errors are logged but not surfaced — callers iterate over multiple seeds
 /// and a single bad sitemap should not abort discovery.
 pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<SitemapResult> {
-    let requested_origin = match url::Url::parse(url).ok().as_ref().and_then(origin_key) {
+    let requested_site = match url::Url::parse(url).ok().as_ref().and_then(site_key) {
         Some(k) => k,
         None => {
             tracing::debug!("sitemap fetch skipped: cannot parse origin for {url}");
@@ -72,10 +72,10 @@ pub async fn fetch_sitemap(url: &str, client: &reqwest::Client) -> CrwResult<Sit
     if final_url.as_str() != url {
         tracing::debug!("sitemap redirect: {} -> {}", url, final_url);
     }
-    match origin_key(&final_url) {
-        Some(ref k) if k == &requested_origin => {}
+    match site_key(&final_url) {
+        Some(ref k) if *k == requested_site => {}
         _ => {
-            tracing::warn!("sitemap {url} redirected cross-origin to {final_url}, dropping");
+            tracing::warn!("sitemap {url} redirected off-site to {final_url}, dropping");
             return Ok(SitemapResult::default());
         }
     }
@@ -254,7 +254,7 @@ pub async fn fetch_sitemap_tree(
     use futures::stream::{self, StreamExt};
     use std::collections::HashSet;
 
-    let target_key = match origin_key(target_origin) {
+    let target_key = match site_key(target_origin) {
         Some(k) => k,
         None => return Vec::new(),
     };
@@ -268,7 +268,7 @@ pub async fn fetch_sitemap_tree(
     let mut all_pages: HashSet<String> = HashSet::new();
     let mut current: Vec<String> = seeds
         .into_iter()
-        .filter(|u| same_origin_url(u, &target_key))
+        .filter(|u| same_site(u, &target_key))
         .collect();
     let mut depth: u32 = 0;
     let mut total_fetched: usize = 0;
@@ -299,19 +299,37 @@ pub async fn fetch_sitemap_tree(
             .await;
 
         let mut next: Vec<String> = Vec::new();
+        // Collect child sitemaps eagerly (BFS frontier for the next level).
+        // Collect page URLs round-robin ACROSS the leaves in this level, not by
+        // draining each leaf fully before the next. Without this, a site whose
+        // index lists `artists` before `tabs` (e.g. songsterr: 75 artist leaves
+        // of 5000 URLs each, then 854 tab leaves) would fill the entire
+        // `max_urls` cap from the first leaf-group — returning 5000 artist-list
+        // pages and zero song tabs. Interleaving makes a capped map representative
+        // of the whole site instead of just its alphabetically-first section.
+        let mut page_lists: Vec<std::vec::IntoIter<String>> = Vec::new();
         for (_parent, res) in results {
-            for page in res.page_urls {
-                if all_pages.len() >= max_urls {
-                    break;
-                }
-                if same_origin_url(&page, &target_key) {
-                    all_pages.insert(page);
-                }
-            }
+            page_lists.push(res.page_urls.into_iter());
             for child in res.child_sitemaps {
-                if same_origin_url(&child, &target_key) && !visited.contains(&child) {
+                if same_site(&child, &target_key) && !visited.contains(&child) {
                     next.push(child);
                 }
+            }
+        }
+        'fill: loop {
+            let mut progressed = false;
+            for it in page_lists.iter_mut() {
+                let Some(page) = it.next() else { continue };
+                progressed = true;
+                if same_site(&page, &target_key) {
+                    all_pages.insert(page);
+                    if all_pages.len() >= max_urls {
+                        break 'fill;
+                    }
+                }
+            }
+            if !progressed {
+                break;
             }
         }
 
@@ -336,47 +354,42 @@ pub async fn fetch_sitemap_tree(
     all_pages.into_iter().collect()
 }
 
-/// Origin tuple: scheme + lowercased host + effective port.
-/// Two URLs match iff all three components match. `http://x` and `https://x`
-/// do not cross over, neither do `:80` vs `:8080`. Subdomains stay distinct
-/// (`cdn.x.com` ≠ `x.com`, and crucially `www.x.com` ≠ `x.com`). The strict
-/// host comparison is the load-bearing security guarantee for the redirect
-/// guard and the sitemap-tree filter — relaxing it (e.g. apex/www equivalence)
-/// would let a redirect or child-sitemap entry escape the requested origin.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct OriginKey {
-    scheme: String,
-    host: String,
-    port: u16,
-}
-
-fn origin_key(u: &url::Url) -> Option<OriginKey> {
+/// Site identity for sitemap scoping: the lowercased host with a single leading
+/// `www.` removed. Scheme and port are intentionally ignored.
+///
+/// SSRF is *not* this function's job — it is enforced separately at the route
+/// entry (`validate_safe_url_resolved`, blocks private IPs / metadata) and at
+/// the reqwest level (`safe_redirect_policy`). Here the only contract is "stay
+/// on the same site", and real-world sitemaps routinely cross http/https and
+/// apex/www for one site: e.g. an https apex (`https://repertuarim.com`) whose
+/// sitemap index lists `http://www.repertuarim.com/...` children. The old strict
+/// (scheme, host, port) tuple silently dropped every such URL → empty map.
+///
+/// Only `www.` is collapsed; other subdomains stay distinct (`cdn.x.com`,
+/// `blog.x.com` ≠ `x.com`), preserving subdomain isolation.
+fn site_key(u: &url::Url) -> Option<String> {
     let scheme = u.scheme();
     if scheme != "http" && scheme != "https" {
         return None;
     }
     let host = u.host_str()?.to_lowercase();
-    let port = u.port_or_known_default()?;
-    Some(OriginKey {
-        scheme: scheme.to_string(),
-        host,
-        port,
+    let host = host.strip_prefix("www.").unwrap_or(&host);
+    // Ignore scheme, but keep an *explicit non-default* port as part of the
+    // identity: `:80`/`:443` collapse to the bare host (so http↔https match),
+    // while `localhost:3000` vs `localhost:8080` stay distinct services.
+    let default_port = if scheme == "https" { 443 } else { 80 };
+    Some(match u.port() {
+        Some(p) if p != default_port => format!("{host}:{p}"),
+        _ => host.to_string(),
     })
 }
 
-fn same_origin_url(u: &str, target: &OriginKey) -> bool {
-    // SSRF safety is enforced at the route entry (validate_safe_url) and at
-    // the reqwest client level (safe_redirect_policy). Inside the sitemap
-    // tree the security boundary is the origin match — a child URL must not
-    // escape the (scheme, host, port) we were asked to map.
-    let parsed = match url::Url::parse(u) {
-        Ok(p) => p,
-        Err(_) => return false,
-    };
-    match origin_key(&parsed) {
-        Some(k) => &k == target,
-        None => false,
-    }
+fn same_site(u: &str, target: &str) -> bool {
+    url::Url::parse(u)
+        .ok()
+        .as_ref()
+        .and_then(site_key)
+        .is_some_and(|k| k == target)
 }
 
 #[cfg(test)]
@@ -445,49 +458,68 @@ mod tests {
         assert!(r.is_empty());
     }
 
-    fn key(u: &str) -> OriginKey {
-        origin_key(&url::Url::parse(u).unwrap()).unwrap()
+    fn key(u: &str) -> String {
+        site_key(&url::Url::parse(u).unwrap()).unwrap()
     }
 
     #[test]
-    fn origin_key_normalizes_case_and_default_port() {
-        let a = key("https://example.com/x");
-        let b = key("https://example.com:443/y");
-        assert_eq!(a, b, "default port (443) is canonicalized");
-        let c = key("https://Example.COM/");
-        assert_eq!(a, c, "host is lowercased");
+    fn site_key_normalizes_case_www_scheme_and_port() {
+        // scheme, port, case, and a leading www. all collapse to one identity.
+        let base = key("https://example.com/x");
+        assert_eq!(key("https://example.com:443/y"), base);
+        assert_eq!(key("https://Example.COM/"), base);
+        assert_eq!(key("http://example.com/x"), base, "scheme ignored");
+        assert_eq!(
+            key("http://example.com:80/x"),
+            base,
+            "default http port collapses"
+        );
+        assert_eq!(key("https://www.example.com/x"), base, "www. collapsed");
+        // An explicit non-default port is a distinct service, not the same site.
+        assert_ne!(
+            key("https://example.com:8443/x"),
+            base,
+            "explicit port kept"
+        );
     }
 
     #[test]
-    fn same_origin_url_treats_www_as_distinct() {
-        // apex and www are different hosts at the URL-spec level. We do NOT
-        // collapse them — a redirect/child-sitemap that crosses between them
-        // is rejected by design.
-        let apex = key("https://example.com/");
-        assert!(same_origin_url("https://example.com/x", &apex));
-        assert!(!same_origin_url("https://www.example.com/x", &apex));
-        assert!(!same_origin_url("https://evil.com/x", &apex));
-        assert!(!same_origin_url("https://cdn.example.com/x", &apex));
+    fn same_site_collapses_www_and_scheme() {
+        // The repertuarim.com case: apex https seed, sitemap lists http://www.
+        let apex = key("https://repertuarim.com/");
+        assert!(same_site(
+            "http://www.repertuarim.com/akor/x-akor-1.html",
+            &apex
+        ));
+        assert!(same_site(
+            "https://www.repertuarim.com/maps/akor1.xml",
+            &apex
+        ));
+        assert!(same_site("https://repertuarim.com/x", &apex));
 
         let www = key("https://www.example.com/");
-        assert!(same_origin_url("https://www.example.com/x", &www));
-        assert!(!same_origin_url("https://example.com/x", &www));
+        assert!(
+            same_site("https://example.com/x", &www),
+            "apex matches www target"
+        );
+        assert!(same_site("http://example.com/x", &www));
     }
 
     #[test]
-    fn same_origin_url_distinguishes_scheme_and_port() {
-        let https = key("https://example.com/");
-        // Different scheme: http vs https → must NOT match.
-        assert!(!same_origin_url("http://example.com/x", &https));
-        // Different port: explicit :8443 vs default :443 → must NOT match.
-        assert!(!same_origin_url("https://example.com:8443/x", &https));
+    fn same_site_keeps_other_hosts_and_subdomains_distinct() {
+        // Only www. is special-cased; everything else stays isolated.
+        let apex = key("https://example.com/");
+        assert!(!same_site("https://evil.com/x", &apex));
+        assert!(!same_site("https://cdn.example.com/x", &apex));
+        assert!(!same_site("https://blog.example.com/x", &apex));
+        assert!(!same_site("https://example.com.evil.com/x", &apex));
     }
 
     #[test]
-    fn same_origin_url_blocks_non_http_schemes() {
+    fn same_site_blocks_non_http_schemes() {
         let target = key("https://example.com/");
-        assert!(!same_origin_url("ftp://example.com/x", &target));
-        assert!(!same_origin_url("file:///etc/passwd", &target));
+        assert!(!same_site("ftp://example.com/x", &target));
+        assert!(!same_site("file:///etc/passwd", &target));
     }
 
     #[test]

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -232,7 +232,7 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                     "limit": {
                         "type": "integer",
                         "minimum": 0,
-                        "description": "Max URLs returned; 0 = unbounded (default 100)"
+                        "description": "Max URLs to discover AND return; 0 = unbounded (default 100). Raise it (e.g. 50000) to pull deep/large sitemaps."
                     }
                 },
                 "required": ["url"]
@@ -694,18 +694,19 @@ pub fn apply_bounds(tool_name: &str, args: &Value, mut value: Value) -> Value {
     value
 }
 
-/// Remove MCP-only control args (`maxLength`, `crw_map`'s `limit`) before a proxy
-/// forwards the call to a REST endpoint that may reject unknown body fields. These
-/// are applied locally via [`apply_bounds`] on the response instead. Note
-/// `crw_search.limit` is a *real* backend param and is intentionally NOT stripped.
+/// Remove MCP-only control args (`maxLength`) before a proxy forwards the call
+/// to a REST endpoint that may reject unknown body fields. These are applied
+/// locally via [`apply_bounds`] on the response instead.
+///
+/// `crw_map`'s `limit` and `crw_search`'s `limit` are *real* backend params and
+/// are intentionally NOT stripped: `/v1/map` now drives sitemap discovery depth
+/// from `limit`, so forwarding it lets a deliberate large limit actually find
+/// (not just slice) more URLs. `apply_bounds` still caps the response.
 pub fn strip_mcp_only_args(tool_name: &str, mut args: Value) -> Value {
     if let Some(obj) = args.as_object_mut() {
         match tool_name {
             "crw_scrape" | "crw_parse_file" | "crw_check_crawl_status" => {
                 obj.remove("maxLength");
-            }
-            "crw_map" => {
-                obj.remove("limit");
             }
             _ => {}
         }
@@ -1169,8 +1170,9 @@ mod tests {
         assert!(scrape.get("maxLength").is_none());
         assert_eq!(scrape["url"], json!("u"));
 
+        // crw_map.limit now drives backend discovery — must NOT be stripped.
         let map = strip_mcp_only_args("crw_map", json!({ "url": "u", "limit": 50 }));
-        assert!(map.get("limit").is_none());
+        assert_eq!(map["limit"], json!(50));
 
         // crw_search.limit is a real backend param — must NOT be stripped.
         let search = strip_mcp_only_args("crw_search", json!({ "query": "q", "limit": 5 }));

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -798,11 +798,19 @@ fn build_auth_response(request_id: &str, creds: Option<(&str, &str)>) -> serde_j
 /// `creds` is composed *per `fetch_inner` call* with the request's country
 /// suffix already applied, captured by move into this future so concurrent
 /// pool slots cannot cross-contaminate credentials.
+///
+/// `continue_paused` controls who owns `Fetch.requestPaused`: in auth-only mode
+/// (no interception pump) this pump must plainly continue every paused request,
+/// because `Fetch.enable` is on with `[*]` patterns and nothing else would
+/// resume them — the page would hang. When the intercept pump runs alongside
+/// (auth + interception) it owns `requestPaused`, so this stays `false` to avoid
+/// two pumps double-continuing the same request.
 async fn run_auth_pump(
     conn: &CdpConnection,
     mut rx: broadcast::Receiver<CdpEvent>,
     creds: Option<(String, String)>,
     session_id: &str,
+    continue_paused: bool,
 ) {
     let cmd_timeout = Duration::from_secs(2);
     loop {
@@ -811,10 +819,27 @@ async fn run_auth_pump(
             Err(broadcast::error::RecvError::Lagged(_)) => continue,
             Err(broadcast::error::RecvError::Closed) => return,
         };
-        if ev.method != "Fetch.authRequired" {
+        if ev.session_id.as_deref() != Some(session_id) {
             continue;
         }
-        if ev.session_id.as_deref() != Some(session_id) {
+        if ev.method == "Fetch.requestPaused" {
+            if !continue_paused {
+                continue;
+            }
+            let Some(request_id) = ev.params.get("requestId").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let _ = conn
+                .send_recv(
+                    "Fetch.continueRequest",
+                    serde_json::json!({ "requestId": request_id }),
+                    Some(session_id),
+                    cmd_timeout,
+                )
+                .await;
+            continue;
+        }
+        if ev.method != "Fetch.authRequired" {
             continue;
         }
         let request_id = ev
@@ -2164,19 +2189,21 @@ impl CdpRenderer {
         // Optionally enable request interception. Must be done before
         // `Page.navigate` because `Fetch.enable` pauses the document request
         // too — pump must already be consuming `Fetch.requestPaused` by then.
-        // When only auth is active (no interception), pass empty `patterns: []`
-        // — omitting the field defaults CDP to "match all" and would pause
-        // every request without a consumer.
+        //
+        // Patterns are ALWAYS `[*]` when we enable Fetch. Chrome rejects an
+        // empty `patterns` array together with `handleAuthRequests: true`
+        // (`-32602 Can't specify empty patterns with handleAuth set`), which
+        // silently broke every proxy that needs auth — e.g. DataImpulse — on the
+        // Chrome path. With `[*]` Chrome pauses every request via
+        // `Fetch.requestPaused`, so a consumer MUST continue them: the intercept
+        // pump (when interception is on) or the auth pump's `continue_paused`
+        // branch (auth-only). Without that consumer every request would hang.
         let intercept_active = self.intercept_active_for(url);
         if intercept_active || auth_active {
             let mut params = serde_json::Map::new();
             params.insert(
                 "patterns".into(),
-                if intercept_active {
-                    serde_json::json!([{ "urlPattern": "*" }])
-                } else {
-                    serde_json::json!([])
-                },
+                serde_json::json!([{ "urlPattern": "*" }]),
             );
             if auth_active {
                 params.insert("handleAuthRequests".into(), serde_json::json!(true));
@@ -2293,8 +2320,13 @@ impl CdpRenderer {
             (true, true) => {
                 let intercept_pump =
                     run_intercept_pump(conn, conn.subscribe(), &self.blocklist, &session_id);
-                let auth_pump =
-                    run_auth_pump(conn, conn.subscribe(), effective_creds.clone(), &session_id);
+                let auth_pump = run_auth_pump(
+                    conn,
+                    conn.subscribe(),
+                    effective_creds.clone(),
+                    &session_id,
+                    false,
+                );
                 tokio::select! {
                     biased;
                     res = work => res,
@@ -2330,8 +2362,13 @@ impl CdpRenderer {
                 }
             }
             (false, true) => {
-                let auth_pump =
-                    run_auth_pump(conn, conn.subscribe(), effective_creds.clone(), &session_id);
+                let auth_pump = run_auth_pump(
+                    conn,
+                    conn.subscribe(),
+                    effective_creds.clone(),
+                    &session_id,
+                    true,
+                );
                 tokio::select! {
                     biased;
                     res = work => res,

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -762,6 +762,14 @@ impl FallbackRenderer {
             .map(|r| Arc::new(r.pick(host).clone()))
     }
 
+    /// True when a JS renderer (chrome / lightpanda / chrome_proxy) is wired in,
+    /// so a `render_js` request can actually execute a page. The sitemap
+    /// escalation arm uses this to skip pointless re-fetches of a challenged
+    /// sitemap when no renderer could clear the wall anyway.
+    pub fn js_capable(&self) -> bool {
+        !self.js_renderers.is_empty() || self.auto_egress_escalation
+    }
+
     /// Like [`Self::pick_proxy`] but derives the host key from a URL using the
     /// same normalization the HTTP fetcher and host limiter use — so the CDP
     /// `proxyServer` and the HTTP client land on the SAME sticky proxy.

--- a/crates/crw-server/src/routes/map.rs
+++ b/crates/crw-server/src/routes/map.rs
@@ -98,6 +98,9 @@ pub async fn map(
         per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
         crawl_fallback: req.crawl_fallback,
         url_filter,
+        max_urls: req
+            .limit
+            .unwrap_or(crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS),
     });
 
     let result =

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -91,6 +91,9 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
                 per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
                 crawl_fallback: req.crawl_fallback,
                 url_filter: state.url_filter.clone(),
+                max_urls: req
+                    .limit
+                    .unwrap_or(crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS),
             })
             .await
             .map_err(|e| format!("{e}"))?;

--- a/crates/crw-server/src/routes/v2/map.rs
+++ b/crates/crw-server/src/routes/v2/map.rs
@@ -83,6 +83,12 @@ pub async fn map(
         per_host_max_concurrent: state.config.crawler.per_host_max_concurrent,
         crawl_fallback,
         url_filter: state.url_filter.clone(),
+        // Push the caller's limit INTO discovery so a large `limit` actually
+        // discovers that many URLs. The post-filter `truncate` below stays as a
+        // safety net (and trims when include/exclude/search narrow the set).
+        max_urls: req
+            .limit
+            .unwrap_or(crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS),
     });
 
     let result = match tokio::time::timeout(Duration::from_secs(timeout_secs), fut).await {
@@ -101,7 +107,8 @@ pub async fn map(
         let needle = s.to_lowercase();
         urls.retain(|u| u.to_lowercase().contains(&needle));
     }
-    if let Some(limit) = req.limit {
+    // `0` means unbounded (matches discovery); only truncate for a positive cap.
+    if let Some(limit) = req.limit.filter(|l| *l > 0) {
         urls.truncate(limit);
     }
 


### PR DESCRIPTION
## Summary

`/map` returned only the seed URL (or a shallow BFS) on several classes of real-world sites. Independent root causes, all fixed and **verified end-to-end**:

| Site | Before | After | Cause |
|---|---|---|---|
| repertuarim.com | 1 | **5001** | sitemap same-site filter rejected http↔https + www↔apex |
| songsterr.com | 3001 | **200001** (`--limit 200000`; 121k real tabs) | round-robin fairness + configurable limit |
| ultimate-guitar.com | 1 / 403 | **9986** | CDP `Fetch.enable` empty-patterns bug broke chrome+auth-proxy |
| e-chords.com (Cloudflare) | 1 | **501** | sitemap challenge → JS-renderer escalation |

## What changed

1. **Same-site scoping relaxed** (`sitemap.rs`) — was scheme+host+port-strict, so an https apex whose sitemap index lists `http://www.` children dropped every URL (and the robots-declared sitemap seed itself). Now host-modulo-`www.`, ignoring scheme and default ports; other subdomains stay isolated. SSRF is still enforced by `validate_safe_url` + `safe_redirect_policy`.

2. **Round-robin URL collection** across the leaves of each sitemap level, so a capped map of a site that lists `artists` before `tabs` (songsterr) is representative instead of 5000 artist-index pages and zero songs.

3. **Configurable discovery limit** — `DiscoverOptions.max_urls` replaces the hard-coded 5000. CLI `--limit`, REST/MCP `limit` (Firecrawl-compatible), default 5000, `0` = unbounded, ceiling 5,000,000. MCP `limit` is no longer stripped before the backend (it drives discovery); the sitemap fetch budget scales with it so large/nested indexes aren't truncated.

4. **CDP auth-proxy fix** (`cdp.rs`) — `Fetch.enable` with `handleAuthRequests:true` was sent with empty `patterns:[]`, which Chrome rejects (`-32602`), breaking the **entire** chrome + authenticated-proxy path (DataImpulse etc.). Always send `[*]` and have the auth pump continue paused requests in auth-only mode. This is what unblocks the production `chrome_proxy` hard-block recovery arm.

5. **Anti-bot sitemap escalation** — a sitemap behind a Cloudflare/JS challenge is retried through the JS renderer (executes the challenge, returns the real XML), bounded by an escalation budget **and** a wall-clock deadline so a deeply-gated index returns partial results instead of grinding to a timeout. Handles Chrome's `webkit-xml-viewer-source-xml` wrapper; gated by `FallbackRenderer::js_capable()` so plain maps pay nothing.

## Notes
- SaaS side needs **no code change** — the prod `chrome-proxy` profile already exists; it was non-functional purely because of the CDP bug above. Enable it with the DataImpulse creds in prod `.env`.
- UG's *child* sitemaps don't render even directly (session-cookie wall beyond a fresh context), so UG maps best via BFS+chrome_proxy; the escalator returns gracefully.

## Tests
- New unit tests: same-site http/www/port matrix, round-robin fairness path, escalation (XML-viewer wrapper parse, unsolved-challenge rejection, 403→escalate→URLs).
- Full suite green: 91 crawl lib + 24 integration; clippy/fmt clean.