### PR TITLE
feat(extract): prompt-based extraction and full meta-tag metadata

### DIFF
--- a/crates/crw-cli/src/commands/scrape.rs
+++ b/crates/crw-cli/src/commands/scrape.rs
@@ -746,7 +746,10 @@ fn build_request(
 ) -> ScrapeRequest {
     let extract = extract_schema
         .clone()
-        .map(|s| crw_core::types::ExtractOptions { schema: Some(s) });
+        .map(|s| crw_core::types::ExtractOptions {
+            schema: Some(s),
+            prompt: None,
+        });
     ScrapeRequest {
         url,
         formats,

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -149,6 +149,11 @@ impl RequestedRenderer {
 pub struct ExtractOptions {
     #[serde(default)]
     pub schema: Option<serde_json::Value>,
+    /// Natural-language extraction instruction (Firecrawl-compatible
+    /// `extract.prompt`). Used alone — the LLM infers the output shape — or
+    /// alongside `schema` to steer which fields are filled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
 }
 
 /// POST /v1/scrape request body.
@@ -463,6 +468,13 @@ pub struct PageMetadata {
     /// URL-sourced pages.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_filename: Option<String>,
+    /// All raw `<meta>` tags (name/property → content) not already surfaced as
+    /// a named field above, flattened onto the metadata object to match
+    /// Firecrawl (e.g. `twitter:creator`, `author`, `keywords`, `og:type`).
+    /// A tag repeated on the page becomes a JSON array; otherwise a string.
+    /// Empty for sources without HTML meta (PDFs, uploads).
+    #[serde(flatten, default)]
+    pub extra: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 /// Token-usage and best-effort cost for one LLM call.

--- a/crates/crw-core/tests/types_tests.rs
+++ b/crates/crw-core/tests/types_tests.rs
@@ -92,6 +92,7 @@ fn page_metadata_skip_serializing_none() {
         elapsed_ms: 100,
         page_count: None,
         source_filename: None,
+        extra: Default::default(),
     };
 
     let json = serde_json::to_value(&meta).unwrap();
@@ -106,6 +107,42 @@ fn page_metadata_skip_serializing_none() {
     // Required fields always present
     assert_eq!(json["sourceURL"], "https://example.com");
     assert_eq!(json["statusCode"], 200);
+}
+
+#[test]
+fn page_metadata_extra_flattens_and_roundtrips() {
+    let mut extra = std::collections::BTreeMap::new();
+    extra.insert(
+        "twitter:creator".to_string(),
+        serde_json::Value::String("@x".into()),
+    );
+    let meta = PageMetadata {
+        title: Some("T".into()),
+        description: None,
+        og_title: None,
+        og_description: None,
+        og_image: None,
+        canonical_url: None,
+        source_url: "https://example.com".into(),
+        language: None,
+        status_code: 200,
+        rendered_with: None,
+        elapsed_ms: 0,
+        page_count: None,
+        source_filename: None,
+        extra,
+    };
+    let json = serde_json::to_value(&meta).unwrap();
+    // Extra meta tags flatten onto the metadata object (Firecrawl-style), not
+    // nested under an "extra" key.
+    assert_eq!(json["twitter:creator"], "@x");
+    assert!(json.get("extra").is_none());
+    // And unknown top-level keys deserialize back into `extra`.
+    let back: PageMetadata = serde_json::from_value(json).unwrap();
+    assert_eq!(
+        back.extra.get("twitter:creator"),
+        Some(&serde_json::Value::String("@x".into()))
+    );
 }
 
 #[test]
@@ -174,6 +211,7 @@ fn scrape_data_skip_serializing_none() {
             elapsed_ms: 50,
             page_count: None,
             source_filename: None,
+            extra: Default::default(),
         },
         debug_extraction: None,
         content_type: None,
@@ -287,6 +325,7 @@ fn scrape_data_serializes_debug_extraction_as_camel_case() {
             elapsed_ms: 0,
             page_count: None,
             source_filename: None,
+            extra: Default::default(),
         },
         debug_extraction: None,
         content_type: None,

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -375,8 +375,14 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         if let (Some(schema), Some(llm)) = (&req.json_schema, llm_config)
             && let Some(md) = &data.markdown
         {
-            match crw_extract::structured::extract_structured_with_usage(md, schema, llm, None)
-                .await
+            match crw_extract::structured::extract_structured_with_usage(
+                md,
+                Some(schema),
+                None,
+                llm,
+                None,
+            )
+            .await
             {
                 Ok(result) => {
                     data.json = Some(result.value);

--- a/crates/crw-crawl/src/pdf.rs
+++ b/crates/crw-crawl/src/pdf.rs
@@ -554,6 +554,7 @@ fn build_scrape_data(
             elapsed_ms,
             page_count: Some(extract.page_count),
             source_filename: source.source_filename.clone(),
+            extra: Default::default(),
         },
         debug_extraction: None,
         content_type: Some("application/pdf".to_string()),
@@ -588,9 +589,14 @@ pub async fn apply_llm_formats(
         match (effective_schema, llm_config) {
             (Some(schema), Some(llm)) => {
                 let md = data.markdown.as_deref().unwrap_or("");
-                let result =
-                    crw_extract::structured::extract_structured_with_usage(md, schema, llm, None)
-                        .await?;
+                let result = crw_extract::structured::extract_structured_with_usage(
+                    md,
+                    Some(schema),
+                    None,
+                    llm,
+                    None,
+                )
+                .await?;
                 data.json = Some(result.value);
                 if data.llm_usage.is_none() {
                     data.llm_usage = result.usage;

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -532,42 +532,56 @@ async fn scrape_url_inner(
         .json_schema
         .as_ref()
         .or_else(|| req.extract.as_ref().and_then(|e| e.schema.as_ref()));
+    // Optional natural-language extraction instruction (`extract.prompt`). Works
+    // alone — the LLM infers the output shape — or alongside a schema to steer
+    // which fields get filled.
+    let effective_prompt = req
+        .extract
+        .as_ref()
+        .and_then(|e| e.prompt.as_deref())
+        .filter(|p| !p.trim().is_empty());
 
     // Build BYOK LlmConfig once; reused by structured JSON + summary paths.
     let byok_config = build_byok_llm_config(req, llm_config);
     let effective_llm = byok_config.as_ref().or(llm_config);
 
     if formats_include_json(&req.formats) {
-        if let (Some(schema), Some(llm)) = (effective_schema, effective_llm) {
-            let md = data.markdown.as_deref().unwrap_or("");
-            match crw_extract::structured::extract_structured_with_usage(md, schema, llm, None)
-                .await
-            {
-                Ok(result) => {
-                    data.json = Some(result.value);
-                    // Surface per-call LLM token usage so callers (billing,
-                    // dashboards) see the structured-extraction spend.
-                    // Summary may overwrite this slot below; that's fine —
-                    // each route triggers at most one of the two paths in
-                    // the dominant flow, and the "first wins" tiebreak is
-                    // preserved by checking is_none() before assignment.
-                    if data.llm_usage.is_none() {
-                        data.llm_usage = result.usage;
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("Structured extraction failed: {e}");
-                    return Err(e);
-                }
-            }
-        } else if effective_schema.is_some() && effective_llm.is_none() {
+        // A schema OR a prompt is enough to run structured extraction.
+        if effective_schema.is_none() && effective_prompt.is_none() {
+            return Err(crw_core::error::CrwError::InvalidRequest(
+                "Structured extraction (formats: json/extract) requires a 'jsonSchema' field or an extraction 'prompt'.".into()
+            ));
+        }
+        let Some(llm) = effective_llm else {
             return Err(crw_core::error::CrwError::ExtractionError(
                 "JSON extraction requested but no LLM configured. Either set [extraction.llm] in server config, or pass 'llmApiKey' in the request body.".into()
             ));
-        } else if effective_schema.is_none() {
-            return Err(crw_core::error::CrwError::InvalidRequest(
-                "Structured extraction (formats: json/extract) requires a 'jsonSchema' field. Provide a JSON Schema object.".into()
-            ));
+        };
+        let md = data.markdown.as_deref().unwrap_or("");
+        match crw_extract::structured::extract_structured_with_usage(
+            md,
+            effective_schema,
+            effective_prompt,
+            llm,
+            None,
+        )
+        .await
+        {
+            Ok(result) => {
+                data.json = Some(result.value);
+                // Surface per-call LLM token usage so callers (billing,
+                // dashboards) see the structured-extraction spend. Summary may
+                // overwrite this slot below; that's fine — each route triggers
+                // at most one of the two paths in the dominant flow, and the
+                // "first wins" tiebreak is preserved by the is_none() check.
+                if data.llm_usage.is_none() {
+                    data.llm_usage = result.usage;
+                }
+            }
+            Err(e) => {
+                tracing::error!("Structured extraction failed: {e}");
+                return Err(e);
+            }
         }
     }
 
@@ -658,7 +672,11 @@ async fn scrape_url_inner(
                 (Some(schema), Some(llm)) => {
                     let md = data.markdown.as_deref().unwrap_or("");
                     match crw_extract::structured::extract_structured_with_usage(
-                        md, schema, llm, None,
+                        md,
+                        Some(schema),
+                        None,
+                        llm,
+                        None,
                     )
                     .await
                     {

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -882,6 +882,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
             elapsed_ms,
             page_count: None,
             source_filename: None,
+            extra: meta.extra,
         },
         debug_extraction: None,
         // Populated post-extract by the caller (single.rs / crawl.rs) from

--- a/crates/crw-extract/src/readability.rs
+++ b/crates/crw-extract/src/readability.rs
@@ -399,6 +399,12 @@ pub struct ExtractedMetadata {
     pub og_description: Option<String>,
     pub og_image: Option<String>,
     pub canonical_url: Option<String>,
+    /// Every other `<meta name|property>` tag on the page, keyed by its raw
+    /// name/property (e.g. `twitter:creator`, `author`). Values are the `content`
+    /// attribute; a tag that repeats becomes an array. Keys already surfaced as
+    /// a named field above (`title`, `description`) are excluded to avoid a
+    /// duplicate key once flattened onto the metadata object.
+    pub extra: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 /// Extract metadata (title, description, OG tags, canonical) from HTML.
@@ -418,6 +424,8 @@ pub fn extract_metadata(html: &str) -> ExtractedMetadata {
     // Extract language from <html lang="..."> attribute.
     let language = select_attr(&document, "html", "lang");
 
+    let extra = collect_meta_tags(&document);
+
     ExtractedMetadata {
         title,
         description,
@@ -426,7 +434,52 @@ pub fn extract_metadata(html: &str) -> ExtractedMetadata {
         og_description,
         og_image,
         canonical_url,
+        extra,
     }
+}
+
+/// Collect every `<meta name|property>` tag into a map, mirroring Firecrawl's
+/// flat metadata. `name` wins over `property` when both are present. A tag that
+/// appears more than once (e.g. `viewport`) becomes a JSON array; a single tag
+/// stays a string. `title` / `description` are skipped — they already ship as
+/// named fields and would collide once flattened onto the metadata object.
+fn collect_meta_tags(document: &Html) -> std::collections::BTreeMap<String, serde_json::Value> {
+    use serde_json::Value;
+    use std::collections::BTreeMap;
+
+    const SKIP: [&str; 2] = ["title", "description"];
+    let mut raw: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    if let Ok(sel) = Selector::parse("meta") {
+        for el in document.select(&sel) {
+            let attrs = el.value();
+            let Some(key) = attrs.attr("name").or_else(|| attrs.attr("property")) else {
+                continue;
+            };
+            let key = key.trim();
+            let Some(content) = attrs.attr("content") else {
+                continue;
+            };
+            let content = content.trim();
+            if key.is_empty() || content.is_empty() || SKIP.contains(&key) {
+                continue;
+            }
+            raw.entry(key.to_string())
+                .or_default()
+                .push(content.to_string());
+        }
+    }
+
+    raw.into_iter()
+        .map(|(k, mut vals)| {
+            let v = if vals.len() == 1 {
+                Value::String(vals.pop().unwrap())
+            } else {
+                Value::Array(vals.into_iter().map(Value::String).collect())
+            };
+            (k, v)
+        })
+        .collect()
 }
 
 fn select_text(doc: &Html, selector: &str) -> Option<String> {
@@ -496,6 +549,42 @@ mod tests {
         let meta = extract_metadata(html);
         assert_eq!(meta.title.unwrap(), "Test Page");
         assert_eq!(meta.description.unwrap(), "A test");
+    }
+
+    #[test]
+    fn collects_arbitrary_meta_tags() {
+        use serde_json::Value;
+        let html = r#"<html><head>
+            <title>T</title>
+            <meta name="description" content="D">
+            <meta name="twitter:creator" content="@behramcelen">
+            <meta property="og:type" content="blog">
+            <meta name="viewport" content="a">
+            <meta name="viewport" content="b">
+            <meta name="empty" content="">
+        </head><body></body></html>"#;
+        let meta = extract_metadata(html);
+        // Arbitrary name/property tags surface verbatim.
+        assert_eq!(
+            meta.extra.get("twitter:creator"),
+            Some(&Value::String("@behramcelen".into()))
+        );
+        assert_eq!(
+            meta.extra.get("og:type"),
+            Some(&Value::String("blog".into()))
+        );
+        // Repeated tag becomes an array.
+        assert_eq!(
+            meta.extra.get("viewport"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into())
+            ]))
+        );
+        // title/description are named fields — excluded to avoid flatten collision.
+        assert!(!meta.extra.contains_key("description"));
+        // Empty content is dropped.
+        assert!(!meta.extra.contains_key("empty"));
     }
 
     #[test]

--- a/crates/crw-extract/src/structured.rs
+++ b/crates/crw-extract/src/structured.rs
@@ -81,9 +81,11 @@ pub async fn extract_structured(
     schema: &serde_json::Value,
     llm: &LlmConfig,
 ) -> CrwResult<serde_json::Value> {
-    Ok(extract_structured_with_usage(markdown, schema, llm, None)
-        .await?
-        .value)
+    Ok(
+        extract_structured_with_usage(markdown, Some(schema), None, llm, None)
+            .await?
+            .value,
+    )
 }
 
 /// Extract structured JSON and return token usage + truncation status.
@@ -96,7 +98,8 @@ pub async fn extract_structured(
 /// downstream billing surfaces can flag pages that were clipped.
 pub async fn extract_structured_with_usage(
     markdown: &str,
-    schema: &serde_json::Value,
+    schema: Option<&serde_json::Value>,
+    user_prompt: Option<&str>,
     llm: &LlmConfig,
     max_input_bytes: Option<usize>,
 ) -> CrwResult<StructuredExtractResult> {
@@ -110,16 +113,32 @@ pub async fn extract_structured_with_usage(
     let max_bytes = max_input_bytes.unwrap_or(DEFAULT_MAX_INPUT_BYTES);
     let (clipped, truncated) = truncate_md(markdown, max_bytes);
 
-    let prompt = format!(
-        "Extract structured data from the following content according to the JSON schema. \
-         Call the extract_data tool with the extracted data.\n\n## Content\n{clipped}"
-    );
+    // When the caller gave only a prompt (no schema), let the LLM shape the
+    // object itself; the tool still needs an input schema, so use a permissive
+    // one that accepts any properties.
+    let permissive_schema = serde_json::json!({ "type": "object", "additionalProperties": true });
+    let tool_schema = schema.unwrap_or(&permissive_schema);
+
+    // The caller-supplied prompt (trusted API input, not scraped content) steers
+    // extraction. Fall back to the generic schema-driven instruction when absent.
+    let user_prompt = user_prompt.map(str::trim).filter(|p| !p.is_empty());
+    let prompt = match user_prompt {
+        Some(p) => format!(
+            "Extract structured data from the following content. \
+             Follow this instruction: {p}\n\
+             Call the extract_data tool with the extracted data.\n\n## Content\n{clipped}"
+        ),
+        None => format!(
+            "Extract structured data from the following content according to the JSON schema. \
+             Call the extract_data tool with the extracted data.\n\n## Content\n{clipped}"
+        ),
+    };
 
     let (value, mut usage) = match llm.provider.as_str() {
         "anthropic" => {
             call_anthropic(
                 &prompt,
-                schema,
+                tool_schema,
                 llm,
                 "extract_data",
                 "Extract structured data from the content",
@@ -129,7 +148,7 @@ pub async fn extract_structured_with_usage(
         "openai" | "deepseek" | "openai-compatible" => {
             call_openai(
                 &prompt,
-                schema,
+                tool_schema,
                 llm,
                 "extract_data",
                 "Extract structured data from the content",
@@ -145,7 +164,11 @@ pub async fn extract_structured_with_usage(
         u.truncated = true;
     }
 
-    validate_against_schema(&value, schema)?;
+    // Only validate against a caller-supplied schema; a prompt-only extraction
+    // has no contract to check the permissive result against.
+    if let Some(schema) = schema {
+        validate_against_schema(&value, schema)?;
+    }
     Ok(StructuredExtractResult {
         value,
         usage,

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -308,6 +308,7 @@ mod tests {
                 elapsed_ms: 0,
                 page_count: None,
                 source_filename: None,
+                extra: Default::default(),
             },
             debug_extraction: None,
             content_type: Some("text/html".into()),


### PR DESCRIPTION
## What

Two extraction improvements that fix empty/low-recall structured extraction.

**Prompt-based extraction.** New `extract.prompt` field. Extraction now runs with a schema, a prompt, or both:
- prompt-only → the LLM infers the output shape (permissive schema)
- schema+prompt → the prompt steers which fields get filled
- schema-only → unchanged

**Full meta-tag metadata.** Every `<meta>` tag is now surfaced in `metadata` (flattened: `twitter:creator`, `author`, `keywords`, `og:type`, …). Repeated tags become arrays; `title`/`description` stay named to avoid a flatten collision.

## Why

Structured extraction returned empty when the target data (social links, author, contact) lived in page regions or meta tags the pipeline dropped. Surfacing all meta tags fixes a whole class of "field is right there in the HTML but comes back empty" cases; prompt support removes the schema-authoring friction for simple asks.

## Compatibility

Additive and backward-compatible: no endpoint/field removed, only `extract.prompt` added (optional). Metadata only gains keys (no `deny_unknown_fields` anywhere; v2 conformance passes). The error path is now more permissive (schema **or** prompt).

## Tests

`cargo fmt`/`clippy -D warnings`/`build`/`test` green. New units: `collects_arbitrary_meta_tags`, `page_metadata_extra_flattens_and_roundtrips`.

https://claude.ai/code/session_012XSSWdqGasVWB9h8gMwki2