### PR TITLE
fix(docs): redirect stubs for pre-flatten legacy doc URLs

### DIFF
--- a/.github/workflows/google-indexing.yml
+++ b/.github/workflows/google-indexing.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/*/index.html docs/sitemap.xml
+          git add docs/*/index.html docs/*/*/index.html docs/sitemap.xml
           git diff --staged --quiet || git commit -m "chore: regenerate static doc pages [skip ci]"
           git push
 

--- a/docs/crawl/index.html
+++ b/docs/crawl/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/crawling">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/crawling">
+  <script>location.replace("https://docs.fastcrw.com/crawling");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/crawling">https://docs.fastcrw.com/crawling</a>.</body>
+</html>

--- a/docs/docs/agent-onboarding/index.html
+++ b/docs/docs/agent-onboarding/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/agent-onboarding">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/agent-onboarding">
+  <script>location.replace("https://docs.fastcrw.com/agent-onboarding");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/agent-onboarding">https://docs.fastcrw.com/agent-onboarding</a>.</body>
+</html>

--- a/docs/docs/architecture/index.html
+++ b/docs/docs/architecture/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/architecture">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/architecture">
+  <script>location.replace("https://docs.fastcrw.com/architecture");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/architecture">https://docs.fastcrw.com/architecture</a>.</body>
+</html>

--- a/docs/docs/authentication/index.html
+++ b/docs/docs/authentication/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/authentication">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/authentication">
+  <script>location.replace("https://docs.fastcrw.com/authentication");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/authentication">https://docs.fastcrw.com/authentication</a>.</body>
+</html>

--- a/docs/docs/capabilities/index.html
+++ b/docs/docs/capabilities/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/capabilities">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/capabilities">
+  <script>location.replace("https://docs.fastcrw.com/capabilities");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/capabilities">https://docs.fastcrw.com/capabilities</a>.</body>
+</html>

--- a/docs/docs/changelog/index.html
+++ b/docs/docs/changelog/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/changelog">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/changelog">
+  <script>location.replace("https://docs.fastcrw.com/changelog");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/changelog">https://docs.fastcrw.com/changelog</a>.</body>
+</html>

--- a/docs/docs/choose-endpoint/index.html
+++ b/docs/docs/choose-endpoint/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/choose-endpoint">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/choose-endpoint">
+  <script>location.replace("https://docs.fastcrw.com/choose-endpoint");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/choose-endpoint">https://docs.fastcrw.com/choose-endpoint</a>.</body>
+</html>

--- a/docs/docs/compatibility/index.html
+++ b/docs/docs/compatibility/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/compatibility">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/compatibility">
+  <script>location.replace("https://docs.fastcrw.com/compatibility");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/compatibility">https://docs.fastcrw.com/compatibility</a>.</body>
+</html>

--- a/docs/docs/configuration/index.html
+++ b/docs/docs/configuration/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/configuration">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/configuration">
+  <script>location.replace("https://docs.fastcrw.com/configuration");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/configuration">https://docs.fastcrw.com/configuration</a>.</body>
+</html>

--- a/docs/docs/crates/index.html
+++ b/docs/docs/crates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/crates">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/crates">
+  <script>location.replace("https://docs.fastcrw.com/crates");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/crates">https://docs.fastcrw.com/crates</a>.</body>
+</html>

--- a/docs/docs/crawl/index.html
+++ b/docs/docs/crawl/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/crawling">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/crawling">
+  <script>location.replace("https://docs.fastcrw.com/crawling");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/crawling">https://docs.fastcrw.com/crawling</a>.</body>
+</html>

--- a/docs/docs/crawling/index.html
+++ b/docs/docs/crawling/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/crawling">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/crawling">
+  <script>location.replace("https://docs.fastcrw.com/crawling");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/crawling">https://docs.fastcrw.com/crawling</a>.</body>
+</html>

--- a/docs/docs/credit-costs/index.html
+++ b/docs/docs/credit-costs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/credit-costs">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/credit-costs">
+  <script>location.replace("https://docs.fastcrw.com/credit-costs");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/credit-costs">https://docs.fastcrw.com/credit-costs</a>.</body>
+</html>

--- a/docs/docs/crw-browse/index.html
+++ b/docs/docs/crw-browse/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/crw-browse">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/crw-browse">
+  <script>location.replace("https://docs.fastcrw.com/crw-browse");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/crw-browse">https://docs.fastcrw.com/crw-browse</a>.</body>
+</html>

--- a/docs/docs/docker/index.html
+++ b/docs/docs/docker/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/docker">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/docker">
+  <script>location.replace("https://docs.fastcrw.com/docker");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/docker">https://docs.fastcrw.com/docker</a>.</body>
+</html>

--- a/docs/docs/error-codes/index.html
+++ b/docs/docs/error-codes/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/error-codes">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/error-codes">
+  <script>location.replace("https://docs.fastcrw.com/error-codes");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/error-codes">https://docs.fastcrw.com/error-codes</a>.</body>
+</html>

--- a/docs/docs/extract/index.html
+++ b/docs/docs/extract/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/extract">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/extract">
+  <script>location.replace("https://docs.fastcrw.com/extract");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/extract">https://docs.fastcrw.com/extract</a>.</body>
+</html>

--- a/docs/docs/glossary/index.html
+++ b/docs/docs/glossary/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/glossary">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/glossary">
+  <script>location.replace("https://docs.fastcrw.com/glossary");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/glossary">https://docs.fastcrw.com/glossary</a>.</body>
+</html>

--- a/docs/docs/installation/index.html
+++ b/docs/docs/installation/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/installation">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/installation">
+  <script>location.replace("https://docs.fastcrw.com/installation");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/installation">https://docs.fastcrw.com/installation</a>.</body>
+</html>

--- a/docs/docs/integrations/index.html
+++ b/docs/docs/integrations/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/integrations">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/integrations">
+  <script>location.replace("https://docs.fastcrw.com/integrations");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/integrations">https://docs.fastcrw.com/integrations</a>.</body>
+</html>

--- a/docs/docs/introduction/index.html
+++ b/docs/docs/introduction/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/introduction">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/introduction">
+  <script>location.replace("https://docs.fastcrw.com/introduction");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/introduction">https://docs.fastcrw.com/introduction</a>.</body>
+</html>

--- a/docs/docs/js-rendering/index.html
+++ b/docs/docs/js-rendering/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/js-rendering">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/js-rendering">
+  <script>location.replace("https://docs.fastcrw.com/js-rendering");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/js-rendering">https://docs.fastcrw.com/js-rendering</a>.</body>
+</html>

--- a/docs/docs/map/index.html
+++ b/docs/docs/map/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/map">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/map">
+  <script>location.replace("https://docs.fastcrw.com/map");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/map">https://docs.fastcrw.com/map</a>.</body>
+</html>

--- a/docs/docs/mcp-clients/index.html
+++ b/docs/docs/mcp-clients/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/mcp-clients">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/mcp-clients">
+  <script>location.replace("https://docs.fastcrw.com/mcp-clients");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/mcp-clients">https://docs.fastcrw.com/mcp-clients</a>.</body>
+</html>

--- a/docs/docs/mcp/index.html
+++ b/docs/docs/mcp/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/mcp">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/mcp">
+  <script>location.replace("https://docs.fastcrw.com/mcp");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/mcp">https://docs.fastcrw.com/mcp</a>.</body>
+</html>

--- a/docs/docs/migrate-from-firecrawl/index.html
+++ b/docs/docs/migrate-from-firecrawl/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/migrate-from-firecrawl">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/migrate-from-firecrawl">
+  <script>location.replace("https://docs.fastcrw.com/migrate-from-firecrawl");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/migrate-from-firecrawl">https://docs.fastcrw.com/migrate-from-firecrawl</a>.</body>
+</html>

--- a/docs/docs/monitoring/index.html
+++ b/docs/docs/monitoring/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/monitoring">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/monitoring">
+  <script>location.replace("https://docs.fastcrw.com/monitoring");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/monitoring">https://docs.fastcrw.com/monitoring</a>.</body>
+</html>

--- a/docs/docs/output-formats/index.html
+++ b/docs/docs/output-formats/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/output-formats">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/output-formats">
+  <script>location.replace("https://docs.fastcrw.com/output-formats");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/output-formats">https://docs.fastcrw.com/output-formats</a>.</body>
+</html>

--- a/docs/docs/pdf-parsing/index.html
+++ b/docs/docs/pdf-parsing/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/pdf-parsing">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/pdf-parsing">
+  <script>location.replace("https://docs.fastcrw.com/pdf-parsing");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/pdf-parsing">https://docs.fastcrw.com/pdf-parsing</a>.</body>
+</html>

--- a/docs/docs/playground/index.html
+++ b/docs/docs/playground/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/playground">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/playground">
+  <script>location.replace("https://docs.fastcrw.com/playground");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/playground">https://docs.fastcrw.com/playground</a>.</body>
+</html>

--- a/docs/docs/proxies/index.html
+++ b/docs/docs/proxies/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/proxies">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/proxies">
+  <script>location.replace("https://docs.fastcrw.com/proxies");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/proxies">https://docs.fastcrw.com/proxies</a>.</body>
+</html>

--- a/docs/docs/quick-start/index.html
+++ b/docs/docs/quick-start/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/quick-start">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/quick-start">
+  <script>location.replace("https://docs.fastcrw.com/quick-start");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/quick-start">https://docs.fastcrw.com/quick-start</a>.</body>
+</html>

--- a/docs/docs/rate-limits/index.html
+++ b/docs/docs/rate-limits/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/rate-limits">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/rate-limits">
+  <script>location.replace("https://docs.fastcrw.com/rate-limits");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/rate-limits">https://docs.fastcrw.com/rate-limits</a>.</body>
+</html>

--- a/docs/docs/recipe-batch/index.html
+++ b/docs/docs/recipe-batch/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-batch">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-batch">
+  <script>location.replace("https://docs.fastcrw.com/recipe-batch");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-batch">https://docs.fastcrw.com/recipe-batch</a>.</body>
+</html>

--- a/docs/docs/recipe-js-spa/index.html
+++ b/docs/docs/recipe-js-spa/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-js-spa">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-js-spa">
+  <script>location.replace("https://docs.fastcrw.com/recipe-js-spa");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-js-spa">https://docs.fastcrw.com/recipe-js-spa</a>.</body>
+</html>

--- a/docs/docs/recipe-mcp-5min/index.html
+++ b/docs/docs/recipe-mcp-5min/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-mcp-5min">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-mcp-5min">
+  <script>location.replace("https://docs.fastcrw.com/recipe-mcp-5min");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-mcp-5min">https://docs.fastcrw.com/recipe-mcp-5min</a>.</body>
+</html>

--- a/docs/docs/recipe-monitoring/index.html
+++ b/docs/docs/recipe-monitoring/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-monitoring">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-monitoring">
+  <script>location.replace("https://docs.fastcrw.com/recipe-monitoring");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-monitoring">https://docs.fastcrw.com/recipe-monitoring</a>.</body>
+</html>

--- a/docs/docs/recipe-pdf/index.html
+++ b/docs/docs/recipe-pdf/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-pdf">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-pdf">
+  <script>location.replace("https://docs.fastcrw.com/recipe-pdf");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-pdf">https://docs.fastcrw.com/recipe-pdf</a>.</body>
+</html>

--- a/docs/docs/recipe-product-catalog/index.html
+++ b/docs/docs/recipe-product-catalog/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-product-catalog">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-product-catalog">
+  <script>location.replace("https://docs.fastcrw.com/recipe-product-catalog");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-product-catalog">https://docs.fastcrw.com/recipe-product-catalog</a>.</body>
+</html>

--- a/docs/docs/recipe-rag/index.html
+++ b/docs/docs/recipe-rag/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/recipe-rag">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/recipe-rag">
+  <script>location.replace("https://docs.fastcrw.com/recipe-rag");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/recipe-rag">https://docs.fastcrw.com/recipe-rag</a>.</body>
+</html>

--- a/docs/docs/research-api/index.html
+++ b/docs/docs/research-api/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/research-api">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/research-api">
+  <script>location.replace("https://docs.fastcrw.com/research-api");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/research-api">https://docs.fastcrw.com/research-api</a>.</body>
+</html>

--- a/docs/docs/response-shapes/index.html
+++ b/docs/docs/response-shapes/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/response-shapes">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/response-shapes">
+  <script>location.replace("https://docs.fastcrw.com/response-shapes");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/response-shapes">https://docs.fastcrw.com/response-shapes</a>.</body>
+</html>

--- a/docs/docs/rest-api/index.html
+++ b/docs/docs/rest-api/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/rest-api">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/rest-api">
+  <script>location.replace("https://docs.fastcrw.com/rest-api");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/rest-api">https://docs.fastcrw.com/rest-api</a>.</body>
+</html>

--- a/docs/docs/scrape/index.html
+++ b/docs/docs/scrape/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/scraping">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/scraping">
+  <script>location.replace("https://docs.fastcrw.com/scraping");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/scraping">https://docs.fastcrw.com/scraping</a>.</body>
+</html>

--- a/docs/docs/scraping/index.html
+++ b/docs/docs/scraping/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/scraping">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/scraping">
+  <script>location.replace("https://docs.fastcrw.com/scraping");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/scraping">https://docs.fastcrw.com/scraping</a>.</body>
+</html>

--- a/docs/docs/sdk-examples/index.html
+++ b/docs/docs/sdk-examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/sdk-examples">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/sdk-examples">
+  <script>location.replace("https://docs.fastcrw.com/sdk-examples");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/sdk-examples">https://docs.fastcrw.com/sdk-examples</a>.</body>
+</html>

--- a/docs/docs/sdk-reference/index.html
+++ b/docs/docs/sdk-reference/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/sdk-reference">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/sdk-reference">
+  <script>location.replace("https://docs.fastcrw.com/sdk-reference");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/sdk-reference">https://docs.fastcrw.com/sdk-reference</a>.</body>
+</html>

--- a/docs/docs/search/index.html
+++ b/docs/docs/search/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/search">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/search">
+  <script>location.replace("https://docs.fastcrw.com/search");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/search">https://docs.fastcrw.com/search</a>.</body>
+</html>

--- a/docs/docs/self-hosting-hardening/index.html
+++ b/docs/docs/self-hosting-hardening/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/self-hosting-hardening">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/self-hosting-hardening">
+  <script>location.replace("https://docs.fastcrw.com/self-hosting-hardening");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/self-hosting-hardening">https://docs.fastcrw.com/self-hosting-hardening</a>.</body>
+</html>

--- a/docs/docs/self-hosting/index.html
+++ b/docs/docs/self-hosting/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/self-hosting">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/self-hosting">
+  <script>location.replace("https://docs.fastcrw.com/self-hosting");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/self-hosting">https://docs.fastcrw.com/self-hosting</a>.</body>
+</html>

--- a/docs/docs/troubleshooting/index.html
+++ b/docs/docs/troubleshooting/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/troubleshooting">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/troubleshooting">
+  <script>location.replace("https://docs.fastcrw.com/troubleshooting");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/troubleshooting">https://docs.fastcrw.com/troubleshooting</a>.</body>
+</html>

--- a/docs/docs/v1/map/index.html
+++ b/docs/docs/v1/map/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/map">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/map">
+  <script>location.replace("https://docs.fastcrw.com/map");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/map">https://docs.fastcrw.com/map</a>.</body>
+</html>

--- a/docs/docs/v2-api/index.html
+++ b/docs/docs/v2-api/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/v2-api">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/v2-api">
+  <script>location.replace("https://docs.fastcrw.com/v2-api");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/v2-api">https://docs.fastcrw.com/v2-api</a>.</body>
+</html>

--- a/docs/scrape/index.html
+++ b/docs/scrape/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/scraping">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/scraping">
+  <script>location.replace("https://docs.fastcrw.com/scraping");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/scraping">https://docs.fastcrw.com/scraping</a>.</body>
+</html>

--- a/docs/v1/map/index.html
+++ b/docs/v1/map/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="https://docs.fastcrw.com/map">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=https://docs.fastcrw.com/map">
+  <script>location.replace("https://docs.fastcrw.com/map");</script>
+</head>
+<body>This page moved to <a href="https://docs.fastcrw.com/map">https://docs.fastcrw.com/map</a>.</body>
+</html>

--- a/scripts/build-docs-pages.mjs
+++ b/scripts/build-docs-pages.mjs
@@ -336,6 +336,51 @@ for (const { slug, title } of slugMeta) {
   generated++;
 }
 
+// ── Generate redirect stubs for legacy URLs ───────────────────────────────────
+// Google still has pre-flatten docs URLs on record (GSC "Not found (404)"):
+//   • /docs/<slug>      — the old prefixed path; every page now lives at /<slug>
+//   • /scrape, /crawl   — slugs renamed to /scraping, /crawling
+//   • /v1/map           — legacy API-style path, now /map
+// Emit a canonical meta-refresh stub at each old location so the 404s and any
+// external backlinks resolve to the live page. Stubs are noindex.
+function buildRedirectStub(target) {
+  const url = `${BASE_URL}/${target}`;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="${url}">
+  <meta name="robots" content="noindex, follow">
+  <meta http-equiv="refresh" content="0; url=${url}">
+  <script>location.replace(${JSON.stringify(url)});</script>
+</head>
+<body>This page moved to <a href="${url}">${url}</a>.</body>
+</html>
+`;
+}
+
+// old path (relative to docs/) → current slug it should resolve to
+const legacyRedirects = {};
+for (const { slug } of slugMeta) legacyRedirects[`docs/${slug}`] = slug;
+const renamedSlugs = { scrape: "scraping", crawl: "crawling", "v1/map": "map" };
+for (const [oldPath, target] of Object.entries(renamedSlugs)) {
+  legacyRedirects[oldPath] = target;
+  legacyRedirects[`docs/${oldPath}`] = target;
+}
+
+let redirectsWritten = 0;
+for (const [oldPath, target] of Object.entries(legacyRedirects)) {
+  const outDir = path.join(DOCS_DIR, oldPath);
+  // Never clobber a real generated page (slugMeta dirs live at docs/<slug>/).
+  if (existsSync(path.join(outDir, "index.html")) && slugTitles[path.basename(oldPath)] && !oldPath.startsWith("docs/") && !(oldPath in renamedSlugs)) {
+    continue;
+  }
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(outDir, "index.html"), buildRedirectStub(target), "utf8");
+  redirectsWritten++;
+}
+
 // ── Regenerate sitemap.xml ────────────────────────────────────────────────────
 const now = new Date().toISOString().split("T")[0];
 
@@ -357,6 +402,7 @@ await writeFile(path.join(DOCS_DIR, "sitemap.xml"), sitemap, "utf8");
 
 // ── Summary ───────────────────────────────────────────────────────────────────
 console.log(`\n✓ Generated ${generated}/${slugMeta.length} static pages`);
+console.log(`✓ Wrote ${redirectsWritten} legacy redirect stubs`);
 console.log(`✓ Updated docs/sitemap.xml (${slugMeta.length + 1} URLs)`);
 if (errors.length) {
   console.warn(`\nWarnings:`);


### PR DESCRIPTION
## Why
Google Search Console reports old **hash-SPA doc URLs** as "Not found (404)" on `docs.fastcrw.com`. The docs site was flattened from `/docs/<slug>` (SPA anchors) to per-page dirs at `/<slug>`, and two slugs were renamed. The old URLs Google still has on record now 404:
- `/docs/quick-start`, `/docs/rate-limits`, `/docs/output-formats`, `/docs/error-codes`, `/docs/scraping`, `/docs/mcp` — old `/docs/` prefix
- `/scrape` → `/scraping`, `/crawl` → `/crawling`, `/v1/map` → `/map` — renames

## What
Extend the static docs generator (`build-docs-pages.mjs`) to emit a **noindex canonical meta-refresh stub** at each legacy location:
- `/docs/<slug>` → `/<slug>` for **every** current slug (systematic; future-proofs any pre-flatten backlink)
- explicit renames: `scrape`→`scraping`, `crawl`→`crawling`, `v1/map`→`map` (at both bare and `/docs/`-prefixed paths)

55 stubs generated. Also widened the `google-indexing` workflow's `git add` glob (`docs/*/*/index.html`) so the nested stubs stay in sync on future regenerations — the old one-level glob wouldn't catch them.

## Checks
Generator runs clean (49/49 pages + 55 stubs) · `scripts/docs-guards.sh` ✅ · verified no real page clobbered (all slug dirs remain full pages) · stub canonical/refresh targets confirmed against live 200 pages. Pre-commit hook skipped (no Rust/TOML staged).