### PR TITLE
feat(server): add /firecrawl/* compat namespace, own /v1 as native API

### DIFF
--- a/crates/crw-server/src/app.rs
+++ b/crates/crw-server/src/app.rs
@@ -29,13 +29,32 @@ pub fn create_app(state: AppState) -> Router {
     let timeout = Duration::from_secs(state.config.effective_request_timeout_secs());
     let rate_limit_rps = state.config.server.rate_limit_rps;
 
-    // v1 + v2 routers merged before the shared auth + rate-limit layers, so the
-    // /v2/* surface (issue #62) inherits auth, rate-limiting, body-limit and the
-    // timeout layer identically to v1. `/mcp` is version-less.
-    let api_routes = routes::v1::router().merge(routes::v2::router()).route(
-        "/mcp",
-        post(routes::mcp::mcp_handler).fallback(method_not_allowed),
+    // Native vs Firecrawl-compat surface split.
+    //
+    // `/v1` (and, transitionally, `/v2`) are fastCRW's own API — free to evolve;
+    // staying Firecrawl-compatible is a bonus, not a contract.
+    //
+    // The SAME handlers are ALSO mounted under `/firecrawl/*`, which is the
+    // canonical, frozen Firecrawl drop-in surface (`/firecrawl/v1/*`,
+    // `/firecrawl/v2/*`). New callers who want guaranteed Firecrawl-shape should
+    // target `/firecrawl/*`; `/v2/*` at the root is a deprecated alias kept for
+    // backward-compat. Nesting reuses the v1/v2 routers verbatim, so both
+    // surfaces share request parsing, error envelopes, and body limits.
+    //
+    // All merged before the shared auth + rate-limit layers, so every surface
+    // inherits auth, rate-limiting, body-limit and the timeout layer identically.
+    // `/mcp` is version-less.
+    let firecrawl_compat = Router::new().nest(
+        "/firecrawl",
+        routes::v1::router().merge(routes::v2::router()),
     );
+    let api_routes = routes::v1::router()
+        .merge(routes::v2::router())
+        .merge(firecrawl_compat)
+        .route(
+            "/mcp",
+            post(routes::mcp::mcp_handler).fallback(method_not_allowed),
+        );
 
     let api_routes = if api_keys.is_empty() {
         api_routes.with_state(state.clone())

--- a/crates/crw-server/tests/v2_api.rs
+++ b/crates/crw-server/tests/v2_api.rs
@@ -167,3 +167,38 @@ async fn v2_scrape_auth_ok_reaches_handler() {
     // Passed auth, hit the handler, which 400s on the bad URL.
     assert_ne!(r.status_code(), StatusCode::UNAUTHORIZED);
 }
+
+// --- Firecrawl-compat namespace (`/firecrawl/*`) ---
+// The frozen Firecrawl drop-in surface re-mounts the same v1/v2 handlers under
+// a `/firecrawl` prefix, leaving root `/v1` (native) and `/v2` (deprecated
+// alias) untouched. These tests prove the prefix routes to the same handlers.
+
+#[tokio::test]
+async fn firecrawl_v2_scrape_routes_to_handler() {
+    let s = test_app();
+    let r = s
+        .post("/firecrawl/v2/scrape")
+        .json(&json!({"url": "not-a-url", "formats": ["markdown"]}))
+        .await;
+    // Reached the v2 handler (400 on bad URL), not a 404 from a missing route.
+    r.assert_status(StatusCode::BAD_REQUEST);
+    let body: Value = r.json();
+    assert_eq!(body["success"], false);
+}
+
+#[tokio::test]
+async fn firecrawl_v1_scrape_routes_to_handler() {
+    let s = test_app();
+    let r = s
+        .post("/firecrawl/v1/scrape")
+        .json(&json!({"url": "not-a-url"}))
+        .await;
+    r.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn firecrawl_prefix_unknown_route_404() {
+    let s = test_app();
+    let r = s.post("/firecrawl/v2/nope").json(&json!({})).await;
+    r.assert_status(StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## What

Adds a `/firecrawl/*` namespace that re-serves the existing Firecrawl-shaped v1/v2 handlers under a dedicated, **frozen** drop-in surface:

- **`/firecrawl/v1/*`, `/firecrawl/v2/*`** — canonical Firecrawl compatibility surface. New callers who want guaranteed Firecrawl shape target this.
- **root `/v1/*`** — now declared fastCRW's own **native** API. Free to evolve; Firecrawl-v1 compatibility is a bonus, not a contract. (Our public docs already center `/v1`.)
- **root `/v2/*`** — kept as a **deprecated alias** for backward-compat.

## Why

Today both `/v1` and `/v2` are deliberate mirrors of Firecrawl, so fastCRW has no surface it can freely evolve. This follows the industry norm (Groq/Together/Anthropic expose OpenAI-compat under a labeled `.../openai/v1/...` namespace, native API at root): native at root, vendor-compat namespaced.

## Backward compatibility

**Purely additive.** Root `/v1` and `/v2` registration is byte-identical — existing callers hit the exact same code path. The nested router reuses the v1/v2 routers verbatim, inheriting auth, rate-limiting, body limits and error envelopes.

## Verification

- Real Firecrawl SDK (firecrawl-py 4.31), end-to-end against a live server (+ SearXNG + LLM):
  - `/firecrawl/v2`: scrape ✅ search ✅ extract ✅ map ✅ crawl ✅ batch ✅
  - `/firecrawl/v1`: scrape ✅ (search/map/crawl-status/extract fail on **pre-existing** fastCRW↔Firecrawl-v1 response-shape gaps — identical on root `/v1`, not introduced here)
- Robustness: 0 panics / 0 500s under malformed / empty / oversized / wrong-method input → clean JSON 4xx.
- Root `/v1` + `/v2` test suites stay green (`api.rs`, `v2_api.rs`, `auth.rs` — 0 regressions). New `/firecrawl/*` routing tests added to `v2_api.rs`.

## Follow-ups (separate issues)

- Make `/firecrawl/v1` a true Firecrawl drop-in (fix v1 search/map/crawl-status response shapes; add v1 extract alias) — requires splitting the shared handlers so native `/v1` keeps its own shape.
- Docs: advertise `/firecrawl/*`, formalize `/v2` deprecation (Deprecation/Sunset headers), fix `docs/index.html` listing `/v1/extract` as a real endpoint (it isn't).