### PR TITLE
fix(api)!: errorCode rename + camelCase guard + CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,63 @@
+# Conventions
+
+Project-wide style and API conventions for the CRW engine. These are enforced
+in CI (`.github/workflows/ci.yml`) and by the opt-in pre-commit hook
+(`git config core.hooksPath .githooks`). Where a convention is machine-checked,
+the check is named below.
+
+## Identifier naming (Rust)
+
+Standard Rust casing, enforced by `clippy`:
+
+| Kind | Convention | Example |
+|---|---|---|
+| Functions, variables, modules | `snake_case` | `fetch_result` |
+| Types, traits, enum variants | `PascalCase` | `ScrapeData` |
+| Constants, statics | `SCREAMING_SNAKE_CASE` | `DEFAULT_MAX_INPUT_BYTES` |
+
+## API JSON naming — **camelCase everywhere**
+
+Every field a public API response serializes is **camelCase**. This is the
+single most important cross-cutting rule.
+
+- **Responses**: camelCase. Two deliberate Firecrawl-compatible exceptions with
+  non-standard capitalization — `sourceURL` and `numPages` — have no underscore
+  and are intentional; nothing else deviates.
+- **Requests**: primary field names are camelCase. For Firecrawl compatibility
+  we ALSO accept `snake_case` via `#[serde(alias = "...")]`, but that is input
+  tolerance, not our convention — never rely on snake_case in docs or examples.
+- **Verbatim external keys** (`metadata`'s meta-tag map: `og:site_name`,
+  `twitter:creator`, …) are the site's own HTML names, passed through as-is.
+  They are not typed fields and are exempt.
+- **Error shape**: `{ "success": false, "error": "...", "errorCode": "..." }`.
+
+**Enforced by:**
+- `crates/crw-core/tests/api_casing.rs` — serializes the public response types
+  and fails on any snake_case key. Add new response types there.
+- `.github/workflows/openapi-check.yml` — the served `/openapi.json` must stay
+  byte-equal to `docs/openapi.json`.
+
+To add a response type: derive `#[serde(rename_all = "camelCase")]` (or rename
+the offending field), update `crates/crw-server/openapi/openapi.json` +
+`docs/openapi.json`, and add an instance to the casing guard.
+
+## Formatting
+
+`rustfmt` defaults. Run `cargo fmt --all`. **Enforced:** `cargo fmt --all -- --check`.
+
+## Linting
+
+`clippy` with warnings-as-errors. **Enforced:** `cargo clippy --workspace --all-targets -- -D warnings`.
+
+## Commits
+
+[Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`,
+`chore:`, `docs:`, `refactor:`, `test:`, `ci:`, `perf:`. `release-please` reads
+these to compute versions and the changelog; never bump versions or edit
+`CHANGELOG.md` by hand.
+
+## API versioning
+
+Paths are versioned (`/v1`, `/v2`). Response shapes are additive within a
+version; the OpenAPI spec is the contract and is drift-checked against the
+binary.

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -648,14 +648,19 @@ fn is_zero_u32(v: &u32) -> bool {
 }
 
 /// Generic API response wrapper.
+///
+/// Serializes camelCase like every other public type; the `error_code` field
+/// therefore ships as `errorCode`. A deserialization `alias` keeps the legacy
+/// snake_case key readable for any client still sending it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiResponse<T: Serialize> {
     pub success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<T>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "error_code")]
     pub error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,

--- a/crates/crw-core/tests/api_casing.rs
+++ b/crates/crw-core/tests/api_casing.rs
@@ -1,0 +1,129 @@
+//! Convention guard: every field a public API response serializes MUST be
+//! camelCase (see `CONVENTIONS.md`).
+//!
+//! This test serializes the primary response types and asserts no JSON key is
+//! snake_case (contains `_`). It exists because the historical `error_code`
+//! (now `errorCode`) slipped through — the OpenAPI drift check only proves the
+//! spec matches the code, not that the convention holds.
+//!
+//! Out of scope by construction: the dynamic `metadata` meta-tag map
+//! (`og:site_name`, `twitter:creator`, …) holds verbatim external keys, not
+//! typed fields, and is left empty here.
+//!
+//! When you add a new public response type, add an instance to `camel_samples`.
+
+use crw_core::types::{ApiResponse, LlmUsage, PageMetadata, ScrapeData};
+use serde_json::Value;
+
+/// Recursively collect every object key in a JSON value.
+fn collect_keys(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            for (k, val) in map {
+                out.push(k.clone());
+                collect_keys(val, out);
+            }
+        }
+        Value::Array(arr) => arr.iter().for_each(|x| collect_keys(x, out)),
+        _ => {}
+    }
+}
+
+/// Keys that are snake_case (an underscore between word chars). Intentional
+/// camelCase like `sourceURL` / `numPages` has no underscore, so it passes.
+fn snake_case_keys(v: &Value) -> Vec<String> {
+    let mut keys = Vec::new();
+    collect_keys(v, &mut keys);
+    keys.into_iter().filter(|k| k.contains('_')).collect()
+}
+
+/// A fully-populated ScrapeData so every optional nested field is exercised.
+fn sample_scrape_data() -> ScrapeData {
+    ScrapeData {
+        markdown: Some("# Hi".into()),
+        source_hash: Some("abc".into()),
+        html: Some("<p>hi</p>".into()),
+        raw_html: Some("<html></html>".into()),
+        plain_text: Some("hi".into()),
+        links: Some(vec!["https://example.com".into()]),
+        json: None,
+        summary: Some("s".into()),
+        llm_usage: Some(LlmUsage {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            estimated_cost_usd: Some(0.001),
+            model: "m".into(),
+            provider: "p".into(),
+            cache_hit_input_tokens: Some(1),
+            cache_miss_input_tokens: Some(9),
+            truncated: true,
+            calls: 2,
+            executed_summaries: 1,
+            answer_executed: true,
+        }),
+        chunks: None,
+        warning: Some("w".into()),
+        warnings: vec!["w2".into()],
+        render_decision: None,
+        credit_cost: 1,
+        metadata: PageMetadata {
+            title: Some("t".into()),
+            description: Some("d".into()),
+            og_title: Some("ot".into()),
+            og_description: Some("od".into()),
+            og_image: Some("oi".into()),
+            canonical_url: Some("https://example.com".into()),
+            source_url: "https://example.com".into(),
+            language: Some("en".into()),
+            status_code: 200,
+            rendered_with: Some("http".into()),
+            elapsed_ms: 42,
+            page_count: Some(3),
+            source_filename: Some("f.pdf".into()),
+            extra: Default::default(),
+        },
+        debug_extraction: None,
+        content_type: Some("text/html".into()),
+        change_tracking: None,
+        screenshot: Some("data:image/png;base64,AAAA".into()),
+    }
+}
+
+#[test]
+fn api_response_error_shape_is_camel_case() {
+    let resp: ApiResponse<()> = ApiResponse {
+        success: false,
+        data: None,
+        error: Some("boom".into()),
+        error_code: Some("timeout".into()),
+        warning: None,
+    };
+    let v = serde_json::to_value(&resp).unwrap();
+    // The historical snake_case `error_code` must serialize as `errorCode`.
+    assert_eq!(v["errorCode"], "timeout");
+    assert!(v.get("error_code").is_none(), "legacy snake key leaked");
+    assert!(
+        snake_case_keys(&v).is_empty(),
+        "snake_case keys in error response: {:?}",
+        snake_case_keys(&v)
+    );
+}
+
+#[test]
+fn scrape_response_is_camel_case() {
+    let resp = ApiResponse {
+        success: true,
+        data: Some(sample_scrape_data()),
+        error: None,
+        error_code: None,
+        warning: None,
+    };
+    let v = serde_json::to_value(&resp).unwrap();
+    let snakes = snake_case_keys(&v);
+    assert!(
+        snakes.is_empty(),
+        "scrape response serializes snake_case keys (should be camelCase): {:?}",
+        snakes
+    );
+}

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -1523,7 +1523,7 @@
             "type": "string",
             "description": "Human-readable error message"
           },
-          "error_code": {
+          "errorCode": {
             "type": "string",
             "description": "Machine-readable error code (see docs/error-codes.md)"
           }

--- a/crates/crw-server/tests/deadline_auto_extend_test.rs
+++ b/crates/crw-server/tests/deadline_auto_extend_test.rs
@@ -134,10 +134,10 @@ async fn auto_extend_disabled_strict_deadline_times_out() {
         }))
         .await;
     // Handler-side timeout, not Tower outer cancellation. CrwError::Timeout
-    // serializes to error_code = "timeout".
+    // serializes to errorCode = "timeout".
     let body: serde_json::Value = resp.json();
     assert_eq!(
-        body["error_code"], "timeout",
+        body["errorCode"], "timeout",
         "strict deadline should produce handler-side timeout, not tower cancel: {body:?}"
     );
 }
@@ -165,7 +165,7 @@ async fn explicit_deadline_bypasses_auto_extend() {
         .await;
     let body: serde_json::Value = resp.json();
     assert_eq!(
-        body["error_code"], "timeout",
+        body["errorCode"], "timeout",
         "explicit 3s deadline should cut the 12s response: {body:?}"
     );
 }

--- a/crates/crw-server/tests/search_route.rs
+++ b/crates/crw-server/tests/search_route.rs
@@ -238,7 +238,7 @@ async fn search_disabled_returns_503_with_search_disabled_code() {
     resp.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
     let body: Value = resp.json();
     assert_eq!(body["success"], false);
-    assert_eq!(body["error_code"], "search_disabled");
+    assert_eq!(body["errorCode"], "search_disabled");
     let err = body["error"].as_str().unwrap();
     assert!(
         err.contains("Search is disabled"),

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1523,7 +1523,7 @@
             "type": "string",
             "description": "Human-readable error message"
           },
-          "error_code": {
+          "errorCode": {
             "type": "string",
             "description": "Machine-readable error code (see docs/error-codes.md)"
           }


### PR DESCRIPTION
Makes the API-casing convention explicit and enforced.

- **`error_code` → `errorCode`**: the lone snake_case response field now matches the camelCase convention. `ApiResponse` serializes camelCase; a deserialization alias keeps the legacy key readable. OpenAPI specs updated (byte-equal, drift check passes).
- **camelCase guard test** (`crates/crw-core/tests/api_casing.rs`): serializes the public response types and fails on any snake_case key — catches this class of regression in `cargo test` (the OpenAPI drift check only proves spec==code, not the convention).
- **CONVENTIONS.md**: documents naming, API camelCase, formatting, linting, commits, versioning + where each is enforced.

**BREAKING**: error responses use `errorCode` not `error_code`. The managed API already strips the field (managed clients unaffected); self-hosted clients should read `errorCode`.

fmt/clippy/test green locally; openapi specs byte-equal.

https://claude.ai/code/session_012XSSWdqGasVWB9h8gMwki2