### PR TITLE
fix(search): charset-aware scrape decode + per-result error + neutral answer warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "clap",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1008,6 +1008,7 @@ dependencies = [
  "crw-extract",
  "dashmap",
  "dirs",
+ "encoding_rs",
  "flate2",
  "futures",
  "libc",
@@ -1027,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1045,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -1314,6 +1314,11 @@ pub struct SearchResult {
     /// LLM-generated summary; populated when `summarizeResults: true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    /// Set when this result's enrichment scrape failed (P3-4), so a partial
+    /// success is observable: distinguishes "scrape failed" from "page simply
+    /// had no markdown". Absent on success — backward-compatible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// A single image result. Mirrors `ImageResult` in

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -37,6 +37,7 @@ dirs = { version = "6", optional = true }
 moka = { workspace = true }
 publicsuffix = { workspace = true }
 regex = { workspace = true }
+encoding_rs = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -384,11 +384,20 @@ impl PageFetcher for HttpFetcher {
             )));
         }
 
-        let content_type = resp
+        let content_type_header = resp
             .headers()
             .get("content-type")
             .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let content_type = content_type_header
+            .as_deref()
             .map(|s| s.split(';').next().unwrap_or(s).trim().to_lowercase());
+        // Charset from the Content-Type header (P1-1): pages served as Latin-1 /
+        // Windows-1252 would otherwise be UTF-8-lossy'd, turning each 0x80–0xFF
+        // byte into U+FFFD. Kept separately since `content_type` drops it.
+        let header_charset = content_type_header
+            .as_deref()
+            .and_then(charset_from_content_type);
 
         let cf_mitigated = resp
             .headers()
@@ -416,7 +425,7 @@ impl PageFetcher for HttpFetcher {
         let (html, raw_bytes) = if is_pdf {
             (String::new(), Some(bytes.to_vec()))
         } else {
-            (String::from_utf8_lossy(&bytes).into_owned(), None)
+            (decode_html_bytes(&bytes, header_charset.as_deref()), None)
         };
 
         let final_url = if final_url_str != url {
@@ -471,9 +480,112 @@ impl PageFetcher for HttpFetcher {
     }
 }
 
+/// Extract the `charset` label from a `Content-Type` header value
+/// (e.g. `text/html; charset=ISO-8859-1` → `ISO-8859-1`).
+fn charset_from_content_type(ct: &str) -> Option<String> {
+    let lower = ct.to_ascii_lowercase();
+    let idx = lower.find("charset")?;
+    let after = ct[idx + "charset".len()..].trim_start();
+    let after = after.strip_prefix('=')?.trim_start();
+    let after = after.trim_start_matches(['"', '\'']);
+    let end = after
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':'))
+        .unwrap_or(after.len());
+    let label = after[..end].trim();
+    (!label.is_empty()).then(|| label.to_string())
+}
+
+/// Sniff a `<meta charset>` / `<meta http-equiv=content-type … charset=…>`
+/// declaration from the first ~2KB of an HTML document.
+fn sniff_meta_charset(bytes: &[u8]) -> Option<String> {
+    let head = &bytes[..bytes.len().min(2048)];
+    let text = String::from_utf8_lossy(head).to_ascii_lowercase();
+    let idx = text.find("charset")?;
+    let after = text[idx + "charset".len()..].trim_start();
+    let after = after.strip_prefix('=')?.trim_start();
+    let after = after.trim_start_matches(['"', '\'']);
+    let end = after
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+        .unwrap_or(after.len());
+    let label = &after[..end];
+    (!label.is_empty()).then(|| label.to_string())
+}
+
+/// Decode fetched HTML bytes to a `String` honoring the declared charset
+/// (P1-1): HTTP `Content-Type` charset first, then a `<meta charset>` sniff,
+/// then UTF-8. Without this, a Latin-1 / Windows-1252 page has every 0x80–0xFF
+/// byte replaced with U+FFFD.
+fn decode_html_bytes(bytes: &[u8], header_charset: Option<&str>) -> String {
+    // Header charset wins, but a bogus/unknown header label must still fall
+    // through to a <meta charset> sniff before giving up on UTF-8.
+    let enc = header_charset
+        .and_then(|l| encoding_rs::Encoding::for_label(l.as_bytes()))
+        .or_else(|| {
+            sniff_meta_charset(bytes).and_then(|l| encoding_rs::Encoding::for_label(l.as_bytes()))
+        });
+    match enc {
+        Some(enc) => enc.decode(bytes).0.into_owned(),
+        None => String::from_utf8_lossy(bytes).into_owned(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn charset_from_content_type_parses_label() {
+        assert_eq!(
+            charset_from_content_type("text/html; charset=ISO-8859-1").as_deref(),
+            Some("ISO-8859-1")
+        );
+        assert_eq!(
+            charset_from_content_type("text/html;charset=\"utf-8\"").as_deref(),
+            Some("utf-8")
+        );
+        assert_eq!(charset_from_content_type("text/html").as_deref(), None);
+    }
+
+    #[test]
+    fn decode_latin1_via_header_no_replacement_char() {
+        // "café ûber" in ISO-8859-1: é=0xE9, û=0xFB.
+        let bytes = b"caf\xE9 \xFBber";
+        let out = decode_html_bytes(bytes, Some("iso-8859-1"));
+        assert_eq!(out, "café ûber");
+        assert!(!out.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn decode_windows1254_via_meta_sniff() {
+        // Turkish "için" in Windows-1254: i=0x69, ç=0xE7, i=0x69, n=0x6E.
+        let bytes = b"<meta charset=windows-1254><p>i\xE7in</p>";
+        let out = decode_html_bytes(bytes, None);
+        assert!(out.contains("için"), "got: {out}");
+        assert!(!out.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn decode_bogus_header_falls_through_to_meta_then_utf8() {
+        // Bogus header label must NOT short-circuit to UTF-8 — a valid <meta>
+        // charset should still win. Turkish "için" in Windows-1254.
+        let bytes = b"<meta charset=windows-1254><p>i\xE7in</p>";
+        let out = decode_html_bytes(bytes, Some("x-bogus-nonsense"));
+        assert!(out.contains("için"), "got: {out}");
+        // Bogus header + no meta → UTF-8 lossy fallback (no panic).
+        let plain = decode_html_bytes(b"plain ascii", Some("x-bogus"));
+        assert_eq!(plain, "plain ascii");
+    }
+
+    #[test]
+    fn decode_utf8_unchanged() {
+        let bytes = "café İstanbul 東京".as_bytes();
+        assert_eq!(
+            decode_html_bytes(bytes, Some("utf-8")),
+            "café İstanbul 東京"
+        );
+        // No charset info → still UTF-8 by default.
+        assert_eq!(decode_html_bytes(bytes, None), "café İstanbul 東京");
+    }
 
     #[test]
     fn with_proxy_is_fail_closed_on_bad_url() {

--- a/crates/crw-search/src/transform.rs
+++ b/crates/crw-search/src/transform.rs
@@ -79,6 +79,7 @@ fn to_search_result(r: &SearxngResult, position: u32) -> SearchResult {
         links: None,
         metadata: None,
         summary: None,
+        error: None,
     }
 }
 

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -627,8 +627,11 @@ pub async fn search_inner(
                             return Ok(resp);
                         }
                         Err(msg) => {
+                            // Log the raw upstream error server-side, but never
+                            // surface it to the client: `{msg}` can carry the
+                            // managed-LLM provider name + raw HTTP status (P1-2).
                             tracing::warn!(error = %msg, "answer synthesis failed");
-                            warnings.push(format!("answer synthesis failed: {msg}"));
+                            warnings.push("answer synthesis unavailable".to_string());
                         }
                     }
                 }
@@ -1231,6 +1234,9 @@ async fn enrich_with_scrape(
             Ok(scrape) => apply_scrape_to_result(slot, scrape, &opts.formats),
             Err(msg) => {
                 tracing::debug!(url = %slot.url, error = %msg, "scrape enrichment skipped");
+                // P3-4: mark the result so a partial scrape is observable to the
+                // caller instead of looking identical to "no markdown found".
+                slot.error = Some(msg);
             }
         }
     }

--- a/crates/crw-server/tests/mcp.rs
+++ b/crates/crw-server/tests/mcp.rs
@@ -414,6 +414,7 @@ fn real_search_result(idx: u32) -> SearchResult {
         links: None,
         metadata: None,
         summary: None,
+        error: None,
     }
 }
 


### PR DESCRIPTION
Engine fixes from the 2026-07-04 prod bug notes. All tests pass, clippy clean.

- **P1-1** charset-aware scrape decode (`encoding_rs`: Content-Type charset → `<meta charset>` sniff → UTF-8). Fixes Latin-1/Windows-1252 → U+FFFD mojibake.
- **P3-4** `SearchResult.error` field, populated on failed enrichment scrape (backward-compatible; /v2 compat unaffected).
- **P1-2** answer-synthesis warning neutralized at source (no provider name / raw HTTP to clients).

https://claude.ai/code/session_01AnmDjHsszmmQXz74FmQzXu