### PR TITLE
fix(scrape): report anti-bot/challenge pages as blocked, not success

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -761,7 +761,12 @@ fn default_proxy_country() -> String {
 /// `escalate_on_signal = true` AND `escalation.enabled = true`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AntibotConfig {
-    /// Run the classifier on every fetch result. Cheap; default on.
+    /// Run the classifier inside the renderer failover loop on every fetch
+    /// result. Cheap; default on. NOTE: this gates only the in-loop classifier
+    /// (see `crw-renderer`); the API-surface block verdict is classified
+    /// separately and unconditionally at the scrape choke
+    /// (`crw_crawl::single::classify_block`) and is not suppressed by this flag.
+    /// To disable in-loop escalation, use `escalate_in_failover`.
     #[serde(default = "default_true")]
     pub enabled: bool,
     /// When the classifier returns a non-`None` signal, advance to the next

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -610,6 +610,29 @@ pub struct ScrapeData {
     /// once in `single.rs` (`FetchResult.screenshot` stays raw base64).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screenshot: Option<String>,
+    /// Anti-bot verdict stamped once at the scrape choke (`single::scrape_url`).
+    /// `Some` means the page is a block/challenge shell — v1/v2 turn this into
+    /// `success:false`. `None` (skipped when serializing) = not blocked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block: Option<BlockOutcome>,
+}
+
+/// Typed anti-bot block verdict. `vendor` is the antibot `class_name`
+/// (cloudflare|datadome|perimeterx|generic_block|structural_failure|…);
+/// `reason` is the detector's human-readable explanation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockOutcome {
+    pub vendor: String,
+    pub reason: String,
+}
+
+impl BlockOutcome {
+    /// Standard anti-bot block error string shared by the v1 and v2 handlers so
+    /// the two API surfaces label the same block identically.
+    pub fn message(&self) -> String {
+        format!("Blocked by anti-bot ({}): {}", self.vendor, self.reason)
+    }
 }
 
 /// Per-request extraction debug trace. One entry per extract() call

--- a/crates/crw-core/tests/api_casing.rs
+++ b/crates/crw-core/tests/api_casing.rs
@@ -87,6 +87,7 @@ fn sample_scrape_data() -> ScrapeData {
         content_type: Some("text/html".into()),
         change_tracking: None,
         screenshot: Some("data:image/png;base64,AAAA".into()),
+        block: None,
     }
 }
 

--- a/crates/crw-core/tests/types_tests.rs
+++ b/crates/crw-core/tests/types_tests.rs
@@ -217,6 +217,7 @@ fn scrape_data_skip_serializing_none() {
         content_type: None,
         change_tracking: None,
         screenshot: None,
+        block: None,
     };
 
     let json = serde_json::to_value(&data).unwrap();
@@ -331,6 +332,7 @@ fn scrape_data_serializes_debug_extraction_as_camel_case() {
         content_type: None,
         change_tracking: None,
         screenshot: None,
+        block: None,
     };
     let v = serde_json::to_value(&data).unwrap();
     assert!(v.get("debugExtraction").is_none(), "absent when None");

--- a/crates/crw-crawl/src/pdf.rs
+++ b/crates/crw-crawl/src/pdf.rs
@@ -561,6 +561,8 @@ fn build_scrape_data(
         change_tracking: None,
         // PDFs are never screenshotted (binary doc path).
         screenshot: None,
+        // PDFs are the content, never an anti-bot shell.
+        block: None,
     }
 }
 

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -2,7 +2,7 @@ use crw_core::Deadline;
 use crw_core::config::{BUILTIN_UA_POOL, ExtractionConfig, LlmConfig};
 use crw_core::error::CrwResult;
 use crw_core::types::{
-    ChangeTrackingMode, FetchResult, OutputFormat, ScrapeData, ScrapeRequest,
+    BlockOutcome, ChangeTrackingMode, FetchResult, OutputFormat, ScrapeData, ScrapeRequest,
     resolve_pinned_renderer, resolve_render_js,
 };
 use crw_renderer::FallbackRenderer;
@@ -507,6 +507,18 @@ async fn scrape_url_inner(
         }
         data
     };
+    // ROOT-CAUSE: classify the anti-bot outcome ONCE here, at the shared choke,
+    // and stamp a typed verdict onto ScrapeData so v1/v2/crawl/batch inherit one
+    // decision. Runs before the summary-mode markdown strip below (~L620) so the
+    // recovered markdown is still populated for the anti-over-trigger guard.
+    data.block = classify_block(
+        fetch_result.status_code,
+        fetch_result.content_type.as_deref(),
+        &fetch_result.html,
+        data.markdown.as_deref(),
+        fetch_result.screenshot.is_some(),
+        extraction_cfg.http_retry_threshold_bytes,
+    );
     // Surface redirect mismatch as warning. Helps detect cases like
     // northernair.ca/history.htm silently 302'ing to the homepage — extraction
     // looks "successful" but the user got the wrong page.
@@ -919,6 +931,45 @@ fn detect_block_interstitial(html: &str) -> Option<String> {
     }
 }
 
+/// Classify whether a fetched page is an anti-bot block/challenge shell. Runs
+/// ONCE at the scrape choke so every consumer (v1/v2/crawl/batch) inherits one
+/// verdict. Returns `None` for real content; `Some(BlockOutcome)` for a block.
+///
+/// Guard ordering matters:
+/// 1. PDF branch has empty `html` → would false-positive as StructuralFailure.
+/// 2. Substantial markdown is authoritative even under a soft-block status
+///    (anti-over-trigger): an accepted JS escalation guarantees markdown >=
+///    `threshold`, so a stale block-shell `html` cannot mislabel it.
+/// 3. Reuse the trusted `crw_extract::antibot::classify` detector.
+/// 4. A captured screenshot may suppress ONLY the generic near-empty
+///    StructuralFailure heuristic — never a positive vendor block.
+fn classify_block(
+    status: u16,
+    content_type: Option<&str>,
+    html: &str,
+    markdown: Option<&str>,
+    screenshot_present: bool,
+    threshold: usize,
+) -> Option<BlockOutcome> {
+    if content_type.map(|c| c.contains("pdf")).unwrap_or(false) {
+        return None;
+    }
+    if markdown.map(|m| m.trim().len()).unwrap_or(0) >= threshold {
+        return None;
+    }
+    let r = crw_extract::antibot::classify(Some(status), html);
+    if !r.signal.is_blocked() {
+        return None;
+    }
+    if screenshot_present && r.signal == crw_extract::antibot::AntibotSignal::StructuralFailure {
+        return None;
+    }
+    Some(BlockOutcome {
+        vendor: r.signal.class_name().to_string(),
+        reason: r.reason,
+    })
+}
+
 fn formats_include_json(formats: &[OutputFormat]) -> bool {
     formats.contains(&OutputFormat::Json)
 }
@@ -952,6 +1003,69 @@ fn build_byok_llm_config(req: &ScrapeRequest, server_cfg: Option<&LlmConfig>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const THRESH: usize = 100;
+
+    #[test]
+    fn classify_block_challenge_on_cf_200() {
+        // Ticket headline: a CF challenge served with HTTP 200. TIER2 "Just a
+        // moment" does NOT run on 200, so a real TIER1 token (__cf_chl_f_tk=) is
+        // required to reach vendor=cloudflare.
+        let html = r#"<html><body><form id="challenge-form" action="/cdn-cgi/?__cf_chl_f_tk=abc"></form></body></html>"#;
+        let b = classify_block(200, Some("text/html"), html, None, false, THRESH)
+            .expect("CF challenge must be flagged");
+        assert_eq!(b.vendor, "cloudflare");
+    }
+
+    #[test]
+    fn classify_block_hard_block_on_datadome_403() {
+        let html = r#"<html><body><script src="https://captcha-delivery.com/c.js"></script></body></html>"#;
+        let b = classify_block(403, Some("text/html"), html, None, false, THRESH)
+            .expect("DataDome block must be flagged");
+        assert_eq!(b.vendor, "datadome");
+    }
+
+    #[test]
+    fn classify_block_no_block_when_markdown_substantial() {
+        // Anti-over-trigger: real recovered content is authoritative even under a
+        // soft-block status with CF markers in the (stale) html.
+        let html = r#"<html><body><form id="challenge-form" action="/cdn-cgi/?__cf_chl_f_tk=abc"></form></body></html>"#;
+        let md = "x".repeat(500);
+        assert!(classify_block(403, Some("text/html"), html, Some(&md), false, THRESH).is_none());
+    }
+
+    #[test]
+    fn classify_block_no_block_on_clean_200() {
+        let html = "<!doctype html><html><head><title>Article</title></head><body>\
+            <article><h1>Hello</h1><p>This is a normal article with plenty of \
+            meaningful text content describing something at length.</p></article></body></html>";
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                html,
+                Some("# Hello\n\nreal body"),
+                false,
+                THRESH
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn classify_block_screenshot_suppresses_structural_only() {
+        // Near-empty 200 shell + screenshot => structural failure suppressed.
+        assert!(classify_block(200, Some("text/html"), "", None, true, THRESH).is_none());
+        // Positive vendor block is NOT suppressed by a screenshot.
+        let html = r#"<html><body><script src="https://captcha-delivery.com/c.js"></script></body></html>"#;
+        assert!(classify_block(403, Some("text/html"), html, None, true, THRESH).is_some());
+    }
+
+    #[test]
+    fn classify_block_pdf_skipped() {
+        // PDF branch has empty html — must not false-flag as StructuralFailure.
+        assert!(classify_block(200, Some("application/pdf"), "", None, false, THRESH).is_none());
+    }
 
     fn sample_fetch(status_code: u16, html: &str) -> FetchResult {
         FetchResult {

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -890,6 +890,8 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         content_type: None,
         change_tracking: None,
         screenshot: None,
+        // Anti-bot verdict is stamped post-extract at the scrape choke.
+        block: None,
     })
 }
 

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -49,6 +49,14 @@ fn is_ratelimit_status(status: u16) -> bool {
     matches!(status, 429)
 }
 
+/// Should the fetch retry once through the fallback proxy? True on an explicit
+/// rate-limit status (429) OR when the `cf-mitigated` response header flags a
+/// Cloudflare challenge/block — the header is a positive signal, so a different
+/// egress IP may clear it even when served as 200/403/503. Pure for unit test.
+fn should_arm_proxy(status: u16, cf_mitigated: bool) -> bool {
+    is_ratelimit_status(status) || cf_mitigated
+}
+
 /// Is `CRW_HTTP_TLS_RELAXED_FALLBACK` enabled? When on, a fetch that fails TLS
 /// certificate verification is retried ONCE with verification disabled (small
 /// orgs frequently misconfigure their chain — e.g. a CA cert served as the leaf,
@@ -329,10 +337,17 @@ impl PageFetcher for HttpFetcher {
                 Ok(Ok(r))
                     if !use_proxy
                         && self.ratelimit_proxy_client.is_some()
-                        && is_ratelimit_status(r.status().as_u16()) =>
+                        && should_arm_proxy(
+                            r.status().as_u16(),
+                            r.headers()
+                                .get("cf-mitigated")
+                                .and_then(|v| v.to_str().ok())
+                                .map(crate::detector::is_cloudflare_mitigated_header)
+                                .unwrap_or(false),
+                        ) =>
                 {
                     tracing::warn!(
-                        "HTTP {} from {url} (origin rate-limited); retrying once via proxy (ratelimit_bypassed)",
+                        "HTTP {} from {url} (origin rate-limited or cf-mitigated); retrying once via proxy (ratelimit_bypassed)",
                         r.status()
                     );
                     drop(r);
@@ -532,6 +547,18 @@ fn decode_html_bytes(bytes: &[u8], header_charset: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_arm_proxy_truth_table() {
+        assert!(should_arm_proxy(429, false), "429 arms on its own");
+        assert!(
+            !should_arm_proxy(403, false),
+            "403 without header does not arm"
+        );
+        assert!(should_arm_proxy(403, true), "403 + cf-mitigated arms");
+        assert!(should_arm_proxy(200, true), "challenge served as 200 arms");
+        assert!(!should_arm_proxy(200, false), "clean 200 does not arm");
+    }
 
     #[test]
     fn charset_from_content_type_parses_label() {

--- a/crates/crw-server/src/routes/scrape.rs
+++ b/crates/crw-server/src/routes/scrape.rs
@@ -102,61 +102,19 @@ pub async fn scrape(
         }
     }
 
-    // Anti-bot interstitial detection: if extraction produced no real content,
-    // classify the response (crw-extract::antibot, ported from crawl4ai's
-    // 3-tier model). Replaces the prior `warning.starts_with("Blocked by
-    // anti-bot")` string-match with a typed signal that surfaces the protection
-    // class (cloudflare/datadome/perimeterx/...) in the error_code.
-    let md_empty = data
-        .markdown
-        .as_deref()
-        .map(|s| s.trim().len() < 100)
-        .unwrap_or(true);
-    if md_empty {
-        let warning_blocked = data
-            .warning
-            .as_deref()
-            .map(|w| w.starts_with("Blocked by anti-bot"))
-            .unwrap_or(false);
-        let typed = if state.config.renderer.antibot.enabled {
-            let html = data
-                .raw_html
-                .as_deref()
-                .or(data.html.as_deref())
-                .unwrap_or("");
-            crw_extract::antibot::classify(Some(status_code), html)
-        } else {
-            crw_extract::antibot::AntibotResult::none()
-        };
-        // A successful screenshot is real content even when no text was requested
-        // (screenshot-only scrape has empty markdown by design). It may ONLY
-        // suppress the generic near-empty `StructuralFailure` heuristic — never a
-        // positive vendor block (Cloudflare/Datadome/GenericBlock/…), which is a
-        // real block that must still fail (and drive anti_bot credit refunds)
-        // even when we captured a screenshot of the challenge page.
-        let suppressed_by_screenshot = data.screenshot.is_some()
-            && !warning_blocked
-            && typed.signal == crw_extract::antibot::AntibotSignal::StructuralFailure;
-        if (typed.signal.is_blocked() || warning_blocked) && !suppressed_by_screenshot {
-            let error_msg = if typed.signal.is_blocked() {
-                format!(
-                    "Blocked by anti-bot ({}): {}",
-                    typed.signal.class_name(),
-                    typed.reason
-                )
-            } else {
-                data.warning
-                    .clone()
-                    .unwrap_or_else(|| "Blocked by anti-bot protection".into())
-            };
-            return Ok(Json(ApiResponse {
-                success: false,
-                data: Some(data),
-                error: Some(error_msg),
-                error_code: Some("anti_bot".into()),
-                warning: None,
-            }));
-        }
+    // Anti-bot block: the verdict is now classified ONCE at the scrape choke
+    // (`single::classify_block`) and stamped onto `data.block`, so v1/v2/crawl
+    // share one decision. `error_code` stays "anti_bot" (identical to the prior
+    // md_empty path) so credit-refund logic is unchanged.
+    if let Some(b) = data.block.clone() {
+        let error_msg = b.message();
+        return Ok(Json(ApiResponse {
+            success: false,
+            data: Some(data),
+            error: Some(error_msg),
+            error_code: Some("anti_bot".into()),
+            warning: None,
+        }));
     }
 
     // Promote data.warning to ApiResponse.warning so it's visible at top level

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -314,6 +314,7 @@ mod tests {
             content_type: Some("text/html".into()),
             change_tracking: None,
             screenshot: None,
+            block: None,
         }
     }
 

--- a/crates/crw-server/src/routes/v2/parse.rs
+++ b/crates/crw-server/src/routes/v2/parse.rs
@@ -170,6 +170,8 @@ pub async fn parse(
         success: true,
         data: doc,
         warning,
+        // PDF upload path is the content itself, never an anti-bot shell.
+        error: None,
     }))
 }
 

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -103,6 +103,9 @@ pub struct V2ScrapeResponse {
     pub data: V2Document,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
+    /// Anti-bot block message (vendor + reason); present iff `success == false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Resolved proxy tier reported in `metadata.proxyUsed`.
@@ -210,11 +213,44 @@ pub async fn scrape(
     .await?;
 
     let warning = formats::unsupported_warning(&decomposed.unsupported);
+    // HTTP-error-first gate (mirrors v1 scrape.rs): a genuine tiny 4xx/5xx page
+    // is a plain HTTP error, not an anti-bot block. It must short-circuit before
+    // the block check so classify()'s StructuralFailure can't mislabel it, and
+    // so both API surfaces label the identical page the same way.
+    let status_code = data.metadata.status_code;
+    let http_error = if status_code >= 400 {
+        let body_len = [
+            data.markdown.as_deref(),
+            data.plain_text.as_deref(),
+            data.html.as_deref(),
+            data.raw_html.as_deref(),
+        ]
+        .iter()
+        .filter_map(|opt| opt.map(|t| t.len()))
+        .max()
+        .unwrap_or(0);
+        (body_len < 200).then(|| {
+            data.warning
+                .clone()
+                .unwrap_or_else(|| format!("Target returned HTTP {status_code}"))
+        })
+    } else {
+        None
+    };
+    // Anti-bot verdict from the choke: a blocked page is `success:false` with an
+    // error string, matching v1's behaviour. Read before `to_v2_document`
+    // consumes `data`.
+    let (success, error) = match (http_error, data.block.as_ref()) {
+        (Some(msg), _) => (false, Some(msg)),
+        (None, Some(b)) => (false, Some(b.message())),
+        (None, None) => (true, None),
+    };
     let doc = to_v2_document(data, &tier, Uuid::new_v4().to_string());
     Ok(Json(V2ScrapeResponse {
-        success: true,
+        success,
         data: doc,
         warning,
+        error,
     }))
 }
 
@@ -257,6 +293,74 @@ mod tests {
             req.proxy_rotation,
             Some(crw_core::proxy::ProxyRotation::RoundRobin)
         );
+    }
+
+    fn minimal_doc() -> V2Document {
+        use crw_core::types::{PageMetadata, ScrapeData};
+        let data = ScrapeData {
+            markdown: Some("# hi".into()),
+            source_hash: None,
+            html: None,
+            raw_html: None,
+            plain_text: None,
+            links: None,
+            json: None,
+            summary: None,
+            llm_usage: None,
+            chunks: None,
+            warning: None,
+            warnings: vec![],
+            render_decision: None,
+            credit_cost: 1,
+            metadata: PageMetadata {
+                title: None,
+                description: None,
+                og_title: None,
+                og_description: None,
+                og_image: None,
+                canonical_url: None,
+                source_url: "https://example.com".into(),
+                language: None,
+                status_code: 200,
+                rendered_with: None,
+                elapsed_ms: 0,
+                page_count: None,
+                source_filename: None,
+                extra: Default::default(),
+            },
+            debug_extraction: None,
+            content_type: Some("text/html".into()),
+            change_tracking: None,
+            screenshot: None,
+            block: None,
+        };
+        to_v2_document(data, "basic", "id".into())
+    }
+
+    #[test]
+    fn v2_response_blocked_serializes_success_false_with_error() {
+        let resp = V2ScrapeResponse {
+            success: false,
+            data: minimal_doc(),
+            warning: None,
+            error: Some("Blocked by anti-bot (cloudflare): CF challenge".into()),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["success"], false);
+        assert_eq!(v["error"], "Blocked by anti-bot (cloudflare): CF challenge");
+    }
+
+    #[test]
+    fn v2_response_clean_omits_error_key() {
+        let resp = V2ScrapeResponse {
+            success: true,
+            data: minimal_doc(),
+            warning: None,
+            error: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["success"], true);
+        assert!(v.get("error").is_none(), "error omitted on success");
     }
 
     #[test]


### PR DESCRIPTION
Closes us/crw-saas#348, us/crw-saas#350.

A Cloudflare "Just a moment" challenge (and other anti-bot/block pages) was returned as `success:true`: v2 set success unconditionally, and v1's gate only fired on tiny (<200B) bodies or empty markdown — so a >100-char challenge body slipped through as a good result. The 429-only proxy-retry trigger also never swapped egress IP on 403/cf-mitigated responses.

**Fix:** classify the anti-bot outcome **once** at the shared `single.rs` choke (reusing `crw_extract::antibot::classify`) and stamp `Option<BlockOutcome>` onto `ScrapeData`, so v1, v2, crawl and batch inherit one verdict. v2 `success` is now `block.is_none()` after an HTTP-error-first gate. The proxy-retry arm is broadened to 403/503 + the cf-mitigated header via `should_arm_proxy`.

**Guards:** PDF bodies and pages with substantial markdown never classify as blocked; `error_code` stays `anti_bot` (credit-refund logic unchanged).

**Verified:** live `barcodelookup.com` returns a 403 cf-mitigated challenge whose body carries the `__cf_chl_f_tk` / `cdn-cgi/challenge-platform` markers the detector keys on (matching the passing `classify_block_challenge_on_cf_200` test); 569 unit/integration tests pass, 0 warnings.

Note: this only guarantees a challenge is **reported as blocked** instead of a silent success — solving challenges (anti-detect browser on a residential IP) is separate infra.