### PR TITLE
fix(renderer): load images/media/fonts for screenshots

### DIFF
--- a/crates/crw-renderer/src/blocklist.rs
+++ b/crates/crw-renderer/src/blocklist.rs
@@ -88,6 +88,19 @@ impl Blocklist {
         }
     }
 
+    /// Screenshot-safe variant: drop resource-type blocking (Image/Media/Font
+    /// etc.) so the capture renders images, web fonts, and video posters —
+    /// blocking them is fine for markdown extraction but leaves broken-image
+    /// placeholders in a screenshot. Keeps host_substrings (analytics/tracker
+    /// hosts serve no visible pixels) and never blocks stylesheets.
+    pub fn for_screenshot(&self) -> Self {
+        Self {
+            resource_types: Vec::new(),
+            host_substrings: self.host_substrings.clone(),
+            block_stylesheets: false,
+        }
+    }
+
     /// Decide whether a request should be blocked. `resource_type` and `url`
     /// are the values reported by `Fetch.requestPaused`.
     pub fn should_block(&self, resource_type: &str, url: &str) -> Option<BlockReason> {
@@ -135,6 +148,23 @@ mod tests {
         assert_eq!(
             bl.should_block("Font", "https://example.com/x.woff2"),
             Some(BlockReason::ResourceType),
+        );
+    }
+
+    #[test]
+    fn for_screenshot_allows_images_but_keeps_host_blocks() {
+        let bl = Blocklist::defaults().for_screenshot();
+        // Visual resources must load so the capture isn't full of broken images.
+        assert_eq!(
+            bl.should_block("Image", "https://example.com/cat.jpg"),
+            None
+        );
+        assert_eq!(bl.should_block("Font", "https://example.com/x.woff2"), None);
+        assert_eq!(bl.should_block("Media", "https://example.com/v.mp4"), None);
+        // Tracker hosts still get blocked (they render nothing visible).
+        assert_eq!(
+            bl.should_block("Script", "https://www.google-analytics.com/g/collect"),
+            Some(BlockReason::Host),
         );
     }
 

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -2448,10 +2448,22 @@ impl CdpRenderer {
         // traffic settles before body innerText hits the threshold.
         let idle_pump = run_network_idle_pump(conn.subscribe(), net_tracker.clone(), &session_id);
 
+        // A screenshot must render images/media/fonts; the default blocklist
+        // strips them (fine for markdown, but leaves broken-image placeholders
+        // in the capture). Relax resource-type blocking for screenshot
+        // requests; host blocks (analytics/trackers) still apply.
+        let screenshot_blocklist;
+        let blocklist: &Blocklist = if crate::current_screenshot_req().is_some() {
+            screenshot_blocklist = self.blocklist.for_screenshot();
+            &screenshot_blocklist
+        } else {
+            &self.blocklist
+        };
+
         let outcome = match (intercept_active, auth_active) {
             (true, true) => {
                 let intercept_pump =
-                    run_intercept_pump(conn, conn.subscribe(), &self.blocklist, &session_id);
+                    run_intercept_pump(conn, conn.subscribe(), blocklist, &session_id);
                 let auth_pump = run_auth_pump(
                     conn,
                     conn.subscribe(),
@@ -2478,7 +2490,7 @@ impl CdpRenderer {
             }
             (true, false) => {
                 let intercept_pump =
-                    run_intercept_pump(conn, conn.subscribe(), &self.blocklist, &session_id);
+                    run_intercept_pump(conn, conn.subscribe(), blocklist, &session_id);
                 tokio::select! {
                     biased;
                     res = work => res,


### PR DESCRIPTION
## Problem
Screenshots rendered images as broken-image placeholders (e.g. the site logo showed a broken icon). Reproduced on fastcrw.com and others.

## Root cause
The renderer's default resource blocklist (`DEFAULT_BLOCKED_RESOURCE_TYPES`) strips `Image`, `Media`, `Font` to speed up markdown/HTML extraction — you don't need pixels to extract text. But a **screenshot** needs them, so every blocked image became a broken placeholder in the capture. Verified: raw CDP (no blocklist) loads 4/4 images on fastcrw.com; the engine (blocklist active) leaves them broken.

## Fix
Add `Blocklist::for_screenshot()` — a relaxed variant that drops resource-type blocking (images/media/fonts render) but keeps host blocks (analytics/tracker hosts render nothing visible, so still blocked). `fetch_inner` uses it when a screenshot is requested (`current_screenshot_req().is_some()`); markdown/HTML scrapes are unchanged.

## Tests
`for_screenshot_allows_images_but_keeps_host_blocks` — Image/Font/Media allowed, google-analytics host still blocked. Full blocklist suite green (10 tests). `cargo check -p crw-renderer` clean; pre-commit fmt/lint/build/test passed.