### PR TITLE
chore(deps): consolidate dependabot updates (round 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,15 +280,16 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "19.1.1"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a28640adad0e99978d38bc455b323c62a5cddc4e22f83eacde93f8c395ae7e3"
+checksum = "3ce104337e4cced59ded9c61f9f18dab0a4670fd339e84f334312686440a9958"
 dependencies = [
  "anyhow",
  "axum",
  "bytes",
  "bytesize",
  "cookie",
+ "educe",
  "expect-json",
  "http",
  "http-body-util",
@@ -617,22 +618,9 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.3",
+ "toml",
+ "winnow",
  "yaml-rust2",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -643,6 +631,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -811,7 +800,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -841,13 +830,13 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "axum",
  "base64",
  "clap",
- "console 0.15.11",
+ "console",
  "crw-browse",
  "crw-core",
  "crw-crawl",
@@ -866,7 +855,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -876,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -887,7 +876,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "url",
  "uuid",
@@ -895,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -905,7 +894,7 @@ dependencies = [
  "flate2",
  "futures",
  "libc",
- "phf 0.11.3",
+ "phf 0.13.1",
  "proptest",
  "publicsuffix",
  "rand 0.10.2",
@@ -921,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "crw-core",
  "hex",
@@ -936,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -948,7 +937,7 @@ dependencies = [
  "lopdf",
  "once_cell",
  "pdf-inspector",
- "phf 0.11.3",
+ "phf 0.13.1",
  "rand 0.10.2",
  "regex",
  "reqwest",
@@ -968,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "base64",
  "clap",
@@ -984,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "jsonschema",
  "serde",
@@ -994,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -1017,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1046,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "crw-core",
  "futures",
@@ -1064,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "axum",
  "axum-test",
@@ -1086,7 +1075,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -1122,7 +1111,20 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros 0.7.0",
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
@@ -1134,6 +1136,16 @@ name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn",
@@ -1280,15 +1292,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.15.11",
+ "console",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1407,10 +1418,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ego-tree"
-version = "0.10.0"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1440,6 +1463,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1989,22 +2032,22 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
-dependencies = [
- "log",
- "markup5ever 0.36.1",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -2266,14 +2309,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
- "console 0.15.11",
- "number_prefix",
+ "console",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2293,7 +2336,7 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
- "console 0.16.4",
+ "console",
  "once_cell",
  "serde",
  "similar 2.7.0",
@@ -2577,7 +2620,7 @@ checksum = "2ae574a677ef0443a0bd3c291f0cab9d1e61a3ad85a1515e3cfc0bc720d5a48e"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cssparser",
+ "cssparser 0.36.0",
  "encoding_rs",
  "foldhash",
  "hashbrown 0.17.1",
@@ -2647,20 +2690,20 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril 0.4.3",
+ "tendril 0.5.1",
  "web_atoms",
 ]
 
 [[package]]
 name = "markup5ever"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril 0.5.1",
@@ -2915,12 +2958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,7 +3119,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3092,7 +3128,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -3135,19 +3171,6 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3270,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -3280,7 +3303,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3304,9 +3327,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "psl-types"
@@ -3677,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -3699,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3953,17 +3990,17 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
 dependencies = [
- "cssparser",
+ "cssparser 0.37.0",
  "ego-tree",
  "getopts",
- "html5ever 0.36.1",
+ "html5ever 0.39.0",
  "precomputed-hash",
- "selectors 0.33.0",
- "tendril 0.4.3",
+ "selectors 0.38.0",
+ "tendril 0.5.1",
 ]
 
 [[package]]
@@ -3991,12 +4028,12 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser",
+ "cssparser 0.36.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
@@ -4010,12 +4047,12 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser",
+ "cssparser 0.37.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
@@ -4108,15 +4145,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4650,9 +4678,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -4679,36 +4707,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -4721,33 +4730,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4907,9 +4902,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -4921,7 +4916,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -5028,6 +5022,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -5366,15 +5366,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5445,15 +5436,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,13 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "coo
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = "1"
 
 # HTML processing
 lol_html = "3"
-scraper = "0.25"
+scraper = "0.27"
 htmd = "0.5"
-ego-tree = "0.10"
+ego-tree = "0.11"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 once_cell = "1"
 
@@ -75,7 +75,7 @@ futures = "0.3"
 dashmap = "6"
 
 # WebSocket client (shared by crw-renderer and crw-browse)
-tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 
 # JSON schema generation (used by rmcp #[tool] macro)
 schemars = "1.0"
@@ -94,7 +94,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive", "env"] }
 
 # Metrics
-prometheus = "0.13"
+prometheus = "0.14"
 
 # Caching (host preferences)
 moka = { version = "0.12", features = ["future"] }
@@ -122,12 +122,12 @@ hmac = "0.13"
 libc = "0.2"
 
 # Compile-time perfect-hash sets (url_filter deny-lists)
-phf = { version = "0.11", features = ["macros"] }
+phf = { version = "0.13", features = ["macros"] }
 
 # Test dependencies
 tokio-test = "0.4"
 wiremock = "0.6"
-axum-test = "19"
+axum-test = "21"
 proptest = "1"
 insta = { version = "1", features = ["json"] }
 

--- a/crates/crw-browse/Cargo.toml
+++ b/crates/crw-browse/Cargo.toml
@@ -13,7 +13,7 @@ description = "MCP server for interactive browser automation over CDP"
 crw-core = { workspace = true }
 crw-renderer = { workspace = true, features = ["cdp"] }
 
-rmcp = { version = "1.5", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "2", features = ["server", "macros", "transport-io"] }
 clap = { workspace = true }
 tracing-subscriber = { workspace = true }
 schemars = { workspace = true }

--- a/crates/crw-browse/src/tools/common.rs
+++ b/crates/crw-browse/src/tools/common.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde_json::Value;
 
 use crate::errors::{ErrorCode, ErrorResponse, RetryHint};
@@ -123,11 +123,11 @@ pub(crate) async fn resolve_ref(
 }
 
 pub(crate) fn ok_result<T: serde::Serialize>(resp: &ToolResponse<T>) -> CallToolResult {
-    CallToolResult::success(vec![Content::text(resp.to_json())])
+    CallToolResult::success(vec![ContentBlock::text(resp.to_json())])
 }
 
 pub(crate) fn err_result(err: &ErrorResponse) -> CallToolResult {
-    let mut result = CallToolResult::success(vec![Content::text(err.to_json())]);
+    let mut result = CallToolResult::success(vec![ContentBlock::text(err.to_json())]);
     result.is_error = Some(true);
     result
 }

--- a/crates/crw-browse/src/tools/console.rs
+++ b/crates/crw-browse/src/tools/console.rs
@@ -103,7 +103,7 @@ mod tests {
         result
             .content
             .first()
-            .and_then(|c| c.raw.as_text().map(|t| t.text.clone()))
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
             .unwrap_or_default()
     }
 

--- a/crates/crw-browse/src/tools/network.rs
+++ b/crates/crw-browse/src/tools/network.rs
@@ -101,7 +101,7 @@ mod tests {
         result
             .content
             .first()
-            .and_then(|c| c.raw.as_text().map(|t| t.text.clone()))
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
             .unwrap_or_default()
     }
 

--- a/crates/crw-browse/src/tools/script.rs
+++ b/crates/crw-browse/src/tools/script.rs
@@ -288,7 +288,7 @@ fn parse_call_result(result: &CallToolResult) -> (bool, Option<Value>, Option<Va
     let ok = !is_error;
     let mut payload: Option<Value> = None;
     if let Some(first) = result.content.first()
-        && let Some(text) = first.raw.as_text().map(|t| &t.text)
+        && let Some(text) = first.as_text().map(|t| &t.text)
     {
         payload = serde_json::from_str::<Value>(text).ok();
     }
@@ -310,7 +310,7 @@ mod tests {
         result
             .content
             .first()
-            .and_then(|c| c.raw.as_text().map(|t| t.text.clone()))
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
             .unwrap_or_default()
     }
 

--- a/crates/crw-browse/src/tools/wait.rs
+++ b/crates/crw-browse/src/tools/wait.rs
@@ -446,7 +446,7 @@ mod tests {
         result
             .content
             .first()
-            .and_then(|c| c.raw.as_text().map(|t| t.text.clone()))
+            .and_then(|c| c.as_text().map(|t| t.text.clone()))
             .unwrap_or_default()
     }
 

--- a/crates/crw-cli/Cargo.toml
+++ b/crates/crw-cli/Cargo.toml
@@ -51,7 +51,7 @@ tower = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 
 # MCP (for browse command)
-rmcp = { version = "1.5", features = ["server", "macros", "transport-io"], optional = true }
+rmcp = { version = "2", features = ["server", "macros", "transport-io"], optional = true }
 
 # Async runtime
 tokio = { workspace = true }
@@ -80,9 +80,9 @@ anyhow = { version = "1", optional = true }
 uuid = { workspace = true }
 
 # Interactive setup wizard
-dialoguer = { version = "0.11", features = ["fuzzy-select"] }
-console = "0.15"
-indicatif = "0.17"
+dialoguer = { version = "0.12", features = ["fuzzy-select"] }
+console = "0.16"
+indicatif = "0.18"
 
 # Crypto (for checksum verification)
 sha2 = { workspace = true }

--- a/crates/crw-cli/src/commands/setup/cloud.rs
+++ b/crates/crw-cli/src/commands/setup/cloud.rs
@@ -163,7 +163,7 @@ async fn get_api_key() -> Result<String, SetupError> {
 
                 let choice = Select::with_theme(&ui::select_style())
                     .with_prompt("  What would you like to do?")
-                    .items(&[
+                    .items([
                         "Try again",
                         "Get a new key (opens browser)",
                         "Continue anyway (key not verified)",
@@ -191,7 +191,7 @@ async fn get_api_key() -> Result<String, SetupError> {
 
                 let choice = Select::with_theme(&ui::select_style())
                     .with_prompt("  What would you like to do?")
-                    .items(&["Retry verification", "Continue anyway (key not verified)"])
+                    .items(["Retry verification", "Continue anyway (key not verified)"])
                     .default(0)
                     .interact()
                     .map_err(ui::handle_dialoguer_error)?;

--- a/crates/crw-cli/src/commands/setup/local.rs
+++ b/crates/crw-cli/src/commands/setup/local.rs
@@ -233,7 +233,7 @@ async fn handle_docker_not_running() -> Result<bool, SetupError> {
 
     let choice = Select::with_theme(&ui::select_style())
         .with_prompt("  What would you like to do?")
-        .items(&[
+        .items([
             "Retry (I just started Docker)",
             "Continue without search (skip SearXNG)",
             "Exit",
@@ -280,7 +280,7 @@ async fn handle_docker_not_found() -> Result<bool, SetupError> {
 
     let choice = Select::with_theme(&ui::select_style())
         .with_prompt("  What would you like to do?")
-        .items(&[
+        .items([
             "Continue without Docker (skip SearXNG)",
             "Exit and install Docker first",
         ])
@@ -422,7 +422,7 @@ async fn prompt_browser_engine() -> Result<BrowserEngine, SetupError> {
 async fn handle_download_failure() -> Result<bool, SetupError> {
     let choice = Select::with_theme(&ui::select_style())
         .with_prompt("  What would you like to do?")
-        .items(&[
+        .items([
             "Retry download",
             "Skip LightPanda (use Chrome if available)",
             "Continue without browser (HTTP only)",
@@ -509,7 +509,7 @@ async fn prompt_searxng_setup() -> Result<Option<String>, SetupError> {
 fn prompt_shell_config() -> Result<bool, SetupError> {
     let choice = Select::with_theme(&ui::select_style())
         .with_prompt("  Also export to your shell rc? (optional)")
-        .items(&[
+        .items([
             "No, config.toml is enough (recommended)",
             "Yes — also add `export CRW_*` lines (for CI/Docker/scripts)",
         ])

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -24,7 +24,7 @@ crw-core = { workspace = true }
 crw-extract = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
-tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"], optional = true }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"], optional = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
Second consolidation round of dependabot PRs. Every bump verified: `cargo build` + `clippy --all-targets -D warnings` + `cargo test --workspace` (62 suites, 0 fail) + pre-commit hook + **live API smoke test** (scrape/metrics HTTP 200, scrape output byte-identical to before).

## ✅ Landed

| Dep | Bump | Notes | Supersedes |
|---|---|---|---|
| **scraper + ego-tree** | 0.25→0.27 / 0.10→0.11 | scraper 0.27 pins ego-tree 0.11 → **unblocks** the ego-tree bump deferred last round; scrape output byte-identical | #240, #224 |
| **prometheus** | 0.13→0.14 | pulls **protobuf 3.7.2** → clears RUSTSEC-2024-0437 | #239 |
| **indicatif** | 0.17→0.18 | drops **number_prefix** → clears RUSTSEC-2025-0119 | #248 |
| **rmcp** | 1.5→2 | **code**: `Content`→`ContentBlock` (now an enum, so `.raw.as_text()`→`.as_text()`), 5 files in crw-browse | #245 |
| **dialoguer** | 0.11→0.12 | **code**: `.items()` takes by value → drop needless `&` | #243 |
| toml | 0.8→1 | | #247 |
| phf | 0.11→0.13 | | #241 |
| tokio-tungstenite | 0.28→0.29 | | #244 |
| console | 0.15→0.16 | | #246 |
| axum-test | 19→21 | test-only | #249 |

## Vulnerabilities: 4 → 2
protobuf + number_prefix cleared. Only `lopdf` + `ttf-parser` remain — both pinned by `pdf-inspector 0.1.3` (Firecrawl's crate), still upstream-blocked.

## Not here
The github-actions group (#242) is handled separately — its release-pipeline action bumps (release-please v5) only exercise on an actual release, so they get their own careful pass.

Only code edits: rmcp 2 API migration + dialoguer needless-borrow — both behavior-preserving (tests + API smoke test green).
