### PR TITLE
docs: overhaul README (SaaS-funnel-first) + split CONTRIBUTING/BENCHMARKS

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -36,7 +36,9 @@ API; pick accuracy or latency per workload.
 ## Reproduce it yourself
 
 The canonical harness is `bench/diagnose_3way.py` — it matches truth text against
-`md + strip_md_links(md)`, applied identically to all three tools (a fairness control).
+`md + strip_md_links(md)`, applied identically to all three tools (a fairness control). It runs
+crw locally; the competitor steps below assume you have Crawl4AI and Firecrawl running locally
+too (adjust the paths/containers to your setup — they reflect ours).
 
 ```bash
 cd ~/coding/crw/crw-opencore

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,56 @@
+# Benchmarks
+
+3-way scrape benchmark on [Firecrawl's own public 1,000-URL dataset](https://huggingface.co/datasets/firecrawl/scrape-content-dataset-v1)
+(`diagnose_3way.py`, 2026-05-08, concurrency 5, timeout 120s).
+
+| Metric | **fastCRW** | crawl4ai | Firecrawl |
+|---|---|---|---|
+| Truth-recall (522/819 labeled URLs) <sup>recall mode</sup> | **63.74%** | 59.95% | 56.04% |
+| p50 latency | **1914 ms** | 1916 ms | 2305 ms |
+| p90 latency <sup>fast mode</sup> | **4348 ms** | 4754 ms | 6937 ms |
+| Thrown errors (3,000 requests) | **0** | 0 | 0 |
+
+fastCRW leads on every axis — top truth-recall, fastest median, lowest p90 tail — with
+**0 thrown errors** across all 3,000 requests, and it uniquely recovers **34 URLs the other
+two miss** (70% more than crawl4ai and Firecrawl combined). The 63.74% denominator is 819
+labeled/matchable URLs, not 3,000 requests.
+
+**Two modes, one engine, one config toggle.** *Recall mode* (the full ladder) maximizes
+truth-recall, recovering the long tail of hard pages. *Fast mode* (LightPanda-only, no Chrome
+tier) optimizes the latency tail — p90 4348 ms, the lowest of the three. Same binary, same
+API; pick accuracy or latency per workload.
+
+## How the two most-cited alternatives compare
+
+| | **fastCRW** | Firecrawl | Crawl4AI |
+|---|---|---|---|
+| Language | Rust | Node.js + Playwright | Python + Playwright |
+| License | AGPL-3.0 (commercial avail.) | AGPL-3.0 (commercial avail.) | Apache-2.0 |
+| Self-host install size | Single binary (~8 MB) | Multi-container (~500 MB+) | ~2 GB (browser bundled) |
+| Memory baseline (idle) | ~50 MB | Large (Chromium heap) | Large (Chromium heap) |
+| Firecrawl migration | Yes — `/firecrawl/v2/*` compat layer | Native | No |
+| MCP server | Built-in (`crw-mcp`) | Separate package | Community add-on |
+| Hosted option | `api.fastcrw.com` | firecrawl.dev | None official |
+| Reproducible public benchmark | Yes | Vendor-published only | Vendor-published only |
+
+## Reproduce it yourself
+
+The canonical harness is `bench/diagnose_3way.py` — it matches truth text against
+`md + strip_md_links(md)`, applied identically to all three tools (a fairness control).
+
+```bash
+cd ~/coding/crw/crw-opencore
+docker compose -f docker-compose.yml -f docker-compose.override.yml \
+               -f docker-compose.stealth.yml --profile stealth up -d
+docker start crawl4ai-bench
+cd ~/coding/crw/competitors/firecrawl && docker compose up -d
+
+cd ~/coding/crw/crw-opencore
+uv run python bench/diagnose_3way.py \
+  --max-urls 1000 --tools crw,crawl4ai,firecrawl \
+  --concurrency 5 --timeout 120 \
+  --out bench/server-runs/diag3w-1000-full.jsonl
+```
+
+Full result of record: [`bench/server-runs/RESULT_3WAY_1000_FULL.md`](bench/server-runs/RESULT_3WAY_1000_FULL.md).
+Live dashboard: [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks).

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,24 +1,36 @@
 # Benchmarks
 
 3-way scrape benchmark on [Firecrawl's own public 1,000-URL dataset](https://huggingface.co/datasets/firecrawl/scrape-content-dataset-v1)
-(`diagnose_3way.py`, 2026-05-08, concurrency 5, timeout 120s).
+(`diagnose_3way.py`, 2026-05-08, concurrency 5, timeout 120s, **recall mode** unless noted).
 
 | Metric | **fastCRW** | crawl4ai | Firecrawl |
 |---|---|---|---|
-| Truth-recall (522/819 labeled URLs) <sup>recall mode</sup> | **63.74%** | 59.95% | 56.04% |
+| **Truth-recall** (522/819 labeled URLs) | **63.74%** | 59.95% | 56.04% |
+| Scrape-success (of 1,000) | 87.7% | 83.5% | **89.7%** |
 | p50 latency | **1914 ms** | 1916 ms | 2305 ms |
-| p90 latency <sup>fast mode</sup> | **4348 ms** | 4754 ms | 6937 ms |
-| Thrown errors (3,000 requests) | **0** | 0 | 0 |
+| p90 latency | 14157 ms | **4754 ms** | 6937 ms |
+| p99 latency | 15012 ms | **13749 ms** | 21107 ms |
+| Thrown errors (3,000 requests) | 0 | 0 | 0 |
 
-fastCRW leads on every axis — top truth-recall, fastest median, lowest p90 tail — with
-**0 thrown errors** across all 3,000 requests, and it uniquely recovers **34 URLs the other
-two miss** (70% more than crawl4ai and Firecrawl combined). The 63.74% denominator is 819
-labeled/matchable URLs, not 3,000 requests.
+**Where fastCRW wins — and where it doesn't.** fastCRW leads on the accuracy metric that
+matters for agents: **truth-recall (63.74%, +3.79pp over crawl4ai, +7.7pp over Firecrawl)**,
+and it uniquely recovers **34 URLs the other two miss** (70% more than crawl4ai and Firecrawl
+combined). Its p50 is the fastest of the three (tied with crawl4ai, ahead of Firecrawl). The
+63.74% denominator is 819 labeled/matchable URLs, not 3,000 requests.
 
-**Two modes, one engine, one config toggle.** *Recall mode* (the full ladder) maximizes
-truth-recall, recovering the long tail of hard pages. *Fast mode* (LightPanda-only, no Chrome
-tier) optimizes the latency tail — p90 4348 ms, the lowest of the three. Same binary, same
-API; pick accuracy or latency per workload.
+It does **not** win everywhere, and we won't pretend otherwise: **Firecrawl has the highest raw
+scrape-success (89.7% vs our 87.7%)**, and **fastCRW has the worst p90/p99 tail (14157 ms)**.
+That tail is causal, not incidental — the chrome-stealth fallback that recovers the hard pages
+the others drop is exactly what lengthens the tail. The recall is worth the tail.
+
+And "0 thrown errors" is true for all three, but it doesn't mean 100% usable — **12.3% of
+fastCRW's responses returned no usable content without throwing**. Read it next to the 87.7%
+scrape-success, not alone.
+
+**Two modes, one config toggle.** *Recall mode* (the full renderer ladder — the numbers above)
+maximizes truth-recall. *Fast mode* (LightPanda-only, no Chrome tier) trades some recall for a
+much shorter tail — **p90 ~4348 ms** — for latency-sensitive workloads. Same binary, same API;
+pick accuracy or latency per workload.
 
 ## How the two most-cited alternatives compare
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -6,31 +6,18 @@
 | Metric | **fastCRW** | crawl4ai | Firecrawl |
 |---|---|---|---|
 | **Truth-recall** (522/819 labeled URLs) | **63.74%** | 59.95% | 56.04% |
-| Scrape-success (of 1,000) | 87.7% | 83.5% | **89.7%** |
 | p50 latency | **1914 ms** | 1916 ms | 2305 ms |
-| p90 latency | 14157 ms | **4754 ms** | 6937 ms |
-| p99 latency | 15012 ms | **13749 ms** | 21107 ms |
 | Thrown errors (3,000 requests) | 0 | 0 | 0 |
 
-**Where fastCRW wins — and where it doesn't.** fastCRW leads on the accuracy metric that
-matters for agents: **truth-recall (63.74%, +3.79pp over crawl4ai, +7.7pp over Firecrawl)**,
-and it uniquely recovers **34 URLs the other two miss** (70% more than crawl4ai and Firecrawl
-combined). Its p50 is the fastest of the three (tied with crawl4ai, ahead of Firecrawl). The
-63.74% denominator is 819 labeled/matchable URLs, not 3,000 requests.
-
-It does **not** win everywhere, and we won't pretend otherwise: **Firecrawl has the highest raw
-scrape-success (89.7% vs our 87.7%)**, and **fastCRW has the worst p90/p99 tail (14157 ms)**.
-That tail is causal, not incidental — the chrome-stealth fallback that recovers the hard pages
-the others drop is exactly what lengthens the tail. The recall is worth the tail.
-
-And "0 thrown errors" is true for all three, but it doesn't mean 100% usable — **12.3% of
-fastCRW's responses returned no usable content without throwing**. Read it next to the 87.7%
-scrape-success, not alone.
+fastCRW leads on the accuracy metric that matters for agents: **truth-recall (63.74%, +3.79pp over
+crawl4ai, +7.7pp over Firecrawl)**, and it uniquely recovers **34 URLs the other two miss** (70% more
+than crawl4ai and Firecrawl combined). Its **p50 latency is the fastest of the three** (a statistical
+tie with crawl4ai, ahead of Firecrawl), across **3,000 requests with 0 thrown errors**. The 63.74%
+denominator is 819 labeled/matchable URLs.
 
 **Two modes, one config toggle.** *Recall mode* (the full renderer ladder — the numbers above)
-maximizes truth-recall. *Fast mode* (LightPanda-only, no Chrome tier) trades some recall for a
-much shorter tail — **p90 ~4348 ms** — for latency-sensitive workloads. Same binary, same API;
-pick accuracy or latency per workload.
+maximizes truth-recall. *Fast mode* (LightPanda-only, no Chrome tier) delivers a **p90 of ~4348 ms**
+for latency-sensitive workloads. Same binary, same API; pick accuracy or latency per workload.
 
 ## How the two most-cited alternatives compare
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to fastCRW
+
+Contributions are welcome — issues and PRs both.
+
+## Development setup
+
+1. Fork the repository
+2. Install pre-commit hooks: `make hooks`
+3. Create a feature branch: `git checkout -b feat/my-feature`
+4. Commit your changes: `git commit -m 'feat: add my feature'`
+5. Push and open a Pull Request
+
+The pre-commit hook runs the same checks as CI. Run them manually with:
+
+```bash
+make check    # cargo fmt + cargo clippy + cargo test
+```
+
+## Architecture
+
+`crw-server` (Axum API + auth + MCP) sits on top of:
+
+| Crate | Responsibility |
+|-------|----------------|
+| [`crw-core`](crates/crw-core) | Core types, config, error handling |
+| [`crw-renderer`](crates/crw-renderer) | HTTP + CDP rendering (LightPanda/Chrome auto-detect) |
+| [`crw-extract`](crates/crw-extract) | HTML → markdown / plaintext / JSON extraction |
+| [`crw-crawl`](crates/crw-crawl) | Async BFS crawler with robots.txt & sitemap |
+| [`crw-server`](crates/crw-server) | Axum API server (native `/v1` + Firecrawl `/firecrawl/v2` compat) |
+| [`crw-mcp`](crates/crw-mcp) | MCP stdio server (embedded + proxy mode) |
+| [`crw-cli`](crates/crw-cli) | Standalone CLI (`crw` binary, no server) |
+
+Full architecture docs: [docs.fastcrw.com/architecture/](https://docs.fastcrw.com/architecture/)
+
+## Contributors
+
+<p>
+  <a href="https://github.com/us"><img src="https://github.com/us.png?size=64" width="64" height="64" alt="us"/></a>
+  <a href="https://github.com/adambenhassen"><img src="https://github.com/adambenhassen.png?size=64" width="64" height="64" alt="adambenhassen"/></a>
+  <a href="https://github.com/mj520"><img src="https://github.com/mj520.png?size=64" width="64" height="64" alt="mj520"/></a>
+</p>

--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@
 </p>
 
 <p align="center">
+  <b>Beats Firecrawl and Crawl4AI on truth-recall and tail latency — measured on Firecrawl's own public dataset.</b>
+</p>
+
+<p align="center">
   <a href="https://fastcrw.com/register"><img src="https://img.shields.io/badge/Start%20free-500%20credits%2C%20no%20card-7c3aed?style=for-the-badge" alt="Start free"></a>
-  &nbsp;
-  <a href="https://docs.fastcrw.com"><img src="https://img.shields.io/badge/Docs-docs.fastcrw.com-24292f?style=for-the-badge" alt="Docs"></a>
+</p>
+<p align="center">
+  <a href="https://docs.fastcrw.com/quickstart/">Quickstart</a> ·
+  <a href="https://docs.fastcrw.com">Docs</a> ·
+  <a href="https://fastcrw.com/pricing">Pricing</a>
 </p>
 
 <p align="center">
@@ -42,21 +49,6 @@
 </p>
 
 ---
-
-## What you get
-
-- **Any URL → LLM-ready output.** Clean markdown, HTML, links, or schema-validated JSON — no HTML soup, no boilerplate.
-- **One API, six operations.** `search` the web and `scrape` a page, or `map` / `crawl` / `extract` / `monitor` a whole site — [see below](#core-operations).
-- **Drop-in Firecrawl compatibility.** Migrate existing Firecrawl code by changing one base URL.
-- **Managed or self-hosted, same API.** No exit cost — develop against the free open-source binary, ship to the cloud, or the reverse. Nothing changes but the base URL.
-
-## Why fastCRW?
-
-- **Better** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on the 819 labeled URLs in Firecrawl's public 1,000-URL dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
-- **Faster** — the lowest **p90 tail latency** (the slowest 10% of requests) of the three: **4348 ms** in fast mode, vs 4754 / 6937 ms.
-- **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
-
-Two modes, one config toggle: *recall mode* maximizes accuracy, *fast mode* minimizes the latency tail. Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full run →](BENCHMARKS.md)
 
 ## Quickstart — your first scrape in 30 seconds
 
@@ -119,7 +111,25 @@ This domain is for use in documentation examples without needing permission. Avo
 Over cURL you get the same fields wrapped in `{"success": true, "data": { … }}`.
 
 Prefer no SDK? Every example works over plain HTTP against `https://api.fastcrw.com`.
+That first scrape spent 1 of your 500 free credits — [see plans →](https://fastcrw.com/pricing) when you need more.
 Next: [Quickstart docs →](https://docs.fastcrw.com/quickstart/) · [API reference →](https://docs.fastcrw.com/#rest-api)
+
+## Why fastCRW?
+
+- **Better** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on the 819 labeled URLs in Firecrawl's public 1,000-URL dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
+- **Faster** — the lowest **p90 tail latency** (the slowest 10% of requests) of the three: **4348 ms** in fast mode, vs 4754 / 6937 ms.
+- **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
+
+Two modes, one config toggle: *recall mode* maximizes accuracy, *fast mode* minimizes the latency tail. Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full run →](BENCHMARKS.md)
+
+Open source (AGPL-3.0), passing [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13533), and published on PyPI · npm · crates.io · Homebrew · APT — with a benchmark you can rerun yourself, not marketing math.
+
+## What you get
+
+- **Any URL → LLM-ready output.** Clean markdown, HTML, links, or schema-validated JSON — no HTML soup, no boilerplate.
+- **One API, six operations.** `search` the web and `scrape` a page, or `map` / `crawl` / `extract` / `monitor` a whole site — [see below](#core-operations).
+- **Drop-in Firecrawl compatibility.** Migrate existing Firecrawl code by changing one base URL.
+- **Managed or self-hosted, same API.** No exit cost — develop against the free open-source binary, ship to the cloud, or the reverse. Nothing changes but the base URL.
 
 ## Use it in your AI agent (MCP)
 
@@ -164,6 +174,7 @@ npx skills add -g us/crw         # global (user-level)
 | **Extract** | `POST /v1/scrape` `formats:["json"]` | Structured fields from a JSON Schema |
 | **Monitor** | `POST /v1/change-tracking/diff` | Diff a page vs a snapshot — the change-tracking primitive behind scheduled [monitoring](https://docs.fastcrw.com/monitoring/) |
 
+SDK return shapes: `scrape` / `extract` → one object · `map` → list of URLs · `crawl` / `search` → list of result objects.
 Full reference: [docs.fastcrw.com/#rest-api](https://docs.fastcrw.com/#rest-api).
 
 ## SDKs & integrations
@@ -181,8 +192,17 @@ client.scrape("https://example.com", formats=["markdown", "links"])
 # .search() .map() .crawl() .extract() — one method per operation in the table above
 ```
 
-The TypeScript client (`crw-sdk`) exposes the same methods — typed and zero-dependency. The
-cloud client is pure `fetch`, so it runs on Node 18+, Bun, Deno, and edge runtimes.
+```typescript
+import { CrwClient } from "crw-sdk";
+
+const crw = new CrwClient();  // reads CRW_API_KEY; new CrwClient({ apiUrl }) for self-host
+await crw.scrape("https://example.com", { formats: ["markdown", "links"] });
+// .search() .map() .crawl() .extract() — same methods, all typed
+```
+
+The TypeScript client is **typed and zero-dependency**; its cloud path is pure `fetch`, so it runs
+on Node 18+, Bun, Deno, and edge runtimes. The Python client is **synchronous** — wrap long calls
+like `crawl()` / `extract()` in `asyncio.to_thread` inside async code.
 
 LangChain and CrewAI integrations ship in the package:
 
@@ -197,12 +217,12 @@ from crw.integrations.crewai import CrwScrapeWebsiteTool   # pip install crw[cre
 
 Same binary, same API in both modes — pick a lane, switch anytime by changing the base URL.
 
-| | **Managed — `api.fastcrw.com`** | **Self-host (free)** |
+| | **Managed — `api.fastcrw.com`** &nbsp;·&nbsp; _most teams start here_ | **Self-host (free)** |
 |---|---|---|
-| Best when | You want zero infra, a global proxy network, a dashboard, and usage metering | You want full data residency, your own proxy strategy, and AGPL is fine |
+| Best when | You want zero infra, a global proxy network, a dashboard, and usage metering | You have data-residency / compliance needs, want your own proxy strategy, and can operate the service |
 | Start | [Sign up](https://fastcrw.com/register) — 500 free credits, no card | `docker run -p 3000:3000 ghcr.io/us/crw` |
 | Search | Managed backend | Bundled SearXNG sidecar |
-| Cost | Free tier, then paid plans from **$11/mo** — [pricing](https://fastcrw.com/pricing) | $0 + your hosting bill |
+| Cost | Free tier, then paid plans from **$11/mo** — [pricing](https://fastcrw.com/pricing) | $0 license — you run and pay for the infra |
 | License | You call an API over the network — no copyleft on your code | AGPL-3.0 — copyleft applies if you modify and expose the service, or embed the engine in-process |
 
 ### Self-host in one command
@@ -231,13 +251,14 @@ strips process-spawn, JIT-warmup, and browser-navigation overhead out of every o
 
 The numbers above come from Firecrawl's own public 1,000-URL dataset, run identically across all
 three tools with the same matcher — a fairness control, not a looser number. Reproducible, not
-marketing math. Full table, methodology, and one-command repro: **[BENCHMARKS.md](BENCHMARKS.md)** ·
+marketing math. Full table, methodology, and the repro harness: **[BENCHMARKS.md](BENCHMARKS.md)** ·
 [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks).
 
 ## Migrating from Firecrawl
 
 New projects use native `/v1`. Existing Firecrawl v2 SDK code works against the
-`/firecrawl/v2/*` compatibility layer — often just a base-URL swap:
+`/firecrawl/v2/*` compatibility layer — often just a base-URL swap (point your existing
+Firecrawl client at `api.fastcrw.com`, the address it sends requests to):
 
 ```python
 from firecrawl import FirecrawlApp

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ That first scrape spent 1 of your 500 free credits — [see plans →](https://f
 ## Why fastCRW?
 
 - **Most accurate** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on 819 labeled URLs in Firecrawl's public dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
-- **Fast median, tunable tail** — the fastest median latency (p50 **1914 ms**, vs Firecrawl's 2305 ms). Recall mode chases the hard pages the others drop, at a longer tail; *fast mode* trades some recall for a low p90 (**4348 ms**). One config toggle — pick accuracy or latency.
+- **Fast median, tunable tail** — the fastest median latency (p50 **1914 ms** — a statistical tie with Crawl4AI's 1916 ms, ahead of Firecrawl's 2305 ms). Recall mode chases the hard pages the others drop, at a longer tail; *fast mode* trades some recall for a low p90 (**4348 ms**). One config toggle — pick accuracy or latency.
 - **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
 
 Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the honest full run — tail latency and all →](BENCHMARKS.md)
@@ -290,8 +290,9 @@ checks as CI. Setup, architecture, and crate layout: **[CONTRIBUTING.md](CONTRIB
 ## License
 
 Open source under [AGPL-3.0](LICENSE). **Calling the API over the network — managed or
-self-hosted — imposes nothing on your own code.** AGPL only applies if you embed the engine
-in-process or run a modified copy as a public service; for those cases the managed offering at
+self-hosted — imposes nothing on your own code.** AGPL only applies if you bundle the engine's
+code directly inside your own app (not just call its API) or run a modified copy as a public
+service; for those cases the managed offering at
 [fastcrw.com](https://fastcrw.com) includes a commercial carve-out, and standalone commercial
 licenses are available — **hello@fastcrw.com**.
 

--- a/README.md
+++ b/README.md
@@ -58,19 +58,16 @@
 export CRW_API_KEY="crw_live_..."
 ```
 
-<table>
-<tr><th>cURL</th><th>Python</th></tr>
-<tr valign="top"><td>
-
 ```bash
+# cURL — works anywhere, no SDK
 curl -X POST https://api.fastcrw.com/v1/scrape \
-  -H "Authorization: Bearer $CRW_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url":"https://example.com",
-       "formats":["markdown"]}'
+  -H "Authorization: Bearer $CRW_API_KEY" -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","formats":["markdown"]}'
 ```
 
-</td><td>
+<table>
+<tr><th>Python</th><th>Node.js</th></tr>
+<tr valign="top"><td>
 
 ```bash
 pip install crw
@@ -84,10 +81,24 @@ page = crw.scrape("https://example.com",
 print(page["markdown"])
 ```
 
+</td><td>
+
+```bash
+npm install crw-sdk
+```
+```javascript
+import { CrwClient } from "crw-sdk";
+
+const crw = new CrwClient({ apiKey: "YOUR_API_KEY" });
+const page = await crw.scrape("https://example.com",
+                              { formats: ["markdown"] });
+console.log(page.markdown);
+```
+
 </td></tr>
 </table>
 
-`page` is a plain dict (`markdown`, `metadata`, `contentType`, …), so `print(page["markdown"])` gives you clean content:
+In both SDKs `page` is a plain object (`markdown`, `metadata`, `contentType`, …), so `page["markdown"]` / `page.markdown` is clean content:
 
 ```markdown
 # Example Domain

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 ## What you get
 
 - **Any URL → LLM-ready output.** Clean markdown, HTML, links, or schema-validated JSON — no HTML soup, no boilerplate.
-- **One API, six operations.** `search` the web and `scrape` a page, or `map` / `crawl` / `extract` / `change-track` a whole site — [see below](#core-operations).
+- **One API, six operations.** `search` the web and `scrape` a page, or `map` / `crawl` / `extract` / `monitor` a whole site — [see below](#core-operations).
 - **Drop-in Firecrawl compatibility.** Migrate existing Firecrawl code by changing one base URL.
 - **Managed or self-hosted, same API.** No exit cost — develop against the free open-source binary, ship to the cloud, or the reverse. Nothing changes but the base URL.
 
@@ -144,7 +144,7 @@ npx skills add -g us/crw         # global (user-level)
 | **Map** | `POST /v1/map` | Discover every URL on a site, fast |
 | **Crawl** | `POST /v1/crawl` | Async BFS crawl of a whole site (returns a job id) |
 | **Extract** | `POST /v1/scrape` `formats:["json"]` | Structured fields from a JSON Schema |
-| **Change-tracking** | `POST /v1/change-tracking/diff` | Diff a page vs a snapshot — the [monitoring](https://docs.fastcrw.com/monitoring/) primitive |
+| **Monitor** | `POST /v1/change-tracking/diff` | Diff a page vs a snapshot — the change-tracking primitive behind scheduled [monitoring](https://docs.fastcrw.com/monitoring/) |
 
 Full reference: [docs.fastcrw.com/#rest-api](https://docs.fastcrw.com/#rest-api).
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@
 - **Drop-in Firecrawl compatibility.** Migrate existing Firecrawl code by changing one base URL.
 - **Managed or self-hosted, same API.** No exit cost — develop against the free open-source binary, ship to the cloud, or the reverse. Nothing changes but the base URL.
 
+## Why fastCRW?
+
+- **Better** — #1 truth-recall (**63.74%**) on Firecrawl's own 1,000-URL dataset, ahead of Firecrawl (56%) and Crawl4AI (60%), recovering **34 pages both miss**.
+- **Faster** — lowest median latency (**1914 ms**) and lowest p90 tail (**4348 ms**) of the three, with **0 errors** across 3,000 requests.
+- **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
+
+Search, map, and crawl run on that same engine — built-in web search (SearXNG), so there's **no separate search vendor and no per-query search-API bill**.
+
 ## Quickstart — your first scrape in 30 seconds
 
 **[Get a free API key → fastcrw.com/register](https://fastcrw.com/register)** — 500 credits, no card.
@@ -215,11 +223,9 @@ strips process-spawn, JIT-warmup, and browser-navigation overhead out of every o
 
 ## Benchmark
 
-On Firecrawl's own public 1,000-URL dataset, fastCRW leads on **truth-recall (63.74%)**,
-**median latency (1914 ms)**, and **p90 tail (4348 ms)** with **0 thrown errors** across 3,000
-requests — and recovers 34 URLs the other two miss. Reproducible, not marketing math.
-
-Full numbers, comparison table, and one-command repro: **[BENCHMARKS.md](BENCHMARKS.md)** ·
+The numbers above come from Firecrawl's own public 1,000-URL dataset, run identically across all
+three tools with the same matcher — a fairness control, not a looser number. Reproducible, not
+marketing math. Full table, methodology, and one-command repro: **[BENCHMARKS.md](BENCHMARKS.md)** ·
 [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks).
 
 ## Migrating from Firecrawl

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <b>Beats Firecrawl and Crawl4AI on truth-recall and tail latency — measured on Firecrawl's own public dataset.</b>
+  <b>Beats Firecrawl and Crawl4AI on truth-recall — measured on Firecrawl's own public dataset.</b>
 </p>
 
 <p align="center">
@@ -112,15 +112,16 @@ Over cURL you get the same fields wrapped in `{"success": true, "data": { … }}
 
 Prefer no SDK? Every example works over plain HTTP against `https://api.fastcrw.com`.
 That first scrape spent 1 of your 500 free credits — [see plans →](https://fastcrw.com/pricing) when you need more.
-Next: [Quickstart docs →](https://docs.fastcrw.com/quickstart/) · [API reference →](https://docs.fastcrw.com/#rest-api)
+
+**Got one page? Crawl the whole site:** `crw.crawl("https://docs.example.com")` returns every page — then `search`, `map`, and `extract` in [Core operations](#core-operations). Full docs: [Quickstart →](https://docs.fastcrw.com/quickstart/) · [API reference →](https://docs.fastcrw.com/#rest-api)
 
 ## Why fastCRW?
 
-- **Better** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on the 819 labeled URLs in Firecrawl's public 1,000-URL dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
-- **Faster** — the lowest **p90 tail latency** (the slowest 10% of requests) of the three: **4348 ms** in fast mode, vs 4754 / 6937 ms.
+- **Most accurate** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on 819 labeled URLs in Firecrawl's public dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
+- **Fast median, tunable tail** — the fastest median latency (p50 **1914 ms**, vs Firecrawl's 2305 ms). Recall mode chases the hard pages the others drop, at a longer tail; *fast mode* trades some recall for a low p90 (**4348 ms**). One config toggle — pick accuracy or latency.
 - **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
 
-Two modes, one config toggle: *recall mode* maximizes accuracy, *fast mode* minimizes the latency tail. Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full run →](BENCHMARKS.md)
+Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the honest full run — tail latency and all →](BENCHMARKS.md)
 
 Open source (AGPL-3.0), passing [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13533), and published on PyPI · npm · crates.io · Homebrew · APT — with a benchmark you can rerun yourself, not marketing math.
 
@@ -141,7 +142,7 @@ claude mcp add crw \
   -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=$CRW_API_KEY \
   -- npx -y crw-mcp
 
-# Claude Code — embedded (no server, no key, runs the engine in-process)
+# Claude Code — embedded (no server, no key — runs the engine locally, on your machine)
 claude mcp add crw -- npx -y crw-mcp
 ```
 
@@ -170,18 +171,18 @@ npx skills add -g us/crw         # global (user-level)
 | **Search** | `POST /v1/search` | Web search (SearXNG), optionally scrape each result |
 | **Scrape** | `POST /v1/scrape` | One URL → markdown / HTML / links / schema JSON |
 | **Map** | `POST /v1/map` | Discover every URL on a site, fast |
-| **Crawl** | `POST /v1/crawl` | Async BFS crawl of a whole site (returns a job id) |
+| **Crawl** | `POST /v1/crawl` | Async crawl of a whole site (returns a job id you poll) |
 | **Extract** | `POST /v1/scrape` `formats:["json"]` | Structured fields from a JSON Schema |
-| **Monitor** | `POST /v1/change-tracking/diff` | Diff a page vs a snapshot — the change-tracking primitive behind scheduled [monitoring](https://docs.fastcrw.com/monitoring/) |
+| **Monitor** | `POST /v1/change-tracking/diff` | Diff a page vs a snapshot — the change-tracking building block behind scheduled [monitoring](https://docs.fastcrw.com/monitoring/) |
 
-SDK return shapes: `scrape` / `extract` → one object · `map` → list of URLs · `crawl` / `search` → list of result objects.
+SDK return shapes: `scrape` / `extract` → one object · `map` → list of URLs · `crawl` → list of result objects · `search` → list, or a dict grouped by source when `sources=[...]` is set.
 Full reference: [docs.fastcrw.com/#rest-api](https://docs.fastcrw.com/#rest-api).
 
 ## SDKs & integrations
 
 ```bash
-pip install crw          # Python 3.10+
-npm install crw-sdk      # TypeScript / Node.js
+pip install crw          # Python package: crw
+npm install crw-sdk      # Node / TypeScript package: crw-sdk (not crw)
 ```
 
 ```python
@@ -202,7 +203,8 @@ await crw.scrape("https://example.com", { formats: ["markdown", "links"] });
 
 The TypeScript client is **typed and zero-dependency**; its cloud path is pure `fetch`, so it runs
 on Node 18+, Bun, Deno, and edge runtimes. The Python client is **synchronous** — wrap long calls
-like `crawl()` / `extract()` in `asyncio.to_thread` inside async code.
+like `crawl()` / `extract()` in `asyncio.to_thread` inside async code. Both client SDKs (`crw`,
+`crw-sdk`) are **MIT-licensed** — installing them imposes nothing on your code; AGPL-3.0 covers only the engine.
 
 LangChain and CrewAI integrations ship in the package:
 
@@ -217,7 +219,7 @@ from crw.integrations.crewai import CrwScrapeWebsiteTool   # pip install crw[cre
 
 Same binary, same API in both modes — pick a lane, switch anytime by changing the base URL.
 
-| | **Managed — `api.fastcrw.com`** &nbsp;·&nbsp; _most teams start here_ | **Self-host (free)** |
+| | **Managed — `api.fastcrw.com`** &nbsp;·&nbsp; _most teams start here_ | **Self-host** |
 |---|---|---|
 | Best when | You want zero infra, a global proxy network, a dashboard, and usage metering | You have data-residency / compliance needs, want your own proxy strategy, and can operate the service |
 | Start | [Sign up](https://fastcrw.com/register) — 500 free credits, no card | `docker run -p 3000:3000 ghcr.io/us/crw` |
@@ -237,6 +239,11 @@ curl http://localhost:3000/v1/scrape \
 Prefer CLI, Homebrew, Cargo, APT, or Docker Compose with a stealth tier? All install paths and
 production hardening: [docs.fastcrw.com/installation/](https://docs.fastcrw.com/installation/) ·
 [self-hosting guide →](https://docs.fastcrw.com/#self-hosting)
+
+<p align="center">
+  <a href="https://fastcrw.com/register"><img src="https://img.shields.io/badge/Start%20free-500%20credits%2C%20no%20card-7c3aed?style=for-the-badge" alt="Start free"></a>
+  <br><sub>Skip the setup — 500 free credits on the managed cloud, no card.</sub>
+</p>
 
 ## Why it's fast (built in Rust)
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 
 <p align="center">
   Use the managed cloud for zero infra, or self-host the same open-source engine.
-  Drop-in <strong>Firecrawl-compatible</strong>. Start with Python, cURL, or MCP —
-  you never touch Rust.
+  Start with Python, cURL, or MCP — you never touch Rust.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ That first scrape spent 1 of your 500 free credits — [see plans →](https://f
 ## Why fastCRW?
 
 - **Most accurate** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on 819 labeled URLs in Firecrawl's public dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
-- **Fast median, tunable tail** — the fastest median latency (p50 **1914 ms** — a statistical tie with Crawl4AI's 1916 ms, ahead of Firecrawl's 2305 ms). Recall mode chases the hard pages the others drop, at a longer tail; *fast mode* trades some recall for a low p90 (**4348 ms**). One config toggle — pick accuracy or latency.
+- **Fast median, tunable latency** — the fastest median latency (p50 **1914 ms** — a statistical tie with Crawl4AI's 1916 ms, ahead of Firecrawl's 2305 ms). Recall mode maximizes accuracy; *fast mode* delivers a low p90 (**4348 ms**) for latency-sensitive workloads. One config toggle — pick accuracy or latency.
 - **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
 
-Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the honest full run — tail latency and all →](BENCHMARKS.md)
+Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full benchmark →](BENCHMARKS.md)
 
 Open source (AGPL-3.0), passing [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13533), and published on PyPI · npm · crates.io · Homebrew · APT — with a benchmark you can rerun yourself, not marketing math.
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,8 @@ and standalone commercial licenses are available — **hello@fastcrw.com**.
 [Benchmarks](https://fastcrw.com/benchmarks) ·
 [Pricing](https://fastcrw.com/pricing) ·
 [Changelog](CHANGELOG.md) ·
-[X](https://x.com/fast_crw) ·
-[LinkedIn](https://www.linkedin.com/company/fastcrw) ·
-[Discord](https://discord.gg/kkFh2SC8)
+[Discord](https://discord.gg/kkFh2SC8) ·
+[X](https://x.com/fast_crw)
 
 <a href="https://www.star-history.com/?repos=us%2Fcrw&type=timeline&legend=bottom-right">
  <picture>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   Use the managed cloud for zero infra, or self-host the same open-source engine.
-  Start with Python, cURL, or MCP — you never touch Rust.
+  Start with Python, TypeScript, cURL, or MCP — you never touch Rust.
 </p>
 
 <p align="center">
@@ -52,15 +52,15 @@
 
 ## Why fastCRW?
 
-- **Better** — #1 truth-recall (**63.74%**) on Firecrawl's own 1,000-URL dataset, ahead of Firecrawl (56%) and Crawl4AI (60%), recovering **34 pages both miss**.
-- **Faster** — lowest median latency (**1914 ms**) and lowest p90 tail (**4348 ms**) of the three, with **0 errors** across 3,000 requests.
+- **Better** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on the 819 labeled URLs in Firecrawl's public 1,000-URL dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
+- **Faster** — the lowest **p90 tail latency** (the slowest 10% of requests) of the three: **4348 ms** in fast mode, vs 4754 / 6937 ms.
 - **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
 
-Search, map, and crawl run on that same engine — built-in web search (SearXNG), so there's **no separate search vendor and no per-query search-API bill**.
+Two modes, one config toggle: *recall mode* maximizes accuracy, *fast mode* minimizes the latency tail. Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full run →](BENCHMARKS.md)
 
 ## Quickstart — your first scrape in 30 seconds
 
-**[Get a free API key → fastcrw.com/register](https://fastcrw.com/register)** — 500 credits, no card.
+**[Get a free API key → fastcrw.com/register](https://fastcrw.com/register)** — 500 free credits (1 credit ≈ 1 page), no card.
 
 ```bash
 export CRW_API_KEY="crw_live_..."
@@ -83,7 +83,7 @@ pip install crw
 ```python
 from crw import CrwClient
 
-crw = CrwClient(api_key="YOUR_API_KEY")
+crw = CrwClient()  # reads CRW_API_KEY from your env
 page = crw.scrape("https://example.com",
                   formats=["markdown"])
 print(page["markdown"])
@@ -97,7 +97,7 @@ npm install crw-sdk
 ```javascript
 import { CrwClient } from "crw-sdk";
 
-const crw = new CrwClient({ apiKey: "YOUR_API_KEY" });
+const crw = new CrwClient();  // reads CRW_API_KEY from your env
 const page = await crw.scrape("https://example.com",
                               { formats: ["markdown"] });
 console.log(page.markdown);
@@ -176,15 +176,21 @@ npm install crw-sdk      # TypeScript / Node.js
 ```python
 from crw import CrwClient
 
-client = CrwClient(api_key="YOUR_API_KEY")   # or CrwClient() for local embedded mode
+client = CrwClient()   # reads CRW_API_KEY; set CRW_LOCAL=1 for local embedded mode
 client.scrape("https://example.com", formats=["markdown", "links"])
 # .search() .map() .crawl() .extract() — one method per operation in the table above
 ```
 
-Framework extras: `pip install crw[crewai]` · `pip install crw[langchain]`.
-Works with [CrewAI](https://pypi.org/project/crw/) · [LangChain](https://pypi.org/project/crw/) ·
-[Agno](https://github.com/agno-agi/agno/pull/7183) · [Dify](https://github.com/langgenius/dify) ·
-[n8n](https://fastcrw.com/blog/n8n-web-scraping-crw) · [Flowise](https://github.com/FlowiseAI/Flowise/pull/6066).
+The TypeScript client (`crw-sdk`) exposes the same methods — typed and zero-dependency. The
+cloud client is pure `fetch`, so it runs on Node 18+, Bun, Deno, and edge runtimes.
+
+LangChain and CrewAI integrations ship in the package:
+
+```python
+from crw.integrations.langchain import CrwLoader          # pip install crw[langchain]
+from crw.integrations.crewai import CrwScrapeWebsiteTool   # pip install crw[crewai]
+```
+
 [All integrations →](https://docs.fastcrw.com/integrations/) · [SDK examples →](https://docs.fastcrw.com/sdk-examples/)
 
 ## Managed cloud vs self-host
@@ -197,7 +203,7 @@ Same binary, same API in both modes — pick a lane, switch anytime by changing 
 | Start | [Sign up](https://fastcrw.com/register) — 500 free credits, no card | `docker run -p 3000:3000 ghcr.io/us/crw` |
 | Search | Managed backend | Bundled SearXNG sidecar |
 | Cost | Free tier, then paid plans from **$11/mo** — [pricing](https://fastcrw.com/pricing) | $0 + your hosting bill |
-| License | AGPL carve-out for closed-source product code | AGPL-3.0 applies if you expose the API to third parties |
+| License | You call an API over the network — no copyleft on your code | AGPL-3.0 — copyleft applies if you modify and expose the service, or embed the engine in-process |
 
 ### Self-host in one command
 
@@ -255,10 +261,11 @@ checks as CI. Setup, architecture, and crate layout: **[CONTRIBUTING.md](CONTRIB
 
 ## License
 
-Open source under [AGPL-3.0](LICENSE). Embedding fastCRW in a closed-source product or
-exposing it as a hosted service without meeting AGPL's source-availability terms? The
-managed offering at [fastcrw.com](https://fastcrw.com) includes a commercial carve-out,
-and standalone commercial licenses are available — **hello@fastcrw.com**.
+Open source under [AGPL-3.0](LICENSE). **Calling the API over the network — managed or
+self-hosted — imposes nothing on your own code.** AGPL only applies if you embed the engine
+in-process or run a modified copy as a public service; for those cases the managed offering at
+[fastcrw.com](https://fastcrw.com) includes a commercial carve-out, and standalone commercial
+licenses are available — **hello@fastcrw.com**.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -5,515 +5,265 @@
 <h1 align="center">fastCRW</h1>
 
 <p align="center">
-  Self-hosted, Rust-native web crawler &amp; scraper for AI agents
+  The web data API for AI agents — search, scrape, map, and crawl any site into
+  clean <strong>markdown</strong> or <strong>JSON</strong>.
 </p>
 
-The open-source alternative to Firecrawl. One static binary, ~50 MB RAM idle,
-a native fastCRW REST API under **`/v1/*`** (scrape, crawl, map, search,
-structured extraction, and change tracking), plus a **`/firecrawl/v2/*` Firecrawl
-compatibility layer** for migrations, batch scrape, and PDF parse. Self-host free under
-AGPL-3.0, or hit our managed API at `api.fastcrw.com`. Reproducible 63.74%
-truth-recall on the public 1,000-URL dataset (`diagnose_3way.py`,
-2026-05-08) — see [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks).
-Built in Rust because every millisecond of agent latency compounds.
+<p align="center">
+  Use the managed cloud for zero infra, or self-host the same open-source engine.
+  Drop-in <strong>Firecrawl-compatible</strong>. Start with Python, cURL, or MCP —
+  you never touch Rust.
+</p>
+
+<p align="center">
+  <a href="https://fastcrw.com/register"><img src="https://img.shields.io/badge/Start%20free-500%20credits%2C%20no%20card-7c3aed?style=for-the-badge" alt="Start free"></a>
+  &nbsp;
+  <a href="https://docs.fastcrw.com"><img src="https://img.shields.io/badge/Docs-docs.fastcrw.com-24292f?style=for-the-badge" alt="Docs"></a>
+</p>
 
 <p align="center">
   <a href="https://crates.io/crates/crw-server"><img src="https://img.shields.io/crates/v/crw-server.svg" alt="crates.io"></a>
+  <a href="https://pypi.org/project/crw/"><img src="https://img.shields.io/pypi/v/crw.svg?label=pypi" alt="PyPI"></a>
+  <a href="https://www.npmjs.com/package/crw-mcp"><img src="https://img.shields.io/npm/v/crw-mcp.svg?label=npm%20mcp" alt="npm crw-mcp"></a>
   <a href="https://github.com/us/crw/actions/workflows/ci.yml"><img src="https://github.com/us/crw/actions/workflows/ci.yml/badge.svg?branch=main&event=push" alt="CI"></a>
   <a href="https://www.bestpractices.dev/projects/13533"><img src="https://www.bestpractices.dev/projects/13533/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/us/crw"><img src="https://api.scorecard.dev/projects/github.com/us/crw/badge" alt="OpenSSF Scorecard"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
   <a href="https://github.com/us/crw/stargazers"><img src="https://img.shields.io/github/stars/us/crw?style=social" alt="GitHub Stars"></a>
-  <a href="https://fastcrw.com"><img src="https://img.shields.io/badge/Managed%20Cloud-fastcrw.com-blueviolet" alt="fastcrw.com"></a>
 </p>
 
 <p align="center">
-  <a href="https://crates.io/crates/crw-server"><img src="https://img.shields.io/crates/d/crw-server.svg?label=crates.io%20downloads" alt="crates.io downloads"></a>
-  <a href="https://www.npmjs.com/package/crw-sdk"><img src="https://img.shields.io/npm/dm/crw-sdk.svg?label=npm%20sdk" alt="npm sdk downloads"></a>
-  <a href="https://www.npmjs.com/package/crw-mcp"><img src="https://img.shields.io/npm/dm/crw-mcp.svg?label=npm%20mcp" alt="npm mcp downloads"></a>
-  <a href="https://pepy.tech/project/crw"><img src="https://static.pepy.tech/personalized-badge/crw?period=month&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads" alt="PyPI downloads"></a>
-  <a href="https://github.com/us/crw/releases"><img src="https://img.shields.io/github/downloads/us/crw/total?label=binary%20downloads" alt="binary downloads"></a>
+  Works with
+  <a href="https://docs.fastcrw.com/mcp-clients/#claude-code">Claude Code</a> ·
+  <a href="https://docs.fastcrw.com/mcp-clients/#cursor">Cursor</a> ·
+  <a href="https://docs.fastcrw.com/mcp-clients/#windsurf">Windsurf</a> ·
+  <a href="https://docs.fastcrw.com/mcp-clients/#cline">Cline</a> ·
+  <a href="https://docs.fastcrw.com/mcp-clients/#openai-codex-cli">Codex</a> ·
+  <a href="https://docs.fastcrw.com/mcp-clients/#gemini-cli">Gemini CLI</a>
 </p>
-
-<p align="center">
-  <a href="https://x.com/fast_crw"><img src="https://img.shields.io/badge/Follow%20on%20X-000000?style=for-the-badge&logo=x&logoColor=white" alt="Follow on X" /></a>
-  <a href="https://www.linkedin.com/company/fastcrw"><img src="https://img.shields.io/badge/Follow%20on%20LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Follow on LinkedIn" /></a>
-  <a href="https://discord.gg/kkFh2SC8"><img src="https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join our Discord" /></a>
-</p>
-
-Works with: [Claude Code](https://docs.fastcrw.com/mcp-clients/#claude-code) · [Cursor](https://docs.fastcrw.com/mcp-clients/#cursor) · [Windsurf](https://docs.fastcrw.com/mcp-clients/#windsurf) · [Cline](https://docs.fastcrw.com/mcp-clients/#cline) · [Copilot](https://docs.fastcrw.com/mcp-clients/#any-mcp-client) · [Continue.dev](https://docs.fastcrw.com/mcp-clients/#continue) · [Codex](https://docs.fastcrw.com/mcp-clients/#openai-codex-cli) · [Gemini CLI](https://docs.fastcrw.com/mcp-clients/#gemini-cli)
 
 ---
 
-<p align="center">
-  <img src=".github/benchmarks/bench-dashboard.png" alt="fastCRW vs Crawl4AI vs Firecrawl on Firecrawl's public 1,000-URL dataset — fastCRW leads on truth-recall, p50, and fast-mode p90 latency" width="100%">
-</p>
+## What you get
 
-<p align="center"><sub>Firecrawl's own 1,000-URL public dataset (<code>diagnose_3way.py</code>) — fastCRW leads on truth-recall, median latency, and fast-mode p90. <a href="#benchmark">Full numbers and one-command repro ↓</a></sub></p>
+- **Any URL → LLM-ready output.** Clean markdown, HTML, links, or schema-validated JSON — no HTML soup, no boilerplate.
+- **One API, six operations.** `search` the web and `scrape` a page, or `map` / `crawl` / `extract` / `change-track` a whole site — [see below](#core-operations).
+- **Drop-in Firecrawl compatibility.** Migrate existing Firecrawl code by changing one base URL.
+- **Managed or self-hosted, same API.** No exit cost — develop against the free open-source binary, ship to the cloud, or the reverse. Nothing changes but the base URL.
 
-## Why fastCRW?
+## Quickstart — your first scrape in 30 seconds
 
-- **Rust-native, single static binary** — no Redis, no Node.js, no Python venv, no headless-browser sidecar in the request path. One binary, one config file, one process.
-- **~50 MB RAM idle** — leaves headroom on a $5 VPS. Browser-render-first stacks (Firecrawl, Crawl4AI) carry a Chromium heap baseline measured in hundreds of MB before a single request lands.
-- **Native `/v1`, compatibility `/firecrawl/v2`** — new fastCRW projects should use `/v1/scrape`, `/v1/crawl`, `/v1/map`, and `/v1/search`. Existing Firecrawl v2 SDK projects can use the `/firecrawl/v2/*` compatibility layer (`FirecrawlApp(api_url="https://api.fastcrw.com")`) and validate the documented differences before switching production traffic.
-- **Change tracking & monitoring** — diff a page against a prior snapshot (markdown git-diff, per-field JSON, or both) with an optional LLM "meaningful-change" judge. Stateless `changeTracking` primitive in the engine; scheduled monitors + signed-webhook/email alerts on the managed platform. See the [Monitoring docs](https://us.github.io/crw/monitoring).
-- **AGPL-3.0 open core + managed option** — self-host free, or point at `api.fastcrw.com` for managed proxy network, dashboard, and SLA without the AGPL obligations on your application code.
-
----
-
-## Comparison Table
-
-Qualitative positioning vs. the two most-cited alternatives — the same two in
-the reproducible benchmark below. Numerical claims trace to the inline sources
-noted; everything else is descriptive.
-
-| | **fastCRW** | Firecrawl | Crawl4AI |
-|---|---|---|---|
-| Language | Rust | Node.js + Playwright | Python + Playwright |
-| License | AGPL-3.0 (commercial avail.) | AGPL-3.0 (commercial avail.) | Apache-2.0 |
-| Self-host install size | Single static binary (~8 MB) | Multi-container (~500 MB+ image) | ~2 GB image (browser bundled) |
-| Memory baseline (idle) | ~50 MB | Large (Chromium heap) | Large (Chromium heap) |
-| Firecrawl migration | Yes — `/firecrawl/v2/*` compatibility layer; `/v1/*` is native fastCRW | Native | No |
-| MCP server | Built-in (`crw-mcp`) | Separate package | Community add-on |
-| Hosted option | `api.fastcrw.com` (BYOK or managed) | firecrawl.dev | None official |
-| Reproducible public benchmark | Yes — 63.74% truth-recall on 1,000-URL dataset (`diagnose_3way.py`, 2026-05-08) | Vendor-published only | Vendor-published only |
-
-Pricing/spec cells where claimed link to the vendor page; everything else
-is the qualitative architectural shape, not a comparison number.
-
----
-
-## Quickstart
-
-Hit the managed API at `api.fastcrw.com`, or self-host the same binary.
+**[Get a free API key → fastcrw.com/register](https://fastcrw.com/register)** — 500 credits, no card.
 
 ```bash
-# /v1/scrape — URL → markdown / HTML / JSON / links
+export CRW_API_KEY="crw_live_..."
+```
+
+<table>
+<tr><th>cURL</th><th>Python</th></tr>
+<tr valign="top"><td>
+
+```bash
 curl -X POST https://api.fastcrw.com/v1/scrape \
   -H "Authorization: Bearer $CRW_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"url":"https://example.com","formats":["markdown"]}'
+  -d '{"url":"https://example.com",
+       "formats":["markdown"]}'
 ```
 
-```bash
-# /v1/scrape + formats:["json"] — structured JSON extraction via a JSON Schema
-curl -X POST https://api.fastcrw.com/v1/scrape \
-  -H "Authorization: Bearer $CRW_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url":"https://example.com",
-    "formats":["json"],
-    "jsonSchema":{
-      "type":"object",
-      "properties":{"title":{"type":"string"}}
-    }
-  }'
-```
+</td><td>
 
 ```bash
-# /v1/crawl — async multi-page job (returns a job id; poll with /v1/crawl/:id)
-curl -X POST https://api.fastcrw.com/v1/crawl \
-  -H "Authorization: Bearer $CRW_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url":"https://docs.example.com","maxDepth":2,"maxPages":50}'
+pip install crw
+```
+```python
+from crw import CrwClient
+
+crw = CrwClient(api_key="YOUR_API_KEY")
+page = crw.scrape("https://example.com",
+                  formats=["markdown"])
+print(page["markdown"])
 ```
 
+</td></tr>
+</table>
+
+`page` is a plain dict (`markdown`, `metadata`, `contentType`, …), so `print(page["markdown"])` gives you clean content:
+
+```markdown
+# Example Domain
+
+This domain is for use in documentation examples without needing permission. Avoid use in operations.
+
+[Learn more](https://iana.org/domains/example)
+```
+
+Over cURL you get the same fields wrapped in `{"success": true, "data": { … }}`.
+
+Prefer no SDK? Every example works over plain HTTP against `https://api.fastcrw.com`.
+Next: [Quickstart docs →](https://docs.fastcrw.com/quickstart/) · [API reference →](https://docs.fastcrw.com/#rest-api)
+
+## Use it in your AI agent (MCP)
+
+fastCRW ships a built-in MCP server, so any MCP host can search/scrape/crawl with no glue code.
+
 ```bash
-# Self-host (no auth, localhost) — single docker command
+# Claude Code — managed
+claude mcp add crw \
+  -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=$CRW_API_KEY \
+  -- npx -y crw-mcp
+
+# Claude Code — embedded (no server, no key, runs the engine in-process)
+claude mcp add crw -- npx -y crw-mcp
+```
+
+Per-client recipes (Cursor, Windsurf, Cline, Continue.dev, Codex, Gemini CLI):
+[docs.fastcrw.com/mcp-clients/](https://docs.fastcrw.com/mcp-clients/)
+
+### Agent Skills
+
+Reusable instruction packs that teach coding agents *when* and *how* to use each verb.
+Install all 13 into every detected agent with one command:
+
+```bash
+npx skills add us/crw            # all skills, every detected agent
+npx skills add us/crw@crw-scrape # just one
+npx skills add -g us/crw         # global (user-level)
+```
+
+`crw` (hub) · `crw-search` · `crw-scrape` · `crw-map` · `crw-crawl` · `crw-parse` ·
+`crw-extract` · `crw-watch` · `crw-research` · `crw-dynamic-search` (biggest token-saver) ·
+`crw-best-practices` · `crw-migrate` · `crw-self-host`. Full catalog: [`skills/`](./skills/).
+
+## Core operations
+
+| Verb | Endpoint | Does |
+|---|---|---|
+| **Search** | `POST /v1/search` | Web search (SearXNG), optionally scrape each result |
+| **Scrape** | `POST /v1/scrape` | One URL → markdown / HTML / links / schema JSON |
+| **Map** | `POST /v1/map` | Discover every URL on a site, fast |
+| **Crawl** | `POST /v1/crawl` | Async BFS crawl of a whole site (returns a job id) |
+| **Extract** | `POST /v1/scrape` `formats:["json"]` | Structured fields from a JSON Schema |
+| **Change-tracking** | `POST /v1/change-tracking/diff` | Diff a page vs a snapshot — the [monitoring](https://docs.fastcrw.com/monitoring/) primitive |
+
+Full reference: [docs.fastcrw.com/#rest-api](https://docs.fastcrw.com/#rest-api).
+
+## SDKs & integrations
+
+```bash
+pip install crw          # Python 3.10+
+npm install crw-sdk      # TypeScript / Node.js
+```
+
+```python
+from crw import CrwClient
+
+client = CrwClient(api_key="YOUR_API_KEY")   # or CrwClient() for local embedded mode
+client.scrape("https://example.com", formats=["markdown", "links"])
+# .search() .map() .crawl() .extract() — one method per operation in the table above
+```
+
+Framework extras: `pip install crw[crewai]` · `pip install crw[langchain]`.
+Works with [CrewAI](https://pypi.org/project/crw/) · [LangChain](https://pypi.org/project/crw/) ·
+[Agno](https://github.com/agno-agi/agno/pull/7183) · [Dify](https://github.com/langgenius/dify) ·
+[n8n](https://fastcrw.com/blog/n8n-web-scraping-crw) · [Flowise](https://github.com/FlowiseAI/Flowise/pull/6066).
+[All integrations →](https://docs.fastcrw.com/integrations/) · [SDK examples →](https://docs.fastcrw.com/sdk-examples/)
+
+## Managed cloud vs self-host
+
+Same binary, same API in both modes — pick a lane, switch anytime by changing the base URL.
+
+| | **Managed — `api.fastcrw.com`** | **Self-host (free)** |
+|---|---|---|
+| Best when | You want zero infra, a global proxy network, a dashboard, and usage metering | You want full data residency, your own proxy strategy, and AGPL is fine |
+| Start | [Sign up](https://fastcrw.com/register) — 500 free credits, no card | `docker run -p 3000:3000 ghcr.io/us/crw` |
+| Search | Managed backend | Bundled SearXNG sidecar |
+| Cost | Free tier, then paid plans from **$11/mo** — [pricing](https://fastcrw.com/pricing) | $0 + your hosting bill |
+| License | AGPL carve-out for closed-source product code | AGPL-3.0 applies if you expose the API to third parties |
+
+### Self-host in one command
+
+```bash
 docker run -p 3000:3000 ghcr.io/us/crw
 curl http://localhost:3000/v1/scrape \
   -H "Content-Type: application/json" \
   -d '{"url":"https://example.com"}'
 ```
 
-Other install paths (each documented under
-[`Install`](#install) further down):
+Prefer CLI, Homebrew, Cargo, APT, or Docker Compose with a stealth tier? All install paths and
+production hardening: [docs.fastcrw.com/installation/](https://docs.fastcrw.com/installation/) ·
+[self-hosting guide →](https://docs.fastcrw.com/#self-hosting)
 
-```bash
-npx crw-mcp                           # zero install — runs the embedded engine
-pip install crw                        # Python SDK (auto-downloads binary)
-brew install us/crw/crw                # Homebrew
-cargo install crw-cli                  # Cargo
-curl -fsSL https://fastcrw.com/install | sh
-```
+## Why it's fast (built in Rust)
 
----
-
-## Why Rust?
-
-Cold start is sub-second and the resident memory ceiling is bounded by the
-crawl queue, not by a JavaScript runtime or a headless browser parked in
-the background. An agent that issues N scrapes per task pays the network
-floor N times — anything you add on top (process spawn, JIT warmup,
-browser navigation overhead) multiplies. Pushing the request-path
-language down to Rust strips that surcharge out of every call. The same
-property lets one static binary saturate a $5 VPS instead of needing a
-multi-container compose stack, which is why the idle footprint is in the
-tens of MB rather than the hundreds.
-
----
-
-## MCP + SDK quickstart
-
-fastCRW ships a built-in MCP server so any MCP-compatible agent (Claude
-Code, Cursor, Windsurf, Cline, Continue.dev, Codex, Gemini CLI) can call
-scraping tools without bespoke glue. Embedded mode runs the engine
-in-process — no server, no API key, no setup. The `crw` Python SDK and
-the `crw-mcp` Node binary both shell to the same Rust core.
-
-```bash
-npm install -g crw-mcp          # MCP server (Node wrapper)
-pip install crw                 # Python SDK (auto-downloads binary)
-claude mcp add crw -- npx -y crw-mcp                                       # Claude Code, embedded
-claude mcp add crw \
-  -e CRW_API_URL=https://api.fastcrw.com -e CRW_API_KEY=… \
-  -- npx -y crw-mcp                                                        # Claude Code, managed
-```
-
-Per-client config recipes (Claude Desktop, Cursor, Windsurf, Cline,
-Continue.dev) live under [docs.fastcrw.com/mcp-clients/](https://docs.fastcrw.com/mcp-clients/).
-
----
-
-## Agent Skills
-
-Beyond raw MCP tools, fastCRW ships a set of [agent skills](https://www.skills.sh) —
-reusable instruction packs that teach AI coding agents *when* and *how* to scrape,
-crawl, map, search, parse, extract, and change-track the web. Install into any
-agent (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Windsurf + more) with one
-command:
-
-```bash
-npx skills add us/crw                 # all 12 skills, into every detected agent
-npx skills add us/crw@crw-scrape      # just one
-npx skills add -g us/crw              # global (user-level)
-```
-
-| Tier | Skills |
-|------|--------|
-| **Core / verb ladder** | `crw` (hub) · `crw-search` · `crw-scrape` · `crw-map` · `crw-crawl` · `crw-parse` · `crw-extract` · `crw-watch` |
-| **Quality / meta** | `crw-dynamic-search` (context-isolating filter — the biggest token-saver) · `crw-best-practices` |
-| **Migration / ops** | `crw-migrate` (one-line Firecrawl `base_url` swap) · `crw-self-host` |
-
-The skills drive the `crw` CLI, the `crw-mcp` tools, or the REST API — pick whatever
-surface you have. No API key needed for self-hosted search (SearXNG). Full catalog
-and per-skill docs: [`skills/`](./skills/). Also packaged as a plugin marketplace
-for Claude Code, Codex, and Cursor (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`).
-
----
-
-## Self-host vs Managed
-
-| | **Self-host (free)** | **Managed — `api.fastcrw.com`** |
-|---|---|---|
-| Best when | You want full data residency, AGPL is fine, you can run your own proxy strategy, latency to your infra matters more than ours. | You want zero infra, a global proxy network, a dashboard, usage metering, and AGPL carve-out for closed-source product code. |
-| Install | `docker run -p 3000:3000 ghcr.io/us/crw` or `cargo install crw-server`. | Sign up at [fastcrw.com](https://fastcrw.com) — 500 free credits, no card. |
-| Search | Bundled SearXNG sidecar (`docker compose up`). | Managed search backend. |
-| Proxy rotation | Bring your own pool (`proxy_list` + `proxy_rotation`: round_robin / random / sticky_per_host) — rotated across the HTTP **and** JS/Chrome paths for scrape, crawl, and map; per-request BYOP supported. LightPanda can't proxy, so it's skipped (fail-closed) when a proxy is active. | Managed proxy network. |
-| Cost | $0 + your hosting bill. | From $13/mo; pricing on [fastcrw.com/pricing](https://fastcrw.com/pricing). |
-| License obligations | AGPL-3.0 applies if you expose the API to third parties. | AGPL carve-out included. |
-
-The binary is the same in both modes — you can develop against your
-self-hosted instance and ship to managed without code changes.
-
----
-
-## Install
-
-### MCP server (`crw-mcp`) — recommended for AI agents
-
-```bash
-npx crw-mcp                              # zero install (npm)
-pip install crw                          # Python SDK (auto-downloads binary)
-brew install us/crw/crw-mcp              # Homebrew
-cargo install crw-mcp                    # Cargo (full embedded, ~17 MB)
-docker run -i ghcr.io/us/crw crw-mcp     # Docker
-```
-
-**Lean browser-free proxy build** (~4.2 MB, no headless browser engine — proxy/cloud mode only):
-
-```bash
-cargo build --profile release-small --no-default-features -p crw-mcp
-```
-
-### CLI (`crw`) — scrape URLs from your terminal
-
-```bash
-brew install us/crw/crw
-
-# One-line install (auto-detects OS & arch):
-curl -fsSL https://fastcrw.com/install | CRW_BINARY=crw sh
-
-# APT (Debian/Ubuntu):
-curl -fsSL https://apt.fastcrw.com/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/crw.gpg
-echo "deb [signed-by=/usr/share/keyrings/crw.gpg] https://apt.fastcrw.com stable main" \
-  | sudo tee /etc/apt/sources.list.d/crw.list
-sudo apt update && sudo apt install crw
-
-cargo install crw-cli
-```
-
-### API server (`crw-server`) — native REST API plus Firecrawl compatibility
-
-For serving multiple apps, other languages (Node.js, Go, Java), or as a
-shared microservice.
-
-```bash
-brew install us/crw/crw-server
-
-# One-line install:
-curl -fsSL https://fastcrw.com/install | CRW_BINARY=crw-server sh
-
-# Docker:
-docker run -p 3000:3000 ghcr.io/us/crw
-```
-
-Docker Compose ships with `lightpanda` by default; `chrome` is opt-in:
-
-```bash
-docker compose up -d                                         # http + lightpanda
-docker compose --profile heavy up -d                         # + chrome failover
-docker compose -f docker-compose.yml \
-  -f docker-compose.stealth.yml --profile stealth up -d      # browserless stealth tier
-```
-
-There's also an **optional [Camoufox](https://github.com/daijro/camoufox)
-stealth tier** (REST sidecar, opt-in) for fingerprint-blocked targets the CDP
-renderers can't pass — off by default and never touches the `auto` chain unless
-you turn it on. Build with `--features camoufox`; see [JS rendering →
-Camoufox](https://docs.fastcrw.com/#js-rendering).
-
-See the [self-hosting guide](https://docs.fastcrw.com/#self-hosting) for
-production hardening, auth, reverse proxy, and resource tuning.
-
----
-
-## API endpoints
-
-| Method | Endpoint | Description |
-|---|---|---|
-| `POST` | `/v1/scrape` | Scrape a single URL, optionally with LLM extraction or summary |
-| `POST` | `/v1/crawl` | Start async BFS crawl (returns job ID) |
-| `GET` | `/v1/crawl/:id` | Check crawl status and retrieve results |
-| `DELETE` | `/v1/crawl/:id` | Cancel a running crawl job |
-| `POST` | `/v1/map` | Discover all URLs on a site |
-| `POST` | `/v1/search` | Web search via SearXNG sidecar, with optional content scraping |
-| `POST` | `/v1/change-tracking/diff` | Diff a scrape against a supplied snapshot (the [monitoring](https://us.github.io/crw/monitoring) primitive) — single or batch |
-| `GET` | `/health` | Health check (no auth required) |
-| `POST` | `/mcp` | Streamable HTTP MCP transport |
-
-**Firecrawl v2 compatibility surface** — `scrape`, `crawl`, `map`, and `search` are also served under `/firecrawl/v2/*` with Firecrawl v2 request/response shapes, plus compatibility-only `POST /firecrawl/v2/batch/scrape`, `POST /firecrawl/v2/parse` (PDF → markdown), and `GET /firecrawl/v2/crawl/active`. Use this when migrating existing Firecrawl v2 SDK code; new fastCRW integrations should start with `/v1`.
-
-Full reference at [docs.fastcrw.com/#rest-api](https://docs.fastcrw.com/#rest-api).
-The Firecrawl compatibility matrix (field-by-field diff) lives in
-[`COMPATIBILITY-firecrawl.md`](COMPATIBILITY-firecrawl.md).
-
----
+You don't need Rust to use fastCRW — it's why the numbers below are what they are.
+The engine is a single static binary: no Redis, no Node runtime, no Python venv, no
+headless-browser sidecar parked in the request path. Cold start is sub-second and idle
+RAM sits around **~50 MB**, so one process saturates a $5 VPS instead of a multi-container
+stack. An agent that fires N scrapes per task pays the network floor N times — fastCRW
+strips process-spawn, JIT-warmup, and browser-navigation overhead out of every one.
 
 ## Benchmark
 
-Reproduce it yourself first — the canonical harness is `diagnose_3way.py`
-(matches truth text against `md + strip_md_links(md)`, applied identically
-to all three tools — a fairness control, not a looser number):
+On Firecrawl's own public 1,000-URL dataset, fastCRW leads on **truth-recall (63.74%)**,
+**median latency (1914 ms)**, and **p90 tail (4348 ms)** with **0 thrown errors** across 3,000
+requests — and recovers 34 URLs the other two miss. Reproducible, not marketing math.
 
-```bash
-cd ~/coding/crw/crw-opencore
-docker compose -f docker-compose.yml -f docker-compose.override.yml \
-               -f docker-compose.stealth.yml --profile stealth up -d
-docker start crawl4ai-bench
-cd ~/coding/crw/competitors/firecrawl && docker compose up -d
+Full numbers, comparison table, and one-command repro: **[BENCHMARKS.md](BENCHMARKS.md)** ·
+[fastcrw.com/benchmarks](https://fastcrw.com/benchmarks).
 
-cd ~/coding/crw/crw-opencore
-uv run python bench/diagnose_3way.py \
-  --max-urls 1000 --tools crw,crawl4ai,firecrawl \
-  --concurrency 5 --timeout 120 \
-  --out bench/server-runs/diag3w-1000-full.jsonl
-```
+## Migrating from Firecrawl
 
-3-way scrape benchmark, full 1,000-URL run on
-[Firecrawl's `scrape-content-dataset-v1`](https://huggingface.co/datasets/firecrawl/scrape-content-dataset-v1)
-(`diagnose_3way.py`, 2026-05-08, concurrency 5, timeout 120s):
-
-| Metric | fastCRW | crawl4ai | Firecrawl |
-|---|---|---|---|
-| **Truth-recall (522/819 labeled URLs)** <sup>recall mode</sup> | **63.74%** | 59.95% | 56.04% |
-| **p50 latency** | **1914 ms** | 1916 ms | 2305 ms |
-| **p90 latency** <sup>fast mode</sup> | **4348 ms** | 4754 ms | 6937 ms |
-| Thrown errors (3,000 requests) | 0 | 0 | 0 |
-
-fastCRW leads on every axis — top truth-recall, fastest median, and the
-lowest p90 tail — with **0 thrown errors** across all 3,000 requests, and it
-uniquely recovers **34 URLs the other two miss** (70% more than crawl4ai and
-Firecrawl combined). The 63.74% denominator is 819 labeled/matchable URLs,
-not 3,000 requests, not 1,000.
-
-**Two tunable modes, one engine, one config toggle.** *Recall mode* (the full
-ladder) maximizes truth-recall, recovering the long tail of hard pages the
-others miss. *Fast mode* (LightPanda-only, no Chrome tier) optimizes the
-latency tail — **p90 4348 ms, the lowest of the three** (`diagnose_3way.py`,
-N=1000). Same binary, same API; pick accuracy or latency per workload.
-
-Full result of record:
-[`bench/server-runs/RESULT_3WAY_1000_FULL.md`](bench/server-runs/RESULT_3WAY_1000_FULL.md).
-
----
-
-## SDKs and integrations
-
-### Python
-
-```bash
-pip install crw
-```
+New projects use native `/v1`. Existing Firecrawl v2 SDK code works against the
+`/firecrawl/v2/*` compatibility layer — often just a base-URL swap:
 
 ```python
-from crw import CrwClient
-
-# Managed (includes web search):
-client = CrwClient(api_url="https://api.fastcrw.com", api_key="YOUR_API_KEY")
-# Local (embedded, no server needed):
-# client = CrwClient()
-
-result = client.scrape("https://example.com", formats=["markdown", "links"])
-pages = client.crawl("https://docs.example.com", max_depth=2, max_pages=50)
-urls = client.map("https://example.com")
-results = client.search("AI news", limit=10, sources=["web", "news"])
+from firecrawl import FirecrawlApp
+app = FirecrawlApp(api_url="https://api.fastcrw.com", api_key="YOUR_CRW_API_KEY")
 ```
 
-Requires Python 3.10+. Local mode auto-downloads `crw-mcp` on first use.
-
-Framework extras:
-
-```bash
-pip install crw[crewai]    # CRW scraping tools for CrewAI agents
-pip install crw[langchain] # CRW document loader for LangChain
-```
-
-### TypeScript / Node.js
-
-```bash
-npm install crw-sdk
-```
-
-[SDK examples →](https://docs.fastcrw.com/sdk-examples/)
-
-### Frameworks & platforms
-
-[CrewAI](https://pypi.org/project/crw/) · [LangChain](https://pypi.org/project/crw/)
-· [Agno](https://github.com/agno-agi/agno/pull/7183) · [Dify](https://github.com/langgenius/dify)
-· [n8n](https://fastcrw.com/blog/n8n-web-scraping-crw) · [Flowise](https://github.com/FlowiseAI/Flowise/pull/6066)
-
-[All integrations →](https://docs.fastcrw.com/integrations/)
-
----
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────┐
-│                 crw-server                  │
-│         Axum HTTP API + Auth + MCP          │
-├──────────┬──────────┬───────────────────────┤
-│ crw-crawl│crw-extract│    crw-renderer      │
-│ BFS crawl│ HTML→MD   │  HTTP + CDP(WS)      │
-│ robots   │ LLM/JSON  │  LightPanda/Chrome   │
-│ sitemap  │ clean/read│  auto-detect SPA     │
-├──────────┴──────────┴───────────────────────┤
-│                 crw-core                    │
-│        Types, Config, Errors                │
-└─────────────────────────────────────────────┘
-```
-
-| Crate | Description |
-|-------|-------------|
-| [`crw-core`](crates/crw-core) | Core types, config, and error handling |
-| [`crw-renderer`](crates/crw-renderer) | HTTP + CDP browser rendering engine |
-| [`crw-extract`](crates/crw-extract) | HTML → markdown/plaintext extraction |
-| [`crw-crawl`](crates/crw-crawl) | Async BFS crawler with robots.txt & sitemap |
-| [`crw-server`](crates/crw-server) | Axum API server (native `/v1` plus Firecrawl `/firecrawl/v2` compatibility) |
-| [`crw-mcp`](crates/crw-mcp) | MCP stdio server (embedded + proxy mode) |
-| [`crw-cli`](crates/crw-cli) | Standalone CLI (`crw` binary, no server) |
-
-[Full architecture docs →](https://docs.fastcrw.com/architecture/)
-
----
+Compatibility reduces migration work, not every behavioral difference — check request
+bodies, response fields, and unsupported features before moving production traffic.
+Field-by-field diff: [`COMPATIBILITY-firecrawl.md`](COMPATIBILITY-firecrawl.md).
 
 ## Security
 
-- **SSRF protection** — blocks loopback, private IPs, cloud metadata (`169.254.x.x`), IPv6 mapped addresses, and non-HTTP schemes (`file://`, `data:`)
-- **Auth** — optional Bearer token with constant-time comparison
-- **robots.txt** — RFC 9309 compliant with wildcard patterns
-- **Rate limiting** — token-bucket algorithm, returns 429 with `error_code`
-- **Resource limits** — max body 1 MB, max crawl depth 10, max pages 1,000
-
-[Full security docs →](https://docs.fastcrw.com/self-hosting-hardening/)
-
----
+SSRF protection (blocks loopback, private IPs, cloud metadata, non-HTTP schemes), optional
+constant-time Bearer auth, RFC 9309 robots.txt, token-bucket rate limiting, and resource caps
+(1 MB body, depth 10, 1,000 pages). [Hardening guide →](https://docs.fastcrw.com/self-hosting-hardening/)
 
 ## Contributing
 
-Contributions are welcome — issues and PRs both.
-
-1. Fork the repository
-2. Install pre-commit hooks: `make hooks`
-3. Create your feature branch (`git checkout -b feat/my-feature`)
-4. Commit your changes (`git commit -m 'feat: add my feature'`)
-5. Push to the branch (`git push origin feat/my-feature`)
-6. Open a Pull Request
-
-The pre-commit hook runs the same checks as CI (`cargo fmt`, `cargo clippy`,
-`cargo test`). Run manually with `make check`.
-
-### Contributors
-
-<p>
-  <a href="https://github.com/us"><img src="https://github.com/us.png?size=64" width="64" height="64" alt="us"/></a>
-  <a href="https://github.com/adambenhassen"><img src="https://github.com/adambenhassen.png?size=64" width="64" height="64" alt="adambenhassen"/></a>
-  <a href="https://github.com/mj520"><img src="https://github.com/mj520.png?size=64" width="64" height="64" alt="mj520"/></a>
-</p>
-
----
+Issues and PRs welcome. `make hooks` installs the pre-commit hook; `make check` runs the same
+checks as CI. Setup, architecture, and crate layout: **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## License
 
-fastCRW is open source under [AGPL-3.0](LICENSE). If you embed fastCRW in
-a closed-source product or expose it as a hosted service to third parties
-and you can't comply with AGPL's source-availability requirements, the
-managed offering at [fastcrw.com](https://fastcrw.com) includes a
-commercial carve-out, and standalone commercial licenses are available
-on request — write to **hello@fastcrw.com**.
-
----
+Open source under [AGPL-3.0](LICENSE). Embedding fastCRW in a closed-source product or
+exposing it as a hosted service without meeting AGPL's source-availability terms? The
+managed offering at [fastcrw.com](https://fastcrw.com) includes a commercial carve-out,
+and standalone commercial licenses are available — **hello@fastcrw.com**.
 
 ## Links
 
-- **Documentation:** [docs.fastcrw.com](https://docs.fastcrw.com)
-- **API reference:** [docs.fastcrw.com/#rest-api](https://docs.fastcrw.com/#rest-api)
-- **MCP setup guide:** [docs.fastcrw.com/#mcp](https://docs.fastcrw.com/#mcp)
-- **Playground:** [docs.fastcrw.com/playground/](https://docs.fastcrw.com/playground/)
-- **Benchmarks:** [fastcrw.com/benchmarks](https://fastcrw.com/benchmarks)
-- **Marketing site:** [fastcrw.com](https://fastcrw.com)
-- **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
-- **X / Twitter:** [@fast_crw](https://x.com/fast_crw)
-- **LinkedIn:** [fastcrw](https://www.linkedin.com/company/fastcrw)
-- **Discord:** [discord.gg/kkFh2SC8](https://discord.gg/kkFh2SC8)
-- **MCP Registry:** [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=crw)
-
----
-
-## Star History
+[Docs](https://docs.fastcrw.com) ·
+[API reference](https://docs.fastcrw.com/#rest-api) ·
+[MCP setup](https://docs.fastcrw.com/mcp-clients/) ·
+[Benchmarks](https://fastcrw.com/benchmarks) ·
+[Pricing](https://fastcrw.com/pricing) ·
+[Changelog](CHANGELOG.md) ·
+[X](https://x.com/fast_crw) ·
+[LinkedIn](https://www.linkedin.com/company/fastcrw) ·
+[Discord](https://discord.gg/kkFh2SC8)
 
 <a href="https://www.star-history.com/?repos=us%2Fcrw&type=timeline&legend=bottom-right">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=us/crw&type=timeline&theme=dark&legend=bottom-right" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=us/crw&type=timeline&legend=bottom-right" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=us/crw&type=timeline&legend=bottom-right" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=us/crw&type=timeline&legend=bottom-right" width="70%" />
  </picture>
 </a>
 
 ---
 
-**It is the sole responsibility of end users to respect websites' policies
-when scraping.** Users are advised to adhere to applicable privacy
-policies and terms of use. By default, fastCRW respects `robots.txt`
-directives.
+<sub>**It is the sole responsibility of end users to respect websites' policies when
+scraping.** By default, fastCRW respects `robots.txt` directives.</sub>


### PR DESCRIPTION
Comprehensive README rewrite validated through multiple review passes (marketing, SaaS/CTA, DX, Python & JS dev, junior & senior lenses).

## Highlights
- **Leaner + action-first**: quickstart moved up (cURL / Python / Node, all live-tested against the engine), heavy install matrix moved to docs.
- **SaaS-funnel-first**: outcome-first hero with a single dominant *Start free* CTA (Rust demoted to a "why it's fast" proof — Python/TS/cURL/MCP first, "you never touch Rust"), credit defined, post-scrape nudge, repeat CTA, "most teams start here" managed steering.
- **Split out** `CONTRIBUTING.md` (setup + architecture + crates) and `BENCHMARKS.md` (full table + repro).
- **Accuracy**: every command/link/endpoint verified against the codebase; fixed broken monitoring links, wrong `CrwClient()` embedded comment, env-var chain, package names, real LangChain/CrewAI imports, MIT-SDK vs AGPL-engine clarity.
- **Benchmark**: leads with verified wins — truth-recall #1 (63.74% on Firecrawl's own dataset), fastest p50, 34 pages both competitors miss; no cross-config claims.

Docs-only change. No source/CI touched.