### PR TITLE
fix(server): batch/crawl cancel terminal state + 10k-URL batch scale guards

### DIFF
--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -231,6 +231,10 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
                 }
                 return Err(CmdError::code_only(1));
             }
+            CrawlStatus::Cancelled => {
+                eprintln!("Crawl cancelled after {} pages", state.completed);
+                break;
+            }
             CrawlStatus::InProgress => {}
         }
     }

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1192,6 +1192,10 @@ pub struct CrawlerConfig {
     /// config when scraping their own infrastructure.
     #[serde(default = "default_per_host_max_concurrent")]
     pub per_host_max_concurrent: u32,
+    /// Maximum number of URLs accepted by a single `/v2/batch/scrape`
+    /// request (sanity cap; plan-level caps live in the SaaS). Default 10000.
+    #[serde(default = "default_max_batch_urls")]
+    pub max_batch_urls: usize,
 }
 
 fn default_per_host_max_concurrent() -> u32 {
@@ -1214,8 +1218,13 @@ impl Default for CrawlerConfig {
             stealth: StealthConfig::default(),
             per_host_min_interval_ms: 0,
             per_host_max_concurrent: default_per_host_max_concurrent(),
+            max_batch_urls: default_max_batch_urls(),
         }
     }
+}
+
+fn default_max_batch_urls() -> usize {
+    10_000
 }
 
 fn default_concurrency() -> usize {

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -978,6 +978,11 @@ pub enum CrawlStatus {
     Completed,
     #[serde(rename = "failed")]
     Failed,
+    /// Job was cancelled via DELETE. Terminal: pollers must stop and TTL
+    /// cleanup must evict — keep every `matches!(.., Completed | Failed)`
+    /// terminal-state check in sync when touching this enum.
+    #[serde(rename = "cancelled")]
+    Cancelled,
 }
 
 /// GET /v1/crawl/:id response body.

--- a/crates/crw-monitor/src/runner.rs
+++ b/crates/crw-monitor/src/runner.rs
@@ -422,7 +422,10 @@ impl EngineSource {
         loop {
             {
                 let state = rx.borrow();
-                if matches!(state.status, CrawlStatus::Completed | CrawlStatus::Failed) {
+                if matches!(
+                    state.status,
+                    CrawlStatus::Completed | CrawlStatus::Failed | CrawlStatus::Cancelled
+                ) {
                     let data = state.data.clone();
                     let failed = state.status == CrawlStatus::Failed;
                     let err = state.error.clone();

--- a/crates/crw-server/src/routes/crawl.rs
+++ b/crates/crw-server/src/routes/crawl.rs
@@ -42,16 +42,22 @@ pub async fn cancel_crawl(
         .ok_or_else(|| CrwError::NotFound(format!("Crawl job {id} not found")))?;
 
     let status = job.rx.borrow().status;
-    if matches!(status, CrawlStatus::Completed | CrawlStatus::Failed) {
+    if matches!(
+        status,
+        CrawlStatus::Completed | CrawlStatus::Failed | CrawlStatus::Cancelled
+    ) {
         return Err(AppError(CrwError::InvalidRequest(
             "Crawl job already finished".into(),
         )));
     }
 
-    // Abort the spawned task.
+    // Abort the spawned task, then mark the job terminal so status polls
+    // return "cancelled" instead of "scraping" forever (and TTL cleanup
+    // can evict it).
     if let Some(handle) = job.abort_handle.take() {
         handle.abort();
     }
+    job.tx.send_modify(|st| st.status = CrawlStatus::Cancelled);
 
     Ok(Json(serde_json::json!({
         "success": true,

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -141,6 +141,7 @@ fn status_str(s: CrawlStatus) -> &'static str {
         CrawlStatus::InProgress => "scraping",
         CrawlStatus::Completed => "completed",
         CrawlStatus::Failed => "failed",
+        CrawlStatus::Cancelled => "cancelled",
     }
 }
 

--- a/crates/crw-server/src/routes/v2/batch.rs
+++ b/crates/crw-server/src/routes/v2/batch.rs
@@ -81,10 +81,11 @@ pub async fn start_batch(
     template.url = String::new();
 
     // Partition URLs into valid / invalid (SSRF-checked, same as v1 scrape).
-    // Validation resolves DNS per URL — run it with bounded concurrency so a
-    // 10k-URL batch submits in seconds instead of minutes, preserving input
-    // order via `buffered`.
-    const VALIDATE_CONCURRENCY: usize = 64;
+    // Validation resolves DNS per URL — run it with bounded concurrency,
+    // preserving input order via `buffered`. Sized from a live test: 8,800
+    // customer URLs across 7,864 unique domains took ~60s at 64 (cold DNS
+    // dominates); DNS is cheap I/O, so 256 in-flight lookups cut it to ~15s.
+    const VALIDATE_CONCURRENCY: usize = 256;
     let checks = futures::stream::iter(urls.into_iter().map(|u| async move {
         let ok = match url::Url::parse(&u) {
             Ok(parsed) => crw_core::url_safety::validate_safe_url_resolved(&parsed)

--- a/crates/crw-server/src/routes/v2/batch.rs
+++ b/crates/crw-server/src/routes/v2/batch.rs
@@ -6,6 +6,7 @@ use axum::Json;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
+use futures::StreamExt;
 use serde::Serialize;
 use serde_json::Value;
 use uuid::Uuid;
@@ -17,6 +18,11 @@ use super::crawl::{PageQuery, base_url};
 use super::scrape::{V2ScrapeRequest, to_internal};
 use crate::error::AppError;
 use crate::state::AppState;
+
+/// Per-route body cap for batch submits: a 10k-URL list at a few hundred
+/// bytes per URL overflows the global 1 MB JSON cap; 8 MB keeps 10k long
+/// URLs submittable while staying DoS-bounded.
+pub const MAX_BATCH_BODY_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -50,6 +56,13 @@ pub async fn start_batch(
             "`urls` must contain at least one URL".into(),
         )));
     }
+    let max_urls = state.config.crawler.max_batch_urls;
+    if urls.len() > max_urls {
+        return Err(AppError::from(CrwError::InvalidRequest(format!(
+            "`urls` exceeds the maximum of {max_urls} URLs per batch (got {})",
+            urls.len()
+        ))));
+    }
     let ignore_invalid = obj
         .get("ignoreInvalidURLs")
         .and_then(Value::as_bool)
@@ -68,22 +81,26 @@ pub async fn start_batch(
     template.url = String::new();
 
     // Partition URLs into valid / invalid (SSRF-checked, same as v1 scrape).
+    // Validation resolves DNS per URL — run it with bounded concurrency so a
+    // 10k-URL batch submits in seconds instead of minutes, preserving input
+    // order via `buffered`.
+    const VALIDATE_CONCURRENCY: usize = 64;
+    let checks = futures::stream::iter(urls.into_iter().map(|u| async move {
+        let ok = match url::Url::parse(&u) {
+            Ok(parsed) => crw_core::url_safety::validate_safe_url_resolved(&parsed)
+                .await
+                .is_ok(),
+            Err(_) => false,
+        };
+        (u, ok)
+    }))
+    .buffered(VALIDATE_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
     let mut valid = Vec::new();
     let mut invalid = Vec::new();
-    for u in urls {
-        match url::Url::parse(&u) {
-            Ok(parsed) => {
-                if crw_core::url_safety::validate_safe_url_resolved(&parsed)
-                    .await
-                    .is_ok()
-                {
-                    valid.push(u);
-                } else {
-                    invalid.push(u);
-                }
-            }
-            Err(_) => invalid.push(u),
-        }
+    for (u, ok) in checks {
+        if ok { valid.push(u) } else { invalid.push(u) }
     }
     if valid.is_empty() {
         return Err(AppError::from(CrwError::InvalidRequest(

--- a/crates/crw-server/src/routes/v2/crawl.rs
+++ b/crates/crw-server/src/routes/v2/crawl.rs
@@ -184,14 +184,20 @@ pub async fn cancel_crawl(
         .get_mut(&id)
         .ok_or_else(|| CrwError::NotFound(format!("Crawl job {id} not found")))?;
     let status = job.rx.borrow().status;
-    if matches!(status, CrawlStatus::Completed | CrawlStatus::Failed) {
+    if matches!(
+        status,
+        CrawlStatus::Completed | CrawlStatus::Failed | CrawlStatus::Cancelled
+    ) {
         return Err(AppError(CrwError::InvalidRequest(
             "Crawl job already finished".into(),
         )));
     }
+    // Abort, then mark terminal — otherwise polls return "scraping" until
+    // TTL eviction and SDK waiters hang.
     if let Some(handle) = job.abort_handle.take() {
         handle.abort();
     }
+    job.tx.send_modify(|st| st.status = CrawlStatus::Cancelled);
     Ok(Json(serde_json::json!({
         "success": true,
         "status": "cancelled",

--- a/crates/crw-server/src/routes/v2/mod.rs
+++ b/crates/crw-server/src/routes/v2/mod.rs
@@ -73,8 +73,12 @@ pub fn router() -> Router<AppState> {
             post(search::search).fallback(method_not_allowed),
         )
         .route(
+            // Batch submits carry up to `max_batch_urls` URLs — needs more
+            // than the global 1 MB JSON cap (innermost DefaultBodyLimit wins).
             "/v2/batch/scrape",
-            post(batch::start_batch).fallback(method_not_allowed),
+            post(batch::start_batch)
+                .layer(DefaultBodyLimit::max(batch::MAX_BATCH_BODY_BYTES))
+                .fallback(method_not_allowed),
         )
         .route(
             "/v2/batch/scrape/{id}",

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -72,6 +72,9 @@ pub(crate) fn validate_crawl_renderer(req: &CrawlRequest, state: &AppState) -> C
 /// Tracks a crawl job receiver + creation time for TTL cleanup.
 pub struct CrawlJob {
     pub rx: watch::Receiver<CrawlState>,
+    /// Sender kept alongside the receiver so cancel handlers can flip the
+    /// job to a terminal `Cancelled` state after aborting the task.
+    pub tx: watch::Sender<CrawlState>,
     pub created_at: Instant,
     /// Handle to abort the crawl task.
     pub abort_handle: Option<tokio::task::AbortHandle>,
@@ -227,7 +230,7 @@ impl AppState {
                 jobs.retain(|_id, job| {
                     let is_done = matches!(
                         job.rx.borrow().status,
-                        CrawlStatus::Completed | CrawlStatus::Failed
+                        CrawlStatus::Completed | CrawlStatus::Failed | CrawlStatus::Cancelled
                     );
                     // Keep if not done, or if done but within TTL.
                     !is_done || job.created_at.elapsed() < ttl
@@ -276,6 +279,7 @@ impl AppState {
                 id,
                 CrawlJob {
                     rx,
+                    tx: tx.clone(),
                     created_at: Instant::now(),
                     abort_handle: None,
                 },
@@ -361,6 +365,7 @@ impl AppState {
                 id,
                 CrawlJob {
                     rx,
+                    tx: tx.clone(),
                     created_at: Instant::now(),
                     abort_handle: None,
                 },
@@ -446,7 +451,9 @@ impl AppState {
                                 st.data.push(d);
                             }
                             st.completed += 1;
-                            if st.completed >= total {
+                            // Only flip to Completed from InProgress — never
+                            // overwrite a terminal Cancelled set by DELETE.
+                            if st.completed >= total && st.status == CrawlStatus::InProgress {
                                 st.status = CrawlStatus::Completed;
                             }
                         });

--- a/crates/crw-server/tests/v2_api.rs
+++ b/crates/crw-server/tests/v2_api.rs
@@ -202,3 +202,59 @@ async fn firecrawl_prefix_unknown_route_404() {
     let r = s.post("/firecrawl/v2/nope").json(&json!({})).await;
     r.assert_status(StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn v2_batch_url_cap_400() {
+    // Sanity cap: max_batch_urls rejects oversized lists BEFORE any
+    // per-URL validation work (the check is O(1) on the list length).
+    let config: AppConfig = toml::from_str("[crawler]\nmax_batch_urls = 5").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    let s = TestServer::new(create_app(state));
+    let urls: Vec<String> = (0..6).map(|i| format!("https://example.com/{i}")).collect();
+    let r = s
+        .post("/v2/batch/scrape")
+        .json(&json!({ "urls": urls }))
+        .await;
+    r.assert_status(StatusCode::BAD_REQUEST);
+    let body: Value = r.json();
+    assert_eq!(body["success"], false);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("maximum of 5"),
+        "error should name the cap: {body}"
+    );
+}
+
+#[tokio::test]
+async fn v2_batch_cancel_flips_status_to_cancelled() {
+    // Cancel must move the job to a terminal "cancelled" state — previously it
+    // only aborted the task, leaving polls at "scraping" until TTL eviction
+    // (SDK waiters hung). Start the job at the state layer with a TEST-NET-1
+    // blackhole IP so it deterministically stays InProgress until we cancel.
+    let config: AppConfig = toml::from_str("").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    let s = TestServer::new(create_app(state.clone()));
+
+    let template = crw_core::types::ScrapeRequest::default();
+    let id = state
+        .start_batch_job(vec!["http://192.0.2.1/".into()], template)
+        .await;
+
+    // Cancel via the public route.
+    let r = s.delete(&format!("/v2/batch/scrape/{id}")).await;
+    r.assert_status_ok();
+    let body: Value = r.json();
+    assert_eq!(body["status"], "cancelled");
+
+    // Status poll now reports the terminal state (not "scraping").
+    let g = s.get(&format!("/v2/batch/scrape/{id}")).await;
+    g.assert_status_ok();
+    let gb: Value = g.json();
+    assert_eq!(gb["status"], "cancelled");
+
+    // Re-cancel is rejected as already finished.
+    let r2 = s.delete(&format!("/v2/batch/scrape/{id}")).await;
+    r2.assert_status(StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## What

Three commits hardening `/v2/batch/scrape` (and `/v2/crawl`, shared machinery):

1. **`fix(server)`: cancelled jobs reach a terminal state.** DELETE only aborted the task — status polls returned `"scraping"` until the 1h TTL evicted the job (SDK waiters hung, TTL cleanup never evicted cancelled jobs, re-cancel kept succeeding). Adds `CrawlStatus::Cancelled`, flips the watch state on cancel via a `Sender` kept in `CrawlJob`, guards re-cancel (v1+v2), and treats `Cancelled` as terminal in TTL cleanup, the monitor waiter, the v2 status mapping, and the CLI poller.
2. **`feat(server)`: 10k-URL scale guards.** `crawler.max_batch_urls` sanity cap (default 10000, rejected O(1) upfront); per-URL SSRF validation on a bounded-concurrency pool (order-preserving); per-route 8 MB body limit (the global 1 MB JSON cap rejects large URL lists).
3. **`perf(server)`: validation concurrency 64→256** — sized from a live test (below).

## Verification

- `cargo test --workspace`: **1141 passed / 0 failed**; clippy `-D warnings` + fmt clean.
- 2 new offline tests: cap-400 + full cancel-terminal flow (cancel → `"cancelled"` → re-cancel 400).
- **Live local run against a real customer dataset** (8,800 distinct URLs / 7,864 domains extracted from prod usage): submit 200 with 317 dead domains correctly in `invalidURLs`; 10,001 URLs → 400; cancel mid-flight → terminal `cancelled`; full 8,483-page job ran to `completed` in 21 min with **flat RSS (70–127 MB)** — no leak, no hang, failures page-isolated (survived a mid-run proxy-quota outage gracefully).

Plan: `plans/batch-scrape-plan.md` (3-reviewer + round-2 verified).
