### PR TITLE
perf(docker): cargo-chef dependency layer for faster engine builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,34 @@
-# Cross-compiling multi-arch build.
+# Cross-compiling multi-arch build with a durable cargo-chef dependency layer.
 #
 # The builder runs on the NATIVE build platform (`--platform=$BUILDPLATFORM`)
 # and cross-compiles to the requested target arch. Previously the builder ran
 # under QEMU for linux/arm64, which emulated the *entire* Rust compile and took
 # ~2h per release. Cross-compiling on the native runner brings arm64 back to
 # minutes; only the tiny runtime layer (ca-certificates) still touches QEMU.
-FROM --platform=$BUILDPLATFORM rust:1.96-bookworm@sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663 AS builder
+#
+# cargo-chef splits the expensive external-crate compile (aws-lc-sys, chromium/
+# CDP, tokio, rustls, ...) into its own `cacher` stage keyed ONLY on the Cargo
+# manifests (recipe.json). A source-only change leaves recipe.json byte-
+# identical -> the cook is reused and only the workspace crates recompile.
+#
+# DURABILITY: prod (rolling-deploy.sh) bakes the `cacher` stage as a TAGGED
+# image `crw-api-deps:<fp>` and overrides DEPS_STAGE to it, so `builder` runs
+# `FROM crw-api-deps:<fp>`. Tagged image layers are referenced (not dangling)
+# and are NOT build cache, so the nightly `docker image prune -f` +
+# `docker builder prune --keep-storage 1GB` cannot evict them. CI leaves
+# DEPS_STAGE=cacher (cooks inline; gha mode=max caches the cacher layer).
+
+# Global ARG (before the first FROM) so it is usable in the `builder` FROM line.
+ARG DEPS_STAGE=cacher
+
+# ---- shared toolchain base --------------------------------------------------
+FROM --platform=$BUILDPLATFORM rust:1.96-bookworm@sha256:a339861ae23e9abb272cea45dfafde21760d2ce6577a70f8a926153677902663 AS chef
 
 # Provided automatically by buildx: amd64 | arm64.
 ARG TARGETARCH
-
 WORKDIR /app
 
-# Install the Rust target + (for arm64) the cross linker, and record the
-# rustc target triple for the build step.
+# Rust target + (arm64) cross linker toolchain; record the target triple.
 RUN set -eux; \
     case "$TARGETARCH" in \
       amd64) RUST_TARGET=x86_64-unknown-linux-gnu ;; \
@@ -29,19 +44,45 @@ RUN set -eux; \
     rustup target add "$RUST_TARGET"; \
     echo "$RUST_TARGET" > /rust_target
 
-COPY . .
+# cargo-chef as a host (BUILDPLATFORM) tool. Pinned so the install layer is
+# deterministic; must be a release that parses this edition-2024 / resolver-2
+# workspace (verify `cargo chef prepare` succeeds before merge — see PR checklist).
+RUN cargo install cargo-chef --locked --version 0.1.77
 
-# Linker for the aarch64 cross target (ignored when building amd64 natively).
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
-
-# The workspace release profile uses fat LTO + codegen-units=1, whose final
-# link of crw-server (aws-lc-sys + the full dep graph) needs several GB and
-# OOM-killed the docker build (see #90's 4 GB OOM warning). The container
-# binary doesn't need max LTO, so use thin LTO across more codegen units —
-# far lower peak memory and a faster link, negligible runtime difference.
-ENV CARGO_PROFILE_RELEASE_LTO=thin \
+# Shared build env — MUST be identical in `cacher` (cook) and `builder` (final
+# compile) or the cooked deps get a different cargo fingerprint and recompile.
+# Baked into `chef` so both inherit it verbatim (and so the tagged deps image
+# carries it too).
+#   - Linker for the aarch64 cross target (ignored on native amd64).
+#   - Workspace release profile is fat LTO + codegen-units=1, whose final link
+#     of crw-server (aws-lc-sys + full graph) needs several GB and OOM-killed
+#     the build (#90). thin LTO + 16 CGUs: far lower peak memory, faster link,
+#     negligible runtime difference.
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CARGO_PROFILE_RELEASE_LTO=thin \
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
 
+# ---- planner: derive the dependency recipe from the manifests only ----------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path /recipe.json
+
+# ---- cacher: compile ONLY the dependency graph (the durable, taggable layer) -
+# Keyed solely on /recipe.json; SAME --target/--features/-p set as the real
+# build so the cooked artifacts fingerprint-match and are reused, not recompiled.
+FROM chef AS cacher
+COPY --from=planner /recipe.json /recipe.json
+RUN set -eux; \
+    RUST_TARGET="$(cat /rust_target)"; \
+    cargo chef cook --release --target "$RUST_TARGET" \
+      -p crw-server --features cdp -p crw-mcp -p crw-cli \
+      --recipe-path /recipe.json
+
+# ---- builder: compile the workspace crates on top of the cooked deps --------
+# DEPS_STAGE defaults to the in-tree `cacher` (CI / any plain `docker build`
+# cooks deps inline). Prod overrides it to the pinned crw-api-deps:<fp> image.
+FROM ${DEPS_STAGE} AS builder
+COPY . .
 RUN set -eux; \
     RUST_TARGET="$(cat /rust_target)"; \
     cargo build --release --target "$RUST_TARGET" \
@@ -51,6 +92,7 @@ RUN set -eux; \
        "target/${RUST_TARGET}/release/crw-server" \
        "target/${RUST_TARGET}/release/crw-mcp" /out/
 
+# ---- runtime (unchanged) ----------------------------------------------------
 FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What

Adds a cargo-chef dependency layer to the engine Dockerfile so a source-only change no longer triggers a full cold recompile of the entire dependency graph (aws-lc-sys, chromium/CDP, tokio, rustls, ...).

## Why

Prod deploy build measured 25-32 min whenever engine source changed, vs 8-12 min when unchanged. Root cause: `COPY . .` sat above the single `cargo build`, and there was **no dependency cache of any kind** — any byte busted the layer.

## How

- `chef` base carries the cross-compile toolchain + the thin-LTO/16-CGU profile env (shared by cook and final build so they fingerprint-match).
- `planner` derives `recipe.json` from manifests only; `cacher` cooks the dep graph keyed solely on that recipe.
- `builder` is `FROM ${DEPS_STAGE}` (default `cacher`). CI / plain `docker build` cook inline; prod's `rolling-deploy.sh` overrides `DEPS_STAGE` to a prebaked `crw-api-deps:<fp>` image.
- Multi-arch cross-compile, the 3-binary build (`crw`/`crw-server`/`crw-mcp`), and the runtime stage are unchanged.

## Safety

- Correctness cannot regress: `builder` still runs `cargo build` with the real manifests, so cargo re-fingerprints and recompiles anything that actually differs — a stale deps image can only ever be *slower*, never a wrong binary.
- Fail-closed: a failed cook/build exits non-zero and blocks the deploy before any canonical recreate.
- CI unchanged: both workflows build the final stage and cook inline (no `DEPS_STAGE` passed); `gha mode=max` now also caches the `cacher` layer.

Pairs with crw-saas `perf/faster-deploy-build` (the deploy-side deps-image bake).

## Verification
- [ ] `docker build --target cacher` then `docker build --build-arg DEPS_STAGE=crw-api-deps:test` → cacher CACHED on 2nd build; all 3 binaries in `/out`.
- [ ] `workflow_dispatch` the Docker Build workflow → amd64 + arm64 green (cross-compile intact).