### PR TITLE
feat: one-command cloud connect across all install paths

### DIFF
--- a/crates/crw-cli/src/commands/setup/cloud.rs
+++ b/crates/crw-cli/src/commands/setup/cloud.rs
@@ -13,12 +13,14 @@ use serde::Deserialize;
 const API_BASE_URL: &str = "https://api.fastcrw.com";
 const DASHBOARD_URL: &str = "https://fastcrw.com/dashboard";
 
-/// Account info returned from API key validation.
+/// Account info returned from `GET /v1/account/balance` (the SaaS balance
+/// endpoint). Only the total-credits field is needed to show a friendly count;
+/// unknown fields are ignored, and a missing value degrades to "validated"
+/// without a number rather than a misleading "0 credits".
 #[derive(Debug, Deserialize)]
 struct AccountInfo {
-    credits_remaining: Option<i64>,
-    #[allow(dead_code)]
-    email: Option<String>,
+    #[serde(rename = "totalCreditsAvailable")]
+    total_credits_available: Option<i64>,
 }
 
 /// API key validation result.
@@ -27,6 +29,69 @@ pub enum ApiKeyStatus {
     Valid { credits: i64 },
     Invalid,
     NetworkError(String),
+}
+
+/// Non-interactive cloud setup for `crw setup --api-key <key>` (and the
+/// `curl … | CRW_API_KEY=… sh` installer pass-through). Validates the key
+/// against the CRW API, persists it to `~/.config/crw/config.toml` pointed at
+/// api.fastcrw.com, and prints a summary — no prompts, no LLM step, no
+/// shell-rc question. This gives brew / curl / cargo the same one-command
+/// cloud connect that `npx crw-mcp install --api-key` gives agents.
+pub async fn run_with_key(api_key: String) -> Result<(), SetupError> {
+    ui::print_section_header("☁️", "CLOUD SETUP");
+
+    let api_key = api_key.trim().to_string();
+    if api_key.is_empty() {
+        return Err(SetupError::Other("API key is empty".to_string()));
+    }
+
+    print!("  ");
+    match validate_api_key(&api_key).await {
+        ApiKeyStatus::Valid { credits } => {
+            if credits >= 0 {
+                ui::print_success(&format!(
+                    "API key validated ({} credits remaining)",
+                    credits
+                ));
+            } else {
+                ui::print_success("API key validated");
+            }
+            println!();
+        }
+        ApiKeyStatus::Invalid => {
+            return Err(SetupError::Other(
+                "Invalid API key — copy it exactly from https://fastcrw.com/dashboard".to_string(),
+            ));
+        }
+        ApiKeyStatus::NetworkError(e) => {
+            return Err(SetupError::Other(format!(
+                "Could not reach fastcrw.com to validate the key ({e}) — check your connection and retry"
+            )));
+        }
+    }
+
+    // Persist canonical cloud config (client → api.fastcrw.com). No LLM leg in
+    // the non-interactive path; users can add one later with `crw setup`.
+    let cfg_path = config_file::write_user_config(build_user_config(&api_key, None))?;
+    ui::print_success(&format!("Saved {}", cfg_path.display()));
+    println!();
+
+    ui::print_summary(
+        "Configuration Summary",
+        &[
+            SummaryItem::new("Cloud API", "Connected (fastcrw.com)", true),
+            SummaryItem::new("Config saved", "~/.config/crw/config.toml", true),
+        ],
+    );
+
+    let quick_start = [
+        "crw example.com              # Scrape a page",
+        "crw search \"rust tutorials\"  # Web search",
+        "crw --help                   # See all commands",
+    ];
+    ui::print_completion_banner(None, &quick_start, &[]);
+
+    Ok(())
 }
 
 /// Run the cloud setup flow.
@@ -145,10 +210,14 @@ async fn get_api_key() -> Result<String, SetupError> {
         print!("  ");
         match validate_api_key(&api_key).await {
             ApiKeyStatus::Valid { credits } => {
-                ui::print_success(&format!(
-                    "API key validated ({} credits remaining)",
-                    credits
-                ));
+                if credits >= 0 {
+                    ui::print_success(&format!(
+                        "API key validated ({} credits remaining)",
+                        credits
+                    ));
+                } else {
+                    ui::print_success("API key validated");
+                }
                 println!();
                 return Ok(api_key);
             }
@@ -220,7 +289,7 @@ async fn validate_api_key(key: &str) -> ApiKeyStatus {
     };
 
     let resp = match client
-        .get(format!("{}/v1/account", API_BASE_URL))
+        .get(format!("{}/v1/account/balance", API_BASE_URL))
         .header("Authorization", format!("Bearer {}", key))
         .send()
         .await
@@ -238,8 +307,10 @@ async fn validate_api_key(key: &str) -> ApiKeyStatus {
     }
 
     match resp.json::<AccountInfo>().await {
+        // No count in the body ⇒ -1, which callers render as "validated" with
+        // no number (never a misleading "0 credits").
         Ok(info) => ApiKeyStatus::Valid {
-            credits: info.credits_remaining.unwrap_or(0),
+            credits: info.total_credits_available.unwrap_or(-1),
         },
         Err(_) => {
             // If we got a 200 but can't parse, assume it's valid
@@ -392,5 +463,26 @@ fn open_browser(url: &str) {
         let _ = std::process::Command::new("cmd")
             .args(["/c", "start", url])
             .spawn();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The core "connects to SaaS" contract of the non-interactive path: the
+    // persisted config points the CLI at api.fastcrw.com with the caller's key
+    // and no LLM leg. If this regresses, `crw setup --api-key` / the installer
+    // pass-through would silently write a config that doesn't reach cloud.
+    #[test]
+    fn build_user_config_wires_cloud_with_key() {
+        let cfg = build_user_config("crw_live_test_key", None);
+        let client = cfg.client.expect("client section");
+        assert_eq!(client.api_url.as_deref(), Some(API_BASE_URL));
+        assert_eq!(client.api_key.as_deref(), Some("crw_live_test_key"));
+        assert!(
+            cfg.extraction.is_none(),
+            "no LLM leg in non-interactive path"
+        );
     }
 }

--- a/crates/crw-cli/src/commands/setup/mod.rs
+++ b/crates/crw-cli/src/commands/setup/mod.rs
@@ -31,6 +31,13 @@ pub struct SetupArgs {
     #[arg(long, conflicts_with = "cloud")]
     pub local: bool,
 
+    /// Connect to CRW Cloud non-interactively with this API key. Validates the
+    /// key, writes ~/.config/crw/config.toml (pointed at api.fastcrw.com), and
+    /// skips every prompt. Implies cloud mode — get a key at
+    /// https://fastcrw.com/dashboard (500 free credits).
+    #[arg(long, value_name = "KEY", conflicts_with_all = ["local", "reset", "reset_shell"])]
+    pub api_key: Option<String>,
+
     /// Disable colored output.
     #[arg(long)]
     pub no_color: bool,
@@ -94,7 +101,10 @@ pub async fn run(args: SetupArgs) {
     }
 
     // If specific mode is requested, run that directly
-    let result = if args.cloud {
+    let result = if let Some(key) = args.api_key.clone() {
+        // Non-interactive cloud connect (--api-key / installer pass-through).
+        cloud::run_with_key(key).await
+    } else if args.cloud {
         cloud::run().await
     } else if args.local {
         local::run().await

--- a/crates/crw-cli/src/main.rs
+++ b/crates/crw-cli/src/main.rs
@@ -175,6 +175,7 @@ async fn main() {
             non_interactive: false,
             cloud: false,
             local: false,
+            api_key: None,
             no_color: false,
             reset_shell: false,
             reset: true,

--- a/crates/crw-extract/src/pdf.rs
+++ b/crates/crw-extract/src/pdf.rs
@@ -238,7 +238,7 @@ fn check_decompression_bomb(bytes: &[u8], cap: usize) -> Result<(), PdfError> {
     };
 
     let mut budget = cap;
-    for (_id, obj) in doc.objects.iter() {
+    for obj in doc.objects.values() {
         let Object::Stream(stream) = obj else {
             continue;
         };

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1646,7 +1646,7 @@ impl CdpRenderer {
             )));
         }
 
-        let final_url = final_href.and_then(|h| if h != url { Some(h) } else { None });
+        let final_url = final_href.filter(|h| *h != url);
         Ok(FetchResult {
             url: url.to_string(),
             final_url,
@@ -1805,7 +1805,7 @@ impl CdpRenderer {
             )));
         }
 
-        let final_url = final_href.and_then(|h| if h != url { Some(h) } else { None });
+        let final_url = final_href.filter(|h| *h != url);
 
         Ok(FetchResult {
             url: url.to_string(),

--- a/install.sh
+++ b/install.sh
@@ -196,7 +196,16 @@ install() {
   # interactive terminal ([ -t 1 ] + readable /dev/tty). Non-interactive runs
   # (CI, logged pipe) just print the next step. Opt out with CRW_NO_SETUP=1.
   if [ "$BINARY" = "crw" ]; then
-    if [ "${CRW_NO_SETUP:-}" != "1" ] && [ -t 1 ] && [ -e /dev/tty ]; then
+    if [ "${CRW_NO_SETUP:-}" != "1" ] && [ -n "${CRW_API_KEY:-}" ]; then
+      # One-command cloud connect: `curl … | CRW_API_KEY=crw_live_… sh`.
+      # Non-interactive — validates the key and writes config.toml, no /dev/tty
+      # needed (works in CI too).
+      echo ""
+      info "Connecting to CRW Cloud with your API key…"
+      echo ""
+      "${INSTALL_DIR}/${BINARY}" setup --api-key "${CRW_API_KEY}" \
+        || info "Cloud connect failed — run 'crw setup --api-key <key>' to retry."
+    elif [ "${CRW_NO_SETUP:-}" != "1" ] && [ -t 1 ] && [ -e /dev/tty ]; then
       echo ""
       info "One step left — let's get you scraping."
       info "Cloud gives you 500 free credits in ~30s (no card, no Docker), or self-host local:"

--- a/mcp/crw-mcp/bin/agents.js
+++ b/mcp/crw-mcp/bin/agents.js
@@ -75,6 +75,15 @@ function writeJson(file, obj) {
  * embedded binary needs no config) or {CRW_API_KEY, CRW_API_URL} for cloud.
  * Returns a short human label of what was done.
  */
+// Spawn the MCP server via `npx -y crw-mcp` rather than a bare `crw-mcp`. A
+// fresh `npx crw-mcp install` leaves NO `crw-mcp` on PATH (npx is ephemeral),
+// so a bare command would give the agent a server it can't launch. npx resolves
+// the launcher each spawn (first run downloads the native binary), so the
+// config works with zero extra install steps. Matches the SaaS "MCP config"
+// docs. Users who prefer the fast native binary can still swap in `crw-mcp`.
+const MCP_CMD = "npx";
+const MCP_ARGS = ["-y", "crw-mcp"];
+
 function installMcp(agent, env) {
   const m = agent.mcp;
   const hasEnv = Object.keys(env).length > 0;
@@ -82,7 +91,7 @@ function installMcp(agent, env) {
   if (m.kind === "claude-cli") {
     // add-json avoids the `-e` variadic-name pitfall and merges ~/.claude.json
     // (user scope) correctly. Idempotent-ish: remove a stale entry first.
-    const server = { command: "crw-mcp", ...(hasEnv ? { env } : {}) };
+    const server = { command: MCP_CMD, args: MCP_ARGS, ...(hasEnv ? { env } : {}) };
     spawnSync("claude", ["mcp", "remove", "--scope", "user", "crw"], { stdio: "ignore" });
     const r = spawnSync(
       "claude",
@@ -101,7 +110,8 @@ function installMcp(agent, env) {
     cfg.mcpServers = cfg.mcpServers || {};
     cfg.mcpServers.crw = {
       ...(m.withType ? { type: "stdio" } : {}),
-      command: "crw-mcp",
+      command: MCP_CMD,
+      args: MCP_ARGS,
       ...(hasEnv ? { env } : {}),
     };
     writeJson(file, cfg);
@@ -115,7 +125,7 @@ function installMcp(agent, env) {
     cfg.mcp = cfg.mcp || {};
     cfg.mcp.crw = {
       type: "local",
-      command: ["crw-mcp"],
+      command: [MCP_CMD, ...MCP_ARGS],
       ...(hasEnv ? { environment: env } : {}),
     };
     writeJson(file, cfg);
@@ -137,7 +147,7 @@ function installMcp(agent, env) {
       ? "\n[mcp_servers.crw.env]\n" +
         Object.entries(env).map(([k, v]) => `${k} = "${v}"`).join("\n") + "\n"
       : "";
-    const block = `\n[mcp_servers.crw]\ncommand = "crw-mcp"\n${envLines}`;
+    const block = `\n[mcp_servers.crw]\ncommand = "${MCP_CMD}"\nargs = [${MCP_ARGS.map((a) => `"${a}"`).join(", ")}]\n${envLines}`;
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.appendFileSync(file, (toml && !toml.endsWith("\n") ? "\n" : "") + block, "utf-8");
     return `MCP → ${m.file}`;


### PR DESCRIPTION
Every install path can now connect to fastCRW Cloud in a single command with the API key baked in — parity with `npx crw-mcp install --api-key`.

## Changes
- **`crw setup --api-key <key>`** (new): non-interactive cloud connect. Validates the key, writes `~/.config/crw/config.toml` pointed at `api.fastcrw.com`, skips every prompt. Enables `brew`/`cargo` + `crw setup --api-key crw_live_…` as a one-liner.
- **install.sh**: `curl … | CRW_API_KEY=crw_live_… sh` now runs the non-interactive cloud setup (no `/dev/tty` needed, works in CI).
- **fix(cli)**: key validation hit `/v1/account` (404, no such route) — now uses `/v1/account/balance` (the real endpoint) and reads `totalCreditsAvailable`. Also repairs the existing interactive `crw setup`, which was silently missing validation the same way.
- **fix(mcp)**: `crw-mcp install` wrote a bare `crw-mcp` command; `npx crw-mcp install` leaves no such binary on PATH, so a fresh install produced a config the agent couldn't launch. Now spawns via `npx -y crw-mcp` (self-resolving, matches the MCP-config docs).

## Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — all green
- Added unit test: `build_user_config` wires cloud (api.fastcrw.com + key, no LLM leg)
- Manual: `crw setup --api-key <bad>` → clean "Invalid API key", no config written; `--api-key`/`--local` conflict enforced
- Manual: `crw-mcp install` into a sandbox HOME writes correct `npx -y crw-mcp` + cloud env configs for Claude Code / Cursor / Codex / Gemini / OpenCode; MCP handshake against the spawned server succeeds in proxy mode