### PR TITLE
feat(server): reserve interactive capacity from batch + plan-scaled width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "base64",
  "clap",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/config.default.toml
+++ b/config.default.toml
@@ -69,6 +69,21 @@ user_agent = "CRW/0.0.1"
 default_max_depth = 2
 default_max_pages = 100
 job_ttl_secs = 3600
+#
+# Interactive-vs-batch traffic isolation (reserved lanes). Single `/scrape`
+# requests are "interactive"; batch-scrape/crawl/extract/monitor jobs are
+# "batch". At every shared chokepoint (per-host limiter, Chrome render pool,
+# HTML extract pool, PDF parse pool, LLM calls) a slice is RESERVED for
+# interactive so a heavy batch can never starve interactive latency. Each
+# reserve knob: absent = ~1/4 of that pool (scaled to the actual size); a
+# number = that many slots; 0 = disable the reservation for that lane. Defaults
+# are safe; tune only if you measure contention.
+#
+# per_host_max_concurrent = 1          # batch in-flight cap per host (politeness)
+# per_host_interactive_reserve = 1     # extra dedicated per-host slots for interactive
+# max_batch_concurrency = 100          # ceiling on one batch job's outer URL fan-out
+# max_aggregate_batch_pipelines = 0    # 0 = UNBOUNDED total batch pipelines (NOT a lock);
+#                                      # set >0 to cap process-wide in-flight batch URLs
 # Proxy support — route crawler requests through an HTTP or SOCKS5 proxy.
 # Useful for bypassing IP-based rate limiting on sites like Reddit, LinkedIn, etc.
 #
@@ -121,6 +136,8 @@ job_ttl_secs = 3600
 [extraction]
 default_format = "markdown"
 only_main_content = true
+# max_concurrent_extracts = 8         # process-wide HTML→markdown parse cap (default ~2/3 cores)
+# reserved_interactive_extracts = 2   # extract slots reserved for interactive (absent = ~1/4; 0 disables)
 
 # Per-domain CSS selector overrides applied before readability narrowing.
 # User-supplied request `selector` still wins over these defaults. Map key is
@@ -175,7 +192,8 @@ always_run = false
 # model = "claude-sonnet-4-20250514"
 # max_tokens = 4096
 # base_url = "https://custom-endpoint.example.com"  # optional, for OpenAI-compatible APIs
-# max_concurrency = 4           # bound for per-result search-summary fan-out
+# max_concurrency = 4           # bound for LLM-call fan-out (now enforced; was previously unbounded)
+# reserved_interactive_llm = 1  # LLM-call slots reserved for interactive (absent = ~1/4; 0 disables)
 # max_html_bytes = 100000       # truncate content past this before sending
 # require_byok_header = ""      # SaaS-only: header name that must be set on LLM-touching requests
 #
@@ -257,6 +275,8 @@ upload_concurrency = 4
 # crawl, batch, upload). Primary memory/CPU-DoS guard — a malicious PDF can
 # decompress far beyond its wire size, so bound how many parse at once.
 max_concurrent_parses = 4
+# reserved_interactive_parses = 1   # PDF parse slots reserved for interactive
+#                                   # scrapes (absent = ~1/4 of the pool; 0 disables)
 # Wall-clock timeout (ms) per PDF parse. A document exceeding this returns a
 # pdf_timeout error instead of pinning a worker. 0 disables.
 parse_timeout_ms = 30000

--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -183,7 +183,14 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
     };
 
     let crawl_handle = tokio::spawn(async move {
-        run_crawl(crawl_opts).await;
+        // A crawl is `Batch` traffic (multi-page). Scoped inside the spawned task
+        // (task-locals don't cross `tokio::spawn`) so its fetches/extracts use the
+        // batch lanes rather than the interactive reserve.
+        crw_core::REQUEST_CLASS
+            .scope(crw_core::ScrapeClass::Batch, async {
+                run_crawl(crawl_opts).await;
+            })
+            .await;
     });
 
     // Stream results as they come in

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -64,6 +64,13 @@ pub struct DocumentConfig {
     /// primary memory-DoS guard. Independent of `upload_concurrency` (which
     /// only bounds upload body buffering).
     pub max_concurrent_parses: usize,
+    /// Of `max_concurrent_parses`, how many parse slots are RESERVED for
+    /// interactive (single-scrape) traffic — a batch/crawl job can never hold
+    /// them, so an interactive PDF scrape isn't starved behind a batch that
+    /// fills the pool. Clamped so the batch lane keeps ≥1 slot. `Some(0)`
+    /// disables the reservation. `None` (absent) → ~1/4 of the ACTUAL configured
+    /// `max_concurrent_parses`, floored at 1.
+    pub reserved_interactive_parses: Option<usize>,
     /// Wall-clock timeout (ms) for a single PDF parse. A parse exceeding this
     /// returns a timeout error to the caller; protects against pathological
     /// documents that spin the parser. `0` disables the timeout.
@@ -99,6 +106,7 @@ impl Default for DocumentConfig {
             max_upload_bytes: 52_428_800, // 50 MiB
             upload_concurrency: 4,
             max_concurrent_parses: 4,
+            reserved_interactive_parses: None,
             parse_timeout_ms: 30_000,
             max_decompressed_bytes: 104_857_600, // 100 MiB
             sandbox: false,
@@ -1192,6 +1200,16 @@ pub struct CrawlerConfig {
     /// config when scraping their own infrastructure.
     #[serde(default = "default_per_host_max_concurrent")]
     pub per_host_max_concurrent: u32,
+    /// Extra per-host in-flight slots RESERVED for interactive (single-scrape)
+    /// traffic, on top of `per_host_max_concurrent`. Batch/crawl stay bounded to
+    /// `per_host_max_concurrent` per host (target politeness), while an
+    /// interactive hit gets its own dedicated slot so it isn't queued behind a
+    /// batch crawling that host. Total in-flight per host is therefore bounded by
+    /// `per_host_max_concurrent + this` (the target is still protected — no
+    /// unbounded hammering). `0` = interactive shares the batch slots (legacy
+    /// single-flight). Default 1.
+    #[serde(default = "default_per_host_interactive_reserve")]
+    pub per_host_interactive_reserve: u32,
     /// Maximum number of URLs accepted by a single `/v2/batch/scrape`
     /// request (sanity cap; plan-level caps live in the SaaS). Default 10000.
     #[serde(default = "default_max_batch_urls")]
@@ -1201,9 +1219,32 @@ pub struct CrawlerConfig {
     /// Default 50.
     #[serde(default = "default_max_extract_urls")]
     pub max_extract_urls: usize,
+    /// Ceiling on a single batch job's OUTER pipeline width (`for_each_concurrent`
+    /// = how many URL tasks are alive at once). A per-request `maxConcurrency`
+    /// (injected by the SaaS per plan tier) is clamped to `[1, this]`; absent →
+    /// `max_concurrency`. This is the OUTER width — it may exceed the inner
+    /// reserved lanes (extract/render/…), extra URL tasks just queue there.
+    /// Distinct from `max_batch_urls` (submit-size cap). Default 100.
+    #[serde(default = "default_max_batch_concurrency")]
+    pub max_batch_concurrency: usize,
+    /// Process-wide cap on the TOTAL number of in-flight `/v2/batch/scrape`
+    /// URL-pipelines across all batch-scrape jobs, so `N jobs × width` can't
+    /// explode into memory / socket pressure. (Batch scrape is the only wide
+    /// fan-out; crawl is BFS-sequential and `/v2/extract` is one URL at a time,
+    /// both bounded by the crawl-job cap.) Each live pipeline takes one permit
+    /// before it fetches. **`0` (or absent) means UNBOUNDED** — NOT a lock. Do NOT set `0`
+    /// to "disable by zero" expecting a small number; `0` skips the cap entirely.
+    /// This is the opposite convention from the reserved-lane `reserved_* = 0`
+    /// (which means "no reservation"). Default 0 (unbounded).
+    #[serde(default)]
+    pub max_aggregate_batch_pipelines: usize,
 }
 
 fn default_per_host_max_concurrent() -> u32 {
+    1
+}
+
+fn default_per_host_interactive_reserve() -> u32 {
     1
 }
 
@@ -1223,8 +1264,11 @@ impl Default for CrawlerConfig {
             stealth: StealthConfig::default(),
             per_host_min_interval_ms: 0,
             per_host_max_concurrent: default_per_host_max_concurrent(),
+            per_host_interactive_reserve: default_per_host_interactive_reserve(),
             max_batch_urls: default_max_batch_urls(),
             max_extract_urls: default_max_extract_urls(),
+            max_batch_concurrency: default_max_batch_concurrency(),
+            max_aggregate_batch_pipelines: 0,
         }
     }
 }
@@ -1235,6 +1279,10 @@ fn default_max_batch_urls() -> usize {
 
 fn default_max_extract_urls() -> usize {
     50
+}
+
+fn default_max_batch_concurrency() -> usize {
+    100
 }
 
 fn default_concurrency() -> usize {
@@ -1294,6 +1342,15 @@ pub struct ExtractionConfig {
     /// 12-vCPU host), floored at 2.
     #[serde(default = "default_max_concurrent_extracts")]
     pub max_concurrent_extracts: usize,
+    /// Of `max_concurrent_extracts`, how many extract slots are RESERVED for
+    /// interactive (single-scrape) traffic — a batch/crawl job can never hold
+    /// them, so an interactive scrape isn't starved behind a batch that fills
+    /// the pool. Clamped so the batch lane keeps ≥1 slot. `Some(0)` disables the
+    /// reservation (single FIFO lane, legacy behaviour). `None` (absent) →
+    /// ~1/4 of the ACTUAL configured pool, floored at 1 (so a custom
+    /// `max_concurrent_extracts` scales the reserve with it).
+    #[serde(default)]
+    pub reserved_interactive_extracts: Option<usize>,
 }
 
 fn default_http_retry_threshold() -> usize {
@@ -1322,8 +1379,16 @@ impl Default for ExtractionConfig {
             http_retry_threshold_bytes: default_http_retry_threshold(),
             lightpanda_retry_threshold_bytes: default_lightpanda_retry_threshold(),
             max_concurrent_extracts: default_max_concurrent_extracts(),
+            reserved_interactive_extracts: None,
         }
     }
+}
+
+/// Resolve an optional interactive reserve against the actual pool `total`:
+/// `None` → ~1/4 of `total` floored at 1; `Some(n)` → `n` (0 disables). Kept
+/// below `total` by the [`crate::ReservedSemaphore`] constructor.
+pub fn resolve_interactive_reserve(reserve: Option<usize>, total: usize) -> usize {
+    reserve.unwrap_or_else(|| (total / 4).max(1))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1379,6 +1444,14 @@ pub struct LlmConfig {
     /// Bounded to avoid hitting provider rate limits.
     #[serde(default = "default_llm_max_concurrency")]
     pub max_concurrency: usize,
+    /// Of `max_concurrency`, how many LLM-call slots are RESERVED for interactive
+    /// (single-scrape) traffic — a batch/crawl job can never hold them, so an
+    /// interactive `formats:["json"]`/summary request isn't starved behind a
+    /// batch's LLM fan-out. Clamped so the batch lane keeps ≥1 slot. `Some(0)`
+    /// disables the reservation. `None` (absent) → `max(1, max_concurrency/4)`
+    /// of the ACTUAL configured `max_concurrency`.
+    #[serde(default)]
+    pub reserved_interactive_llm: Option<usize>,
     /// Byte cap on content sent to the LLM in a single call. Content beyond
     /// the cap is truncated on a UTF-8 char boundary.
     #[serde(default = "default_llm_max_html_bytes")]
@@ -1413,6 +1486,7 @@ impl Default for LlmConfig {
             max_tokens: default_llm_max_tokens(),
             azure_api_version: None,
             max_concurrency: default_llm_max_concurrency(),
+            reserved_interactive_llm: None,
             max_html_bytes: default_llm_max_html_bytes(),
             require_byok_header: None,
             temperature: None,

--- a/crates/crw-core/src/lib.rs
+++ b/crates/crw-core/src/lib.rs
@@ -24,6 +24,8 @@ pub mod mcp;
 pub mod metrics;
 pub mod proxy;
 pub mod research_types;
+pub mod reserved_sem;
+pub mod scrape_class;
 pub mod types;
 pub mod url_safety;
 
@@ -31,3 +33,5 @@ pub use config::AppConfig;
 pub use deadline::Deadline;
 pub use error::{CrwError, CrwResult};
 pub use proxy::{ProxyEntry, ProxyRotation, ProxyRotator};
+pub use reserved_sem::{BatchGate, LanePermit, ReservedSemaphore};
+pub use scrape_class::{REQUEST_CLASS, ScrapeClass, current_scrape_class};

--- a/crates/crw-core/src/metrics.rs
+++ b/crates/crw-core/src/metrics.rs
@@ -78,6 +78,13 @@ pub struct Metrics {
     pub chrome_pool_idle: IntGauge,
     /// Current `CheckedOut` slot count.
     pub chrome_pool_inflight: IntGauge,
+    /// Wait time to acquire a reserved concurrency lane, by `lane`
+    /// ∈ {extract, pdf, llm, host, render} and `class` ∈ {interactive, batch}.
+    /// The proof metric for interactive isolation: interactive p99 should stay
+    /// flat while batch saturates a lane.
+    pub reserved_lane_wait_seconds: HistogramVec,
+    /// Current in-flight `/v2/batch/scrape` URL-pipelines (aggregate cap gauge).
+    pub batch_pipelines_inflight: IntGauge,
     /// Time spent in `pool.acquire()` (waiting for a permit + slot creation).
     pub chrome_pool_acquire_seconds: Histogram,
     /// Acquire-path accounting.
@@ -334,6 +341,22 @@ impl Metrics {
             registry
         )
         .unwrap();
+        let reserved_lane_wait_seconds = register_histogram_vec_with_registry!(
+            histogram_opts!(
+                "crw_reserved_lane_wait_seconds",
+                "Wait to acquire a reserved concurrency lane, by lane and class",
+                lat_buckets.clone()
+            ),
+            &["lane", "class"],
+            registry
+        )
+        .unwrap();
+        let batch_pipelines_inflight = register_int_gauge_with_registry!(
+            "crw_batch_pipelines_inflight",
+            "Current in-flight /v2/batch/scrape URL-pipelines",
+            registry
+        )
+        .unwrap();
         let chrome_pool_acquire_seconds = register_histogram_with_registry!(
             histogram_opts!(
                 "crw_chrome_pool_acquire_seconds",
@@ -512,6 +535,8 @@ impl Metrics {
             chrome_pool_size,
             chrome_pool_idle,
             chrome_pool_inflight,
+            reserved_lane_wait_seconds,
+            batch_pipelines_inflight,
             chrome_pool_acquire_seconds,
             chrome_pool_acquires_total,
             chrome_pool_recycle_seconds,

--- a/crates/crw-core/src/reserved_sem.rs
+++ b/crates/crw-core/src/reserved_sem.rs
@@ -1,0 +1,302 @@
+//! A two-lane reserved semaphore: bounds total concurrency while guaranteeing
+//! [`ScrapeClass::Interactive`] traffic a protected slice that
+//! [`ScrapeClass::Batch`] can never hold.
+//!
+//! Shape (Postgres `superuser_reserved_connections` model): one `shared`
+//! semaphore of `total` permits that EVERY caller acquires, plus a `batch_gate`
+//! of `total - reserved` that ONLY batch acquires first. Because batch can hold
+//! at most `total - reserved` `shared` permits, at least `reserved` are always
+//! reachable by interactive. This is a *static capacity* guarantee, not a
+//! priority queue — tokio's `Semaphore` is FIFO, so under interactive's own
+//! saturation a new interactive waiter still queues; the guarantee is that
+//! batch can never be the reason interactive has zero capacity.
+//!
+//! Asymmetric by design: interactive is protected from batch, not vice-versa.
+//! `batch_gate` is floored at 1 so batch degrades but never deadlocks.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::scrape_class::ScrapeClass;
+
+/// Record a reserved-lane acquire wait into `crw_reserved_lane_wait_seconds`.
+fn record_lane_wait(lane: &str, class: ScrapeClass, waited: Duration) {
+    let class = match class {
+        ScrapeClass::Interactive => "interactive",
+        ScrapeClass::Batch => "batch",
+    };
+    crate::metrics::metrics()
+        .reserved_lane_wait_seconds
+        .with_label_values(&[lane, class])
+        .observe(waited.as_secs_f64());
+}
+
+/// A permit held by a batch task: both the gate and the shared permit, dropped
+/// as a unit. Field order = drop order (Rust drops fields in declaration
+/// order), so `shared` releases before `gate` — matching the stated intent.
+/// (Drop order is cosmetic here: `Semaphore::drop` is synchronous with no
+/// `.await` between, so no waiter observes a half-released state. The named
+/// struct just keeps a future refactor from acquiring `shared` without the
+/// gate.)
+#[derive(Debug)]
+pub struct BatchPermit {
+    #[allow(dead_code)]
+    shared: OwnedSemaphorePermit,
+    #[allow(dead_code)]
+    gate: OwnedSemaphorePermit,
+}
+
+/// An acquired permit from a [`ReservedSemaphore`], regardless of class.
+#[derive(Debug)]
+pub enum LanePermit {
+    /// Interactive: holds one `shared` permit.
+    Interactive(#[allow(dead_code)] OwnedSemaphorePermit),
+    /// Batch: holds a gate permit + a shared permit.
+    Batch(#[allow(dead_code)] BatchPermit),
+}
+
+/// Two-lane reserved semaphore. See module docs.
+#[derive(Debug, Clone)]
+pub struct ReservedSemaphore {
+    shared: Arc<Semaphore>,
+    batch_gate: Arc<Semaphore>,
+    /// Lane name for the `crw_reserved_lane_wait_seconds{lane}` metric
+    /// (e.g. "extract", "pdf", "llm", "host").
+    name: &'static str,
+}
+
+impl ReservedSemaphore {
+    /// Build a reserved semaphore with `total` permits, reserving `reserved`
+    /// for interactive. `name` labels the wait metric.
+    ///
+    /// - `total` is floored at 1 (a zero-capacity pool would deadlock everyone).
+    /// - `reserved` is clamped to `total - 1` so `batch_gate >= 1` always: batch
+    ///   degrades under a large reserve but never deadlocks, even at
+    ///   `total == 2, reserved == 1` or a misconfigured `reserved >= total`.
+    /// - `reserved == 0` makes `batch_gate == total`, i.e. the two lanes
+    ///   collapse to a single FIFO pool identical to today's behaviour — the
+    ///   documented per-lane disable / rollback value.
+    pub fn new(total: usize, reserved: usize, name: &'static str) -> Self {
+        let total = total.max(1);
+        let reserved = reserved.min(total - 1);
+        Self {
+            shared: Arc::new(Semaphore::new(total)),
+            batch_gate: Arc::new(Semaphore::new(total - reserved)),
+            name,
+        }
+    }
+
+    /// Acquire a permit for `class`. Interactive takes only a `shared` permit;
+    /// batch takes a `batch_gate` permit first (bounding batch's share of
+    /// `shared`), then a `shared` permit. Held until the returned [`LanePermit`]
+    /// is dropped. Records the wait into `crw_reserved_lane_wait_seconds`.
+    ///
+    /// Read `class` on the async side BEFORE any `spawn_blocking` — the
+    /// [`crate::scrape_class::REQUEST_CLASS`] task-local does not cross that
+    /// boundary.
+    pub async fn acquire(&self, class: ScrapeClass) -> LanePermit {
+        let t0 = std::time::Instant::now();
+        let permit = match class {
+            ScrapeClass::Interactive => {
+                let shared = Semaphore::acquire_owned(self.shared.clone())
+                    .await
+                    .expect("shared reserved-lane semaphore never closed");
+                LanePermit::Interactive(shared)
+            }
+            ScrapeClass::Batch => {
+                let gate = Semaphore::acquire_owned(self.batch_gate.clone())
+                    .await
+                    .expect("batch_gate semaphore never closed");
+                let shared = Semaphore::acquire_owned(self.shared.clone())
+                    .await
+                    .expect("shared reserved-lane semaphore never closed");
+                LanePermit::Batch(BatchPermit { shared, gate })
+            }
+        };
+        record_lane_wait(self.name, class, t0.elapsed());
+        permit
+    }
+
+    /// Permits currently available in the shared pool (for metrics).
+    pub fn available(&self) -> usize {
+        self.shared.available_permits()
+    }
+
+    /// Permits currently available in the batch gate (for metrics).
+    pub fn batch_available(&self) -> usize {
+        self.batch_gate.available_permits()
+    }
+}
+
+/// A reserved lane placed IN FRONT of a pool that already owns its own
+/// concurrency semaphore (the Chrome render pools). Rather than replace the
+/// pool's semaphore (which may be a checkout source-of-truth), a batch caller
+/// first takes a `gate` permit sized `total - reserved`, then proceeds into the
+/// existing pool acquire; an interactive caller skips the gate. Because batch
+/// holds at most `total - reserved` gate permits and each gate holder occupies
+/// at most one pool slot, interactive always finds ≥`reserved` pool slots free —
+/// the same guarantee as [`ReservedSemaphore`] without touching the pool's
+/// internals. The gate permit must be held for the whole fetch (bind it
+/// alongside the pool guard).
+#[derive(Debug, Clone)]
+pub struct BatchGate {
+    gate: Arc<Semaphore>,
+    /// Lane name for the wait metric (e.g. "render").
+    name: &'static str,
+}
+
+impl BatchGate {
+    /// Gate sized `total - reserved`, floored at 1 so batch never deadlocks.
+    /// `reserved == 0` makes the gate == `total` (no reservation). `name` labels
+    /// the wait metric.
+    pub fn new(total: usize, reserved: usize, name: &'static str) -> Self {
+        let total = total.max(1);
+        let reserved = reserved.min(total - 1);
+        Self {
+            gate: Arc::new(Semaphore::new((total - reserved).max(1))),
+            name,
+        }
+    }
+
+    /// Batch takes a gate permit (bounding batch's share of the downstream
+    /// pool); interactive returns `None` and goes straight to the pool. Read
+    /// `class` on the async side before any `spawn_blocking`. Records the batch
+    /// wait into `crw_reserved_lane_wait_seconds`.
+    pub async fn enter(&self, class: ScrapeClass) -> Option<OwnedSemaphorePermit> {
+        match class {
+            ScrapeClass::Interactive => None,
+            ScrapeClass::Batch => {
+                let t0 = std::time::Instant::now();
+                let permit = Semaphore::acquire_owned(self.gate.clone())
+                    .await
+                    .expect("batch render gate never closed");
+                record_lane_wait(self.name, class, t0.elapsed());
+                Some(permit)
+            }
+        }
+    }
+
+    /// Gate permits currently available (for metrics).
+    pub fn available(&self) -> usize {
+        self.gate.available_permits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_gate_floored_at_one() {
+        // reserved >= total must never zero the batch gate (deadlock guard).
+        for (total, reserved) in [(2, 1), (2, 5), (1, 0), (1, 9), (4, 4)] {
+            let rs = ReservedSemaphore::new(total, reserved, "test");
+            assert!(
+                rs.batch_available() >= 1,
+                "batch_gate must be >=1 for total={total} reserved={reserved}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_zero_is_single_pool() {
+        // reserved=0 => both lanes see the full total (legacy FIFO behaviour).
+        let rs = ReservedSemaphore::new(8, 0, "test");
+        assert_eq!(rs.available(), 8);
+        assert_eq!(rs.batch_available(), 8);
+    }
+
+    #[tokio::test]
+    async fn interactive_reserve_survives_batch_saturation() {
+        // total=4, reserve 1 => batch_gate=3. Saturate the batch lane with 3
+        // held batch permits; an interactive acquire must still succeed.
+        let rs = ReservedSemaphore::new(4, 1, "test");
+        let mut held = Vec::new();
+        for _ in 0..3 {
+            held.push(rs.acquire(ScrapeClass::Batch).await);
+        }
+        // batch_gate now exhausted; a 4th batch acquire would block.
+        assert_eq!(rs.batch_available(), 0);
+        // Interactive still gets in immediately (the reserved shared permit).
+        let interactive = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            rs.acquire(ScrapeClass::Interactive),
+        )
+        .await;
+        assert!(
+            interactive.is_ok(),
+            "interactive must acquire while batch_gate is saturated"
+        );
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn batch_gate_reserves_pool_slots_for_interactive() {
+        // total=4, reserve 1 => gate=3. Batch can hold at most 3 gate permits,
+        // so at least 1 downstream pool slot is always free for interactive.
+        let g = BatchGate::new(4, 1, "test");
+        let mut held = Vec::new();
+        for _ in 0..3 {
+            held.push(g.enter(ScrapeClass::Batch).await);
+        }
+        assert_eq!(g.available(), 0, "gate exhausted after 3 batch holders");
+        // Interactive never touches the gate.
+        assert!(g.enter(ScrapeClass::Interactive).await.is_none());
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn batch_gate_floored_never_zero() {
+        // pool_size=1 => gate floored at 1 (batch not deadlocked).
+        let g = BatchGate::new(1, 1, "test");
+        assert!(g.available() >= 1);
+    }
+
+    #[tokio::test]
+    async fn task_local_class_drives_lane_end_to_end() {
+        // Proves the full mechanism the real lanes use: REQUEST_CLASS scope →
+        // current_scrape_class() → correct lane. total=2, reserve 1 => batch_gate=1.
+        let rs = ReservedSemaphore::new(2, 1, "test");
+        // A batch-scoped acquire takes the batch lane and exhausts batch_gate.
+        let _batch = crate::scrape_class::REQUEST_CLASS
+            .scope(ScrapeClass::Batch, async {
+                rs.acquire(crate::current_scrape_class()).await
+            })
+            .await;
+        assert_eq!(rs.batch_available(), 0, "batch lane exhausted");
+        // An interactive-scoped acquire takes the interactive lane and gets its
+        // reserved slot immediately despite the batch lane being full.
+        let got = crate::scrape_class::REQUEST_CLASS
+            .scope(ScrapeClass::Interactive, async {
+                tokio::time::timeout(
+                    std::time::Duration::from_millis(200),
+                    rs.acquire(crate::current_scrape_class()),
+                )
+                .await
+            })
+            .await;
+        assert!(
+            got.is_ok(),
+            "interactive lane must not be blocked by a saturated batch lane"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_blocked_when_gate_full_then_freed() {
+        // A queued batch waiter proceeds once a held batch permit is released.
+        let rs = ReservedSemaphore::new(2, 1, "test"); // batch_gate = 1
+        let first = rs.acquire(ScrapeClass::Batch).await;
+        let rs2 = rs.clone();
+        let waiter = tokio::spawn(async move { rs2.acquire(ScrapeClass::Batch).await });
+        // Give the waiter a chance to block.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!waiter.is_finished(), "second batch acquire should block");
+        drop(first);
+        let _second = tokio::time::timeout(std::time::Duration::from_millis(200), waiter)
+            .await
+            .expect("waiter should finish after release")
+            .expect("join ok");
+    }
+}

--- a/crates/crw-core/src/scrape_class.rs
+++ b/crates/crw-core/src/scrape_class.rs
@@ -1,0 +1,53 @@
+//! Request traffic class — `Interactive` (single `/scrape`) vs `Batch`
+//! (batch-scrape / crawl jobs) — carried via a task-local so every shared
+//! concurrency chokepoint (per-host limiter, render pool, extract pool, PDF
+//! parse pool, LLM calls) can reserve a protected lane for interactive traffic
+//! without threading a parameter through dozens of signatures.
+//!
+//! Lives in `crw-core` (not `crw-renderer`) deliberately: `crw-renderer`
+//! depends on `crw-extract`, so an LLM-lane read of a `crw-renderer`-owned
+//! task-local would form a dependency cycle. `crw-core` is a dependency of all
+//! three, so every lane can read it.
+//!
+//! The class is set by the JOB ENTRY POINT, not the wire request — there is no
+//! deserialized field a client could set to jump the interactive reserve. A
+//! single scrape leaves the task-local unscoped and reads back `Interactive`
+//! via [`current_scrape_class`]'s default; batch/crawl jobs wrap their work in
+//! `REQUEST_CLASS.scope(ScrapeClass::Batch, …)` INSIDE the spawned task (a
+//! handler-level scope would be lost across the job's `tokio::spawn`).
+
+/// Traffic class for a scrape. `Interactive` is the protected default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ScrapeClass {
+    /// A single interactive `/scrape` request. Gets the reserved lane at every
+    /// shared chokepoint.
+    #[default]
+    Interactive,
+    /// A URL inside a batch-scrape or crawl job. Uses the batch lane, which can
+    /// never consume the interactive reserve.
+    Batch,
+}
+
+impl ScrapeClass {
+    /// `true` for [`ScrapeClass::Batch`].
+    pub fn is_batch(self) -> bool {
+        matches!(self, ScrapeClass::Batch)
+    }
+}
+
+tokio::task_local! {
+    /// The current request's traffic class. Scoped by batch/crawl job entry
+    /// points; unscoped for single scrapes (reads back `Interactive`). Read via
+    /// [`current_scrape_class`] — do NOT `try_with` it inside a `spawn_blocking`
+    /// closure, task-locals do not cross that boundary; read it on the async
+    /// side before spawning the blocking work.
+    pub static REQUEST_CLASS: ScrapeClass;
+}
+
+/// The current task's [`ScrapeClass`], or [`ScrapeClass::Interactive`] when the
+/// task-local is not in scope (every direct single-scrape caller). MUST be
+/// called on the async side, before any `spawn_blocking` — the task-local is
+/// not visible inside a blocking closure.
+pub fn current_scrape_class() -> ScrapeClass {
+    REQUEST_CLASS.try_with(|c| *c).unwrap_or_default()
+}

--- a/crates/crw-crawl/src/extract_pool.rs
+++ b/crates/crw-crawl/src/extract_pool.rs
@@ -10,18 +10,19 @@
 //! (`worker_threads`/`max_blocking_threads` at their defaults) — this semaphore
 //! is the real bound. Mirrors the PDF parse gate in [`crate::pdf`].
 
-use std::sync::{Arc, OnceLock};
-
-use tokio::sync::Semaphore;
+use std::sync::OnceLock;
 
 use crw_core::error::{CrwError, CrwResult};
 use crw_core::types::ScrapeData;
+use crw_core::{ReservedSemaphore, current_scrape_class};
 use crw_extract::OwnedExtractInput;
 
-/// Process-wide cap on concurrent HTML extractions. Installed once at startup
-/// via [`configure_extract_limit`]; surfaces that never configure (CLI, tests)
-/// fall back to [`default_extract_limit`].
-static EXTRACT_SEM: OnceLock<Arc<Semaphore>> = OnceLock::new();
+/// Process-wide reserved cap on concurrent HTML extractions. Installed once at
+/// startup via [`configure_extract_limit`]; surfaces that never configure (CLI,
+/// tests) fall back to [`default_extract_limit`]. The reserve guarantees
+/// interactive single-scrape extractions a slice of CPU permits that batch/crawl
+/// extractions can never hold (see [`ReservedSemaphore`]).
+static EXTRACT_SEM: OnceLock<ReservedSemaphore> = OnceLock::new();
 
 /// Fallback bound when [`configure_extract_limit`] is never called: ~2/3 of the
 /// available cores, floored at 2. Leaves headroom for the async reactor and
@@ -33,33 +34,41 @@ fn default_extract_limit() -> usize {
     (cpus * 2 / 3).max(2)
 }
 
-/// Install the concurrent-extraction cap. Idempotent — the first call wins
-/// (subsequent calls are ignored), so call it once at boot. Mirrors
-/// [`crate::pdf::configure_limits`].
-pub fn configure_extract_limit(n: usize) {
-    let _ = EXTRACT_SEM.set(Arc::new(Semaphore::new(n.max(1))));
+/// Default interactive reserve: a quarter of the pool, floored at 1. `0`
+/// disables the reserve (single-lane FIFO, legacy behaviour).
+fn default_reserve(total: usize) -> usize {
+    (total / 4).max(1)
 }
 
-fn sem() -> &'static Arc<Semaphore> {
-    EXTRACT_SEM.get_or_init(|| Arc::new(Semaphore::new(default_extract_limit())))
+/// Install the concurrent-extraction cap with `reserved` permits held for
+/// interactive traffic. Idempotent — the first call wins (subsequent calls are
+/// ignored), so call it once at boot. Mirrors [`crate::pdf::configure_limits`].
+pub fn configure_extract_limit(total: usize, reserved: usize) {
+    let _ = EXTRACT_SEM.set(ReservedSemaphore::new(total, reserved, "extract"));
+}
+
+fn sem() -> &'static ReservedSemaphore {
+    EXTRACT_SEM.get_or_init(|| {
+        let total = default_extract_limit();
+        ReservedSemaphore::new(total, default_reserve(total), "extract")
+    })
 }
 
 /// Run one HTML → markdown extraction off the async reactor.
 ///
-/// Acquires a concurrency permit (held for the whole CPU job, even if the
-/// caller is dropped early), then runs [`crw_extract::extract`] on the blocking
-/// pool. This keeps the reactor responsive and bounds peak CPU parallelism to
-/// the configured limit so a burst of concurrent scrapes can't stall the
-/// runtime.
+/// Reads the traffic class and acquires the matching reserved lane BEFORE
+/// spawning — the [`crw_core::REQUEST_CLASS`] task-local is not visible inside
+/// the blocking closure, so lane selection must happen on the async side. The
+/// permit is moved into the closure and held for the whole CPU job.
+///
+/// `ponytail:` the parse has no internal deadline — a caller-side timeout (see
+/// the callers) unblocks the awaiting task but does NOT cancel this
+/// `spawn_blocking`, so a pathological document holds its permit until the parse
+/// returns naturally. Ceiling = worst-case single-document parse time; upgrade
+/// path = a size/complexity pre-check before spawn_blocking, or a
+/// cancellable/process-isolated parser.
 pub async fn extract_offloaded(input: OwnedExtractInput) -> CrwResult<ScrapeData> {
-    // Acquire BEFORE spawning and move the permit into the closure so it is held
-    // for the full duration of the blocking parse — keeping the semaphore an
-    // honest bound on real concurrent CPU work.
-    let permit = sem()
-        .clone()
-        .acquire_owned()
-        .await
-        .map_err(|_| CrwError::ExtractionError("extract semaphore closed".to_string()))?;
+    let permit = sem().acquire(current_scrape_class()).await;
 
     tokio::task::spawn_blocking(move || {
         let _permit = permit;

--- a/crates/crw-crawl/src/pdf.rs
+++ b/crates/crw-crawl/src/pdf.rs
@@ -8,10 +8,8 @@
 //! compile, and running the parse on an async worker would stall the runtime
 //! for large documents.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use std::time::Duration;
-
-use tokio::sync::Semaphore;
 
 use crw_core::config::{DocumentConfig, LlmConfig};
 use crw_core::error::{CrwError, CrwResult};
@@ -24,8 +22,10 @@ use crw_extract::pdf::{PdfError, PdfExtract};
 /// batch, upload). Configured once at server startup via [`configure_limits`];
 /// callers that never configure (CLI, tests) get the safe defaults below.
 struct ParseLimits {
-    /// Caps concurrent parses → bounds peak CPU and decompressed memory.
-    sem: Arc<Semaphore>,
+    /// Caps concurrent parses → bounds peak CPU and decompressed memory. A
+    /// reserved lane keeps interactive PDF scrapes from queuing behind a batch
+    /// that fills every parse slot (same shape as the extract pool).
+    sem: crw_core::ReservedSemaphore,
     /// Per-parse wall-clock budget (`None` = disabled).
     timeout: Option<Duration>,
     /// Hard server-side page cap (0 = unlimited), combined with any per-request
@@ -45,7 +45,14 @@ static LIMITS: OnceLock<ParseLimits> = OnceLock::new();
 /// the first call wins (subsequent calls are ignored), so call it once at boot.
 pub fn configure_limits(cfg: &DocumentConfig) {
     let _ = LIMITS.set(ParseLimits {
-        sem: Arc::new(Semaphore::new(cfg.max_concurrent_parses.max(1))),
+        sem: crw_core::ReservedSemaphore::new(
+            cfg.max_concurrent_parses.max(1),
+            crw_core::config::resolve_interactive_reserve(
+                cfg.reserved_interactive_parses,
+                cfg.max_concurrent_parses.max(1),
+            ),
+            "pdf",
+        ),
         timeout: (cfg.parse_timeout_ms > 0).then(|| Duration::from_millis(cfg.parse_timeout_ms)),
         max_pages_cap: cfg.max_pages,
         max_decompressed_bytes: cfg.max_decompressed_bytes,
@@ -56,7 +63,8 @@ pub fn configure_limits(cfg: &DocumentConfig) {
 
 fn limits() -> &'static ParseLimits {
     LIMITS.get_or_init(|| ParseLimits {
-        sem: Arc::new(Semaphore::new(4)),
+        // Default total 4, reserve 1 for interactive (floored, batch_gate=3).
+        sem: crw_core::ReservedSemaphore::new(4, 1, "pdf"),
         timeout: Some(Duration::from_millis(30_000)),
         max_pages_cap: 0,
         max_decompressed_bytes: 104_857_600, // 100 MiB
@@ -92,12 +100,9 @@ async fn run_parse(
     // Acquire BEFORE spawning; move the permit into the closure so it is held
     // for the full duration of the (possibly orphaned-after-timeout) parse —
     // this keeps the semaphore an honest bound on real concurrent CPU work.
-    let permit = lim
-        .sem
-        .clone()
-        .acquire_owned()
-        .await
-        .map_err(|_| PdfError::Corrupt("parse semaphore closed".to_string()))?;
+    // Read the traffic class on the async side (not inside spawn_blocking) so
+    // interactive PDF scrapes take the reserved lane.
+    let permit = lim.sem.acquire(crw_core::current_scrape_class()).await;
 
     // Sandbox path (Unix): run the parse in an isolated child process. The
     // permit is held for the whole call so the concurrency bound still holds.

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -89,6 +89,7 @@ pub fn debug_candidate(
 
 pub mod answer;
 pub mod llm;
+pub mod llm_gate;
 pub mod pricing;
 pub mod summary;
 

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -240,6 +240,10 @@ async fn dispatch(
     system_prompt: &str,
     user_msg: &str,
 ) -> CrwResult<LlmCallResult> {
+    // D reserved lane: bound LLM-call concurrency and keep a slice for
+    // interactive traffic. Read the class here (async side) and hold the permit
+    // across the provider HTTP call.
+    let _llm_permit = crate::llm_gate::acquire_llm().await;
     let client = shared_client();
     match provider.to_ascii_lowercase().as_str() {
         "anthropic" => {

--- a/crates/crw-extract/src/llm_gate.rs
+++ b/crates/crw-extract/src/llm_gate.rs
@@ -1,0 +1,38 @@
+//! Process-wide reserved concurrency gate for LLM provider calls (the D lane).
+//!
+//! Every LLM HTTP call — fallback extraction, structured JSON, summary, and
+//! change-tracking judge — funnels through the two lowest provider-call
+//! boundaries ([`crate::llm::dispatch`] and [`crate::structured::call_anthropic`]
+//! / [`call_openai`]), which acquire a permit here. LLM calls run on the async
+//! path (no `spawn_blocking`), so the [`crw_core::REQUEST_CLASS`] task-local is
+//! read directly at the call site.
+//!
+//! Before this gate the advertised `extraction.llm.max_concurrency` knob was
+//! dead code (only echoed in `/v1/capabilities`); wiring it here both bounds LLM
+//! fan-out and reserves a lane so a batch's `formats:["json"]` fan-out can't
+//! starve interactive LLM requests via provider-side rate-limiting/latency.
+
+use std::sync::OnceLock;
+
+use crw_core::{LanePermit, ReservedSemaphore, current_scrape_class};
+
+static LLM_SEM: OnceLock<ReservedSemaphore> = OnceLock::new();
+
+/// Install the LLM concurrency cap with `reserved` permits held for interactive
+/// traffic. Idempotent — the first call wins, so call it once at boot from
+/// `extraction.llm.{max_concurrency, reserved_interactive_llm}`.
+pub fn configure_llm_limits(total: usize, reserved: usize) {
+    let _ = LLM_SEM.set(ReservedSemaphore::new(total, reserved, "llm"));
+}
+
+fn gate() -> &'static ReservedSemaphore {
+    // Fallback for surfaces that never configure (CLI, tests): default total 4,
+    // reserve 1, matching `default_llm_max_concurrency` / its reserve.
+    LLM_SEM.get_or_init(|| ReservedSemaphore::new(4, 1, "llm"))
+}
+
+/// Acquire the LLM-call lane for the current traffic class. Hold the returned
+/// permit across the provider HTTP call. MUST be called on the async side.
+pub async fn acquire_llm() -> LanePermit {
+    gate().acquire(current_scrape_class()).await
+}

--- a/crates/crw-extract/src/structured.rs
+++ b/crates/crw-extract/src/structured.rs
@@ -244,6 +244,9 @@ pub(crate) async fn call_anthropic(
     tool_name: &str,
     tool_desc: &str,
 ) -> CrwResult<(serde_json::Value, Option<LlmUsage>)> {
+    // D reserved lane (covers structured JSON + the change-tracking judge, which
+    // both route through here). Held across the provider HTTP call.
+    let _llm_permit = crate::llm_gate::acquire_llm().await;
     let url = anthropic_messages_url(llm.base_url.as_deref(), "https://api.anthropic.com");
 
     let body = AnthropicRequest {
@@ -479,6 +482,8 @@ pub(crate) async fn call_openai(
     tool_name: &str,
     tool_desc: &str,
 ) -> CrwResult<(serde_json::Value, Option<LlmUsage>)> {
+    // D reserved lane (structured JSON + judge). Held across the HTTP call.
+    let _llm_permit = crate::llm_gate::acquire_llm().await;
     let default_base = match llm.provider.as_str() {
         "deepseek" => "https://api.deepseek.com",
         _ => "https://api.openai.com",

--- a/crates/crw-monitor/src/runner.rs
+++ b/crates/crw-monitor/src/runner.rs
@@ -400,22 +400,29 @@ impl EngineSource {
         let llm = cfg.extraction.llm.clone();
         let id = uuid::Uuid::new_v4();
         let handle = tokio::spawn(async move {
-            run_crawl(CrawlOptions {
-                id,
-                req,
-                renderer,
-                max_concurrency: cfg.crawler.max_concurrency,
-                respect_robots: cfg.crawler.respect_robots_txt,
-                requests_per_second: cfg.crawler.requests_per_second,
-                user_agent: &user_agent,
-                state_tx: tx,
-                llm_config: llm.as_ref(),
-                proxy: cfg.crawler.proxy.clone(),
-                jitter_factor: cfg.crawler.stealth.jitter_factor,
-                deadline_ms_per_page: cfg.effective_deadline_ms(None, None),
-                per_host_max_concurrent: cfg.crawler.per_host_max_concurrent,
-            })
-            .await;
+            // Monitor crawl targets are background `Batch` traffic. Scoped INSIDE
+            // this spawned task — a task-local set by the scheduler is lost across
+            // `tokio::spawn`, so the scope must be (re-)entered here.
+            crw_core::REQUEST_CLASS
+                .scope(crw_core::ScrapeClass::Batch, async {
+                    run_crawl(CrawlOptions {
+                        id,
+                        req,
+                        renderer,
+                        max_concurrency: cfg.crawler.max_concurrency,
+                        respect_robots: cfg.crawler.respect_robots_txt,
+                        requests_per_second: cfg.crawler.requests_per_second,
+                        user_agent: &user_agent,
+                        state_tx: tx,
+                        llm_config: llm.as_ref(),
+                        proxy: cfg.crawler.proxy.clone(),
+                        jitter_factor: cfg.crawler.stealth.jitter_factor,
+                        deadline_ms_per_page: cfg.effective_deadline_ms(None, None),
+                        per_host_max_concurrent: cfg.crawler.per_host_max_concurrent,
+                    })
+                    .await;
+                })
+                .await;
         });
 
         // Wait for terminal state.

--- a/crates/crw-monitor/src/scheduler.rs
+++ b/crates/crw-monitor/src/scheduler.rs
@@ -86,16 +86,23 @@ impl Scheduler {
 
         for target in &targets {
             let prior = self.store.load_prior(&monitor.id)?;
-            let check = run_check(
-                monitor,
-                target,
-                &prior,
-                self.source.as_ref(),
-                &self.cfg,
-                judge_llm.as_ref(),
-                now,
-            )
-            .await?;
+            // Monitor checks are background work — `Batch` traffic, so their
+            // fetches and LLM judge calls use the batch lanes and never consume
+            // the interactive reserve.
+            let check = crw_core::REQUEST_CLASS
+                .scope(
+                    crw_core::ScrapeClass::Batch,
+                    run_check(
+                        monitor,
+                        target,
+                        &prior,
+                        self.source.as_ref(),
+                        &self.cfg,
+                        judge_llm.as_ref(),
+                        now,
+                    ),
+                )
+                .await?;
 
             // Persist the check (also advances snapshot baselines).
             self.store.record_check(&check)?;

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -435,11 +435,21 @@ pub struct CdpRenderer {
     /// even when `intercept_enabled = true`.
     host_intercept_disable: Vec<String>,
     conn_semaphore: Arc<Semaphore>,
+    /// Batch reserved-lane gate in front of `conn_semaphore` (the B lane, legacy
+    /// `fetch_with_ws` path): batch renders take a gate permit first, interactive
+    /// go straight to the pool, so interactive always finds reserved render slots.
+    conn_batch_gate: crw_core::BatchGate,
     /// Browser context pool. `Some` when `[renderer.chrome.pool] enabled = true`
     /// AND backend is vanilla chrome (not browserless v2 — gated off in v1
     /// per plan §"Out of scope"). When `Some`, `fetch` dispatches through
     /// `fetch_with_pool`; when `None`, legacy `fetch_with_ws` is used.
     pool: Option<Arc<crate::browser_pool::BrowserContextPool<CdpConnection>>>,
+    /// Batch reserved-lane gate in front of `pool` (the B lane, pooled
+    /// `fetch_with_pool` path). Held OUTSIDE the pool so `BrowserContextPool`'s
+    /// permit-as-checkout-source-of-truth invariant stays untouched: batch takes
+    /// a gate permit before `pool.acquire()`, interactive skips it. `Some` iff
+    /// `pool` is `Some`, sized from the pool size.
+    pool_batch_gate: Option<crw_core::BatchGate>,
     /// DataImpulse base credentials (username without country suffix, password).
     /// When `Some`, the renderer drives Chrome's proxy auth via CDP
     /// `Fetch.authRequired`, composing the country-suffixed username per request.
@@ -483,7 +493,13 @@ impl CdpRenderer {
             blocklist: Blocklist::defaults(),
             host_intercept_disable: Vec::new(),
             conn_semaphore: Arc::new(Semaphore::new(pool_size)),
+            conn_batch_gate: crw_core::BatchGate::new(
+                pool_size,
+                crate::render_reserve(pool_size),
+                "render",
+            ),
             pool: None,
+            pool_batch_gate: None,
             proxy_auth_base: None,
             default_country: None,
             challenge_max_retries: CHALLENGE_MAX_RETRIES,
@@ -564,6 +580,11 @@ impl CdpRenderer {
         crw_core::metrics::metrics()
             .chrome_pool_size
             .set(cfg.size as i64);
+        self.pool_batch_gate = Some(crw_core::BatchGate::new(
+            cfg.size,
+            crate::render_reserve(cfg.size),
+            "render",
+        ));
         self.pool = Some(crate::browser_pool::BrowserContextPool::new(cfg, factory));
         self
     }
@@ -1589,6 +1610,14 @@ impl CdpRenderer {
     ) -> CrwResult<FetchResult> {
         let start = Instant::now();
         let handshake_t0 = Instant::now();
+        // Reserved lane (B, pooled path): batch takes the gate before checking
+        // out a pool slot so interactive always finds reserved slots free; held
+        // for the whole fetch alongside the pool guard. Class read on the async
+        // side. `pool_batch_gate` is `Some` whenever `pool` is set.
+        let _render_gate = match &self.pool_batch_gate {
+            Some(gate) => gate.enter(crw_core::current_scrape_class()).await,
+            None => None,
+        };
         let acquire_t0 = Instant::now();
         let guard = pool.acquire().await?;
         let acquire_elapsed = acquire_t0.elapsed();
@@ -1685,7 +1714,14 @@ impl CdpRenderer {
         let start = Instant::now();
         let handshake_t0 = Instant::now();
 
-        // Limit concurrent WebSocket connections to pool_size.
+        // Limit concurrent WebSocket connections to pool_size, with a reserved
+        // lane for interactive: batch takes the gate first (bounding batch's
+        // share of the pool); interactive skips it. Both held for the whole
+        // fetch. Class read on the async side (before any spawn_blocking).
+        let _render_gate = self
+            .conn_batch_gate
+            .enter(crw_core::current_scrape_class())
+            .await;
         let _permit = self
             .conn_semaphore
             .acquire()

--- a/crates/crw-renderer/src/host_limiter.rs
+++ b/crates/crw-renderer/src/host_limiter.rs
@@ -15,27 +15,36 @@
 use dashmap::DashMap;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
-use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::Mutex;
 use tokio::time::Instant;
+
+use crw_core::{LanePermit, ReservedSemaphore};
 
 /// Stale entries are dropped after this idle duration during periodic GC.
 const RATE_LIMITER_TTL: Duration = Duration::from_secs(3600);
 
-type RateLimiterEntry = (Arc<Mutex<RateLimiter>>, Arc<Semaphore>, Instant);
+type RateLimiterEntry = (Arc<Mutex<RateLimiter>>, ReservedSemaphore, Instant);
 
 static DOMAIN_RATE_LIMITERS: LazyLock<DashMap<String, RateLimiterEntry>> =
     LazyLock::new(DashMap::new);
 
 static LIMITER_CALL_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Get or create a (rate limiter, per-host semaphore) pair for the given
-/// **already-normalized** host key. Pass the eTLD+1 form produced by
+/// Get or create a (rate limiter, per-host reserved semaphore) pair for the
+/// given **already-normalized** host key. Pass the eTLD+1 form produced by
 /// [`crate::preference::normalize_host`].
+///
+/// The semaphore is a [`ReservedSemaphore`] sized `per_host_max_concurrent +
+/// interactive_reserve`: batch/crawl are bounded to `per_host_max_concurrent`
+/// per host (target politeness), while interactive gets `interactive_reserve`
+/// dedicated slots so it's never queued behind a batch — yet total in-flight
+/// per host stays bounded (no target hammering).
 pub fn get_host_limiter(
     host_key: &str,
     rps: f64,
     per_host_max_concurrent: usize,
-) -> (Arc<Mutex<RateLimiter>>, Arc<Semaphore>) {
+    interactive_reserve: usize,
+) -> (Arc<Mutex<RateLimiter>>, ReservedSemaphore) {
     let now = Instant::now();
     if LIMITER_CALL_COUNT
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -69,7 +78,8 @@ pub fn get_host_limiter(
         .or_insert_with(|| {
             (
                 Arc::new(Mutex::new(RateLimiter::new(rps))),
-                Arc::new(Semaphore::new(cap)),
+                // total = batch cap + interactive reserve; reserved = interactive.
+                ReservedSemaphore::new(cap + interactive_reserve, interactive_reserve, "host"),
                 now,
             )
         });
@@ -80,15 +90,23 @@ pub fn get_host_limiter(
 /// the caller must sleep to honour the rate limit. The caller is responsible
 /// for performing the sleep (so it doesn't happen while holding any other
 /// async lock) and for keeping the permit alive across the request.
+///
+/// Class-aware (the A reserved lane): interactive takes a reserved per-host slot
+/// (never queued behind batch), batch stays bounded to `per_host_max_concurrent`
+/// per host. Both honour the rate limiter (target RPS). The returned
+/// [`LanePermit`] must be held across the request.
 pub async fn acquire(
     host_key: &str,
     rps: f64,
     per_host_max_concurrent: usize,
-) -> Result<(OwnedSemaphorePermit, Duration), tokio::sync::AcquireError> {
-    let (rate_limiter, sem) = get_host_limiter(host_key, rps, per_host_max_concurrent);
-    let permit = sem.acquire_owned().await?;
+    interactive_reserve: usize,
+) -> (LanePermit, Duration) {
+    let (rate_limiter, sem) =
+        get_host_limiter(host_key, rps, per_host_max_concurrent, interactive_reserve);
+    // Read class on the async side; acquire is infallible (semaphore never closed).
+    let permit = sem.acquire(crw_core::current_scrape_class()).await;
     let sleep = rate_limiter.lock().await.next_sleep();
-    Ok((permit, sleep))
+    (permit, sleep)
 }
 
 /// Minimum-interval rate limiter. Public so `crw-crawl` can keep its existing
@@ -158,25 +176,58 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_returns_permit_and_sleep() {
-        let (_p, sleep) = acquire("test-acquire-1.example", 0.0, 1).await.unwrap();
+        // Unscoped = Interactive = takes a reserved per-host slot, no sleep.
+        let (_p, sleep) = acquire("test-acquire-1.example", 0.0, 1, 1).await;
         assert_eq!(sleep, Duration::ZERO);
     }
 
     #[tokio::test]
-    async fn per_host_cap_serializes() {
-        let (p1, _) = acquire("test-cap.example", 0.0, 1).await.unwrap();
-        // Second acquire must wait — verify it doesn't complete in 50ms.
-        let acquire_fut = acquire("test-cap.example", 0.0, 1);
-        let race = tokio::time::timeout(Duration::from_millis(50), acquire_fut).await;
-        assert!(race.is_err(), "second acquire should block while p1 held");
-        drop(p1);
-        // Now it should succeed quickly.
-        let (_p2, _) = tokio::time::timeout(
-            Duration::from_millis(200),
-            acquire("test-cap.example", 0.0, 1),
-        )
-        .await
-        .expect("second acquire should succeed after release")
-        .unwrap();
+    async fn per_host_cap_serializes_batch() {
+        // Batch traffic is bounded to `per_host_max_concurrent` (=1 here); a
+        // second concurrent batch acquire to the same host must wait.
+        crw_core::REQUEST_CLASS
+            .scope(crw_core::ScrapeClass::Batch, async {
+                let (p1, _) = acquire("test-cap.example", 0.0, 1, 1).await;
+                // Second batch acquire must wait — verify it doesn't complete in 50ms.
+                let acquire_fut = acquire("test-cap.example", 0.0, 1, 1);
+                let race = tokio::time::timeout(Duration::from_millis(50), acquire_fut).await;
+                assert!(
+                    race.is_err(),
+                    "second batch acquire should block while p1 held (batch cap=1)"
+                );
+                drop(p1);
+                // Now it should succeed quickly.
+                let _p2 = tokio::time::timeout(
+                    Duration::from_millis(200),
+                    acquire("test-cap.example", 0.0, 1, 1),
+                )
+                .await
+                .expect("second batch acquire should succeed after release");
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn interactive_reserved_slot_survives_batch() {
+        // Interactive gets a dedicated reserved slot, so it never blocks on the
+        // batch-held per-host cap.
+        crw_core::REQUEST_CLASS
+            .scope(crw_core::ScrapeClass::Batch, async {
+                let (_batch, _) = acquire("test-bypass.example", 0.0, 1, 1).await;
+                // A concurrent interactive request to the same host gets straight
+                // through (its reserved slot).
+                let interactive =
+                    crw_core::REQUEST_CLASS.scope(crw_core::ScrapeClass::Interactive, async {
+                        tokio::time::timeout(
+                            Duration::from_millis(100),
+                            acquire("test-bypass.example", 0.0, 1, 1),
+                        )
+                        .await
+                    });
+                let (_p, _) = interactive
+                    .await
+                    .expect("interactive should not block on the batch-held host cap");
+            })
+            .await;
     }
 }

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -106,6 +106,19 @@ tokio::task_local! {
     pub static REQUEST_SCREENSHOT: Option<ScreenshotReq>;
 }
 
+/// Interactive render-slot reserve for a Chrome pool of `pool_size` (the B
+/// reserved lane). About a quarter of the pool, floored at 1 whenever there are
+/// ≥2 slots so even small (2–3 slot) self-hosted pools keep interactive render
+/// isolation; only a 1-slot pool disables it (a reserve there would starve
+/// batch). Always kept below `pool_size` so the batch gate stays ≥1.
+pub fn render_reserve(pool_size: usize) -> usize {
+    if pool_size <= 1 {
+        0
+    } else {
+        (pool_size / 4).max(1).min(pool_size - 1)
+    }
+}
+
 /// Whether a screenshot was requested for the current task (reads the
 /// [`REQUEST_SCREENSHOT`] task-local). `false` when unset / outside a scope.
 pub fn screenshot_requested() -> bool {
@@ -298,8 +311,13 @@ pub struct FallbackRenderer {
     /// floor; the concurrency cap below still applies. Configured via
     /// [`Self::with_host_limits`].
     requests_per_second: f64,
-    /// Process-wide per-eTLD+1 in-flight cap. `1` enforces strict politeness.
+    /// Process-wide per-eTLD+1 in-flight cap for batch/crawl. `1` enforces strict
+    /// politeness. Interactive gets `per_host_interactive_reserve` extra slots.
     per_host_max_concurrent: u32,
+    /// Extra per-host in-flight slots reserved for interactive traffic (the A
+    /// reserved lane). Total per-host in-flight is bounded by
+    /// `per_host_max_concurrent + this`.
+    per_host_interactive_reserve: u32,
     /// Anti-bot classifier policy. Drives the in-loop `classify()` call that
     /// decides whether a 200-status block page is a soft failure (escalate
     /// toward `chrome_proxy`) or a genuine success.
@@ -420,6 +438,7 @@ impl FallbackRenderer {
                 tier_timeouts: tier_timeouts_from(config),
                 requests_per_second: 0.0,
                 per_host_max_concurrent: 1,
+                per_host_interactive_reserve: 1,
                 antibot: config.antibot.clone(),
                 proxy_rotator: None,
                 http_ua: effective_ua.clone(),
@@ -685,6 +704,7 @@ impl FallbackRenderer {
             tier_timeouts: tier_timeouts_from(config),
             requests_per_second: 0.0,
             per_host_max_concurrent: 1,
+            per_host_interactive_reserve: 1,
             antibot: config.antibot.clone(),
             proxy_rotator: None,
             http_ua: effective_ua.clone(),
@@ -806,9 +826,11 @@ impl FallbackRenderer {
         mut self,
         requests_per_second: f64,
         per_host_max_concurrent: u32,
+        per_host_interactive_reserve: u32,
     ) -> Self {
         self.requests_per_second = requests_per_second;
         self.per_host_max_concurrent = per_host_max_concurrent;
+        self.per_host_interactive_reserve = per_host_interactive_reserve;
         self
     }
 
@@ -921,11 +943,12 @@ impl FallbackRenderer {
                     key,
                     self.requests_per_second,
                     self.per_host_max_concurrent as usize,
+                    self.per_host_interactive_reserve as usize,
                 ),
             )
             .await
             {
-                Ok(Ok((permit, sleep))) => {
+                Ok((permit, sleep)) => {
                     if !sleep.is_zero() {
                         let budget = deadline.remaining();
                         if sleep > budget {
@@ -933,9 +956,11 @@ impl FallbackRenderer {
                         }
                         tokio::time::sleep(sleep).await;
                     }
+                    // Reserved per-host lane permit (interactive gets a dedicated
+                    // slot, batch a bounded one). Held for the whole fetch by
+                    // binding it to `_host_permit`.
                     Some(permit)
                 }
-                Ok(Err(_)) => return Err(CrwError::RendererError("host limiter closed".into())),
                 Err(_) => {
                     return Err(CrwError::Timeout(
                         deadline.overrun().as_millis().max(1) as u64

--- a/crates/crw-server/src/main.rs
+++ b/crates/crw-server/src/main.rs
@@ -54,16 +54,9 @@ async fn run_server() {
         }
     };
 
-    // Install process-wide PDF-parse limits (concurrency cap, timeout, page
-    // cap) from [document] config before any request can trigger a parse.
-    crw_crawl::pdf::configure_limits(&config.document);
-
-    // Bound concurrent HTML extraction (html5ever + htmd). Extraction is moved
-    // off the async reactor onto the blocking pool; this semaphore caps its
-    // parallelism so a burst of concurrent scrapes can't oversubscribe the
-    // cores and stall the runtime. The tokio runtime builder is left at its
-    // defaults — this is the real capacity bound.
-    crw_crawl::extract_pool::configure_extract_limit(config.extraction.max_concurrent_extracts);
+    // Process-wide reserved-lane limits (PDF / extract / LLM) are installed by
+    // `AppState::new` (below) so the `crw serve` / embedded CLI entry points get
+    // them too — see `state.rs`. All idempotent (first-call-wins).
 
     let addr = format!("{}:{}", config.server.host, config.server.port);
     tracing::info!("Starting CRW on {addr}");

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -1159,6 +1159,11 @@ async fn enrich_with_scrape(
         let deadline_ms = state.config.effective_deadline_ms(None, None);
         let permit_src = semaphore.clone();
 
+        // Deliberately NOT scoped to `ScrapeClass::Batch`: `/v1/search` is a
+        // synchronous, latency-sensitive interactive endpoint (not a job entry
+        // point), so its enrichment scrapes are interactive traffic and correctly
+        // read the `Interactive` default — they legitimately use interactive
+        // capacity rather than the batch lane.
         set.spawn(async move {
             let _permit = match permit_src.acquire_owned().await {
                 Ok(p) => p,

--- a/crates/crw-server/src/routes/v2/batch.rs
+++ b/crates/crw-server/src/routes/v2/batch.rs
@@ -68,6 +68,17 @@ pub async fn start_batch(
         .and_then(Value::as_bool)
         .unwrap_or(true);
 
+    // Optional per-job OUTER pipeline width (SaaS injects this per plan tier).
+    // Removed symmetric with `urls` so it doesn't leak into the per-URL scrape
+    // template below. Clamped to a safe range inside `start_batch_job`; a
+    // client-supplied value is not authoritative (the SaaS overrides it, and the
+    // engine clamps regardless).
+    let max_concurrency_override = obj
+        .remove("maxConcurrency")
+        .as_ref()
+        .and_then(Value::as_u64)
+        .map(|n| n as usize);
+
     // Build the per-page scrape template from the remaining (base scrape)
     // options by reusing the v2 scrape request → internal conversion. A
     // placeholder URL satisfies the required field; it's cleared afterward.
@@ -115,7 +126,9 @@ pub async fn start_batch(
         ))));
     }
 
-    let id = state.start_batch_job(valid, template).await;
+    let id = state
+        .start_batch_job(valid, template, max_concurrency_override)
+        .await;
     let base = base_url(&headers);
     Ok(Json(V2BatchStartResponse {
         success: true,

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -80,6 +80,21 @@ pub struct CrawlJob {
     pub abort_handle: Option<tokio::task::AbortHandle>,
 }
 
+/// RAII guard that inc/decrements the `crw_batch_pipelines_inflight` gauge for
+/// the lifetime of one in-flight batch URL-pipeline.
+struct InflightGuard;
+impl InflightGuard {
+    fn new() -> Self {
+        crw_core::metrics::metrics().batch_pipelines_inflight.inc();
+        InflightGuard
+    }
+}
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        crw_core::metrics::metrics().batch_pipelines_inflight.dec();
+    }
+}
+
 /// Maximum number of concurrent crawl jobs.
 const MAX_CONCURRENT_CRAWLS: usize = 10;
 /// Interval between expired crawl job cleanup runs.
@@ -149,6 +164,14 @@ pub struct AppState {
     /// is a single merged JSON object, not a `Vec<ScrapeData>`.
     pub extract_jobs: Arc<RwLock<HashMap<Uuid, ExtractRecord>>>,
     pub crawl_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Process-wide cap on the total in-flight `/v2/batch/scrape` URL-pipelines
+    /// across all batch-scrape jobs (aggregate bound so `N jobs × width` can't
+    /// explode). Targets batch scrape specifically because that's the only wide
+    /// fan-out: crawl is BFS-sequential and `/v2/extract` scrapes one URL at a
+    /// time, both already bounded by the `crawl_semaphore` job cap. `None` =
+    /// unbounded (config `max_aggregate_batch_pipelines = 0`/absent). Acquired
+    /// as the first op in each batch URL future, before fetch.
+    pub batch_pipeline_sem: Option<Arc<tokio::sync::Semaphore>>,
     /// SearXNG client. `None` when `[search].searxng_url` is unset, in which
     /// case `/v1/search` returns a clear `search_disabled` error.
     pub searxng: Option<Arc<SearxngClient>>,
@@ -182,6 +205,7 @@ impl AppState {
         .with_host_limits(
             config.crawler.requests_per_second,
             config.crawler.per_host_max_concurrent,
+            config.crawler.per_host_interactive_reserve,
         );
 
         let searxng = if config.search.enabled
@@ -231,12 +255,44 @@ impl AppState {
             .inc_by(url_filter_cfg.host_overrides.len() as u64);
         let url_filter = Some(Arc::new(url_filter_cfg));
 
+        // Install the process-wide reserved-lane limits (extract / PDF / LLM)
+        // HERE — inside `AppState::new` — so every entry point that builds an
+        // AppState (the `crw-server` binary AND `crw serve` / embedded CLI) gets
+        // the configured concurrency + reservations, not just the fallbacks.
+        // All three are idempotent (first-call-wins).
+        let extract_total = config.extraction.max_concurrent_extracts;
+        crw_crawl::extract_pool::configure_extract_limit(
+            extract_total,
+            crw_core::config::resolve_interactive_reserve(
+                config.extraction.reserved_interactive_extracts,
+                extract_total,
+            ),
+        );
+        crw_crawl::pdf::configure_limits(&config.document);
+        if let Some(llm) = &config.extraction.llm {
+            crw_extract::llm_gate::configure_llm_limits(
+                llm.max_concurrency,
+                crw_core::config::resolve_interactive_reserve(
+                    llm.reserved_interactive_llm,
+                    llm.max_concurrency,
+                ),
+            );
+        }
+
+        // `0`/absent = unbounded aggregate (no cap); any n>0 bounds total
+        // in-flight batch URL-pipelines process-wide.
+        let batch_pipeline_sem = match config.crawler.max_aggregate_batch_pipelines {
+            0 => None,
+            n => Some(Arc::new(tokio::sync::Semaphore::new(n))),
+        };
+
         let state = Self {
             config: Arc::new(config),
             renderer: Arc::new(renderer),
             crawl_jobs: Arc::new(RwLock::new(HashMap::new())),
             extract_jobs: Arc::new(RwLock::new(HashMap::new())),
             crawl_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_CRAWLS)),
+            batch_pipeline_sem,
             searxng,
             url_filter,
         };
@@ -337,22 +393,30 @@ impl AppState {
                     return;
                 }
             };
-            run_crawl(CrawlOptions {
-                id,
-                req,
-                renderer,
-                max_concurrency,
-                respect_robots,
-                requests_per_second: rps,
-                user_agent: &user_agent,
-                state_tx: tx,
-                llm_config: llm_config.as_ref(),
-                proxy,
-                jitter_factor,
-                deadline_ms_per_page,
-                per_host_max_concurrent,
-            })
-            .await;
+            // Crawl pages are `Batch` traffic (same reserved-lane treatment as
+            // batch scrape). Scoped inside the job's spawned task so the
+            // task-local reaches every per-page fetch/extract; a handler-level
+            // scope would be lost across this `tokio::spawn`.
+            crw_core::REQUEST_CLASS
+                .scope(crw_core::ScrapeClass::Batch, async {
+                    run_crawl(CrawlOptions {
+                        id,
+                        req,
+                        renderer,
+                        max_concurrency,
+                        respect_robots,
+                        requests_per_second: rps,
+                        user_agent: &user_agent,
+                        state_tx: tx,
+                        llm_config: llm_config.as_ref(),
+                        proxy,
+                        jitter_factor,
+                        deadline_ms_per_page,
+                        per_host_max_concurrent,
+                    })
+                    .await;
+                })
+                .await;
         });
 
         // Store the abort handle so the job can be cancelled via DELETE.
@@ -370,7 +434,12 @@ impl AppState {
     /// UUID. Reuses the crawl-job machinery (`crawl_jobs` + `CrawlState`) but
     /// scrapes the given URLs directly — no link discovery, no same-origin
     /// filtering, no dedup; input order is recoverable via `metadata.sourceURL`.
-    pub async fn start_batch_job(&self, urls: Vec<String>, template: ScrapeRequest) -> Uuid {
+    pub async fn start_batch_job(
+        &self,
+        urls: Vec<String>,
+        template: ScrapeRequest,
+        max_concurrency_override: Option<usize>,
+    ) -> Uuid {
         let id = Uuid::new_v4();
         let total = urls.len() as u32;
         let (tx, rx) = watch::channel(CrawlState {
@@ -397,8 +466,16 @@ impl AppState {
 
         let renderer = self.renderer.clone();
         let crawl_semaphore = self.crawl_semaphore.clone();
+        let batch_pipeline_sem = self.batch_pipeline_sem.clone();
         let config = self.config.clone();
-        let max_concurrency = config.crawler.max_concurrency.max(1);
+        // Per-job OUTER pipeline width: the SaaS-injected (plan-scaled)
+        // `maxConcurrency`, or `max_concurrency` when absent. BOTH paths are
+        // clamped to `[1, max_batch_concurrency]` so a batch job never exceeds
+        // the ceiling regardless of source (wire value never trusted).
+        let width_ceiling = config.crawler.max_batch_concurrency.max(1);
+        let max_concurrency = max_concurrency_override
+            .unwrap_or(config.crawler.max_concurrency)
+            .clamp(1, width_ceiling);
 
         let handle = tokio::spawn(async move {
             let _permit = match crawl_semaphore.acquire().await {
@@ -445,42 +522,66 @@ impl AppState {
                 })
                 .collect();
 
-            futures::stream::iter(reqs)
-                .for_each_concurrent(max_concurrency, |req| {
-                    let renderer = renderer.clone();
-                    let config = config.clone();
-                    let user_agent = user_agent.clone();
-                    let tx = tx.clone();
-                    async move {
-                        let deadline = Deadline::from_request_ms(deadline_ms);
-                        let scraped = scrape_url(
-                            &req,
-                            &renderer,
-                            config.extraction.llm.as_ref(),
-                            &config.extraction,
-                            &user_agent,
-                            default_stealth,
-                            render_js_default,
-                            deadline,
-                        )
-                        .await
-                        .ok();
-                        // Mutate the shared status in place — push one document and
-                        // bump the counter without cloning the whole accumulated Vec
-                        // on every completion (avoids O(n^2) copying on large
-                        // batches). A failed scrape still advances `completed`.
-                        tx.send_modify(|st| {
-                            if let Some(d) = scraped {
-                                st.data.push(d);
+            // Stamp every URL in this job as `Batch` traffic. The scope wraps the
+            // whole `for_each_concurrent` stream; that combinator polls its
+            // futures cooperatively within THIS task (no `tokio::spawn` per URL),
+            // so the task-local propagates to each per-URL `scrape_url` and on to
+            // the reserved lanes it reads. Scoped here (inside the job's spawned
+            // task), not at the handler, because the task-local would be lost
+            // across this job's `tokio::spawn`.
+            crw_core::REQUEST_CLASS
+                .scope(crw_core::ScrapeClass::Batch, async move {
+                    futures::stream::iter(reqs)
+                        .for_each_concurrent(max_concurrency, |req| {
+                            let renderer = renderer.clone();
+                            let config = config.clone();
+                            let user_agent = user_agent.clone();
+                            let tx = tx.clone();
+                            let batch_pipeline_sem = batch_pipeline_sem.clone();
+                            async move {
+                                // Aggregate cap: acquire a process-wide pipeline
+                                // permit BEFORE fetching so `N jobs × width` can't
+                                // explode. `None` = unbounded. Held for this URL's
+                                // whole lifetime.
+                                let _pipeline_permit = match &batch_pipeline_sem {
+                                    Some(sem) => sem.acquire().await.ok(),
+                                    None => None,
+                                };
+                                // In-flight batch-pipeline gauge (RAII inc/dec).
+                                let _inflight = InflightGuard::new();
+                                let deadline = Deadline::from_request_ms(deadline_ms);
+                                let scraped = scrape_url(
+                                    &req,
+                                    &renderer,
+                                    config.extraction.llm.as_ref(),
+                                    &config.extraction,
+                                    &user_agent,
+                                    default_stealth,
+                                    render_js_default,
+                                    deadline,
+                                )
+                                .await
+                                .ok();
+                                // Mutate the shared status in place — push one document
+                                // and bump the counter without cloning the whole
+                                // accumulated Vec on every completion (avoids O(n^2)
+                                // copying on large batches). A failed scrape still
+                                // advances `completed`.
+                                tx.send_modify(|st| {
+                                    if let Some(d) = scraped {
+                                        st.data.push(d);
+                                    }
+                                    st.completed += 1;
+                                    // Only flip to Completed from InProgress — never
+                                    // overwrite a terminal Cancelled set by DELETE.
+                                    if st.completed >= total && st.status == CrawlStatus::InProgress
+                                    {
+                                        st.status = CrawlStatus::Completed;
+                                    }
+                                });
                             }
-                            st.completed += 1;
-                            // Only flip to Completed from InProgress — never
-                            // overwrite a terminal Cancelled set by DELETE.
-                            if st.completed >= total && st.status == CrawlStatus::InProgress {
-                                st.status = CrawlStatus::Completed;
-                            }
-                        });
-                    }
+                        })
+                        .await;
                 })
                 .await;
         });
@@ -528,101 +629,107 @@ impl AppState {
         let extract_jobs = self.extract_jobs.clone();
 
         tokio::spawn(async move {
-            let user_agent = config.crawler.user_agent.clone();
-            let default_stealth =
-                config.crawler.stealth.enabled && config.crawler.stealth.inject_headers;
-            let render_js_default = config.renderer.render_js_default;
-            let deadline_ms = config.effective_deadline_ms(template.deadline_ms, template.wait_for);
+            // `/v2/extract` is a multi-URL background job — `Batch` traffic, so its
+            // scrapes use the batch lanes and don't consume the interactive reserve.
+            // Scoped inside the spawned task (a handler-level scope is lost across
+            // `tokio::spawn`).
+            crw_core::REQUEST_CLASS
+                .scope(crw_core::ScrapeClass::Batch, async move {
+                    let user_agent = config.crawler.user_agent.clone();
+                    let default_stealth =
+                        config.crawler.stealth.enabled && config.crawler.stealth.inject_headers;
+                    let render_js_default = config.renderer.render_js_default;
+                    let deadline_ms =
+                        config.effective_deadline_ms(template.deadline_ms, template.wait_for);
 
-            let mut merged = serde_json::Map::new();
-            let mut per_url: Vec<UrlResult> = Vec::with_capacity(entries.len());
-            let mut tokens = 0u32;
-            let mut credits = 0u32;
-            let mut last_err: Option<String> = None;
-            let mut any_ok = false;
+                    let mut merged = serde_json::Map::new();
+                    let mut per_url: Vec<UrlResult> = Vec::with_capacity(entries.len());
+                    let mut tokens = 0u32;
+                    let mut credits = 0u32;
+                    let mut last_err: Option<String> = None;
+                    let mut any_ok = false;
 
-            for entry in entries {
-                // Preflight-failed URLs (bad parse / SSRF) surface as `failed`
-                // without a fetch — never silently dropped. Record the error at
-                // job level too so an all-preflight-failed job reports `Failed`
-                // (not `Completed`) via the `!any_ok && last_err` check below.
-                if let Some(err) = entry.preflight_error {
-                    last_err = Some(err.clone());
-                    per_url.push(UrlResult {
-                        url: entry.url,
-                        status: ExtractStatus::Failed,
-                        data: None,
-                        error: Some(err),
-                        llm_usage: None,
-                    });
-                    continue;
-                }
+                    for entry in entries {
+                        // Preflight-failed URLs (bad parse / SSRF) surface as
+                        // `failed` without a fetch — never silently dropped.
+                        if let Some(err) = entry.preflight_error {
+                            last_err = Some(err.clone());
+                            per_url.push(UrlResult {
+                                url: entry.url,
+                                status: ExtractStatus::Failed,
+                                data: None,
+                                error: Some(err),
+                                llm_usage: None,
+                            });
+                            continue;
+                        }
 
-                let mut req = template.clone();
-                req.url = entry.url.clone();
-                let deadline = Deadline::from_request_ms(deadline_ms);
-                match scrape_url(
-                    &req,
-                    &renderer,
-                    config.extraction.llm.as_ref(),
-                    &config.extraction,
-                    &user_agent,
-                    default_stealth,
-                    render_js_default,
-                    deadline,
-                )
-                .await
-                {
-                    Ok(d) => {
-                        any_ok = true;
-                        if let Some(serde_json::Value::Object(obj)) = &d.json {
-                            for (k, v) in obj {
-                                merged.insert(k.clone(), v.clone());
+                        let mut req = template.clone();
+                        req.url = entry.url.clone();
+                        let deadline = Deadline::from_request_ms(deadline_ms);
+                        match scrape_url(
+                            &req,
+                            &renderer,
+                            config.extraction.llm.as_ref(),
+                            &config.extraction,
+                            &user_agent,
+                            default_stealth,
+                            render_js_default,
+                            deadline,
+                        )
+                        .await
+                        {
+                            Ok(d) => {
+                                any_ok = true;
+                                if let Some(serde_json::Value::Object(obj)) = &d.json {
+                                    for (k, v) in obj {
+                                        merged.insert(k.clone(), v.clone());
+                                    }
+                                }
+                                if let Some(usage) = &d.llm_usage {
+                                    tokens += usage.total_tokens;
+                                }
+                                credits += if d.credit_cost == 0 { 1 } else { d.credit_cost };
+                                per_url.push(UrlResult {
+                                    url: entry.url,
+                                    status: ExtractStatus::Completed,
+                                    data: d.json,
+                                    error: None,
+                                    llm_usage: d.llm_usage,
+                                });
+                            }
+                            Err(e) => {
+                                let msg = e.to_string();
+                                last_err = Some(msg.clone());
+                                per_url.push(UrlResult {
+                                    url: entry.url,
+                                    status: ExtractStatus::Failed,
+                                    data: None,
+                                    error: Some(msg),
+                                    llm_usage: None,
+                                });
                             }
                         }
-                        if let Some(usage) = &d.llm_usage {
-                            tokens += usage.total_tokens;
-                        }
-                        credits += if d.credit_cost == 0 { 1 } else { d.credit_cost };
-                        per_url.push(UrlResult {
-                            url: entry.url,
-                            status: ExtractStatus::Completed,
-                            data: d.json,
-                            error: None,
-                            llm_usage: d.llm_usage,
-                        });
                     }
-                    Err(e) => {
-                        let msg = e.to_string();
-                        last_err = Some(msg.clone());
-                        per_url.push(UrlResult {
-                            url: entry.url,
-                            status: ExtractStatus::Failed,
-                            data: None,
-                            error: Some(msg),
-                            llm_usage: None,
-                        });
-                    }
-                }
-            }
 
-            let mut jobs = extract_jobs.write().await;
-            if let Some(rec) = jobs.get_mut(&id) {
-                if !any_ok && last_err.is_some() {
-                    rec.status = ExtractStatus::Failed;
-                    rec.error = last_err;
-                } else {
-                    rec.status = ExtractStatus::Completed;
-                    rec.data = Some(serde_json::Value::Object(merged));
-                }
-                rec.per_url = per_url;
-                rec.tokens_used = tokens;
-                // ponytail: 1-credit floor even on an all-failed job — inherited
-                // from the v2 worker's accounting; preflight-failed URLs add 0
-                // (they `continue` before the credit tally). SaaS settles the
-                // real cost separately, so this engine figure is a floor, not a bill.
-                rec.credits_used = credits.max(1);
-            }
+                    let mut jobs = extract_jobs.write().await;
+                    if let Some(rec) = jobs.get_mut(&id) {
+                        if !any_ok && last_err.is_some() {
+                            rec.status = ExtractStatus::Failed;
+                            rec.error = last_err;
+                        } else {
+                            rec.status = ExtractStatus::Completed;
+                            rec.data = Some(serde_json::Value::Object(merged));
+                        }
+                        rec.per_url = per_url;
+                        rec.tokens_used = tokens;
+                        // ponytail: 1-credit floor even on an all-failed job —
+                        // preflight-failed URLs add 0 (they `continue` before the
+                        // tally). SaaS settles the real cost separately.
+                        rec.credits_used = credits.max(1);
+                    }
+                })
+                .await;
         });
 
         id

--- a/crates/crw-server/tests/v2_api.rs
+++ b/crates/crw-server/tests/v2_api.rs
@@ -239,7 +239,7 @@ async fn v2_batch_cancel_flips_status_to_cancelled() {
 
     let template = crw_core::types::ScrapeRequest::default();
     let id = state
-        .start_batch_job(vec!["http://192.0.2.1/".into()], template)
+        .start_batch_job(vec!["http://192.0.2.1/".into()], template, None)
         .await;
 
     // Cancel via the public route.


### PR DESCRIPTION
## Problem

Batch scrape / crawl / extract / monitor jobs could **starve single interactive `/scrape` requests** by monopolizing the shared concurrency chokepoints, and a batch job's fan-out width was a **fixed global constant** regardless of the caller's plan tier. A heavy batch tenant could degrade interactive p99 for everyone — a self-inflicted DoS.

## Approach

A request **traffic class** (`Interactive` | `Batch`) carried via a `crw-core` task-local, stamped at every background job entry point (inside each `tokio::spawn` so it survives the boundary), plus a **two-lane reserved semaphore** (`ReservedSemaphore` / `BatchGate`) applied at each shared chokepoint so interactive always keeps a protected slice:

- **A — per-host limiter**: interactive gets dedicated per-host slots; batch stays bounded to `per_host_max_concurrent`, and total in-flight per host stays bounded (no target hammering).
- **B — Chrome render pool**: both `fetch_with_ws` and pooled `fetch_with_pool` paths.
- **C — HTML extract pool** and **E — PDF parse pool**: CPU parse lanes (class read on the async side, before `spawn_blocking`).
- **D — LLM calls**: gated at the provider-call boundary, covering fallback extraction, structured JSON, summary and change-tracking judge — also wiring the previously-**dead** `extraction.llm.max_concurrency` knob.

Batch **outer pipeline width** is now a per-request `maxConcurrency` (injected by the SaaS per plan tier), clamped to `[1, crawler.max_batch_concurrency]`; a process-wide **aggregate cap** bounds total in-flight batch pipelines.

## Safety / back-compat

- Reserves default to ~1/4 of each pool **scaled to the configured size**; `0` disables a lane; `max_aggregate_batch_pipelines = 0` means **unbounded** (not a lock).
- `ReservedSemaphore` floors the batch lane at ≥1 so no reserve value can deadlock batch.
- Self-hosted behaviour is unchanged when the new knobs are absent.
- Single `/scrape`, `crw scrape`, MCP `crw_scrape` and `/v1/search` enrichment correctly stay `Interactive`.

## Observability

New metrics: `crw_reserved_lane_wait_seconds{lane,class}` (the proof metric — interactive p99 should stay flat under batch saturation) and `crw_batch_pipelines_inflight`.

## Verification

- Unit tests for the reserved-lane primitive + per-lane guarantees (batch-gate floor, reserved-slot survives saturation, task-local drives lane end-to-end).
- Live smoke test: a 5-URL batch runs entirely through the `batch` lanes while a concurrent single scrape runs through the `interactive` lanes (confirmed via the per-class metric), batch completes 5/5, no deadlock.
- `cargo fmt` / `cargo clippy --workspace` clean, full test suite green.

## Notes

- `extraction.llm.max_concurrency` was dead code and is now actually enforced (default 4). Heavy-LLM batch deployments may want to raise it.
- The SaaS side (`maxConcurrency` injection per plan tier) is a separate change in the SaaS repo; the engine accepts and clamps the field, ignoring it when absent.