### PR TITLE
fix(renderer): recover blocked-egress scrapes and stop degenerate JS attempts

### DIFF
--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -30,7 +30,44 @@ const HTTP_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis
 /// arriving. `is_request()` is intentionally NOT included — it also fires on
 /// permanent builder/config errors that no amount of retrying will fix.
 fn is_retriable_error(e: &reqwest::Error) -> bool {
-    e.is_connect() || e.is_timeout()
+    // `is_egress_rejected` is included so a reset gets one cheap direct retry: a stale
+    // pooled connection, a restarting origin, or a transient fault produces the same
+    // ErrorKind as a genuine egress block, and retrying costs milliseconds while a
+    // proxy hop costs bandwidth (billed per GB). Only if the retry also fails do we
+    // escalate to the proxy — see the `egress_rejected` arm in `fetch`.
+    e.is_connect() || e.is_timeout() || is_egress_rejected(e)
+}
+
+/// Returns true when the peer refused, reset, or aborted the transport. That is
+/// a signal our egress IP is unwelcome, which a different egress (the fallback
+/// proxy) often clears.
+///
+/// Deliberately NOT `is_connect()`. reqwest reports a reset on an *established*
+/// connection as `Kind::Request` (hyper_util `ErrorKind::SendRequest`), for which
+/// `is_connect()` is false — and that is precisely the WAF-style block we must
+/// catch (an origin that completes the handshake, inspects the request, then
+/// sends RST). Verified against this workspace's reqwest:
+///   reset   -> is_connect=false, chain contains io::ConnectionReset
+///   refused -> is_connect=true,  chain contains io::ConnectionRefused
+///   dns     -> is_connect=true,  chain contains no io::Error
+/// DNS failures are excluded on purpose: the proxy resolves the same name, so a
+/// retry through it is a wasted round trip.
+fn is_egress_rejected(e: &reqwest::Error) -> bool {
+    let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
+    while let Some(s) = src {
+        if let Some(io) = s.downcast_ref::<std::io::Error>()
+            && matches!(
+                io.kind(),
+                std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::ConnectionRefused
+                    | std::io::ErrorKind::ConnectionAborted
+            )
+        {
+            return true;
+        }
+        src = std::error::Error::source(s);
+    }
+    false
 }
 
 /// Returns true if a response status warrants one retry. Limited to the
@@ -368,6 +405,30 @@ impl PageFetcher for HttpFetcher {
                     );
                     use_relaxed = true;
                 }
+                // The origin refused or reset the connection: our egress IP is
+                // unwelcome. Switch to the fallback proxy — a different egress usually
+                // clears it. Arming does not consume the transient retry budget (same
+                // policy as the 429 arm above), so the proxy still gets one transient
+                // retry of its own if it answers with a 5xx. `!use_proxy` bounds this
+                // to a single switch: worst case is direct, direct-retry,
+                // [relaxed-TLS], proxy, proxy-retry — each bounded by
+                // `deadline.remaining()`.
+                //
+                // Deliberately placed AFTER the generic retriable arm. A reset/refused is
+                // not proof our egress is blocked: a stale pooled connection, a restarting
+                // origin, or a closed port produce the same ErrorKind. So we spend one
+                // cheap direct retry first (`is_retriable_error` now covers these), and
+                // only escalate to the billed proxy hop when that retry also fails.
+                //
+                // Skipped when too little budget remains for a proxy round trip to
+                // plausibly complete; otherwise we pay a TCP setup only to be cancelled
+                // milliseconds later.
+                //
+                // Note `active_client` prefers the proxy over the relaxed-TLS client, so
+                // a site that needs BOTH a relaxed cert and a different egress keeps the
+                // strict-TLS proxy client and will still fail. That ordering predates
+                // this arm (the 429 arm has the same property) and no origin observed in
+                // production needs both.
                 Ok(Err(e)) if attempt < HTTP_MAX_RETRIES && is_retriable_error(&e) => {
                     tracing::debug!(
                         "transient HTTP error to {url} ({e}), retrying (attempt {})",
@@ -379,7 +440,27 @@ impl PageFetcher for HttpFetcher {
                         tokio::time::sleep(backoff).await;
                     }
                 }
+                // Last resort before giving up: the direct retry above also failed with a
+                // refused/reset transport, so this looks like a genuine egress block.
+                // Switch to the fallback proxy for one more try.
+                Ok(Err(e))
+                    if !use_proxy
+                        && self.ratelimit_proxy_client.is_some()
+                        && deadline.remaining() >= crate::MIN_TIER_BUDGET
+                        && is_egress_rejected(&e) =>
+                {
+                    tracing::warn!(
+                        "connection refused/reset for {url} ({e}); retrying via proxy (egress_rejected)"
+                    );
+                    // Like the 429 arm: switching egress does not refund the transient
+                    // retry budget, so the proxy gets exactly one attempt. Worst case is
+                    // direct, direct-retry, proxy — three round trips.
+                    use_proxy = true;
+                }
                 Ok(Err(e)) => {
+                    // Unchanged: `is_connect()` (refused/DNS/TLS-handshake) means the target
+                    // is unreachable (422). A bare reset stays an HttpError (502, retryable)
+                    // — it can still be transient, and we do not know it is permanent.
                     return Err(if e.is_connect() {
                         CrwError::TargetUnreachable(format!("Could not reach {url}: {e}"))
                     } else {
@@ -558,6 +639,191 @@ mod tests {
         assert!(should_arm_proxy(403, true), "403 + cf-mitigated arms");
         assert!(should_arm_proxy(200, true), "challenge served as 200 arms");
         assert!(!should_arm_proxy(200, false), "clean 200 does not arm");
+    }
+
+    /// Complete the handshake, read the request, THEN abort with RST
+    /// (unix only: forcing an RST needs SO_LINGER; on other platforms `close()`
+    /// sends FIN and the test would assert the wrong error class).
+    /// This is the WAF-style block seen in production: the
+    /// origin inspects the request before rejecting it. Reading first is what makes
+    /// the test deterministic — it forces the error into hyper's send-request phase
+    /// rather than the connect phase.
+    #[cfg(unix)]
+    fn spawn_resetting_origin() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                use std::io::Read;
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                #[cfg(unix)]
+                unsafe {
+                    use std::os::fd::AsRawFd;
+                    let l = libc::linger {
+                        l_onoff: 1,
+                        l_linger: 0,
+                    };
+                    libc::setsockopt(
+                        stream.as_raw_fd(),
+                        libc::SOL_SOCKET,
+                        libc::SO_LINGER,
+                        std::ptr::from_ref(&l).cast(),
+                        std::mem::size_of::<libc::linger>() as libc::socklen_t,
+                    );
+                }
+                drop(stream);
+            }
+        });
+        format!("http://{addr}/")
+    }
+
+    /// A reset on an established connection must arm the proxy. `is_connect()` is
+    /// false here — which is exactly why the predicate cannot be built on it. This
+    /// mirrors the production trace for `sabir.com`, where the engine reported
+    /// `HttpError` ("HTTP request failed") rather than `TargetUnreachable`, proving
+    /// `is_connect()` was false for the real block.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn egress_rejected_catches_connection_reset() {
+        let url = spawn_resetting_origin();
+        let err = reqwest::Client::new().get(&url).send().await.unwrap_err();
+        assert!(
+            !err.is_connect(),
+            "a post-handshake reset must not be is_connect(); \
+             if this ever flips, the arm ordering below needs revisiting"
+        );
+        assert!(is_egress_rejected(&err), "reset must arm the proxy");
+    }
+
+    /// A refused connection (nothing listening) must also arm the proxy.
+    #[tokio::test]
+    async fn egress_rejected_catches_connection_refused() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let err = reqwest::Client::new()
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .unwrap_err();
+        assert!(is_egress_rejected(&err), "refused must arm the proxy");
+    }
+
+    /// Minimal forward proxy: reads the absolute-URI request reqwest sends for a
+    /// plain-HTTP proxied GET and answers 200 with a marker body.
+    #[cfg(unix)]
+    fn spawn_stub_proxy() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 2048];
+                let _ = stream.read(&mut buf);
+                const BODY: &str = "<html><body>served via proxy</body></html>";
+                let _ = stream.write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{BODY}",
+                        BODY.len()
+                    )
+                    .as_bytes(),
+                );
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// End-to-end: an origin that resets the connection is retried through the
+    /// fallback proxy and succeeds. This is the production `sabir.com` case
+    /// (prod egress IP refused, proxy reaches it in ~1.6s). Without the
+    /// `is_egress_rejected` arm the request dies with `HttpError` and the caller
+    /// sees a 502.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connection_reset_is_retried_through_proxy() {
+        let origin = spawn_resetting_origin();
+        let proxy = spawn_stub_proxy();
+
+        let fetcher = HttpFetcher {
+            client: reqwest::Client::new(),
+            relaxed_client: None,
+            ratelimit_proxy_client: Some(
+                build_client(
+                    "test-ua",
+                    Some(&proxy),
+                    std::time::Duration::from_secs(5),
+                    false,
+                )
+                .unwrap(),
+            ),
+            inject_stealth_headers: false,
+        };
+
+        let res = fetcher
+            .fetch(
+                &origin,
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(10_000),
+            )
+            .await
+            .expect("reset origin must be recovered through the proxy");
+        assert!(
+            res.html.contains("served via proxy"),
+            "expected the proxy's body, got: {}",
+            res.html
+        );
+    }
+
+    /// Without an armed proxy the same reset still fails — the arm is what fixes
+    /// it, not some incidental retry.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connection_reset_without_proxy_still_fails() {
+        let origin = spawn_resetting_origin();
+        let fetcher = HttpFetcher {
+            client: reqwest::Client::new(),
+            relaxed_client: None,
+            ratelimit_proxy_client: None,
+            inject_stealth_headers: false,
+        };
+        let err = fetcher
+            .fetch(
+                &origin,
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(10_000),
+            )
+            .await
+            .expect_err("no proxy armed => the reset must surface as an error");
+        assert!(
+            matches!(err, CrwError::HttpError(_) | CrwError::TargetUnreachable(_)),
+            "unexpected error variant: {err:?}"
+        );
+    }
+
+    /// A DNS failure must NOT arm the proxy: it resolves the same name, so the
+    /// extra round trip buys nothing.
+    /// A DNS failure must NOT arm the proxy: it resolves the same name, so the extra
+    /// round trip buys nothing. Written to be network-tolerant: if the environment's
+    /// resolver hijacks NXDOMAIN and returns a response, there is no error to classify
+    /// and the assertion is vacuous rather than flaky.
+    #[tokio::test]
+    async fn egress_rejected_ignores_dns_failure() {
+        let res = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap()
+            .get("http://nonexistent.invalid./")
+            .send()
+            .await;
+        if let Err(err) = res {
+            assert!(
+                !is_egress_rejected(&err),
+                "DNS failure must not arm the proxy (got {err:?})"
+            );
+        }
     }
 
     #[test]

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -281,6 +281,39 @@ enum HedgeOutcome {
     Thin(FetchResult, bool),
 }
 
+/// Did this renderer error come from failing to reach/navigate the ORIGIN, as
+/// opposed to a fault on our side (CDP pool exhausted, browser discovery failed,
+/// a pinned renderer that does not exist)?
+///
+/// Only used to decide whether an unreachable origin should outrank a JS-tier error
+/// when both fail. Getting it wrong in the permissive direction (treating our fault as
+/// the origin's) would blame the caller for our outage, so the match is deliberately
+/// narrow.
+///
+/// `Timeout` is NOT included: a JS-tier timeout is just as likely to be a local CDP
+/// websocket/command timeout as a slow origin, and it already maps to 504 on its own,
+/// which is the honest answer either way.
+fn is_origin_navigation_failure(e: &CrwError) -> bool {
+    match e {
+        CrwError::TargetUnreachable(_) => true,
+        // Chrome/LightPanda report a failure to reach the origin as a navigation error
+        // with a `net::ERR_*` code. Internal faults (pool exhausted, CDP discovery)
+        // carry different messages and keep their own error.
+        CrwError::RendererError(msg) => {
+            let m = msg.to_ascii_lowercase();
+            m.contains("navigation failed") || m.contains("net::err_")
+        }
+        _ => false,
+    }
+}
+
+/// Minimum remaining request budget for a network attempt to be worth making.
+/// Below this a CDP tier cannot complete its handshake and returns a fabricated
+/// `Timeout after Nms` (single-digit N) while still consuming a pool slot.
+/// Guards the main ladder loop, the hedge dispatch, the breaker leak-through arm,
+/// and the HTTP tier's proxy retry (`http_only`).
+pub(crate) const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
+
 /// Composite renderer that tries multiple backends in order.
 pub struct FallbackRenderer {
     http: Arc<dyn PageFetcher>,
@@ -1067,7 +1100,23 @@ impl FallbackRenderer {
                             .await
                             .map_err(|js_err| {
                                 tracing::warn!("Both HTTP and JS failed: http={e}, js={js_err}");
-                                js_err
+                                // When the HTTP tier could not reach the origin AND the JS tier
+                                // failed navigating to that same origin, the origin is the root
+                                // cause: surface TargetUnreachable (422 — the caller handed us a
+                                // dead target) instead of the JS tier's RendererError, which
+                                // falls through to a 500 and reads as "our server broke".
+                                //
+                                // A JS failure can also be OUR fault (pool exhausted, CDP
+                                // discovery failed, pinned renderer missing). Those keep their
+                                // own error, or we would blame the caller for our outage.
+                                match (&e, &js_err) {
+                                    (CrwError::TargetUnreachable(_), js)
+                                        if is_origin_navigation_failure(js) =>
+                                    {
+                                        e
+                                    }
+                                    _ => js_err,
+                                }
                             });
                     }
                     Err(e) => return Err(e),
@@ -1289,6 +1338,16 @@ impl FallbackRenderer {
             drop(ch_guard);
             return Ok(None);
         }
+        // Both `acquire_with_guard` calls above await, so the budget may have drained
+        // since the caller's floor check. Re-check before dispatching, or the floor is
+        // only advisory here. Bail to the serial loop, which applies its own floor and
+        // records the skip.
+        if deadline.remaining() < MIN_TIER_BUDGET {
+            drop(lp_guard);
+            drop(ch_guard);
+            return Ok(None);
+        }
+
         let mut lp_guard = Some(lp_guard);
         let mut ch_guard = Some(ch_guard);
 
@@ -1595,6 +1654,10 @@ impl FallbackRenderer {
         if self.chrome_hedge
             && !is_user_pinned
             && !proxy_active
+            // Same degenerate-budget guard as the serial loop: the hedge dispatches
+            // both CDP tiers directly, bypassing that check. Prod runs with
+            // CRW_CHROME_HEDGE=true, so this is load-bearing, not defensive.
+            && deadline.remaining() >= MIN_TIER_BUDGET
             && renderers.first().map(|r| r.name()) == Some("lightpanda")
             && renderers.iter().any(|r| r.name() == "chrome")
             && let Ok(_permit) = self.hedge_sem.clone().try_acquire_owned()
@@ -1635,13 +1698,47 @@ impl FallbackRenderer {
             // with the "" key when URL parsing failed.
             let trackable = kind.filter(|_| !host.is_empty());
 
-            // Pre-flight deadline skip removed: classify_outcome in the
-            // breaker layer already ignores DeadlineClamped outcomes, so a
-            // tier-side timeout on near-exhausted budget doesn't poison the
-            // breaker. Letting chrome attempt with partial-DOM budget gives
-            // higher success on legitimately-slow tail URLs than aborting
-            // pre-flight. tier_timeouts is still used by AttemptContext to
-            // detect clamping post-hoc.
+            // A tier-side skip on a *partial* budget stays removed (86dd10f): letting
+            // chrome attempt with a partial-DOM budget beats aborting pre-flight on
+            // legitimately-slow tail URLs, and classify_outcome ignores DeadlineClamped
+            // so the breaker isn't poisoned. What is reinstated here is narrower: a
+            // *degenerate* budget. A CDP attempt cannot even finish its handshake in
+            // single-digit milliseconds, so it returns a fabricated `Timeout after 5ms`
+            // that pollutes logs and burns a pool slot. Measured in prod: 432 of 536
+            // escalations ran with <50ms of budget. Skip those, and only those.
+            //
+            // Note this is skip-*without*-attempting, distinct from the post-hoc
+            // DeadlineClamped classification, which still only applies to tiers that
+            // were actually invoked.
+            let remaining = deadline.remaining();
+            if remaining < MIN_TIER_BUDGET {
+                tracing::debug!(
+                    renderer = renderer.name(),
+                    remaining_ms = remaining.as_millis() as u64,
+                    "budget below minimum tier budget, skipping renderer"
+                );
+                if let Some(k) = kind {
+                    // Deliberately NOT `breaker_skipped`: that vec means "the circuit
+                    // breaker rejected this tier" and gates the leak-through arm.
+                    metrics()
+                        .render_route_decision_total
+                        .with_label_values(&[k.as_str(), "budgetSkipped"])
+                        .inc();
+                }
+                // Preserve the status code a starved request returns today. The tier we
+                // are skipping would have been invoked with `remaining`, timed out, and
+                // written `CrwError::Timeout` here — overwriting any earlier error, as
+                // every other `last_error` assignment in this function does. Assign
+                // unconditionally for the same reason: `get_or_insert_with` would let an
+                // earlier tier's `RendererError` survive and map to 500 instead of 504.
+                //
+                // Report the budget the tier would have had, matching what the CDP tier
+                // reports when invoked and clamped (`Timeout after 5ms`). `overrun()` is
+                // 0 whenever the deadline has not actually expired — the common case
+                // here (1-499ms left).
+                last_error = Some(CrwError::Timeout(remaining.as_millis().max(1) as u64));
+                continue;
+            }
 
             // Consult breaker for tracked renderers. Untracked names (e.g.
             // "playwright") bypass the breaker for now.
@@ -1664,6 +1761,28 @@ impl FallbackRenderer {
                 }
                 probe_guard = Some(guard);
             }
+
+            // `acquire_with_guard` awaits, so the budget may have drained while we
+            // waited for a breaker permit. Re-check before dispatching, or the floor
+            // above is only advisory. Dropping `probe_guard` here cancels the probe
+            // (see `ProbeGuard::drop`), so the breaker is left as we found it.
+            let remaining = deadline.remaining();
+            if remaining < MIN_TIER_BUDGET {
+                tracing::debug!(
+                    renderer = renderer.name(),
+                    remaining_ms = remaining.as_millis() as u64,
+                    "budget drained while acquiring breaker permit, skipping renderer"
+                );
+                if let Some(k) = kind {
+                    metrics()
+                        .render_route_decision_total
+                        .with_label_values(&[k.as_str(), "budgetSkipped"])
+                        .inc();
+                }
+                last_error = Some(CrwError::Timeout(remaining.as_millis().max(1) as u64));
+                continue;
+            }
+
             if let Some(k) = kind {
                 chain.push(k);
             }
@@ -2048,11 +2167,11 @@ impl FallbackRenderer {
         // entering a renderer with <500ms budget produced 37/128 of the
         // first leak run's failures as "Timeout after 1-2ms" — the
         // attempt cannot succeed and just consumes a CDP connection.
-        const LEAK_MIN_BUDGET: Duration = Duration::from_millis(500);
+        // (Same reasoning now guards the main ladder loop; see MIN_TIER_BUDGET.)
         if thin_result.is_none()
             && !breaker_skipped.is_empty()
             && !is_user_pinned
-            && deadline.remaining() >= LEAK_MIN_BUDGET
+            && deadline.remaining() >= MIN_TIER_BUDGET
         {
             for renderer in &renderers_snapshot {
                 let kind = renderer_kind_for(renderer.name());
@@ -2063,6 +2182,11 @@ impl FallbackRenderer {
                 }
                 let permit = self.breakers.try_acquire_host_only(&host, k).await;
                 if permit == Permit::Rejected {
+                    continue;
+                }
+                // That acquire awaits; re-check the budget before dispatching so the
+                // floor above is not merely advisory (same TOCTOU as the serial loop).
+                if deadline.remaining() < MIN_TIER_BUDGET {
                     continue;
                 }
                 tracing::info!(
@@ -2135,7 +2259,11 @@ impl FallbackRenderer {
                 .get(&kind)
                 .copied()
                 .unwrap_or_else(|| std::time::Duration::from_secs(30));
-            if saw_hard_block && deadline.remaining() >= tier_budget {
+            // `tier_budget` is normally far above MIN_TIER_BUDGET (chrome_proxy defaults
+            // to chrome_timeout + 15s), but an operator can configure it lower. Take the
+            // stricter of the two so no JS dispatch path can run on a degenerate budget.
+            let arm_floor = tier_budget.max(MIN_TIER_BUDGET);
+            if saw_hard_block && deadline.remaining() >= arm_floor {
                 chain.push(kind);
                 let entry = self.pick_proxy_for_url(url);
                 let attempt = REQUEST_PROXY
@@ -2574,6 +2702,247 @@ mod tests {
             marker,
             "x".repeat(200)
         )
+    }
+
+    /// Mock that records whether it was invoked. Separate from `MockFetcher` so the
+    /// ~12 existing constructor sites stay untouched.
+    struct CountingFetcher {
+        name: &'static str,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl PageFetcher for CountingFetcher {
+        async fn fetch(
+            &self,
+            url: &str,
+            _headers: &HashMap<String, String>,
+            _wait_for_ms: Option<u64>,
+            _deadline: crw_core::Deadline,
+        ) -> CrwResult<FetchResult> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(FetchResult {
+                url: url.to_string(),
+                final_url: None,
+                status_code: 200,
+                html: rich_html("rendered"),
+                content_type: Some("text/html".to_string()),
+                raw_bytes: None,
+                rendered_with: Some(self.name.to_string()),
+                elapsed_ms: 0,
+                warning: None,
+                render_decision: None,
+                credit_cost: 0,
+                warnings: Vec::new(),
+                truncated: false,
+                deadline_exceeded: false,
+                captured_responses: Vec::new(),
+                screenshot: None,
+            })
+        }
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn supports_js(&self) -> bool {
+            true
+        }
+        async fn is_available(&self) -> bool {
+            true
+        }
+    }
+
+    /// A degenerate budget must not invoke a JS tier at all (prod: 432 of 536
+    /// escalations ran with <50ms, returning a fabricated `Timeout after 5ms`),
+    /// and the request must still surface `CrwError::Timeout` so the server keeps
+    /// mapping it to 504 rather than a 500 from the `RendererError` tail.
+    #[tokio::test]
+    async fn degenerate_budget_skips_js_tier_and_preserves_timeout() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mock = Arc::new(CountingFetcher {
+            name: "chrome",
+            calls: calls.clone(),
+        });
+        let r = make_renderer_with_mocks(vec![mock]);
+
+        let err = r
+            .fetch_with_js(
+                "https://example.com",
+                &HashMap::new(),
+                None,
+                None,
+                crw_core::Deadline::from_request_ms(0),
+            )
+            .await
+            .expect_err("an exhausted budget must not produce a rendered page");
+
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "renderer must be skipped, not invoked with a few milliseconds"
+        );
+        assert!(
+            matches!(err, CrwError::Timeout(_)),
+            "must stay a Timeout (504), not RendererError (500); got {err:?}"
+        );
+    }
+
+    /// Burns most of the budget, then fails — so the NEXT tier lands below the floor.
+    struct SlowFailingFetcher {
+        name: &'static str,
+        burn: Duration,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl PageFetcher for SlowFailingFetcher {
+        async fn fetch(
+            &self,
+            _url: &str,
+            _headers: &HashMap<String, String>,
+            _wait_for_ms: Option<u64>,
+            _deadline: crw_core::Deadline,
+        ) -> CrwResult<FetchResult> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            tokio::time::sleep(self.burn).await;
+            Err(CrwError::RendererError("anti-bot wall".to_string()))
+        }
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn supports_js(&self) -> bool {
+            true
+        }
+        async fn is_available(&self) -> bool {
+            true
+        }
+    }
+
+    /// A tier that fails for a real reason, followed by a tier skipped for lack of
+    /// budget, must still report Timeout (504) — not the earlier RendererError (500).
+    /// The skipped tier would have been invoked, timed out, and overwritten
+    /// `last_error`; skipping must not change the status the caller sees. Guards
+    /// against reintroducing `get_or_insert_with` here.
+    #[tokio::test]
+    async fn budget_skip_overrides_an_earlier_renderer_error() {
+        let slow_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let slow = Arc::new(SlowFailingFetcher {
+            name: "lightpanda",
+            burn: Duration::from_millis(1_200),
+            calls: slow_calls.clone(),
+        });
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let chrome = Arc::new(CountingFetcher {
+            name: "chrome",
+            calls: calls.clone(),
+        });
+        let r = make_renderer_with_mocks(vec![slow, chrome]);
+
+        // 1500ms budget: lightpanda is comfortably above the 500ms floor even under
+        // CI scheduling jitter, burns 1200ms and errors, leaving ~300ms — chrome is
+        // then below the floor and is skipped.
+        let err = r
+            .fetch_with_js(
+                "https://example.com",
+                &HashMap::new(),
+                None,
+                None,
+                crw_core::Deadline::from_request_ms(1_500),
+            )
+            .await
+            .expect_err("both tiers must fail");
+
+        assert_eq!(
+            slow_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the first tier must actually run, or this test proves nothing"
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "chrome must be skipped for lack of budget"
+        );
+        assert!(
+            matches!(err, CrwError::Timeout(_)),
+            "a budget skip must overwrite the earlier RendererError so the server \
+             still maps this to 504; got {err:?}"
+        );
+    }
+
+    /// When the HTTP tier could not reach the origin at all, that error must win over
+    /// the JS tier's generic RendererError. `TargetUnreachable` maps to 422 (the caller
+    /// gave us a dead target); `RendererError` falls through to a 500 and reads as "our
+    /// server broke". Production emitted 11 such 500s that should have been 422s.
+    #[tokio::test]
+    async fn unreachable_origin_beats_js_renderer_error() {
+        struct Unreachable;
+        #[async_trait::async_trait]
+        impl PageFetcher for Unreachable {
+            async fn fetch(
+                &self,
+                url: &str,
+                _h: &HashMap<String, String>,
+                _w: Option<u64>,
+                _d: crw_core::Deadline,
+            ) -> CrwResult<FetchResult> {
+                Err(CrwError::TargetUnreachable(format!(
+                    "Could not reach {url}"
+                )))
+            }
+            fn name(&self) -> &str {
+                "http"
+            }
+            fn supports_js(&self) -> bool {
+                false
+            }
+            async fn is_available(&self) -> bool {
+                true
+            }
+        }
+
+        let js = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Err("Navigation failed: net::ERR_SSL".to_string()),
+        });
+        let mut r = make_renderer_with_mocks(vec![js]);
+        r.http = Arc::new(Unreachable);
+        r.render_js_default = None; // auto branch
+
+        let err = r
+            .fetch(
+                "https://dead.example",
+                &HashMap::new(),
+                None, // render_js: auto
+                None, // wait_for_ms
+                None, // requested_renderer
+                tdl(),
+            )
+            .await
+            .expect_err("both tiers fail");
+
+        assert!(
+            matches!(err, CrwError::TargetUnreachable(_)),
+            "an unreachable origin must surface as TargetUnreachable (422), not the JS \
+             tier's RendererError (500); got {err:?}"
+        );
+    }
+
+    /// Control: with a healthy budget the same tier IS invoked. Guards against the
+    /// floor silently disabling the ladder.
+    #[tokio::test]
+    async fn healthy_budget_still_invokes_js_tier() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mock = Arc::new(CountingFetcher {
+            name: "chrome",
+            calls: calls.clone(),
+        });
+        let r = make_renderer_with_mocks(vec![mock]);
+
+        let res = r
+            .fetch_with_js("https://example.com", &HashMap::new(), None, None, tdl())
+            .await
+            .expect("healthy budget must render");
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(res.html.contains("rendered"));
     }
 
     fn make_renderer_with_mocks(mocks: Vec<Arc<dyn PageFetcher>>) -> FallbackRenderer {


### PR DESCRIPTION
## What

Three fixes on the scrape renderer ladder, from a production investigation into elevated `/v1/scrape` 5xx.

**1. Arm the fallback proxy on connection-level failures.** The HTTP tier only switched to the fallback proxy on a `429` / cf-mitigated *response*. Origins that refuse or reset our egress IP but serve fine through the proxy fell straight through to an error. A post-handshake reset is not `is_connect()` (verified against the vendored reqwest: a reset surfaces as `Kind::Request` with `io::ConnectionReset` in the source chain), so it never even reached the transient-retry arm. Now `is_egress_rejected()` walks the error chain for `ConnectionReset/Refused/Aborted`; such an error gets one cheap direct retry and then, as a last resort, one attempt through the proxy. DNS failures are excluded (the proxy resolves the same name).

**2. Skip a renderer tier below a 500ms budget floor.** A near-exhausted deadline still invoked JS tiers, which returned a fabricated `Timeout after 5ms` while holding a browser-pool slot. The floor guards the serial loop, the hedge dispatch, the leak-through arm, and the `chrome_proxy` arm, with a re-check after every async breaker acquire (TOCTOU). The skip preserves the `Timeout` status so the request maps to 504, not a 500 from the `RendererError` tail.

**3. Map an unreachable origin to 422, not 500.** When the HTTP tier could not reach the origin AND the JS tier failed navigating to that same origin, the caller handed us a dead target, not a broken gateway. Surface `TargetUnreachable` (422) instead of the renderer's `RendererError` (500). Internal renderer faults (pool exhausted, CDP discovery) keep their own status.

## Why

- `sabir.com` from prod: direct connect resets; via DataImpulse returns 200 in ~1.6s; from a different datacenter it opens in ~0.5s — the prod egress IPv4 is being blocked, and the proxy is the correct remedy.
- Prod emitted a fabricated `Timeout after {1..17}ms` on 432 of 536 JS escalations in a 20-minute window — the ladder was effectively invoking browser tiers with no budget.
- Prod emitted 11 `500`s for dead old-TLS origins that should have been `422` (the SaaS refunds credits on 4xx).

## Scope

Engine only. No SaaS change; the scrape default deadline is intentionally left at 5s (an empirical deadline sweep showed raising it recovers ~1 URL of 20 while doubling the latency of the ones that still fail). Follow-ups (separate): origin 4xx surfaced as 5xx on other paths, the redirect-policy failures, Caddy `:3002`/`keepAliveTimeout`.

## Tests

New unit tests, each mutation-checked (reverting its fix makes it fail):
- proxy is used when a reset origin is unreachable directly; not used when unarmed
- `is_egress_rejected` catches reset/refused, ignores DNS
- a degenerate budget skips the JS tier and preserves `Timeout` (504)
- a budget skip after an earlier renderer error still yields 504, not 500
- an unreachable origin outranks the JS renderer error (422, not 500)

Verified end-to-end with the release binary against a stub proxy. `cargo fmt`/`clippy -D warnings` clean, full workspace suite green.