### PR TITLE
feat(bench): live answer track + managed-endpoint support

### DIFF
--- a/bench/answer.py
+++ b/bench/answer.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Answer track — end-to-end answer quality on FRAMES (the metric FRAMES is
+actually designed for, unlike the Wikipedia-URL relevance proxy).
+
+For each FRAMES question:
+  1. POST /v1/search {answer:true, scrapeOptions.formats:[markdown]} → synthesized answer
+  2. an independent judge LLM grades the answer PASS/FAIL against the gold Answer
+  3. emit an `answer`-track `pass` row (1/0) to the shared items.jsonl
+
+Single-system pass rate (absolute crw-vs-gold). The judge is pinned temp=0 and
+recorded in the manifest by its provider/model. Answer content that comes back
+empty is a genuine FAIL (value 0, status ok) — only a search infra timeout/error
+is excluded (status timeout/error), matching the missing-pair policy.
+
+Config via env (secrets never written to disk):
+  CRW_API_URL, CRW_API_KEY            — fastCRW endpoint under test
+  JUDGE_BASE_URL, JUDGE_API_KEY, JUDGE_MODEL — OpenAI-compatible judge
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+import aiohttp
+
+from schema import append_items, item_record, read_manifest
+
+CRW_URL = os.getenv("CRW_API_URL", "http://localhost:3000")
+CRW_API_KEY = os.getenv("CRW_API_KEY", "")
+JUDGE_BASE_URL = os.getenv("JUDGE_BASE_URL", "")
+JUDGE_API_KEY = os.getenv("JUDGE_API_KEY", "")
+JUDGE_MODEL = os.getenv("JUDGE_MODEL", "")
+SEARCH_LIMIT = int(os.getenv("BENCH_SEARCH_LIMIT", "5"))
+SEARCH_TIMEOUT = int(os.getenv("BENCH_TIMEOUT", "90"))
+
+GRADER_SYS = (
+    "You grade whether a predicted answer is correct for a question, given the "
+    "gold answer. Reply with exactly one word: PASS if the prediction states the "
+    "same fact as the gold answer (allow paraphrase, extra detail, or different "
+    "formatting), otherwise FAIL. If the prediction says it cannot find or does "
+    "not know the answer, reply FAIL."
+)
+
+
+def _headers(key: str) -> dict:
+    h = {"Content-Type": "application/json"}
+    if key:
+        h["Authorization"] = f"Bearer {key}"
+    return h
+
+
+async def search_answer(session, query: str) -> tuple[str, str]:
+    """POST /v1/search answer:true → (answer_text, status)."""
+    body = {
+        "query": query,
+        "answer": True,
+        "limit": SEARCH_LIMIT,
+        "scrapeOptions": {"formats": ["markdown"]},
+    }
+    try:
+        async with session.post(
+            f"{CRW_URL}/v1/search",
+            json=body,
+            headers=_headers(CRW_API_KEY),
+            timeout=aiohttp.ClientTimeout(total=SEARCH_TIMEOUT),
+        ) as resp:
+            payload = await resp.json()
+    except asyncio.TimeoutError:
+        return "", "timeout"
+    except Exception:  # noqa: BLE001
+        return "", "error"
+    ans = (payload.get("answer") or "").strip()
+    if not ans:
+        return "", "empty_answer"  # search ran but produced no answer → a FAIL
+    return ans, "ok"
+
+
+async def judge(session, question: str, gold: str, pred: str) -> bool:
+    """Grade pred against gold via the judge LLM (temp 0). PASS→True."""
+    user = f"Question: {question}\nGold answer: {gold}\nPredicted answer: {pred}"
+    body = {
+        "model": JUDGE_MODEL,
+        "messages": [
+            {"role": "system", "content": GRADER_SYS},
+            {"role": "user", "content": user},
+        ],
+        "temperature": 0,
+        "max_tokens": 8,
+    }
+    async with session.post(
+        JUDGE_BASE_URL,
+        json=body,
+        headers=_headers(JUDGE_API_KEY),
+        timeout=aiohttp.ClientTimeout(total=60),
+    ) as resp:
+        data = await resp.json()
+    verdict = (data["choices"][0]["message"]["content"] or "").strip().upper()
+    return verdict.startswith("PASS")
+
+
+async def one(session, run_id, idx, row, sem) -> dict:
+    q, gold = row["Prompt"], row["Answer"]
+    async with sem:
+        ans, status = await search_answer(session, q)
+        if status in ("timeout", "error"):
+            return item_record(run_id, "answer", f"q{idx}", "crw", "pass", 0.0, status)
+        if status == "empty_answer":
+            return item_record(run_id, "answer", f"q{idx}", "crw", "pass", 0.0, "ok")
+        try:
+            passed = await judge(session, q, gold, ans)
+        except Exception:  # noqa: BLE001 — judge failure ≠ crw fail; exclude it
+            return item_record(run_id, "answer", f"q{idx}", "crw", "pass", 0.0, "error")
+        return item_record(run_id, "answer", f"q{idx}", "crw", "pass",
+                           1.0 if passed else 0.0, "ok")
+
+
+async def amain(run_id: str, limit: int, concurrency: int) -> int:
+    read_manifest(run_id)  # fail early if the run wasn't init'd
+    for name, val in (("JUDGE_BASE_URL", JUDGE_BASE_URL), ("JUDGE_API_KEY", JUDGE_API_KEY),
+                      ("JUDGE_MODEL", JUDGE_MODEL)):
+        if not val:
+            raise SystemExit(f"missing env {name}")
+    from datasets import load_dataset
+    ds = load_dataset("google/frames-benchmark", split="test")
+    rows = [{"Prompt": r["Prompt"], "Answer": r["Answer"]} for r in ds][:limit]
+    sem = asyncio.Semaphore(concurrency)
+    passed = done = 0
+    async with aiohttp.ClientSession() as session:
+        tasks = [one(session, run_id, i, r, sem) for i, r in enumerate(rows)]
+        for coro in asyncio.as_completed(tasks):
+            rec = await coro
+            append_items(run_id, [rec])  # crash-safe: persist each item as it lands
+            done += 1
+            if rec["status"] == "ok" and rec["value"] == 1.0:
+                passed += 1
+            if done % 10 == 0 or done == len(rows):
+                print(f"  [{done}/{len(rows)}] running pass≈{passed}/{done}")
+    print(f"answer: {passed}/{done} PASS on the judge (status=ok rows)")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("run_id")
+    p.add_argument("--limit", type=int, default=100)
+    p.add_argument("--concurrency", type=int, default=5)
+    a = p.parse_args()
+    return asyncio.run(amain(a.run_id, a.limit, a.concurrency))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/map_recall.py
+++ b/bench/map_recall.py
@@ -103,11 +103,11 @@ def _host(u: str) -> str:
 def run_live(site: Site) -> tuple[list[str], float]:
     """POST /v1/map and return (links, elapsed_seconds)."""
     body = json.dumps({"url": site.url}).encode()
-    req = urllib.request.Request(
-        f"{CRW_URL}/v1/map",
-        data=body,
-        headers={"Content-Type": "application/json"},
-    )
+    headers = {"Content-Type": "application/json"}
+    api_key = os.getenv("CRW_API_KEY", "")
+    if api_key:  # required for managed endpoints (self-host runs auth-off)
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(f"{CRW_URL}/v1/map", data=body, headers=headers)
     t0 = time.monotonic()
     with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
         payload = json.load(resp)

--- a/bench/relevance.py
+++ b/bench/relevance.py
@@ -30,8 +30,10 @@ import urllib.request
 from schema import content_hash, item_record
 
 CRW_URL = os.getenv("CRW_API_URL", "http://localhost:3000")
+CRW_API_KEY = os.getenv("CRW_API_KEY", "")  # required for managed endpoints
 TIMEOUT = int(os.getenv("BENCH_TIMEOUT", "60"))
 K = 10
+SEARCH_LIMIT = int(os.getenv("BENCH_SEARCH_LIMIT", "20"))  # fetch ≥K to score Recall@10
 
 # Query params that carry no semantics — dropped in canonicalization. Anything
 # NOT on this denylist is kept (a semantic ?q=/?id= must survive).
@@ -164,10 +166,11 @@ def score_query(returned: list[str], gold_urls: list[str], k: int = K) -> dict |
 # --- Live path -------------------------------------------------------------
 def search_ranked(query: str) -> tuple[list[str], str]:
     """POST /v1/search answer:false → (urls ordered by position, status)."""
-    body = json.dumps({"query": query, "answer": False}).encode()
-    req = urllib.request.Request(
-        f"{CRW_URL}/v1/search", data=body,
-        headers={"Content-Type": "application/json"})
+    body = json.dumps({"query": query, "answer": False, "limit": SEARCH_LIMIT}).encode()
+    headers = {"Content-Type": "application/json"}
+    if CRW_API_KEY:
+        headers["Authorization"] = f"Bearer {CRW_API_KEY}"
+    req = urllib.request.Request(f"{CRW_URL}/v1/search", data=body, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
             payload = json.load(resp)
@@ -175,8 +178,10 @@ def search_ranked(query: str) -> tuple[list[str], str]:
         return [], "timeout"
     except Exception:  # noqa: BLE001 — bench records the failure, does not crash
         return [], "error"
-    data = payload.get("data") or {}
-    results = data.get("results") or []
+    # /v1/search serializes results at `data` directly (a list); older/self-host
+    # shapes nested them under `data.results`. Handle both.
+    data = payload.get("data")
+    results = data if isinstance(data, list) else (data or {}).get("results") or []
     if not results:
         return [], "empty"
     ordered = sorted(results, key=lambda r: r.get("position", 1 << 30))


### PR DESCRIPTION
Makes the benchmark harness actually runnable against a managed endpoint, and
adds the FRAMES answer-quality track. Test-side only — `bench/` python, not in
the engine, not deployed, not a CI gate. Verified live against prod.

## Why
The merged harness could not hit a managed endpoint: it sent no auth header, and
it mis-parsed the current `/v1/search` shape (results now serialize as a
top-level `data` list; the code read `data.results`), so the relevance track
returned nothing against real prod.

## Changes
- `answer.py` (new) — FRAMES answer-quality track: `/v1/search answer:true`
  synthesized answer graded PASS/FAIL by an independent judge LLM, crash-safe
  incremental writes into the shared `items.jsonl`. Judge config via env
  (`JUDGE_BASE_URL/JUDGE_API_KEY/JUDGE_MODEL`); no secrets on disk.
- `relevance.py` — accept `data` as a top-level list (fallback to `data.results`
  for self-host), add `CRW_API_KEY` bearer auth, configurable search limit so
  Recall@10 has enough results to score.
- `map_recall.py` — send `CRW_API_KEY` bearer auth for managed endpoints.

## Verification
- `bash bench/verify.sh` offline suite green (fixes don't break the selfchecks)
- `ruff check` clean
- Exercised live against prod: relevance (n=200), answer (n=95), map (n=1109)
  all produced CI-backed numbers

Ref: plans/roadmap/phase-0-benchmark-discipline.md