### PR TITLE
feat(mcp): advertise server instructions and web-first tool guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -29,6 +29,7 @@
     "./skills/crw-crawl",
     "./skills/crw-parse",
     "./skills/crw-extract",
+    "./skills/crw-research",
     "./skills/crw-watch",
     "./skills/crw-dynamic-search",
     "./skills/crw-best-practices",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crw",
   "displayName": "fastCRW",
-  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW — the open-source, self-hostable Firecrawl alternative. Single Rust binary, ~6 MB RAM, Firecrawl-compatible /v1 + /v2 API, bundled SearXNG search.",
+  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, ~6 MB RAM, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
   "version": "0.3.0",
   "author": {
     "name": "us",
@@ -18,7 +18,6 @@
     "extract",
     "web-data",
     "firecrawl",
-    "searxng",
     "rag",
     "mcp"
   ],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crw",
   "displayName": "fastCRW",
-  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW — the open-source, self-hostable Firecrawl alternative. Single Rust binary, Firecrawl-compatible /v1 + /v2 API, bundled SearXNG search.",
+  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
   "version": "0.3.0",
   "author": {
     "name": "us",
@@ -17,8 +17,7 @@
     "search",
     "extract",
     "web-data",
-    "firecrawl",
-    "searxng"
+    "firecrawl"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "crw",
   "displayName": "fastCRW",
-  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW — the open-source, self-hostable Firecrawl alternative. Single Rust binary, Firecrawl-compatible /v1 + /v2 API, bundled SearXNG search.",
+  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
   "version": "0.3.0",
   "author": {
     "name": "us",
@@ -17,8 +17,7 @@
     "search",
     "extract",
     "web-data",
-    "firecrawl",
-    "searxng"
+    "firecrawl"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -16,6 +16,15 @@ use serde_json::{Value, json};
 /// this constant — it intentionally stays on 2024-11-05.
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
 
+/// Server-level usage guidance returned in the `initialize` result's optional
+/// `instructions` field (MCP InitializeResult). Clients surface this to the model
+/// as "how to use this server", so it is the single sanctioned lever for steering
+/// an agent to reach for these tools on web-shaped tasks. Kept factual (states the
+/// tools' real capability + when they apply) — NOT a "always use instead of X"
+/// directive, which reviewers and hosts penalize. Sits outside `tools/list`, so it
+/// does not count against the tools/list token budget.
+pub const SERVER_INSTRUCTIONS: &str = "fastCRW gives you live web access. Prefer these tools whenever a task needs information from the internet rather than answering from memory: crw_search for web search and current or real-time facts, crw_scrape to read a specific URL as clean markdown, crw_map to discover a site's URLs, crw_crawl to gather many pages across a site, and crw_extract to pull structured data from pages. When the user asks about recent, live, or source-specific information, reach for these instead of guessing.";
+
 // --- JSON-RPC types ---
 
 #[derive(Deserialize)]
@@ -302,7 +311,7 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
     tools.push(json!({
         "name": "crw_search",
         "title": "Web search",
-        "description": "Search the web (needs a configured search backend; embedded uses a local SearXNG sidecar). Returns results with url/title/description/snippet.",
+        "description": "Search the web for current information, news, facts, or docs. Use whenever the answer may depend on up-to-date or external information. Returns ranked results (url/title/description/snippet); optionally scrape each result inline.",
         "annotations": {
             "readOnlyHint": true,
             "destructiveHint": false,
@@ -337,7 +346,7 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                 "categories": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Category bias; e.g. \"pdf\", \"github\", \"research\", or a native SearXNG category"
+                    "description": "Category bias; e.g. \"pdf\", \"github\", \"research\", \"news\", \"images\""
                 },
                 "scrapeOptions": {
                     "type": "object",
@@ -507,7 +516,8 @@ pub fn handle_protocol_method(
                     "serverInfo": {
                         "name": server_name,
                         "version": server_version
-                    }
+                    },
+                    "instructions": SERVER_INSTRUCTIONS
                 }),
             ))
         }
@@ -1354,6 +1364,39 @@ mod tests {
         let without = list(false);
         assert!(!without.contains(&"crw_search".to_string()));
         assert_eq!(without.len(), 7);
+    }
+
+    /// A4 — initialize advertises server usage `instructions` (the model-facing
+    /// steering lever) and never leaks the search backend's identity anywhere in
+    /// the advertised surface (tool descriptions + instructions).
+    #[test]
+    fn a4_initialize_advertises_instructions_no_backend_leak() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "initialize".into(),
+            params: json!({}),
+        };
+        let ProtocolResult::Response(resp) = handle_protocol_method("crw", "0", &req, false, true)
+        else {
+            panic!("expected response");
+        };
+        let result = resp.result.unwrap();
+        let instructions = result["instructions"]
+            .as_str()
+            .expect("initialize returns an instructions string");
+        assert!(
+            instructions.contains("crw_search"),
+            "names the tools to prefer"
+        );
+
+        // The advertised surface (descriptions + instructions) must never name the
+        // search backend — locks the crw_search description SearXNG-leak fix.
+        let advertised = format!("{instructions} {}", tool_definitions(false));
+        assert!(
+            !advertised.to_lowercase().contains("searxng"),
+            "search backend identity must not leak into the advertised MCP surface"
+        );
     }
 
     /// B13 — crw_search inlined scrape content (flat + grouped) is truncated.

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -316,11 +316,11 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
         }),
     ];
 
-    // `crw_search` is always advertised. In embedded mode it dispatches to a
-    // local SearXNG sidecar via crw-server's `/v1/search` pipeline; in proxy
-    // mode it forwards to the configured remote API. Whether the underlying
-    // SearXNG instance is configured is a runtime concern — the server returns
-    // a clear `search_disabled` error when [search].searxng_url is unset.
+    // `tool_definitions` always emits `crw_search`; whether the client SEES it is
+    // decided one level up, in `handle_protocol_method`'s `tools/list` arm, which
+    // retains it out when `search_available` is false (an embedded install with no
+    // search backend configured). Proxy mode always has it: the remote decides.
+    // The tool set itself does not depend on the mode, hence the discard.
     let _ = proxy_mode;
     tools.push(json!({
         "name": "crw_search",

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -25,6 +25,20 @@ pub const PROTOCOL_VERSION: &str = "2025-06-18";
 /// does not count against the tools/list token budget.
 pub const SERVER_INSTRUCTIONS: &str = "fastCRW gives you live web access. Prefer these tools whenever a task needs information from the internet rather than answering from memory: crw_search for web search and current or real-time facts, crw_scrape to read a specific URL as clean markdown, crw_map to discover a site's URLs, crw_crawl to gather many pages across a site, and crw_extract to pull structured data from pages. When the user asks about recent, live, or source-specific information, reach for these instead of guessing.";
 
+/// Variant used when no search backend is configured. `tools/list` strips
+/// `crw_search` in that case, so the default instructions would name a tool the
+/// client can never call — the two surfaces must agree.
+pub const SERVER_INSTRUCTIONS_NO_SEARCH: &str = "fastCRW gives you live web access. Prefer these tools whenever a task needs information from the internet rather than answering from memory: crw_scrape to read a specific URL as clean markdown, crw_map to discover a site's URLs, crw_crawl to gather many pages across a site, and crw_extract to pull structured data from pages. When the user asks about recent, live, or source-specific information, reach for these instead of guessing.";
+
+/// The `instructions` string that matches the tool set actually advertised.
+pub fn server_instructions(search_available: bool) -> &'static str {
+    if search_available {
+        SERVER_INSTRUCTIONS
+    } else {
+        SERVER_INSTRUCTIONS_NO_SEARCH
+    }
+}
+
 // --- JSON-RPC types ---
 
 #[derive(Deserialize)]
@@ -517,7 +531,7 @@ pub fn handle_protocol_method(
                         "name": server_name,
                         "version": server_version
                     },
-                    "instructions": SERVER_INSTRUCTIONS
+                    "instructions": server_instructions(search_available)
                 }),
             ))
         }
@@ -1388,6 +1402,28 @@ mod tests {
         assert!(
             instructions.contains("crw_search"),
             "names the tools to prefer"
+        );
+
+        // instructions must agree with the advertised tool set: tools/list strips
+        // crw_search when no backend is configured, so the guidance must not name it.
+        let no_search = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(json!(1)),
+            method: "initialize".into(),
+            params: json!({}),
+        };
+        let ProtocolResult::Response(resp2) =
+            handle_protocol_method("crw", "0", &no_search, false, false)
+        else {
+            panic!("expected response");
+        };
+        let instructions2 = resp2.result.unwrap()["instructions"]
+            .as_str()
+            .expect("instructions string")
+            .to_string();
+        assert!(
+            !instructions2.contains("crw_search"),
+            "must not name crw_search when tools/list strips it"
         );
 
         // The advertised surface (descriptions + instructions) must never name the

--- a/crates/crw-mcp/README.md
+++ b/crates/crw-mcp/README.md
@@ -24,7 +24,7 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 | `crw_crawl` | Start an async BFS crawl (returns job ID) |
 | `crw_check_crawl_status` | Poll crawl job status and retrieve results |
 | `crw_map` | Discover all URLs on a website |
-| `crw_search` | Search the web (needs a configured search backend; always available in proxy mode, available in embedded mode only when a SearXNG backend is configured) |
+| `crw_search` | Search the web (needs a configured search backend; always available in proxy mode, available in embedded mode only when a search backend is configured) |
 | `crw_parse_file` | Parse a local PDF (base64) to markdown |
 
 > **Output bounding:** By default, content fields are truncated to ~15 000 chars and `crw_map` returns at most 100 URLs to keep agent context small. Pass `maxLength: 0` (scrape / check_status / parse_file) or `limit: 0` (map) to opt out.

--- a/crates/crw-mcp/README.md
+++ b/crates/crw-mcp/README.md
@@ -7,7 +7,7 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 
 ## Overview
 
-`crw-mcp` is a self-contained MCP server that gives any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, Windsurf, Cline, Continue.dev, OpenAI Codex CLI) 6 web scraping tools. No external server needed — just add and go.
+`crw-mcp` is a self-contained MCP server that gives any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, Windsurf, Cline, Continue.dev, OpenAI Codex CLI) 8 web scraping tools. No external server needed — just add and go.
 
 **Two modes:**
 
@@ -16,7 +16,7 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 | **Embedded** (default) | No `--api-url` set | Self-contained, zero setup |
 | **Proxy** | `--api-url` provided | Forwards to remote CRW server |
 
-**6 MCP tools:**
+**8 MCP tools:**
 
 | Tool | Description |
 |------|-------------|
@@ -24,6 +24,8 @@ MCP (Model Context Protocol) server for the [CRW](https://github.com/us/crw) web
 | `crw_crawl` | Start an async BFS crawl (returns job ID) |
 | `crw_check_crawl_status` | Poll crawl job status and retrieve results |
 | `crw_map` | Discover all URLs on a website |
+| `crw_extract` | Extract structured JSON from URLs via a prompt and/or JSON schema (async job, returns job ID) |
+| `crw_check_extract_status` | Poll extract job status and retrieve results |
 | `crw_search` | Search the web (needs a configured search backend; always available in proxy mode, available in embedded mode only when a search backend is configured) |
 | `crw_parse_file` | Parse a local PDF (base64) to markdown |
 

--- a/crates/crw-mcp/src/main.rs
+++ b/crates/crw-mcp/src/main.rs
@@ -14,7 +14,7 @@
 //! - `crw_crawl` — start an async BFS crawl
 //! - `crw_check_crawl_status` — poll crawl job status
 //! - `crw_map` — discover URLs on a website
-//! - `crw_search` — web search (embedded uses local SearXNG sidecar; proxy forwards to remote API)
+//! - `crw_search` — web search (embedded: only when a search backend is configured; proxy: forwards to the remote API)
 //! - `crw_extract` — start an async multi-URL structured extraction job
 //! - `crw_check_extract_status` — poll extract job status
 //! - `crw_parse_file` — parse a local PDF (base64) to markdown

--- a/crates/crw-mcp/src/main.rs
+++ b/crates/crw-mcp/src/main.rs
@@ -17,6 +17,7 @@
 //! - `crw_search` — web search (embedded uses local SearXNG sidecar; proxy forwards to remote API)
 //! - `crw_extract` — start an async multi-URL structured extraction job
 //! - `crw_check_extract_status` — poll extract job status
+//! - `crw_parse_file` — parse a local PDF (base64) to markdown
 //!
 //! # Usage
 //!

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -82,7 +82,7 @@ Returns: `{ "status": "scraping|completed|failed", "data": [...] }`
 
 ### crw_search
 
-Search the web and return relevant results with titles, URLs, and descriptions. Always available in proxy/cloud mode; in embedded mode only when a SearXNG backend is configured.
+Search the web for current information, news, facts, or docs. Use whenever the answer may depend on up-to-date or external information. Returns ranked results (url/title/description/snippet); optionally scrape each result inline. Always available in proxy/cloud mode; in embedded mode only when a search backend is configured.
 
 Parameters:
 - `query` (required) — The search query
@@ -90,7 +90,7 @@ Parameters:
 - `lang` — Language code for results (e.g. `"en"`, `"tr"`)
 - `tbs` — Time filter: `qdr:h|qdr:d|qdr:w|qdr:m|qdr:y` (past hour/day/week/month/year)
 - `sources` — If set, group results by source: `web`, `news`, `images`
-- `categories` — Bias toward a category (e.g. `"pdf"`, `"github"`, `"research"`, or a native SearXNG category)
+- `categories` — Category bias; e.g. `"pdf"`, `"github"`, `"research"`, `"news"`, `"images"`
 - `scrapeOptions` — Options for scraping each result page (e.g. `{"formats": ["markdown"]}`)
 
 ### crw_map

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -24,10 +24,11 @@ Use this skill when:
 ## Installation
 
 ```bash
-crw fastcrw.com
+npx crw-mcp@latest install   # installs the skill + MCP server into detected agents
+npx crw-mcp@latest init      # skill only
 ```
 
-This installs the CRW skill and MCP server to all detected AI agents (Claude Code, Cursor, Gemini CLI, Codex, OpenCode, Windsurf, Roo Code).
+`install` sets up the CRW skill and MCP server for all detected AI agents (Claude Code, Cursor, Gemini CLI, Codex, OpenCode, Windsurf, Roo Code).
 
 ## Authentication
 
@@ -105,6 +106,29 @@ Parameters:
 - `limit` — Maximum URLs to return. `0` = unbounded. Default: `100`
 
 Returns: `{ "links": ["url1", "url2", ...] }`
+
+### crw_extract
+
+Extract structured JSON from one or more URLs via a prompt and/or JSON schema. Async job, poll with `crw_check_extract_status`. Needs an LLM.
+
+Parameters:
+- `urls` (required) — URLs to extract from
+- `prompt` — Free-text extraction objective (required unless `schema` is given)
+- `schema` — JSON schema constraining the extracted output
+- `llmApiKey` — BYOK LLM API key
+- `llmProvider` — LLM provider (used with `llmApiKey`)
+- `llmModel` — LLM model (used with `llmApiKey`)
+
+Returns: `{ "id": "job-uuid" }` — use this ID with crw_check_extract_status.
+
+### crw_check_extract_status
+
+Poll an async extract job for results.
+
+Parameters:
+- `id` (required) — The extract job ID from `crw_extract`
+
+Returns: status and, when complete, a per-URL results array.
 
 ### crw_parse_file
 

--- a/docs/docs/mcp-clients.md
+++ b/docs/docs/mcp-clients.md
@@ -35,7 +35,7 @@ Embedded local mode (`crw-mcp`) exposes up to 8 tools:
 - `crw_extract` — structured extraction across URLs (async job)
 - `crw_check_extract_status` — poll an extract job
 - `crw_parse_file` — parse a local PDF (base64) to markdown, no OCR (always present)
-- `crw_search` — only advertised when a SearXNG backend is configured; hidden otherwise
+- `crw_search` — only advertised when a search backend is configured; hidden otherwise
 
 fastcrw.com cloud mode exposes all 8 tools:
 
@@ -54,7 +54,7 @@ Browser automation mode (`crw-browse`, separate server — v0.4.0+) exposes:
 - `tree` — accessibility snapshot of the current page
 
 :::tip
-If you only remember one rule, remember this one: local embedded mode is the easiest setup (up to 8 tools, with `crw_search` appearing automatically when SearXNG is configured), and fastcrw.com cloud mode is the easiest way to get all 8 tools including always-on web search.
+If you only remember one rule, remember this one: local embedded mode is the easiest setup (up to 8 tools, with `crw_search` appearing automatically when a search backend is configured), and fastcrw.com cloud mode is the easiest way to get all 8 tools including always-on web search.
 :::
 
 ## Claude Code
@@ -230,7 +230,7 @@ Edit `~/.codeium/windsurf/mcp_config.json`.
 ```
 
 :::note
-Windsurf has a total MCP tool limit. CRW stays lightweight: local embedded mode exposes up to 8 tools (`crw_search` is hidden unless a SearXNG backend is configured), and cloud mode always exposes all 8 tools.
+Windsurf has a total MCP tool limit. CRW stays lightweight: local embedded mode exposes up to 8 tools (`crw_search` is hidden unless a search backend is configured), and cloud mode always exposes all 8 tools.
 :::
 
 ## Cline
@@ -365,7 +365,7 @@ Open Management (`⌘⇧M`) → **Providers** → **MCP Providers** → **Add MC
 | Command | `npx` |
 | Args | `crw-mcp` |
 
-`crw_*` tools then appear in chat namespaced as `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_parse_file` (and `crw_search` when SearXNG is configured).
+`crw_*` tools then appear in chat namespaced as `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_parse_file` (and `crw_search` when a search backend is configured).
 
 ### Or edit the config file
 
@@ -418,7 +418,7 @@ Add `CRW_API_URL` and your `CRW_API_KEY` as environment variables. Add `CRW_API_
 }
 ```
 
-Cloud mode exposes `crw_search` (always-on managed search backend); local embedded mode shows it only when you configure SearXNG.
+Cloud mode exposes `crw_search` (always-on managed search backend); local embedded mode shows it only when you configure a search backend.
 
 ## Any MCP client
 

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -152,6 +152,8 @@ This yields a ~4.2 MB binary (vs ~17 MB for the default embedded build) because 
 | `crw_crawl` | Start async crawl → returns job ID | `POST /v1/crawl` | All modes |
 | `crw_check_crawl_status` | Poll crawl status and get results | `GET /v1/crawl/:id` | All modes |
 | `crw_map` | Discover all URLs on a site | `POST /v1/map` | All modes |
+| `crw_extract` | Extract structured JSON from URLs → async job ID | `POST /v1/extract` | All modes |
+| `crw_check_extract_status` | Poll extract status and get results | `GET /v1/extract/:id` | All modes |
 | `crw_search` | Search the web → titles, URLs, descriptions | `POST /v1/search` | Always in proxy mode; embedded only when a search backend is configured |
 | `crw_parse_file` | Parse a local PDF (base64) → markdown | `POST /firecrawl/v2/parse` (multipart) | All modes |
 
@@ -258,7 +260,7 @@ In **proxy mode** `crw_search` is always advertised. In **embedded mode** it is 
 | `limit` | integer | no | Max results (default: 5) |
 | `lang` | string | no | Language code (e.g. `"en"`, `"tr"`) |
 | `tbs` | string | no | Time-based filter (e.g. `"qdr:d"` for past day) |
-| `sources` | string[] | no | Restrict results to specific sources |
+| `sources` | string[] | no | Group results by source instead of a flat list |
 | `categories` | string[] | no | Category bias (e.g. `["general","news"]`) |
 | `scrapeOptions` | object | no | Scrape each result page (e.g. `{"formats": ["markdown"]}`) |
 

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -10,8 +10,8 @@ CRW includes a built-in MCP (Model Context Protocol) server that gives any MCP-c
 
 | Mode | When | Tools | Description |
 |------|------|-------|-------------|
-| **Embedded** (default) | No `--api-url` / `CRW_API_URL` set | scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file + **search** (when SearXNG configured) | Self-contained. No server needed. The scraping engine runs inside the MCP process. `crw_search` is advertised only when a SearXNG backend is configured (e.g. the Docker compose sidecar). |
-| **Proxy / Server** | `--api-url` / `CRW_API_URL` set | scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file, search | Forwards tool calls to a remote CRW server — the [fastcrw.com](https://fastcrw.com) cloud **or your own self-hosted server**. `crw_search` is always advertised in proxy mode; it works whenever the server has SearXNG configured (the Docker stack enables it by default). |
+| **Embedded** (default) | No `--api-url` / `CRW_API_URL` set | scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file + **search** (when a search backend is configured) | Self-contained. No server needed. The scraping engine runs inside the MCP process. `crw_search` is advertised only when a search backend is configured (e.g. the Docker compose sidecar). |
+| **Proxy / Server** | `--api-url` / `CRW_API_URL` set | scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file, search | Forwards tool calls to a remote CRW server — the [fastcrw.com](https://fastcrw.com) cloud **or your own self-hosted server**. `crw_search` is always advertised in proxy mode; it works whenever the server has a search backend configured (the Docker stack enables it by default). |
 
 ## Where to use what
 
@@ -152,7 +152,7 @@ This yields a ~4.2 MB binary (vs ~17 MB for the default embedded build) because 
 | `crw_crawl` | Start async crawl → returns job ID | `POST /v1/crawl` | All modes |
 | `crw_check_crawl_status` | Poll crawl status and get results | `GET /v1/crawl/:id` | All modes |
 | `crw_map` | Discover all URLs on a site | `POST /v1/map` | All modes |
-| `crw_search` | Search the web → titles, URLs, descriptions | `POST /v1/search` | Always in proxy mode; embedded only when a SearXNG backend is configured |
+| `crw_search` | Search the web → titles, URLs, descriptions | `POST /v1/search` | Always in proxy mode; embedded only when a search backend is configured |
 | `crw_parse_file` | Parse a local PDF (base64) → markdown | `POST /firecrawl/v2/parse` (multipart) | All modes |
 
 > **Output bounding:** Tool results are bounded by default to keep agent context small. Content fields (markdown/html/etc.) are truncated to ~15 000 chars; `crw_map` returns at most 100 URLs. Truncated responses include `truncated: true` and `totalDiscovered` markers. Pass `maxLength: 0` (scrape / check_status / parse_file) or `limit: 0` (map) to opt out.
@@ -250,7 +250,7 @@ For cloud mode and file-based configs, continue in [MCP Client Setup](#mcp-clien
 
 ### crw_search
 
-In **proxy mode** `crw_search` is always advertised. In **embedded mode** it is advertised only when a SearXNG backend is configured (e.g. via the Docker compose sidecar — see [Docker → Search (SearXNG)](/docker)). With no backend configured, the tool is hidden from `tools/list`.
+In **proxy mode** `crw_search` is always advertised. In **embedded mode** it is advertised only when a search backend is configured (e.g. via the Docker compose sidecar — see [Docker → Search](/docker)). With no backend configured, the tool is hidden from `tools/list`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -259,7 +259,7 @@ In **proxy mode** `crw_search` is always advertised. In **embedded mode** it is 
 | `lang` | string | no | Language code (e.g. `"en"`, `"tr"`) |
 | `tbs` | string | no | Time-based filter (e.g. `"qdr:d"` for past day) |
 | `sources` | string[] | no | Restrict results to specific sources |
-| `categories` | string[] | no | SearXNG categories (e.g. `["general","news"]`) |
+| `categories` | string[] | no | Category bias (e.g. `["general","news"]`) |
 | `scrapeOptions` | object | no | Scrape each result page (e.g. `{"formats": ["markdown"]}`) |
 
 ### crw_parse_file

--- a/docs/mcp-clients/index.html
+++ b/docs/mcp-clients/index.html
@@ -336,7 +336,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
 <li><code>crw_extract</code> — structured extraction across URLs (async job)</li>
 <li><code>crw_check_extract_status</code> — poll an extract job</li>
 <li><code>crw_parse_file</code> — parse a local PDF (base64) to markdown, no OCR (always present)</li>
-<li><code>crw_search</code> — only advertised when a SearXNG backend is configured; hidden otherwise</li>
+<li><code>crw_search</code> — only advertised when a search backend is configured; hidden otherwise</li>
 </ul>
 <p>fastcrw.com cloud mode exposes all 8 tools:</p>
 <ul>
@@ -354,7 +354,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
 <li><code>goto</code> — navigate the browser to an URL</li>
 <li><code>tree</code> — accessibility snapshot of the current page</li>
 </ul>
-<div class="callout callout-tip"><div class="callout-icon"></div><div class="callout-content">If you only remember one rule, remember this one: local embedded mode is the easiest setup (up to 8 tools, with `crw_search` appearing automatically when SearXNG is configured), and fastcrw.com cloud mode is the easiest way to get all 8 tools including always-on web search.</div></div><h2 id="claude-code">Claude Code</h2>
+<div class="callout callout-tip"><div class="callout-icon"></div><div class="callout-content">If you only remember one rule, remember this one: local embedded mode is the easiest setup (up to 8 tools, with `crw_search` appearing automatically when a search backend is configured), and fastcrw.com cloud mode is the easiest way to get all 8 tools including always-on web search.</div></div><h2 id="claude-code">Claude Code</h2>
 <h3 id="local-embedded">Local embedded</h3>
 <pre data-lang="bash"><code class="language-bash">claude mcp add crw -- npx -y crw-mcp</code></pre>
 <h3 id="fastcrwcom-cloud">fastcrw.com cloud</h3>
@@ -478,7 +478,7 @@ CRW_API_KEY = &quot;YOUR_API_KEY&quot;</code></pre>
     }
   }
 }</code></pre>
-<div class="callout callout-note"><div class="callout-icon"></div><div class="callout-content">Windsurf has a total MCP tool limit. CRW stays lightweight: local embedded mode exposes up to 8 tools (`crw_search` is hidden unless a SearXNG backend is configured), and cloud mode always exposes all 8 tools.</div></div><h2 id="cline">Cline</h2>
+<div class="callout callout-note"><div class="callout-icon"></div><div class="callout-content">Windsurf has a total MCP tool limit. CRW stays lightweight: local embedded mode exposes up to 8 tools (`crw_search` is hidden unless a search backend is configured), and cloud mode always exposes all 8 tools.</div></div><h2 id="cline">Cline</h2>
 <p>Edit the Cline MCP settings file:</p>
 <table>
 <thead>
@@ -606,7 +606,7 @@ CRW_API_KEY = &quot;YOUR_API_KEY&quot;</code></pre>
 <td><code>crw-mcp</code></td>
 </tr>
 </tbody></table>
-<p><code>crw_*</code> tools then appear in chat namespaced as <code>crw_scrape</code>, <code>crw_crawl</code>, <code>crw_check_crawl_status</code>, <code>crw_map</code>, <code>crw_extract</code>, <code>crw_check_extract_status</code>, <code>crw_parse_file</code> (and <code>crw_search</code> when SearXNG is configured).</p>
+<p><code>crw_*</code> tools then appear in chat namespaced as <code>crw_scrape</code>, <code>crw_crawl</code>, <code>crw_check_crawl_status</code>, <code>crw_map</code>, <code>crw_extract</code>, <code>crw_check_extract_status</code>, <code>crw_parse_file</code> (and <code>crw_search</code> when a search backend is configured).</p>
 <h3 id="or-edit-the-config-file">Or edit the config file</h3>
 <p>Edit <code>~/.osaurus/providers/mcp.json</code> (the root is an object with a <code>providers</code> array):</p>
 <pre data-lang="json"><code class="language-json">{
@@ -644,7 +644,7 @@ CRW_API_KEY = &quot;YOUR_API_KEY&quot;</code></pre>
     }
   ]
 }</code></pre>
-<p>Cloud mode exposes <code>crw_search</code> (always-on managed search backend); local embedded mode shows it only when you configure SearXNG.</p>
+<p>Cloud mode exposes <code>crw_search</code> (always-on managed search backend); local embedded mode shows it only when you configure a search backend.</p>
 <h2 id="any-mcp-client">Any MCP client</h2>
 <p>If your client accepts the standard JSON <code>mcpServers</code> shape, start here:</p>
 <h3 id="local-embedded-8">Local embedded</h3>

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -484,6 +484,18 @@ claude mcp add crw \
 <td>All modes</td>
 </tr>
 <tr>
+<td><code>crw_extract</code></td>
+<td>Extract structured JSON from URLs → async job ID</td>
+<td><code>POST /v1/extract</code></td>
+<td>All modes</td>
+</tr>
+<tr>
+<td><code>crw_check_extract_status</code></td>
+<td>Poll extract status and get results</td>
+<td><code>GET /v1/extract/:id</code></td>
+<td>All modes</td>
+</tr>
+<tr>
 <td><code>crw_search</code></td>
 <td>Search the web → titles, URLs, descriptions</td>
 <td><code>POST /v1/search</code></td>
@@ -761,7 +773,7 @@ codex mcp add crw -- npx crw-mcp</code></pre>
 <td><code>sources</code></td>
 <td>string[]</td>
 <td>no</td>
-<td>Restrict results to specific sources</td>
+<td>Group results by source instead of a flat list</td>
 </tr>
 <tr>
 <td><code>categories</code></td>

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -301,14 +301,14 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
 <tbody><tr>
 <td><strong>Embedded</strong> (default)</td>
 <td>No <code>--api-url</code> / <code>CRW_API_URL</code> set</td>
-<td>scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file + <strong>search</strong> (when SearXNG configured)</td>
-<td>Self-contained. No server needed. The scraping engine runs inside the MCP process. <code>crw_search</code> is advertised only when a SearXNG backend is configured (e.g. the Docker compose sidecar).</td>
+<td>scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file + <strong>search</strong> (when a search backend is configured)</td>
+<td>Self-contained. No server needed. The scraping engine runs inside the MCP process. <code>crw_search</code> is advertised only when a search backend is configured (e.g. the Docker compose sidecar).</td>
 </tr>
 <tr>
 <td><strong>Proxy / Server</strong></td>
 <td><code>--api-url</code> / <code>CRW_API_URL</code> set</td>
 <td>scrape, crawl, check_crawl_status, map, extract, check_extract_status, parse_file, search</td>
-<td>Forwards tool calls to a remote CRW server — the <a href="https://fastcrw.com">fastcrw.com</a> cloud <strong>or your own self-hosted server</strong>. <code>crw_search</code> is always advertised in proxy mode; it works whenever the server has SearXNG configured (the Docker stack enables it by default).</td>
+<td>Forwards tool calls to a remote CRW server — the <a href="https://fastcrw.com">fastcrw.com</a> cloud <strong>or your own self-hosted server</strong>. <code>crw_search</code> is always advertised in proxy mode; it works whenever the server has a search backend configured (the Docker stack enables it by default).</td>
 </tr>
 </tbody></table>
 <h2 id="where-to-use-what">Where to use what</h2>
@@ -487,7 +487,7 @@ claude mcp add crw \
 <td><code>crw_search</code></td>
 <td>Search the web → titles, URLs, descriptions</td>
 <td><code>POST /v1/search</code></td>
-<td>Always in proxy mode; embedded only when a SearXNG backend is configured</td>
+<td>Always in proxy mode; embedded only when a search backend is configured</td>
 </tr>
 <tr>
 <td><code>crw_parse_file</code></td>
@@ -723,7 +723,7 @@ codex mcp add crw -- npx crw-mcp</code></pre>
 </tr>
 </tbody></table>
 <h3 id="crw_search">crw_search</h3>
-<p>In <strong>proxy mode</strong> <code>crw_search</code> is always advertised. In <strong>embedded mode</strong> it is advertised only when a SearXNG backend is configured (e.g. via the Docker compose sidecar — see <a href="/docker">Docker → Search (SearXNG)</a>). With no backend configured, the tool is hidden from <code>tools/list</code>.</p>
+<p>In <strong>proxy mode</strong> <code>crw_search</code> is always advertised. In <strong>embedded mode</strong> it is advertised only when a search backend is configured (e.g. via the Docker compose sidecar — see <a href="/docker">Docker → Search</a>). With no backend configured, the tool is hidden from <code>tools/list</code>.</p>
 <table>
 <thead>
 <tr>
@@ -767,7 +767,7 @@ codex mcp add crw -- npx crw-mcp</code></pre>
 <td><code>categories</code></td>
 <td>string[]</td>
 <td>no</td>
-<td>SearXNG categories (e.g. <code>[&quot;general&quot;,&quot;news&quot;]</code>)</td>
+<td>Category bias (e.g. <code>[&quot;general&quot;,&quot;news&quot;]</code>)</td>
 </tr>
 <tr>
 <td><code>scrapeOptions</code></td>

--- a/mcp/crw-mcp/package.json
+++ b/mcp/crw-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crw-mcp",
   "version": "0.23.0",
-  "description": "MCP server for CRW web scraper — scrape, crawl, map, search, and PDF-parse tools for AI agents",
+  "description": "MCP server for CRW web scraper — scrape, crawl, map, extract, search, and PDF-parse tools for AI agents",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/us/crw",
   "repository": {

--- a/mcp/crw-mcp/skills/SKILL.md
+++ b/mcp/crw-mcp/skills/SKILL.md
@@ -82,7 +82,7 @@ Returns: `{ "status": "scraping|completed|failed", "data": [...] }`
 
 ### crw_search
 
-Search the web and return relevant results with titles, URLs, and descriptions. Always available in proxy/cloud mode; in embedded mode only when a SearXNG backend is configured.
+Search the web for current information, news, facts, or docs. Use whenever the answer may depend on up-to-date or external information. Returns ranked results (url/title/description/snippet); optionally scrape each result inline. Always available in proxy/cloud mode; in embedded mode only when a search backend is configured.
 
 Parameters:
 - `query` (required) — The search query
@@ -90,7 +90,7 @@ Parameters:
 - `lang` — Language code for results (e.g. `"en"`, `"tr"`)
 - `tbs` — Time filter: `qdr:h|qdr:d|qdr:w|qdr:m|qdr:y` (past hour/day/week/month/year)
 - `sources` — If set, group results by source: `web`, `news`, `images`
-- `categories` — Bias toward a category (e.g. `"pdf"`, `"github"`, `"research"`, or a native SearXNG category)
+- `categories` — Category bias; e.g. `"pdf"`, `"github"`, `"research"`, `"news"`, `"images"`
 - `scrapeOptions` — Options for scraping each result page (e.g. `{"formats": ["markdown"]}`)
 
 ### crw_map

--- a/mcp/crw-mcp/skills/SKILL.md
+++ b/mcp/crw-mcp/skills/SKILL.md
@@ -24,10 +24,11 @@ Use this skill when:
 ## Installation
 
 ```bash
-crw fastcrw.com
+npx crw-mcp@latest install   # installs the skill + MCP server into detected agents
+npx crw-mcp@latest init      # skill only
 ```
 
-This installs the CRW skill and MCP server to all detected AI agents (Claude Code, Cursor, Gemini CLI, Codex, OpenCode, Windsurf, Roo Code).
+`install` sets up the CRW skill and MCP server for all detected AI agents (Claude Code, Cursor, Gemini CLI, Codex, OpenCode, Windsurf, Roo Code).
 
 ## Authentication
 
@@ -105,6 +106,29 @@ Parameters:
 - `limit` — Maximum URLs to return. `0` = unbounded. Default: `100`
 
 Returns: `{ "links": ["url1", "url2", ...] }`
+
+### crw_extract
+
+Extract structured JSON from one or more URLs via a prompt and/or JSON schema. Async job, poll with `crw_check_extract_status`. Needs an LLM.
+
+Parameters:
+- `urls` (required) — URLs to extract from
+- `prompt` — Free-text extraction objective (required unless `schema` is given)
+- `schema` — JSON schema constraining the extracted output
+- `llmApiKey` — BYOK LLM API key
+- `llmProvider` — LLM provider (used with `llmApiKey`)
+- `llmModel` — LLM model (used with `llmApiKey`)
+
+Returns: `{ "id": "job-uuid" }` — use this ID with crw_check_extract_status.
+
+### crw_check_extract_status
+
+Poll an async extract job for results.
+
+Parameters:
+- `id` (required) — The extract job ID from `crw_extract`
+
+Returns: status and, when complete, a per-URL results array.
 
 ### crw_parse_file
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -87,7 +87,7 @@ print(urls)
 
 ### Search
 
-Works in both modes. In subprocess mode the engine needs a SearXNG URL
+Works in both modes. In subprocess mode the engine needs a search backend
 configured (`[search].searxng_url` or `CRW_SEARCH__SEARXNG_URL`); the managed
 cloud has one preconfigured.
 

--- a/sdks/python/src/crw/client.py
+++ b/sdks/python/src/crw/client.py
@@ -121,10 +121,11 @@ class CrwClient:
 
     Feature availability:
         * scrape / crawl / map / parse_file — work in both local and HTTP mode.
-        * search — works in both modes, but local mode needs a SearXNG URL
+        * search — works in both modes, but local mode needs a search backend
           configured ([search].searxng_url); cloud has it preconfigured.
         * extract / batch_scrape / capabilities / change_tracking_diff — HTTP mode
-          only (no MCP tool exists for these on the engine).
+          only. The engine's MCP server does expose crw_extract, but this SDK's
+          local transport does not route it yet.
     """
 
     def __init__(self, api_url: str | None = None, api_key: str | None = None):
@@ -263,7 +264,7 @@ class CrwClient:
     ) -> list[dict] | dict:
         """Search the web and optionally scrape results.
 
-        Works in both modes. In subprocess mode the engine needs a SearXNG URL
+        Works in both modes. In subprocess mode the engine needs a search backend
         configured (``[search].searxng_url`` or ``CRW_SEARCH__SEARXNG_URL``); the
         managed cloud has one preconfigured. If search is not configured the engine
         returns a clear ``search_disabled`` error.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -58,7 +58,7 @@ CRW_LOCAL=1 node app.js
 | `changeTrackingDiff(cur, prev?)` | Diff vs a prior snapshot | HTTP |
 | `close()` | Shut down the local subprocess | — |
 
-¹ Local search needs a SearXNG URL configured on the engine.
+¹ Local search needs a search backend configured on the engine.
 
 ```ts
 // Structured extraction (async job → per-URL results array):

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -122,7 +122,7 @@ export class CrwClient {
   }
 
   /**
-   * Works in both modes; local mode needs a SearXNG URL configured on the engine.
+   * Works in both modes; local mode needs a search backend configured on the engine.
    */
   async search(query: string, opts: SearchOptions = {}): Promise<SearchResult> {
     const { limit = 5, lang, tbs, sources, categories, scrapeOptions, ...rest } = opts;


### PR DESCRIPTION
## What

Give MCP clients a server-level steer so an agent reaches for crw tools on any web-shaped task, and stop the search backend's name leaking into the advertised tool surface.

- Add `InitializeResult.instructions` (MCP 2025-06-18) in the shared `handle_protocol_method`, so BOTH the HTTP endpoint (`crw-server`) and the stdio proxy (`crw-mcp`) advertise the same "prefer these tools for live/web info" guidance. It sits outside `tools/list`, so it adds no per-turn token cost and does not touch the tools/list budget gate.
- Rewrite `crw_search`'s description to lead with its use-cases (current info / news / facts / docs), and remove the backend name from the `categories` param description. A new test (`a4`) locks that neither the descriptions nor the instructions ever name the backend.

Wording is factual (states capability + when it applies), not an "always use instead of X" directive.

## Why

Users adding the crw MCP to their agents want it used by default for web search / scraping. The `instructions` field is the sanctioned, cross-client lever (ChatGPT/Codex, Claude, Cursor, self-host). The description fix also closes a backend-identity leak that shipped in every `tools/list`.

## Tests

`cargo test -p crw-mcp-proto` (33) + `crw-server --test mcp` (18) green; full pre-commit gate (fmt/clippy/build/test) passed.