### PR TITLE
feat(server): native /v1/batch/scrape endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "base64",
  "clap",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "crw-monitor"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crw-core",
  "crw-crawl",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-server/openapi/openapi-3.0.json
+++ b/crates/crw-server/openapi/openapi-3.0.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "CRW REST API",
-    "version": "0.16.0",
+    "version": "0.23.0",
     "description": "Firecrawl-compatible web scraping, crawling, mapping, search, and extraction API. Hosted at https://api.fastcrw.com; self-host with `docker run -p 3000:3000 ghcr.io/us/crw:latest`.",
     "license": {
       "name": "AGPL-3.0",
@@ -250,6 +250,92 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch/scrape": {
+      "post": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Start an async batch scrape over an explicit URL list",
+        "operationId": "batchScrapeStart",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchScrapeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch job accepted; poll with /v1/batch/scrape/{id}",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchScrapeAccepted"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batch/scrape/{id}": {
+      "get": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Get batch job status and results",
+        "operationId": "batchScrapeStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status + scraped pages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlStatus"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Cancel an active batch job",
+        "operationId": "batchScrapeCancel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job cancelled; status becomes \"cancelled\""
           }
         }
       }
@@ -758,15 +844,23 @@
       "CrawlStatus": {
         "type": "object",
         "required": [
-          "status"
+          "success",
+          "status",
+          "total",
+          "completed",
+          "data"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "status": {
             "type": "string",
             "enum": [
               "scraping",
               "completed",
-              "failed"
+              "failed",
+              "cancelled"
             ]
           },
           "completed": {
@@ -780,6 +874,9 @@
             "items": {
               "$ref": "#/components/schemas/ScrapeResponse"
             }
+          },
+          "error": {
+            "type": "string"
           }
         }
       },
@@ -1232,6 +1329,64 @@
           },
           "tokensUsed": {
             "type": "integer"
+          }
+        }
+      },
+      "BatchScrapeRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ScrapeOptions"
+          },
+          {
+            "type": "object",
+            "required": [
+              "urls"
+            ],
+            "properties": {
+              "urls": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "minItems": 1,
+                "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
+              },
+              "ignoreInvalidUrls": {
+                "type": "boolean",
+                "default": true,
+                "description": "When false, a single invalid URL rejects the whole submit with 400."
+              },
+              "maxConcurrency": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
+              }
+            }
+          }
+        ]
+      },
+      "BatchScrapeAccepted": {
+        "type": "object",
+        "required": [
+          "success",
+          "id",
+          "invalidUrls"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "description": "Batch job id; poll with GET /v1/batch/scrape/{id}"
+          },
+          "invalidUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Submitted URLs rejected by parsing or the SSRF guard, verbatim."
           }
         }
       }

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -254,6 +254,92 @@
         }
       }
     },
+    "/v1/batch/scrape": {
+      "post": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Start an async batch scrape over an explicit URL list",
+        "operationId": "batchScrapeStart",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchScrapeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch job accepted; poll with /v1/batch/scrape/{id}",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchScrapeAccepted"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batch/scrape/{id}": {
+      "get": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Get batch job status and results",
+        "operationId": "batchScrapeStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status + scraped pages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlStatus"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Cancel an active batch job",
+        "operationId": "batchScrapeCancel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job cancelled; status becomes \"cancelled\""
+          }
+        }
+      }
+    },
     "/v1/change-tracking/diff": {
       "post": {
         "tags": [
@@ -1154,15 +1240,23 @@
       "CrawlStatus": {
         "type": "object",
         "required": [
-          "status"
+          "success",
+          "status",
+          "total",
+          "completed",
+          "data"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "status": {
             "type": "string",
             "enum": [
               "scraping",
               "completed",
-              "failed"
+              "failed",
+              "cancelled"
             ]
           },
           "completed": {
@@ -1176,6 +1270,9 @@
             "items": {
               "$ref": "#/components/schemas/ScrapeResponse"
             }
+          },
+          "error": {
+            "type": "string"
           }
         }
       },
@@ -1704,6 +1801,64 @@
           },
           "tokensUsed": {
             "type": "integer"
+          }
+        }
+      },
+      "BatchScrapeRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ScrapeOptions"
+          },
+          {
+            "type": "object",
+            "required": [
+              "urls"
+            ],
+            "properties": {
+              "urls": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "minItems": 1,
+                "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
+              },
+              "ignoreInvalidUrls": {
+                "type": "boolean",
+                "default": true,
+                "description": "When false, a single invalid URL rejects the whole submit with 400."
+              },
+              "maxConcurrency": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
+              }
+            }
+          }
+        ]
+      },
+      "BatchScrapeAccepted": {
+        "type": "object",
+        "required": [
+          "success",
+          "id",
+          "invalidUrls"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "description": "Batch job id; poll with GET /v1/batch/scrape/{id}"
+          },
+          "invalidUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Submitted URLs rejected by parsing or the SSRF guard, verbatim."
           }
         }
       }

--- a/crates/crw-server/src/routes/batch.rs
+++ b/crates/crw-server/src/routes/batch.rs
@@ -1,0 +1,199 @@
+//! Native `POST /v1/batch/scrape` (+ status / cancel).
+//!
+//! Scrapes an explicit URL list, reusing the crawl-job machinery over that list
+//! (`AppState::start_batch_job`) — no link discovery, no same-origin filtering,
+//! no dedup. Input order is recoverable via each document's `metadata.sourceURL`.
+//!
+//! Shapes follow the native v1 conventions (strict camelCase, the same status
+//! envelope as `GET /v1/crawl/{id}`), NOT the Firecrawl-compatible `/v2` surface
+//! — `/v2/batch/scrape` keeps `invalidURLs` for SDK parity and must not change.
+
+use axum::Json;
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{Path, State};
+use futures::StreamExt;
+use serde::Serialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crw_core::error::CrwError;
+use crw_core::types::{CrawlState, ScrapeRequest};
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+/// Per-route body cap for batch submits: a 10k-URL list at a few hundred bytes
+/// per URL overflows the global 1 MB JSON cap; 8 MB keeps 10k long URLs
+/// submittable while staying DoS-bounded. Mirrors the `/v2` batch route.
+pub const MAX_BATCH_BODY_BYTES: usize = 8 * 1024 * 1024;
+
+/// Per-URL SSRF validation resolves DNS. Bounded concurrency keeps a 10k-URL
+/// submit at seconds rather than minutes (cold DNS dominates); order is
+/// preserved via `buffered`.
+const VALIDATE_CONCURRENCY: usize = 256;
+
+/// `POST /v1/batch/scrape` response.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchStartResponse {
+    pub success: bool,
+    pub id: String,
+    /// URLs rejected by parsing or the SSRF guard, returned verbatim. Empty
+    /// unless `ignoreInvalidUrls` accepted a partially-valid list.
+    pub invalid_urls: Vec<String>,
+}
+
+/// `POST /v1/batch/scrape` — start a batch scrape over `urls`.
+///
+/// Body: `{ "urls": [...], "ignoreInvalidUrls": true, "maxConcurrency": 10, ...scrapeOptions }`
+/// where `scrapeOptions` are the same fields `POST /v1/scrape` accepts (minus `url`).
+pub async fn start_batch(
+    State(state): State<AppState>,
+    body: Result<Json<Value>, JsonRejection>,
+) -> Result<Json<BatchStartResponse>, AppError> {
+    let Json(mut raw) = body.map_err(AppError::from)?;
+    let obj = raw
+        .as_object_mut()
+        .ok_or_else(|| CrwError::InvalidRequest("request body must be a JSON object".into()))?;
+
+    let urls_val = obj
+        .remove("urls")
+        .ok_or_else(|| CrwError::InvalidRequest("`urls` is required".into()))?;
+    let urls: Vec<String> = serde_json::from_value(urls_val)
+        .map_err(|e| CrwError::InvalidRequest(format!("invalid `urls`: {e}")))?;
+    if urls.is_empty() {
+        return Err(AppError::from(CrwError::InvalidRequest(
+            "`urls` must contain at least one URL".into(),
+        )));
+    }
+    let max_urls = state.config.crawler.max_batch_urls;
+    if urls.len() > max_urls {
+        return Err(AppError::from(CrwError::InvalidRequest(format!(
+            "`urls` exceeds the maximum of {max_urls} URLs per batch (got {})",
+            urls.len()
+        ))));
+    }
+
+    let ignore_invalid = obj
+        .remove("ignoreInvalidUrls")
+        .as_ref()
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
+    // Optional per-job OUTER pipeline width (the SaaS injects this per plan
+    // tier). Removed symmetric with `urls` so it can't leak into the per-URL
+    // scrape template. `start_batch_job` clamps it to a safe range — a
+    // client-supplied value is never authoritative.
+    let max_concurrency_override = obj
+        .remove("maxConcurrency")
+        .as_ref()
+        .and_then(Value::as_u64)
+        .map(|n| n as usize);
+
+    // Build the per-page scrape template from the remaining (native scrape)
+    // options. A placeholder URL satisfies the required field; it's cleared
+    // afterward, and `start_batch_job` stamps each URL onto a clone.
+    obj.insert(
+        "url".to_string(),
+        Value::String("https://placeholder.invalid/".into()),
+    );
+    let mut template: ScrapeRequest = serde_json::from_value(Value::Object(obj.clone()))
+        .map_err(|e| CrwError::InvalidRequest(format!("invalid batch scrape options: {e}")))?;
+    // Reject an unavailable pinned renderer up front (as /v1/scrape and /v1/crawl
+    // do) instead of failing every URL individually deep in the pipeline.
+    crate::state::validate_renderer_pin(template.renderer, template.render_js, &state)?;
+    template.url = String::new();
+
+    // Partition URLs into valid / invalid (SSRF-checked, same guard as
+    // `/v1/scrape`), with bounded concurrency and preserved input order.
+    let checks = futures::stream::iter(urls.into_iter().map(|u| async move {
+        let ok = match url::Url::parse(&u) {
+            Ok(parsed) => crw_core::url_safety::validate_safe_url_resolved(&parsed)
+                .await
+                .is_ok(),
+            Err(_) => false,
+        };
+        (u, ok)
+    }))
+    .buffered(VALIDATE_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+
+    let mut valid = Vec::new();
+    let mut invalid = Vec::new();
+    for (u, ok) in checks {
+        if ok { valid.push(u) } else { invalid.push(u) }
+    }
+    if valid.is_empty() {
+        return Err(AppError::from(CrwError::InvalidRequest(
+            "no valid URLs to scrape".into(),
+        )));
+    }
+    if !invalid.is_empty() && !ignore_invalid {
+        return Err(AppError::from(CrwError::InvalidRequest(format!(
+            "invalid URLs: {}",
+            invalid.join(", ")
+        ))));
+    }
+
+    let id = state
+        .start_batch_job(valid, template, max_concurrency_override)
+        .await;
+
+    Ok(Json(BatchStartResponse {
+        success: true,
+        id: id.to_string(),
+        invalid_urls: invalid,
+    }))
+}
+
+/// `GET /v1/batch/scrape/{id}` — batch status. Same envelope as
+/// `GET /v1/crawl/{id}`: `{ success, status, total, completed, data, error? }`.
+pub async fn get_batch(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<CrawlState>, AppError> {
+    let jobs = state.crawl_jobs.read().await;
+    let job = jobs
+        .get(&id)
+        .ok_or_else(|| CrwError::NotFound(format!("Batch job {id} not found")))?;
+    Ok(Json(job.rx.borrow().clone()))
+}
+
+/// `DELETE /v1/batch/scrape/{id}` — cancel an active batch job. Flips the job to
+/// the terminal `cancelled` state so status polls stop reporting `scraping`.
+///
+/// Batch jobs live in the same `crawl_jobs` map as crawls, so this is exactly
+/// `cancel_crawl`. Delegate rather than copy it: the terminal-state guard has to
+/// stay in lockstep with every other `Completed | Failed | Cancelled` check, and
+/// a duplicate would drift the first time a state is added. `/v2/batch/scrape`
+/// delegates the same way.
+pub async fn cancel_batch(state: State<AppState>, id: Path<Uuid>) -> Result<Json<Value>, AppError> {
+    super::crawl::cancel_crawl(state, id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BatchStartResponse;
+
+    #[test]
+    fn batch_start_response_is_camel_case() {
+        // The v1 surface is strict camelCase: this must serialize `invalidUrls`
+        // (not the v2/Firecrawl `invalidURLs`, nor a snake_case `invalid_urls`).
+        let v = serde_json::to_value(BatchStartResponse {
+            success: true,
+            id: "job-1".into(),
+            invalid_urls: vec!["bad".into()],
+        })
+        .unwrap();
+        assert!(
+            v.get("invalidUrls").is_some(),
+            "expected camelCase invalidUrls"
+        );
+        assert!(v.get("invalid_urls").is_none(), "snake_case key leaked");
+        assert!(
+            v.get("invalidURLs").is_none(),
+            "v2 capital-URL key leaked into v1"
+        );
+    }
+}

--- a/crates/crw-server/src/routes/mod.rs
+++ b/crates/crw-server/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch;
 pub mod breakers;
 pub mod capabilities;
 pub mod change_tracking;

--- a/crates/crw-server/src/routes/v1/mod.rs
+++ b/crates/crw-server/src/routes/v1/mod.rs
@@ -1,4 +1,5 @@
 use axum::Router;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 
 use crate::routes::{self, method_not_allowed};
@@ -17,6 +18,20 @@ pub fn router() -> Router<AppState> {
         .route(
             "/v1/crawl",
             post(routes::crawl::start_crawl).fallback(method_not_allowed),
+        )
+        .route(
+            // Batch submits carry up to `max_batch_urls` URLs — needs more than
+            // the global 1 MB JSON cap (innermost DefaultBodyLimit wins).
+            "/v1/batch/scrape",
+            post(routes::batch::start_batch)
+                .layer(DefaultBodyLimit::max(routes::batch::MAX_BATCH_BODY_BYTES))
+                .fallback(method_not_allowed),
+        )
+        .route(
+            "/v1/batch/scrape/{id}",
+            get(routes::batch::get_batch)
+                .delete(routes::batch::cancel_batch)
+                .fallback(method_not_allowed),
         )
         .route(
             "/v1/crawl/{id}",

--- a/crates/crw-server/tests/api.rs
+++ b/crates/crw-server/tests/api.rs
@@ -158,3 +158,101 @@ async fn map_endpoint_invalid_url() {
         .await;
     resp.assert_status(axum::http::StatusCode::BAD_REQUEST);
 }
+
+// ---------------------------------------------------------------------------
+// Native /v1/batch/scrape — offline guards + cancel-terminal flow.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_batch_requires_urls_400() {
+    let s = test_app();
+    let r = s.post("/v1/batch/scrape").json(&json!({"urls": []})).await;
+    r.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn v1_batch_missing_urls_400() {
+    let s = test_app();
+    let r = s
+        .post("/v1/batch/scrape")
+        .json(&json!({"formats": ["markdown"]}))
+        .await;
+    r.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn v1_batch_all_invalid_urls_400() {
+    // Unparseable URLs are rejected before any DNS lookup, so this stays offline.
+    let s = test_app();
+    let r = s
+        .post("/v1/batch/scrape")
+        .json(&json!({"urls": ["not-a-url", "also bad"]}))
+        .await;
+    r.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn v1_batch_exceeds_cap_400() {
+    let config: AppConfig = toml::from_str("[crawler]\nmax_batch_urls = 2\n").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    let s = TestServer::new(create_app(state));
+    let r = s
+        .post("/v1/batch/scrape")
+        .json(&json!({"urls": ["not-a-url", "not-a-url", "not-a-url"]}))
+        .await;
+    r.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn v1_batch_status_unknown_404() {
+    let s = test_app();
+    let r = s
+        .get("/v1/batch/scrape/00000000-0000-0000-0000-000000000000")
+        .await;
+    r.assert_status(axum::http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn v1_batch_cancel_unknown_404() {
+    let s = test_app();
+    let r = s
+        .delete("/v1/batch/scrape/00000000-0000-0000-0000-000000000000")
+        .await;
+    r.assert_status(axum::http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn v1_batch_wrong_method_405() {
+    let s = test_app();
+    let r = s.get("/v1/batch/scrape").await;
+    r.assert_status(axum::http::StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn v1_batch_cancel_flips_status_to_cancelled() {
+    // Start the job at the state layer with a TEST-NET-1 blackhole IP so it
+    // deterministically stays in progress until we cancel it.
+    let config: AppConfig = toml::from_str("").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    let s = TestServer::new(create_app(state.clone()));
+
+    let template = crw_core::types::ScrapeRequest::default();
+    let id = state
+        .start_batch_job(vec!["http://192.0.2.1/".into()], template, None)
+        .await;
+
+    let r = s.delete(&format!("/v1/batch/scrape/{id}")).await;
+    r.assert_status_ok();
+    let body: serde_json::Value = r.json();
+    assert_eq!(body["success"], true);
+
+    // Status poll reports the terminal state, not "scraping".
+    let g = s.get(&format!("/v1/batch/scrape/{id}")).await;
+    g.assert_status_ok();
+    let st: serde_json::Value = g.json();
+    assert_eq!(st["status"], "cancelled");
+
+    // Re-cancelling a finished job is rejected.
+    let again = s.delete(&format!("/v1/batch/scrape/{id}")).await;
+    again.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}

--- a/docs/docs/recipe-batch.md
+++ b/docs/docs/recipe-batch.md
@@ -17,6 +17,8 @@ Scrape dozens (or hundreds) of unrelated URLs in one async job — no crawling, 
 
 Batch (`POST /firecrawl/v2/batch/scrape`) and crawl (`POST /firecrawl/v2/crawl`) share the same async job machinery and identical status/response envelopes. The difference is the input: batch takes an explicit `urls` array, crawl takes a single seed URL and discovers the rest itself.
 
+> **Native vs Firecrawl-compat.** This recipe uses the Firecrawl-compatible `/firecrawl/v2/batch/scrape` surface. There is also a native twin at `POST /v1/batch/scrape` (+ `GET`/`DELETE /v1/batch/scrape/{id}`) that follows the native v1 conventions: strict camelCase, so the flag is spelled `ignoreInvalidUrls` (not the v2 `ignoreInvalidURLs`) and the rejected list is returned as `invalidUrls` (not `invalidURLs`), and the status envelope matches `GET /v1/crawl/{id}`. Prefer `/v1` for new native integrations; keep `/firecrawl/v2` only when reusing Firecrawl SDK payloads verbatim.
+
 ---
 
 ## How It Works
@@ -29,7 +31,7 @@ DELETE /firecrawl/v2/batch/scrape/{id}  (cancel)
 GET  /firecrawl/v2/batch/scrape/{id}/errors
 ```
 
-**Status values:** `scraping` → `completed` | `failed`
+**Status values:** `scraping` → `completed` | `failed` | `cancelled`
 
 The response is paginated (100 documents per page, max ~10 MB per page). While `status` is `scraping`, the `next` cursor is set even if the current page is empty — keep polling forward until `next` is `null` and `status` is `completed`.
 

--- a/docs/openapi-3.0.json
+++ b/docs/openapi-3.0.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "CRW REST API",
-    "version": "0.16.0",
+    "version": "0.23.0",
     "description": "Firecrawl-compatible web scraping, crawling, mapping, search, and extraction API. Hosted at https://api.fastcrw.com; self-host with `docker run -p 3000:3000 ghcr.io/us/crw:latest`.",
     "license": {
       "name": "AGPL-3.0",
@@ -250,6 +250,92 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch/scrape": {
+      "post": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Start an async batch scrape over an explicit URL list",
+        "operationId": "batchScrapeStart",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchScrapeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch job accepted; poll with /v1/batch/scrape/{id}",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchScrapeAccepted"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batch/scrape/{id}": {
+      "get": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Get batch job status and results",
+        "operationId": "batchScrapeStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status + scraped pages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlStatus"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Cancel an active batch job",
+        "operationId": "batchScrapeCancel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job cancelled; status becomes \"cancelled\""
           }
         }
       }
@@ -758,15 +844,23 @@
       "CrawlStatus": {
         "type": "object",
         "required": [
-          "status"
+          "success",
+          "status",
+          "total",
+          "completed",
+          "data"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "status": {
             "type": "string",
             "enum": [
               "scraping",
               "completed",
-              "failed"
+              "failed",
+              "cancelled"
             ]
           },
           "completed": {
@@ -780,6 +874,9 @@
             "items": {
               "$ref": "#/components/schemas/ScrapeResponse"
             }
+          },
+          "error": {
+            "type": "string"
           }
         }
       },
@@ -1232,6 +1329,64 @@
           },
           "tokensUsed": {
             "type": "integer"
+          }
+        }
+      },
+      "BatchScrapeRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ScrapeOptions"
+          },
+          {
+            "type": "object",
+            "required": [
+              "urls"
+            ],
+            "properties": {
+              "urls": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "minItems": 1,
+                "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
+              },
+              "ignoreInvalidUrls": {
+                "type": "boolean",
+                "default": true,
+                "description": "When false, a single invalid URL rejects the whole submit with 400."
+              },
+              "maxConcurrency": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
+              }
+            }
+          }
+        ]
+      },
+      "BatchScrapeAccepted": {
+        "type": "object",
+        "required": [
+          "success",
+          "id",
+          "invalidUrls"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "description": "Batch job id; poll with GET /v1/batch/scrape/{id}"
+          },
+          "invalidUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Submitted URLs rejected by parsing or the SSRF guard, verbatim."
           }
         }
       }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -254,6 +254,92 @@
         }
       }
     },
+    "/v1/batch/scrape": {
+      "post": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Start an async batch scrape over an explicit URL list",
+        "operationId": "batchScrapeStart",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchScrapeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch job accepted; poll with /v1/batch/scrape/{id}",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchScrapeAccepted"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/batch/scrape/{id}": {
+      "get": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Get batch job status and results",
+        "operationId": "batchScrapeStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status + scraped pages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlStatus"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "batch"
+        ],
+        "summary": "Cancel an active batch job",
+        "operationId": "batchScrapeCancel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Batch job id returned by POST /v1/batch/scrape"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job cancelled; status becomes \"cancelled\""
+          }
+        }
+      }
+    },
     "/v1/change-tracking/diff": {
       "post": {
         "tags": [
@@ -1154,15 +1240,23 @@
       "CrawlStatus": {
         "type": "object",
         "required": [
-          "status"
+          "success",
+          "status",
+          "total",
+          "completed",
+          "data"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "status": {
             "type": "string",
             "enum": [
               "scraping",
               "completed",
-              "failed"
+              "failed",
+              "cancelled"
             ]
           },
           "completed": {
@@ -1176,6 +1270,9 @@
             "items": {
               "$ref": "#/components/schemas/ScrapeResponse"
             }
+          },
+          "error": {
+            "type": "string"
           }
         }
       },
@@ -1704,6 +1801,64 @@
           },
           "tokensUsed": {
             "type": "integer"
+          }
+        }
+      },
+      "BatchScrapeRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ScrapeOptions"
+          },
+          {
+            "type": "object",
+            "required": [
+              "urls"
+            ],
+            "properties": {
+              "urls": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "minItems": 1,
+                "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
+              },
+              "ignoreInvalidUrls": {
+                "type": "boolean",
+                "default": true,
+                "description": "When false, a single invalid URL rejects the whole submit with 400."
+              },
+              "maxConcurrency": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
+              }
+            }
+          }
+        ]
+      },
+      "BatchScrapeAccepted": {
+        "type": "object",
+        "required": [
+          "success",
+          "id",
+          "invalidUrls"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "description": "Batch job id; poll with GET /v1/batch/scrape/{id}"
+          },
+          "invalidUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Submitted URLs rejected by parsing or the SSRF guard, verbatim."
           }
         }
       }


### PR DESCRIPTION
Adds a native `/v1/batch/scrape` endpoint to the engine. Batch scraping only existed on the Firecrawl-compatible `/v2` surface; `/v1` is the native API, so it needed its own twin with native conventions.

**Endpoint**
- `POST /v1/batch/scrape` — scrape an explicit URL list as one async job
- `GET /v1/batch/scrape/{id}` — status (same envelope as `GET /v1/crawl/{id}`)
- `DELETE /v1/batch/scrape/{id}` — cancel

**Native conventions, not the v2 ones**
`/v1` is strict camelCase: the flag is `ignoreInvalidUrls` and the rejected list comes back as `invalidUrls`. `/v2/batch/scrape` keeps `ignoreInvalidURLs` / `invalidURLs` for Firecrawl SDK parity and is untouched by this PR.

**Reuses the existing machinery**
- the job runs on `AppState::start_batch_job`, the same one `/v2` uses, so status and cancel share one code path
- `cancel_batch` delegates to `crawl::cancel_crawl` rather than copying it; batch jobs live in the same `crawl_jobs` map and the terminal-state guard has to stay in lockstep
- every URL goes through `validate_safe_url_resolved` before it is fetched; the URL-count cap and the 8 MB body limit are enforced before any DNS work
- a client-supplied `maxConcurrency` is clamped server-side

**Also**
- OpenAPI (3.1 + 3.0, served and docs copies byte-identical) gains the two paths, and `CrawlStatus` now matches the real `CrawlState` struct: `success` and `error` were missing and the status enum lacked `cancelled`, which `DELETE` has always been able to produce
- `docs/docs/recipe-batch.md` notes the native twin and the camelCase difference

**Checks**
`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test -p crw-server` (184 passed), OpenAPI drift and doc guards all clean.
