### PR TITLE
fix(sdk,engine): extract works against the managed API, search stops discarding the answer, LLM usage adds up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2318,9 +2318,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2334,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.32"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -2963,9 +2963,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pdf-inspector"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a814c9c6a4f520b34789e4519969b4c77325d2a757f13655091ef5f603e25d4f"
+checksum = "156c914888fd0efdfc53911208b74c0adf00e9322b264ec5bfe10fd320f8ebae"
 dependencies = [
  "env_logger",
  "log",
@@ -3090,7 +3090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3278,7 +3278,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.5",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3409,18 +3409,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3571,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3583,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4116,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4492,9 +4492,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
@@ -4550,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4836,7 +4836,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.5",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -5458,18 +5458,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -530,6 +530,56 @@ pub struct LlmUsage {
     pub answer_executed: bool,
 }
 
+impl LlmUsage {
+    /// Fold another leg's usage into this one.
+    ///
+    /// A single scrape can make MORE THAN ONE model call: structured extraction,
+    /// the summary, and the change-tracking judge are three separate legs. The old
+    /// code kept whichever landed first (`if usage.is_none()`), so the second and
+    /// third calls were invisible: the provider billed us for them and the SaaS,
+    /// which prices off this field, billed the customer for one.
+    ///
+    /// Tokens add up. `calls` counts the legs. The model/provider labels are kept
+    /// from the first leg, which is the managed model on every path today.
+    pub fn merge(&mut self, other: LlmUsage) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.total_tokens = self.total_tokens.saturating_add(other.total_tokens);
+        self.calls = self.calls.saturating_add(other.calls.max(1));
+        self.executed_summaries = self
+            .executed_summaries
+            .saturating_add(other.executed_summaries);
+        self.answer_executed |= other.answer_executed;
+        self.truncated |= other.truncated;
+        self.cache_hit_input_tokens =
+            sum_opt(self.cache_hit_input_tokens, other.cache_hit_input_tokens);
+        self.cache_miss_input_tokens =
+            sum_opt(self.cache_miss_input_tokens, other.cache_miss_input_tokens);
+        self.estimated_cost_usd = match (self.estimated_cost_usd, other.estimated_cost_usd) {
+            (Some(a), Some(b)) => Some(a + b),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        };
+    }
+
+    /// Merge into an optional slot, seeding it when empty.
+    pub fn accumulate(slot: &mut Option<LlmUsage>, other: Option<LlmUsage>) {
+        let Some(other) = other else { return };
+        match slot {
+            Some(existing) => existing.merge(other),
+            None => *slot = Some(other),
+        }
+    }
+}
+
+fn sum_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.saturating_add(y)),
+        (Some(x), None) => Some(x),
+        (None, y) => y,
+    }
+}
+
 fn one_u32() -> u32 {
     1
 }
@@ -790,6 +840,53 @@ pub fn resolve_pinned_renderer(req: Option<RequestedRenderer>) -> Option<&'stati
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn usage(input: u32, output: u32) -> LlmUsage {
+        LlmUsage {
+            input_tokens: input,
+            output_tokens: output,
+            total_tokens: input + output,
+            estimated_cost_usd: None,
+            model: "crw-managed-pro".into(),
+            provider: "azure".into(),
+            cache_hit_input_tokens: None,
+            cache_miss_input_tokens: None,
+            truncated: false,
+            calls: 1,
+            executed_summaries: 0,
+            answer_executed: false,
+        }
+    }
+
+    #[test]
+    fn llm_usage_accumulates_every_leg() {
+        // A scrape can call the model three times: structured extraction, the
+        // summary, and the change-tracking judge. Keeping only the first one is
+        // how we ended up paying the provider for calls the SaaS never billed.
+        let mut slot: Option<LlmUsage> = None;
+        LlmUsage::accumulate(&mut slot, Some(usage(1000, 100))); // json
+        LlmUsage::accumulate(&mut slot, Some(usage(500, 50))); // summary
+        LlmUsage::accumulate(&mut slot, Some(usage(200, 20))); // judge
+
+        let merged = slot.expect("usage");
+        assert_eq!(merged.input_tokens, 1700);
+        assert_eq!(merged.output_tokens, 170);
+        assert_eq!(merged.total_tokens, 1870);
+        assert_eq!(merged.calls, 3);
+    }
+
+    #[test]
+    fn llm_usage_accumulate_seeds_an_empty_slot_and_ignores_none() {
+        let mut slot: Option<LlmUsage> = None;
+        LlmUsage::accumulate(&mut slot, None);
+        assert!(slot.is_none(), "no call, no usage");
+
+        LlmUsage::accumulate(&mut slot, Some(usage(10, 1)));
+        LlmUsage::accumulate(&mut slot, None);
+        let merged = slot.expect("usage");
+        assert_eq!(merged.input_tokens, 10);
+        assert_eq!(merged.calls, 1);
+    }
 
     #[test]
     fn resolve_render_js_request_wins_true() {

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -581,14 +581,12 @@ async fn scrape_url_inner(
         {
             Ok(result) => {
                 data.json = Some(result.value);
-                // Surface per-call LLM token usage so callers (billing,
-                // dashboards) see the structured-extraction spend. Summary may
-                // overwrite this slot below; that's fine — each route triggers
-                // at most one of the two paths in the dominant flow, and the
-                // "first wins" tiebreak is preserved by the is_none() check.
-                if data.llm_usage.is_none() {
-                    data.llm_usage = result.usage;
-                }
+                // ACCUMULATE, never overwrite. A request can ask for json AND
+                // summary, and change tracking can add a judge on top: three
+                // separate model calls. Keeping only the first one made the others
+                // invisible to the SaaS, which prices off this field — we paid the
+                // provider for calls we never billed.
+                crw_core::types::LlmUsage::accumulate(&mut data.llm_usage, result.usage);
             }
             Err(e) => {
                 tracing::error!("Structured extraction failed: {e}");
@@ -617,9 +615,7 @@ async fn scrape_url_inner(
         {
             Ok(result) => {
                 data.summary = Some(result.content);
-                if data.llm_usage.is_none() {
-                    data.llm_usage = result.usage;
-                }
+                crw_core::types::LlmUsage::accumulate(&mut data.llm_usage, result.usage);
                 if let Some(w) = result.warning {
                     data.warnings.push(w);
                 }
@@ -772,6 +768,16 @@ async fn scrape_url_inner(
                                     .with_label_values(&["output"])
                                     .inc_by(u.output_tokens as u64);
                             }
+                            // The judge is a real model call. Its tokens only ever
+                            // reached Prometheus, so the SaaS — which prices off
+                            // data.llm_usage — never saw them: a judged page either
+                            // billed nothing for the judge, or (with no other leg
+                            // to report usage) fell back to charging the whole
+                            // worst-case reserve. Fold it in like every other leg.
+                            crw_core::types::LlmUsage::accumulate(
+                                &mut data.llm_usage,
+                                judgment.llm_usage.clone(),
+                            );
                             result.judgment = Some(judgment);
                         }
                         Err(e) => {

--- a/sdks/python/src/crw/client.py
+++ b/sdks/python/src/crw/client.py
@@ -463,7 +463,13 @@ class CrwClient:
         start = self._http_request("POST", "/v1/extract", body, raw=True)
         job_id = start.get("id")
         if not job_id:
-            raise CrwError(f"extract did not return job ID: {start}")
+            # The managed API answers synchronously: the extraction is already
+            # finished and the payload is in this first response, with no job to
+            # poll. Only the async path hands back an `id`. Demanding one made
+            # every managed extract() raise.
+            if isinstance(start.get("results"), list):
+                return start["results"]
+            raise CrwError(f"extract returned neither a job id nor results: {start}")
 
         deadline = time.monotonic() + timeout
         while True:

--- a/sdks/python/src/crw/client.py
+++ b/sdks/python/src/crw/client.py
@@ -94,6 +94,21 @@ def _encode_multipart(filename: str, content: bytes, options: dict[str, Any]) ->
     return bytes(buf), f"multipart/form-data; boundary={boundary}"
 
 
+class SearchResults(list):
+    """The results list, with the search's synthesis hanging off it.
+
+    `answer`, `citations` and `llmUsage` ride BESIDE `data` in the managed API's
+    response, and unwrapping `data` dropped them: a caller could pay for an AI
+    answer and have no way to read it. Subclassing `list` keeps every existing
+    caller working (`for r in results`, indexing, len) while `results.answer`
+    becomes reachable.
+    """
+
+    answer: str | None = None
+    citations: list | None = None
+    llm_usage: dict | None = None
+
+
 class CrwClient:
     """CRW web scraper client.
 
@@ -295,7 +310,19 @@ class CrwClient:
         args.update(kwargs)
 
         if self._api_url:
-            return self._http_post("/v1/search", args)
+            raw = self._http_request("POST", "/v1/search", args, raw=True)
+            data = raw.get("data", [])
+            # `data` IS the results, in whatever shape was asked for: a flat list,
+            # a {"web": [...], "news": [...]} dict when `sources` is set, or the
+            # engine's own {"results": [...], "answer": ...} when the client points
+            # at a self-hosted server. Only the flat list can carry the synthesis.
+            if isinstance(data, list):
+                out = SearchResults(data)
+                out.answer = raw.get("answer")
+                out.citations = raw.get("citations")
+                out.llm_usage = raw.get("llmUsage")
+                return out
+            return data
         return self._tool_call("crw_search", args)
 
     # --- Firecrawl-compatible Research API (cloud only) ---------------------

--- a/sdks/typescript/bun.lock
+++ b/sdks/typescript/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "crw-sdk",
+      "devDependencies": {
+        "@types/node": "^26",
+        "typescript": "^6",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -134,18 +134,34 @@ export class CrwClient {
     if (scrapeOptions) args.scrapeOptions = scrapeOptions;
     Object.assign(args, rest);
     if (this.apiUrl) {
-      // `answer`, `citations` and `llmUsage` ride at the TOP level of the response,
-      // beside `data`. httpPost unwraps `data` and drops them, so an `answer: true`
-      // search could never reach the answer it billed for. Keep the results array as
-      // the return value (that is the documented shape) and hang the synthesis off
-      // it, so both `for (const r of results)` and `results.answer` work.
-      const raw = await this.httpRequest("POST", "/v1/search", args, { raw: true });
-      const results = (Array.isArray(raw.data) ? raw.data : (raw.results ?? [])) as Json[];
-      const out = results as Json[] & { answer?: unknown; citations?: unknown; llmUsage?: unknown };
-      if (raw.answer !== undefined) out.answer = raw.answer;
-      if (raw.citations !== undefined) out.citations = raw.citations;
-      if (raw.llmUsage !== undefined) out.llmUsage = raw.llmUsage;
-      return out as unknown as SearchResult;
+      // `data` IS the results, in whatever shape the caller asked for: a flat
+      // array, a `{ web, news }` object when `sources` is set, or the engine's
+      // `{ results, answer, … }` when you point the client at a self-hosted
+      // server. Return it untouched — reshaping it here silently emptied both the
+      // grouped and the self-hosted cases.
+      //
+      // `answer` / `citations` / `llmUsage` ride BESIDE `data` on the managed API,
+      // and the old `data` unwrap dropped them: you could pay for an AI answer and
+      // have no way to read it. Attach them non-enumerably, so `results.answer`
+      // works while `for…of`, spread and JSON.stringify keep seeing exactly the
+      // array they saw before.
+      const raw = await this.httpRequest("POST", "/v1/search", args, {
+        raw: true,
+      });
+      const data = (raw.data ?? []) as Json;
+      if (data !== null && typeof data === "object") {
+        for (const key of ["answer", "citations", "llmUsage"] as const) {
+          if (raw[key] !== undefined) {
+            Object.defineProperty(data, key, {
+              value: raw[key],
+              enumerable: false,
+              configurable: true,
+              writable: true,
+            });
+          }
+        }
+      }
+      return data as SearchResult;
     }
     return this.localTransport().toolCall("crw_search", args) as Promise<SearchResult>;
   }

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -133,7 +133,20 @@ export class CrwClient {
     if (categories) args.categories = categories;
     if (scrapeOptions) args.scrapeOptions = scrapeOptions;
     Object.assign(args, rest);
-    if (this.apiUrl) return this.httpPost("/v1/search", args) as Promise<SearchResult>;
+    if (this.apiUrl) {
+      // `answer`, `citations` and `llmUsage` ride at the TOP level of the response,
+      // beside `data`. httpPost unwraps `data` and drops them, so an `answer: true`
+      // search could never reach the answer it billed for. Keep the results array as
+      // the return value (that is the documented shape) and hang the synthesis off
+      // it, so both `for (const r of results)` and `results.answer` work.
+      const raw = await this.httpRequest("POST", "/v1/search", args, { raw: true });
+      const results = (Array.isArray(raw.data) ? raw.data : (raw.results ?? [])) as Json[];
+      const out = results as Json[] & { answer?: unknown; citations?: unknown; llmUsage?: unknown };
+      if (raw.answer !== undefined) out.answer = raw.answer;
+      if (raw.citations !== undefined) out.citations = raw.citations;
+      if (raw.llmUsage !== undefined) out.llmUsage = raw.llmUsage;
+      return out as unknown as SearchResult;
+    }
     return this.localTransport().toolCall("crw_search", args) as Promise<SearchResult>;
   }
 
@@ -207,7 +220,13 @@ export class CrwClient {
     if (llmModel !== undefined) body.llmModel = llmModel;
     const start = await this.httpRequest("POST", "/v1/extract", body, { raw: true });
     const jobId = start.id as string | undefined;
-    if (!jobId) throw new CrwError(`extract did not return job ID: ${JSON.stringify(start)}`);
+    // The managed API answers synchronously: the extraction is already finished and
+    // the payload is in this first response, with no job to poll. Only the async
+    // path hands back an `id`. Demanding one made every managed extract() throw.
+    if (!jobId) {
+      if (Array.isArray(start.results)) return start.results as Json[];
+      throw new CrwError(`extract returned neither a job id nor results: ${JSON.stringify(start)}`);
+    }
     const deadline = Date.now() + timeout * 1000;
     for (;;) {
       if (Date.now() > deadline) throw new CrwTimeoutError(`Extract ${jobId} timed out after ${timeout}s`);


### PR DESCRIPTION
Found by executing every snippet the playground's code panel generates, in both SDKs, against the live API.

## SDKs

- **`extract()` never worked against the managed API, in either language.** It demanded an `{id}` job to poll, but the managed API answers synchronously with the finished results. Every call threw. It now accepts the synchronous shape and still polls when an id is returned (self-hosted).
- **The TypeScript `search()` discarded the AI answer.** `answer`, `citations` and `llmUsage` ride beside `data` in the response, and unwrapping `data` dropped them: a caller could pay for an answer and have no way to read it. They are attached non-enumerably, so `results.answer` reads while `for…of`, spread and `JSON.stringify` see exactly the array they saw before. Python gains the same access through a list subclass.

## Engine

- **A scrape can call the model three times** (structured extraction, summary, change-tracking judge) and `data.llm_usage` kept whichever landed first, while the judge's usage only ever reached Prometheus. So `json` + `summary` in one request billed one call and paid the provider for two, and a judged page reported no usage from the judge at all. Tokens add up now and `calls` counts the legs.

## Verified live

`client.extract()` returns real data; `search()` returns 3 results flat, the `{web, news}` object when `sources` is set, and exposes the answer ("Stripe was founded in 2010 by Patrick and John Collison"). `JSON.stringify` and spread are unchanged.

fmt, clippy and 262 engine tests green.