### PR TITLE
fix: stop leaking the search backend's name to users, and guard it

### DIFF
--- a/COMPATIBILITY-firecrawl.md
+++ b/COMPATIBILITY-firecrawl.md
@@ -20,7 +20,7 @@ This is a **capability matrix**, not an API-shape compatibility matrix (which th
 | `/v1/scrape` (single URL → markdown/html) | ✅ | ✅ (no Fire-engine) | ✅ |
 | `/v1/crawl` (multi-page) | ✅ | ✅ | ✅ |
 | `/v1/map` (URL discovery) | ✅ | ✅ | ✅ |
-| `/v1/search` (web search → grounded results) | ✅ | ⚠️ (no Fire-engine; Cloud has stronger anti-bot) | ✅ (SearXNG-backed) |
+| `/v1/search` (web search → grounded results) | ✅ | ⚠️ (no Fire-engine; Cloud has stronger anti-bot) | ✅ (own search backend) |
 | `/v1/extract` (LLM extraction) | ✅ (standalone route) | ⚠️ (requires LLM provider key + manual `.env`) | ⚠️ **No standalone `/v1/extract` route.** LLM extraction is exposed via `/v1/scrape` with `formats: ["json"]` + a JSON schema. Firecrawl `/extract` callers must port to `/v1/scrape` (single-URL only — multi-URL `/extract` is not matched). |
 | `/v1/deep-research` | ✅ | ❌ (Cloud-only) | ❌ |
 | `/firecrawl/v2/parse` (file upload → markdown) | ✅ (PDF/DOCX/XLSX/HTML/…) | ⚠️ (rolling out) | ✅ **PDF only** (multipart `file` + `options`; pure-Rust `pdf-inspector`, no OCR) |
@@ -142,8 +142,8 @@ This is a **capability matrix**, not an API-shape compatibility matrix (which th
 
 | | Firecrawl self-host | fastCRW |
 |---|---|---|
-| Stack | Docker Compose: API + workers + Postgres + Redis | Single Rust binary (or `docker compose up` with bundled SearXNG sidecar) |
-| Memory baseline | ~1-2GB (full stack) | ~6.6 MB idle (binary); +SearXNG container if used |
+| Stack | Docker Compose: API + workers + Postgres + Redis | Single Rust binary (or `docker compose up` with bundled search backend sidecar) |
+| Memory baseline | ~1-2GB (full stack) | ~6.6 MB idle (binary); +search backend container if used |
 | Cold start | ~5-15s (full stack warmup) | ~85ms (binary) |
 | Languages | TypeScript (workers), some Rust (`/parse` Apr 2026) | Rust |
 
@@ -179,7 +179,7 @@ This is a **capability matrix**, not an API-shape compatibility matrix (which th
 ## 12. Recent moves (Mar–May 2026)
 
 - **Firecrawl:** Lockdown Mode (Apr 30), Rust-based `/parse` engine (Apr 28), Spark 1 models on `/agent`, multiple status incidents Mar 21/24/31 + Apr 19-30 (`status.firecrawl.dev/incidents`), Series A $14.5M (Aug 2025).
-- **fastCRW:** `/v1/search` SearXNG-backed (Q2 2026), bundled Docker sidecar, Tavily-cluster pages shipped 2026-05-09.
+- **fastCRW:** `/v1/search` on our own search backend (Q2 2026), bundled Docker sidecar, Tavily-cluster pages shipped 2026-05-09.
 
 ---
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,7 +47,7 @@ This decision drives Phase 1 hub title selection, Phase 4 README/Show HN copy, a
 | `results[].title` | `data[].title` | ✅ |
 | `results[].url` | `data[].url` | ✅ |
 | `results[].content` | `data[].description` | **rename: `content` → `description`** |
-| `results[].score` (float; range unspecified in Tavily docs) | `data[].score` (float, optional, SearXNG-derived) | scale differs (treat as ordinal, not absolute) |
+| `results[].score` (float; range unspecified in Tavily docs) | `data[].score` (float, optional, search-backend-derived) | scale differs (treat as ordinal, not absolute) |
 | `results[].raw_content` | `data[].markdown` / `data[].html` / `data[].raw_html` (when `scrapeOptions` set) | CRW separates by format |
 | `results[].favicon` | not present | gap |
 | `results[].published_date` (news only) | `data[].published_date` (news only) | ✅ |
@@ -126,7 +126,7 @@ class CrwTavilyShim:
       - No `answer` synthesis (returns "" if include_answer is set).
       - No `include_domains` / `exclude_domains` / `country` filtering.
       - `topic="finance"` is not supported.
-      - `score` is SearXNG-derived; treat as ordinal not absolute.
+      - `score` is search-backend-derived; treat as ordinal not absolute.
       - `raw_content` requires scrapeOptions on CRW; this shim wires it through.
     """
     def __init__(self, base_url: str, api_key: str | None = None):
@@ -172,7 +172,7 @@ class CrwTavilyShim:
         }
 ```
 
-This shim is the artifact `/alternatives/open-source-tavily` should ship to honor Branch B's "delay until Tavily-client adapter ships" condition. Without it, Phase 2 `/alternatives/open-source-tavily` should narrow to "Open-source SearXNG-based search APIs" per plan iter-6.
+This shim is the artifact `/alternatives/open-source-tavily` should ship to honor Branch B's "delay until Tavily-client adapter ships" condition. Without it, Phase 2 `/alternatives/open-source-tavily` should narrow to "Open-source, self-hosted search APIs" per plan iter-6.
 
 ---
 
@@ -181,7 +181,7 @@ This shim is the artifact `/alternatives/open-source-tavily` should ship to hono
 1. **Branch B applies.** Hub title cannot use "Tavily-compatible" without qualification. Two approved title variants (per plan iter-7):
    - `"Tavily-Style Search API — Free to Self-Host (2026)"` (53 chars)
    - `"Migrate from Tavily — Self-Hosted Search API (2026)"` (52 chars)
-2. **README repo description (Phase 4 step 1):** `"Free, self-hostable search API for AI agents — Rust + SearXNG. Tavily-style endpoints."` (Branch B variant).
+2. **README repo description (Phase 4 step 1):** `"Free, self-hostable search API for AI agents — built in Rust. Tavily-style endpoints."` (Branch B variant).
 3. **`/alternatives/open-source-tavily` ships with the adapter shim above** referenced inline (no delay), since the shim removes the "Tavily-client adapter must ship first" blocker.
 4. **The plan's "drop-in replacement" copy is forbidden** until either (a) param names align, or (b) the adapter ships and is tested in CI. Use "drop-in via adapter shim" only.
 5. **Compatibility gate for the `tavily compatible api` keyword** (per Phase 0 priority table): redirect to `/alternatives/tavily#migration` anchor that documents the matrix above. Do not promise drop-in.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ That first scrape spent 1 of your 500 free credits — [see plans →](https://f
 - **Fast median, tunable latency** — the fastest median latency (p50 **1914 ms** — a statistical tie with Crawl4AI's 1916 ms, ahead of Firecrawl's 2305 ms). Recall mode maximizes accuracy; *fast mode* delivers a low p90 (**4348 ms**) for latency-sensitive workloads. One config toggle — pick accuracy or latency.
 - **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
 
-Search, map, and crawl run on the same engine — built-in web search (SearXNG, a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full benchmark →](BENCHMARKS.md)
+Search, map, and crawl run on the same engine — built-in web search (a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full benchmark →](BENCHMARKS.md)
 
 Open source (AGPL-3.0), passing [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13533), and published on PyPI · npm · crates.io · Homebrew · APT — with a benchmark you can rerun yourself, not marketing math.
 
@@ -168,7 +168,7 @@ npx skills add -g us/crw         # global (user-level)
 
 | Verb | Endpoint | Does |
 |---|---|---|
-| **Search** | `POST /v1/search` | Web search (SearXNG), optionally scrape each result |
+| **Search** | `POST /v1/search` | Web search (own search backend), optionally scrape each result |
 | **Scrape** | `POST /v1/scrape` | One URL → markdown / HTML / links / schema JSON |
 | **Map** | `POST /v1/map` | Discover every URL on a site, fast |
 | **Crawl** | `POST /v1/crawl` | Async crawl of a whole site (returns a job id you poll) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,7 +148,7 @@ CRW 提供 Firecrawl 的 API，但资源占用极低。无运行时依赖，无 
 claude mcp add crw -- npx -y crw-mcp
 ```
 
-> 完成。Claude Code 现在拥有 `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file` 工具（`crw_search` 在配置 SearXNG 后端后自动出现）。Cursor、Windsurf、Cline 等 MCP 客户端请参见 [MCP 服务器](#mcp-服务器)。
+> 完成。Claude Code 现在拥有 `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file` 工具（`crw_search` 在配置搜索后端后自动出现）。Cursor、Windsurf、Cline 等 MCP 客户端请参见 [MCP 服务器](#mcp-服务器)。
 
 **CLI（无需服务器）：**
 
@@ -316,7 +316,7 @@ claude mcp add crw -- npx -y crw-mcp
 }
 ```
 
-**工具（共 6 个）：** `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file`（本地 PDF 转 Markdown）、`crw_search`（配置 SearXNG 后端后可用；云模式始终可用）
+**工具（共 6 个）：** `crw_scrape`、`crw_crawl`、`crw_check_crawl_status`、`crw_map`、`crw_parse_file`（本地 PDF 转 Markdown）、`crw_search`（配置搜索后端后可用；云模式始终可用）
 
 ## JS 渲染
 

--- a/crates/crw-cli/src/commands/bench.rs
+++ b/crates/crw-cli/src/commands/bench.rs
@@ -77,9 +77,9 @@ pub struct BenchArgs {
     pub query_expand: Option<usize>,
 
     /// How many questions to run concurrently. 1 = sequential. Higher cuts
-    /// wall-clock but the ceiling is the upstream limits — SearXNG engine
-    /// blocks, residential-proxy connection caps, and the synth model's TPM —
-    /// not CPU. Watch the empty/error rate when raising it.
+    /// wall-clock but the ceiling is the upstream limits — search backend
+    /// engine blocks, residential-proxy connection caps, and the synth model's
+    /// TPM — not CPU. Watch the empty/error rate when raising it.
     #[arg(long, default_value_t = 1)]
     pub concurrency: usize,
 }

--- a/crates/crw-cli/src/commands/scrape.rs
+++ b/crates/crw-cli/src/commands/scrape.rs
@@ -518,7 +518,7 @@ fn maybe_show_first_run_hint() {
     }
     eprintln!();
     eprintln!(
-        "  Tip: run `crw setup` to enable AI features (--summary, --extract) and SearXNG search."
+        "  Tip: run `crw setup` to enable AI features (--summary, --extract) and web search."
     );
     eprintln!();
     if let Some(parent) = sentinel.parent() {

--- a/crates/crw-cli/src/commands/search.rs
+++ b/crates/crw-cli/src/commands/search.rs
@@ -33,12 +33,12 @@ pub struct SearchArgs {
     #[arg(short, long, default_value = "10")]
     pub limit: u32,
 
-    /// SearXNG instance URL.
+    /// Search backend instance URL.
     ///
     /// Resolution order: this flag > `CRW_SEARXNG_URL` env > `search.searxng_url`
     /// in `~/.config/crw/config.toml` > `http://127.0.0.1:8080` (the default
-    /// `crw setup --local` SearXNG sidecar). Public instances (searx.be, etc.)
-    /// usually block JSON requests with 403/429 — prefer a local sidecar.
+    /// `crw setup --local` sidecar). Public instances usually block JSON
+    /// requests with 403/429 — prefer a local sidecar.
     #[arg(long, env = "CRW_SEARXNG_URL")]
     pub searxng_url: Option<String>,
 
@@ -109,24 +109,21 @@ pub async fn run(args: SearchArgs) {
         Err(e) => {
             eprintln!("error: search failed: {e}");
             eprintln!();
-            eprintln!(
-                "hint: SearXNG (the search backend) is unreachable at {}",
-                searxng_url
-            );
+            eprintln!("hint: the search backend is unreachable at {}", searxng_url);
             eprintln!();
             eprintln!("      Easiest fix — let `crw setup` boot a local one for you:");
             eprintln!("          crw setup --local");
             eprintln!();
-            eprintln!("      Manual fix — boot SearXNG with JSON output enabled (the stock");
-            eprintln!("      image ships with JSON disabled, which causes 403s):");
+            eprintln!("      Manual fix — boot a search backend with JSON output enabled (the");
+            eprintln!("      stock image ships with JSON disabled, which causes 403s):");
             eprintln!("          docker run -d --name searxng -p 8080:8080 \\");
             eprintln!(
                 "            -v ~/.config/crw/searxng-settings.yml:/etc/searxng/settings.yml \\"
             );
             eprintln!("            searxng/searxng");
             eprintln!();
-            eprintln!("      Public instances (searx.be, priv.au, etc.) usually block JSON");
-            eprintln!("      requests with 403/429 and are not recommended.");
+            eprintln!("      Public instances usually block JSON requests with 403/429 and");
+            eprintln!("      are not recommended.");
             std::process::exit(1);
         }
     };

--- a/crates/crw-cli/src/commands/setup/local.rs
+++ b/crates/crw-cli/src/commands/setup/local.rs
@@ -110,16 +110,16 @@ pub async fn run() -> Result<(), SetupError> {
     // Step 3: Search engine
     ui::print_step(3, 5, "Search Engine (for web search)");
 
-    println!("  CRW's search feature uses SearXNG, a privacy-respecting");
-    println!("  meta search engine that aggregates results from Google,");
-    println!("  Bing, DuckDuckGo, and 70+ other sources.");
+    println!("  CRW's search feature uses a privacy-respecting meta search");
+    println!("  engine that aggregates results from Google, Bing, DuckDuckGo,");
+    println!("  and 70+ other sources.");
     println!();
 
     let searxng_url = if docker_available {
         prompt_searxng_setup().await?
     } else {
-        ui::print_warning("Skipping SearXNG (Docker not available)");
-        ui::print_detail("crw search command won't work without SearXNG");
+        ui::print_warning("Skipping search backend (Docker not available)");
+        ui::print_detail("crw search command won't work without a search backend");
         None
     };
 
@@ -202,7 +202,7 @@ pub async fn run() -> Result<(), SetupError> {
 
     let mut extras = Vec::new();
     if searxng_url.is_some() {
-        extras.push("SearXNG management:");
+        extras.push("Search backend management:");
         extras.push("  docker start searxng         # Start search engine");
         extras.push("  docker stop searxng          # Stop search engine");
         extras.push("");
@@ -235,7 +235,7 @@ async fn handle_docker_not_running() -> Result<bool, SetupError> {
         .with_prompt("  What would you like to do?")
         .items([
             "Retry (I just started Docker)",
-            "Continue without search (skip SearXNG)",
+            "Continue without search (skip search backend)",
             "Exit",
         ])
         .default(0)
@@ -267,7 +267,7 @@ async fn handle_docker_not_found() -> Result<bool, SetupError> {
     let mut lines = vec![
         "Docker is required for local search setup",
         "",
-        "Docker runs SearXNG (search engine) in a container.",
+        "Docker runs the search engine in a container.",
         "Without it, you can still scrape but not search.",
         "",
         "Install Docker:",
@@ -281,7 +281,7 @@ async fn handle_docker_not_found() -> Result<bool, SetupError> {
     let choice = Select::with_theme(&ui::select_style())
         .with_prompt("  What would you like to do?")
         .items([
-            "Continue without Docker (skip SearXNG)",
+            "Continue without Docker (skip search backend)",
             "Exit and install Docker first",
         ])
         .default(0)
@@ -463,18 +463,18 @@ async fn prompt_searxng_setup() -> Result<Option<String>, SetupError> {
 
     // If already running, just return the URL
     if let searxng::SearxngStatus::Running { url } = &status {
-        ui::print_success(&format!("SearXNG already running at {}", url));
+        ui::print_success(&format!("Search backend already running at {}", url));
         return Ok(Some(url.clone()));
     }
 
     let items = vec![
         "Yes, using Docker (recommended)\n      • Auto-managed container\n      • ~500MB disk space\n      • Starts automatically when needed",
-        "No, I'll set it up myself\n      • Manual setup required\n      • See: https://docs.searxng.org",
+        "No, I'll set it up myself\n      • Manual setup required\n      • Point CRW_SEARXNG_URL at your own instance",
         "Skip (no search feature)\n      • crw search command won't work\n      • Scraping still works fine",
     ];
 
     let choice = Select::with_theme(&ui::select_style())
-        .with_prompt("  Set up SearXNG for web search?")
+        .with_prompt("  Set up a search backend for web search?")
         .items(&items)
         .default(0)
         .interact_opt()
@@ -489,11 +489,13 @@ async fn prompt_searxng_setup() -> Result<Option<String>, SetupError> {
             Ok(Some(url))
         }
         1 => {
-            ui::print_info("You can set up SearXNG manually and configure CRW_SEARXNG_URL");
+            ui::print_info(
+                "You can set up a search backend manually and configure CRW_SEARXNG_URL",
+            );
             Ok(None)
         }
         2 => {
-            ui::print_info("Skipping SearXNG setup");
+            ui::print_info("Skipping search backend setup");
             Ok(None)
         }
         _ => unreachable!(),

--- a/crates/crw-cli/src/main.rs
+++ b/crates/crw-cli/src/main.rs
@@ -53,7 +53,7 @@ use teardown::{CmdError, finish, install_signal_teardown};
         curl -fsSL https://fastcrw.com/install | sh\n\n\
         DOCS:    https://docs.fastcrw.com  ·  https://github.com/us/crw\n\
         CLOUD:   https://fastcrw.com (500 free credits, no monthly reset)\n\
-        SEARCH:  `crw setup --local` boots a JSON-enabled SearXNG on 127.0.0.1:8080.\n\
+        SEARCH:  `crw setup --local` boots a JSON-enabled search backend on 127.0.0.1:8080.\n\
         \x20        Public instances (searx.be, priv.au, ...) usually block JSON requests.\n\
         "
 )]
@@ -140,7 +140,7 @@ enum Commands {
     /// Scrape a single URL and output content
     Scrape(commands::scrape::ScrapeArgs),
 
-    /// Web search via SearXNG
+    /// Web search via the built-in search backend
     Search(commands::search::SearchArgs),
 
     /// BFS crawl a website starting from a URL

--- a/crates/crw-server/openapi/openapi-3.0.json
+++ b/crates/crw-server/openapi/openapi-3.0.json
@@ -31,7 +31,7 @@
   "tags": [
     {
       "name": "search",
-      "description": "Web search via SearXNG (self-hosted) or managed (hosted)"
+      "description": "Web search via our own search backend (self-hosted) or managed (hosted)"
     },
     {
       "name": "scrape",
@@ -564,7 +564,7 @@
           },
           "category": {
             "type": "string",
-            "description": "SearXNG result category (e.g. 'general')"
+            "description": "Search backend result category (e.g. 'general')"
           },
           "markdown": {
             "type": "string",

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -31,7 +31,7 @@
   "tags": [
     {
       "name": "search",
-      "description": "Web search via SearXNG (self-hosted) or managed (hosted)"
+      "description": "Web search via our own search backend (self-hosted) or managed (hosted)"
     },
     {
       "name": "scrape",
@@ -787,7 +787,7 @@
           },
           "category": {
             "type": "string",
-            "description": "SearXNG result category (e.g. 'general')"
+            "description": "Search backend result category (e.g. 'general')"
           },
           "markdown": {
             "type": "string",

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -158,7 +158,7 @@ pub async fn search_inner(
         .ok_or_else(|| {
             CrwError::SearchDisabled(
                 "Search is disabled. Set [search].searxng_url in config or define \
-                 CRW_SEARCH__SEARXNG_URL to point at a SearXNG instance."
+                 CRW_SEARCH__SEARXNG_URL to point at a search backend instance."
                     .into(),
             )
         })?
@@ -1006,14 +1006,14 @@ fn map_search_error(err: SearchError, timeout_ms: u64, base_url: &str) -> CrwErr
     match err {
         SearchError::Timeout => CrwError::Timeout(timeout_ms),
         SearchError::Upstream { status, body } => CrwError::HttpError(format!(
-            "SearXNG returned HTTP {status}: {}",
+            "Search backend returned HTTP {status}: {}",
             body.chars().take(200).collect::<String>()
         )),
         SearchError::InvalidResponse(msg) => {
-            CrwError::HttpError(format!("SearXNG returned invalid JSON: {msg}"))
+            CrwError::HttpError(format!("Search backend returned invalid JSON: {msg}"))
         }
         SearchError::Transport(msg) => CrwError::TargetUnreachable(format!(
-            "SearXNG ({}): {msg}",
+            "Search backend ({}): {msg}",
             crate::diagnostics::sanitize_url_origin(base_url)
         )),
     }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -37,7 +37,7 @@ All routes on the engine namespace (https://api.fastcrw.com or self-hosted base)
 | GET    | /v1/crawl/{id}         | Poll crawl job status and retrieve results               |
 | DELETE | /v1/crawl/{id}         | Cancel a running crawl job                               |
 | POST   | /v1/map                | URL discovery without scraping page bodies               |
-| POST   | /v1/search             | Web search (SearXNG-backed), returns ranked results      |
+| POST   | /v1/search             | Web search (own search backend), returns ranked results  |
 | POST   | /firecrawl/v2/parse              | Parse a file (PDF) into markdown/structured output       |
 | POST   | /v1/change-tracking/diff | Stateless per-page diff; accepts single item or batch  |
 | GET    | /v1/capabilities       | Surface what this instance supports (renderers, search)  |
@@ -263,7 +263,7 @@ Response:
 ### 4.4  POST /v1/search
 ────────────────────────────────────────────────────────────────────────────────
 
-Web search via SearXNG backend. No "country" parameter — use "lang" for locale.
+Web search via our own search backend. No "country" parameter — use "lang" for locale.
 
 Request:
   {"query": "web scraping tools 2025", "limit": 5}
@@ -274,15 +274,15 @@ Key parameters:
   lang            string    opt       Language code, e.g. "en", "tr"
   tbs             string    opt       Time filter: qdr:h|qdr:d|qdr:w|qdr:m|qdr:y
   sources         string[]  opt       Group results by source: "web", "news", "images"
-  categories      string[]  opt       Category bias; each element: "pdf", "github", "research", or any SearXNG category string (max 5)
+  categories      string[]  opt       Category bias; each element: "pdf", "github", "research", or any search backend category string (max 5)
   scrapeOptions   object    opt       Options to scrape each result page
   summarizeResults boolean  opt       Per-result LLM summary (needs LLM config)
   answer          boolean   opt       LLM-synthesized answer over top results
 
 Availability:
   Cloud (fastcrw.com): always available
-  Self-hosted: requires SearXNG sidecar configured (docker compose up starts it automatically)
-  Embedded MCP mode: only when SearXNG backend is configured
+  Self-hosted: requires a search backend sidecar configured (docker compose up starts it automatically)
+  Embedded MCP mode: only when a search backend is configured
 
 Flat response (no sources param):
   {
@@ -408,7 +408,7 @@ MCP key prefix: crw_live_
 
 Two MCP modes:
   Embedded  — no CRW_API_URL set; scraping engine runs inside the MCP process (~6 MB RAM)
-              crw_search only appears when SearXNG backend is configured
+              crw_search only appears when a search backend is configured
   Proxy     — CRW_API_URL set; forwards tool calls to a remote CRW server (cloud or self-hosted)
               crw_search always advertised (search backend is on the server)
 
@@ -510,10 +510,10 @@ Parameters:
   lang            string    opt       Language code, e.g. "en", "tr"
   tbs             string    opt       Time filter: "qdr:h"|"qdr:d"|"qdr:w"|"qdr:m"|"qdr:y"
   sources         string[]  opt       Group by source: "web", "news", "images"
-  categories      string[]  opt       Category bias; each element: "pdf", "github", "research", or any SearXNG category string (max 5)
+  categories      string[]  opt       Category bias; each element: "pdf", "github", "research", or any search backend category string (max 5)
   scrapeOptions   object    opt       Options for scraping each result
 
-Availability: always in proxy/cloud mode; embedded only when SearXNG is configured.
+Availability: always in proxy/cloud mode; embedded only when a search backend is configured.
 
 Example:
   crw_search(query="renewable energy 2025", limit=5)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,7 +14,7 @@
 
 ## API endpoints (live HTML, agent-facing)
 
-- [POST /v1/search](https://docs.fastcrw.com/api-reference/search/): Web search via SearXNG, returns ranked results
+- [POST /v1/search](https://docs.fastcrw.com/api-reference/search/): Web search via our own search backend, returns ranked results
 - [POST /v1/scrape](https://docs.fastcrw.com/api-reference/scrape/): Single-URL content extraction; add `formats:["json"]` + `jsonSchema` for structured JSON extraction
 - [POST /v1/map](https://docs.fastcrw.com/api-reference/map/): URL discovery without scraping bodies
 - [POST /v1/crawl](https://docs.fastcrw.com/api-reference/crawl/) + GET /v1/crawl/{id}: Async multi-page crawl

--- a/docs/openapi-3.0.json
+++ b/docs/openapi-3.0.json
@@ -31,7 +31,7 @@
   "tags": [
     {
       "name": "search",
-      "description": "Web search via SearXNG (self-hosted) or managed (hosted)"
+      "description": "Web search via our own search backend (self-hosted) or managed (hosted)"
     },
     {
       "name": "scrape",
@@ -564,7 +564,7 @@
           },
           "category": {
             "type": "string",
-            "description": "SearXNG result category (e.g. 'general')"
+            "description": "Search backend result category (e.g. 'general')"
           },
           "markdown": {
             "type": "string",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -31,7 +31,7 @@
   "tags": [
     {
       "name": "search",
-      "description": "Web search via SearXNG (self-hosted) or managed (hosted)"
+      "description": "Web search via our own search backend (self-hosted) or managed (hosted)"
     },
     {
       "name": "scrape",
@@ -787,7 +787,7 @@
           },
           "category": {
             "type": "string",
-            "description": "SearXNG result category (e.g. 'general')"
+            "description": "Search backend result category (e.g. 'general')"
           },
           "markdown": {
             "type": "string",

--- a/scripts/docs-guards.sh
+++ b/scripts/docs-guards.sh
@@ -125,6 +125,69 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Guard 3: the search backend's identity must never appear on a user-facing
+# surface. Config/contract identifiers are fine and must keep working, so we
+# only reject the bare NAME in prose: any "searxng" that is not part of a config
+# key, env var, docker service/image, CLI flag, or URL host.
+#
+# Allowed (contract the user must be able to type):
+#   searxng_url, [search].searxng_url, CRW_SEARCH__SEARXNG_URL, CRW_SEARXNG_URL,
+#   SEARXNG_SECRET_KEY, --searxng-url, the docker service/image/host `searxng`.
+
+BACKEND_SURFACES=(
+  README.md
+  README.zh-CN.md
+  COMPATIBILITY.md
+  COMPATIBILITY-firecrawl.md
+  docs/llms.txt
+  docs/llms-full.txt
+  crates/crw-server/openapi/openapi.json
+  crates/crw-server/openapi/openapi-3.0.json
+  crates/crw-server/src/routes/search.rs
+)
+
+# A hit is ALLOWED when the match is immediately part of an identifier: it is
+# followed by _url / _SECRET / :port / / (image or host path), preceded by - or _
+# or $ or / , or wrapped in the env-var prefix. Everything else is prose.
+BACKEND_ALLOWED='searxng_url|SEARXNG_URL|SEARXNG_SECRET|--searxng-url|searxng/searxng|searxng:[0-9]|//searxng|-searxng|searxng-internal|my-searxng'
+
+backend_hits=""
+for f in "${BACKEND_SURFACES[@]}" $(find skills -name 'SKILL.md' 2>/dev/null) skills/README.md; do
+  [ -f "$f" ] || continue
+  # crw-self-host legitimately documents running the compose stack by name.
+  case "$f" in skills/crw-self-host/SKILL.md) continue ;; esac
+
+  case "$f" in
+    *.rs)
+      # In Rust, only STRING LITERALS reach a user (error bodies, printed text).
+      # Type names (SearxngClient), fields (state.searxng) and internal comments
+      # are code, not surface, so require a quote and skip comment lines.
+      hits=$(grep -in "searxng" "$f" 2>/dev/null \
+        | grep -v '^[0-9]*:[[:space:]]*//' \
+        | grep '"' \
+        | grep -Eiv "$BACKEND_ALLOWED" || true)
+      ;;
+    *)
+      hits=$(grep -in "searxng" "$f" 2>/dev/null | grep -Eiv "$BACKEND_ALLOWED" || true)
+      ;;
+  esac
+
+  if [ -n "$hits" ]; then
+    backend_hits="${backend_hits}${f}:\n$(echo "$hits" | sed 's/^/  /')\n"
+  fi
+done
+
+if [ -n "$backend_hits" ]; then
+  echo "FAIL: the search backend's name leaked into a user-facing surface." >&2
+  echo "      Say \"the search backend\" in prose. Config keys, env vars, CLI" >&2
+  echo "      flags and docker service names are fine and must stay verbatim." >&2
+  printf "%b" "$backend_hits" >&2
+  FAIL=1
+else
+  echo "ok: no search-backend name in user-facing prose"
+fi
+
+# ---------------------------------------------------------------------------
 
 if [ "$FAIL" -ne 0 ]; then
   exit 1

--- a/skills/README.md
+++ b/skills/README.md
@@ -3,7 +3,7 @@
 Reusable [agent skills](https://www.skills.sh) that teach AI coding agents how
 to use **fastCRW** — the open-source, self-hostable Firecrawl alternative
 (single Rust binary, ~6 MB RAM, Firecrawl-compatible `/v1` + `/v2` API, bundled
-SearXNG search, first-class MCP).
+search backend, first-class MCP).
 
 Works with Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Windsurf, and any
 agent the [`skills`](https://github.com/vercel-labs/skills) tool supports.
@@ -27,7 +27,7 @@ skills plus the `crw-mcp` server (`.mcp.json`).
 
 The skills drive the `crw` CLI, the `crw-mcp` MCP tools, or the REST API — see
 each skill's Quick Start for all three call surfaces. No API key is needed for
-self-hosted search (SearXNG); the managed `api.fastcrw.com` offers a free tier.
+self-hosted search; the managed `api.fastcrw.com` offers a free tier.
 
 ## Catalog
 
@@ -37,7 +37,7 @@ Climb in order; stop at the cheapest rung that answers the need.
 | Skill | What it does |
 |-------|--------------|
 | [`crw`](./crw/SKILL.md) | Hub — which verb to use, in what order. Start here. |
-| [`crw-search`](./crw-search/SKILL.md) | Web search (SearXNG-backed, no API key). Step 1. |
+| [`crw-search`](./crw-search/SKILL.md) | Web search (own search backend, no API key). Step 1. |
 | [`crw-scrape`](./crw-scrape/SKILL.md) | Single-page → markdown / HTML / JSON / links. Step 2. |
 | [`crw-map`](./crw-map/SKILL.md) | Discover all URLs on a site (no content). Step 3. |
 | [`crw-crawl`](./crw-crawl/SKILL.md) | Scrape many pages under a site/section. Step 4. |
@@ -55,7 +55,7 @@ Climb in order; stop at the cheapest rung that answers the need.
 | Skill | What it does |
 |-------|--------------|
 | [`crw-migrate`](./crw-migrate/SKILL.md) | Coming from Firecrawl? Usually a one-line `base_url` swap. |
-| [`crw-self-host`](./crw-self-host/SKILL.md) | Stand up your own crw + SearXNG + proxy pool. |
+| [`crw-self-host`](./crw-self-host/SKILL.md) | Stand up your own crw + search backend + proxy pool. |
 
 ## Links
 

--- a/skills/crw-best-practices/SKILL.md
+++ b/skills/crw-best-practices/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Reference skill for building production-ready crw integrations. Covers verb
   selection, call surfaces (CLI/MCP/REST), post-filtering strategies, context-window
   hygiene, Hybrid RAG patterns, common pitfalls, and crw-specific operational
-  considerations (SearXNG limits, renderer pool, proxy rotation). Load this when
+  considerations (search backend limits, renderer pool, proxy rotation). Load this when
   writing application code that embeds crw, designing a multi-step agent workflow,
   or debugging an integration that isn't behaving as expected.
 license: AGPL-3.0
@@ -28,7 +28,7 @@ than the task requires.
 
 | Need | Verb | Notes |
 |------|------|-------|
-| You have a question/topic, not a URL | **search** | SearXNG-backed, no API key required. Returns titles + URLs + snippets. Add `scrapeOptions` to get markdown inline. |
+| You have a question/topic, not a URL | **search** | Own search backend, no API key required. Returns titles + URLs + snippets. Add `scrapeOptions` to get markdown inline. |
 | You have one (or a few) known URLs | **scrape** | Returns markdown, HTML, links, or structured JSON. JS auto-detected. |
 | You need to discover which URLs exist on a site | **map** | Fast URL discovery via sitemap + BFS. No content fetched. Use before committing to a crawl. |
 | You need content from many pages under a site | **crawl** | Async BFS job. Poll with `crw_check_crawl_status`. Always `map` first to estimate size. |
@@ -105,9 +105,10 @@ signal.
 
 ### Layer 1: Rank/order-based triage (free)
 
-SearXNG's raw score is unreliable (engine-dependent, often null). **Position is the
-reliable signal** — it reflects the aggregator's Reciprocal Rank Fusion over N
-engines. Default: trust the top 3-5 results unless they're obviously off-topic.
+The search backend's raw score is unreliable (engine-dependent, often null).
+**Position is the reliable signal** — it reflects the aggregator's Reciprocal
+Rank Fusion over N engines. Default: trust the top 3-5 results unless they're
+obviously off-topic.
 
 ```python
 # Rely on position, not score
@@ -191,7 +192,7 @@ crw search "query" → top-N results (titles + snippets)
 ```
 
 **Why crw for RAG:**
-- SearXNG search costs $0 per query (no per-call API fees)
+- Search costs $0 per query (no per-call API fees)
 - Recurring crawls use VPS cost, not per-page credits
 - `crw_crawl` + `jsonSchema` can extract typed objects per page directly —
   skip the embed step for structured data
@@ -227,7 +228,7 @@ fresh `crw search` results at query time (hybrid retrieval).
 | Problem | Impact | Solution |
 |---------|--------|----------|
 | Piping raw JSON into context | 50K-500K chars enters context; token waste, reasoning degradation | Always filter in a Python subprocess — see [crw-dynamic-search](../crw-dynamic-search/SKILL.md) |
-| Trusting `score` for triage | SearXNG scores are engine-dependent, often `null`; wrong results picked | Triage by `position` (rank order) + keyword density in `description` |
+| Trusting `score` for triage | The search backend's scores are engine-dependent, often `null`; wrong results picked | Triage by `position` (rank order) + keyword density in `description` |
 | Crawling without mapping first | Committing to a 500-page crawl when you needed 20 pages | Always `crw map` first to estimate site size; cap with `maxPages` |
 | JS rendering on every scrape | Unnecessary browser spawn on plain-HTML pages; slow | crw auto-detects SPAs — don't add `--js` / `renderJs: true` unless the page is blank |
 | Blocking on crawl job poll | Agent hangs waiting for async crawl | Set a poll interval (5-10s), set `maxPages` to bound job size, check `status: "completed"` |
@@ -241,14 +242,13 @@ Unlike credit-based APIs (Firecrawl, Tavily), crw's costs are infra-denominated.
 The right mental model: **you're paying for VPS time and renderer pool capacity, not
 per-page fees.**
 
-### SearXNG rate limits and politeness
+### Search backend rate limits and politeness
 
-- SearXNG is the search backend. Public instances (`searx.be`, etc.) rate-limit or
-  block JSON requests — **always use a local instance** (`crw setup --local` boots
-  one via Docker).
-- Self-hosted SearXNG has no built-in per-client rate limit, but the upstream
-  engines (Google, Bing, DDG) do. Burst too hard and engines start returning 429s
-  or CAPTCHAs to your SearXNG instance.
+- Public instances rate-limit or block JSON requests — **always use a local
+  instance** (`crw setup --local` boots one via Docker).
+- The self-hosted search backend has no built-in per-client rate limit, but the
+  upstream engines (Google, Bing, DDG) do. Burst too hard and engines start
+  returning 429s or CAPTCHAs to your instance.
 - Practical safe rate: 2-4 searches/second burst, < 1/second sustained. Space
   parallel searches with a short sleep or process them in series.
 - `--category news` and `--time-range week` bypass the general engine pool —
@@ -281,13 +281,13 @@ Self-hosted crw supports per-request BYOP (bring-your-own-proxy) via `--proxy UR
   `proxyRotation: "sticky_per_host"` so sessions from the same domain always hit
   the same exit IP (avoids anti-bot CAPTCHA triggers from IP-hopping mid-session).
 - Proxy rotation applies to `scrape`, `crawl`, and `map` — not `search` (which
-  goes to your local SearXNG, not directly to search engines).
+  goes to your local search backend, not directly to search engines).
 
 ### Managed vs self-hosted call-surface differences
 
 | Feature | Self-hosted | Managed (`api.fastcrw.com`) |
 |---------|-------------|------------------------------|
-| Search | Requires local SearXNG sidecar | Included (managed backend) |
+| Search | Requires a local search-backend sidecar | Included (managed backend) |
 | Proxy pool | BYOP via config | Managed proxy network |
 | Rate limiting | Token-bucket (configurable) | Per-plan limits; `X-RateLimit-*` headers |
 | Credits | N/A | 500 one-time lifetime free credits |

--- a/skills/crw-dynamic-search/SKILL.md
+++ b/skills/crw-dynamic-search/SKILL.md
@@ -79,7 +79,7 @@ The CLI outputs a **JSON array** of result objects (not a wrapper object):
   {
     "title": "string",
     "url": "string",
-    "description": "string (~200-600 chars from SearXNG snippet)",
+    "description": "string (~200-600 chars from the search backend snippet)",
     "snippet": "string (alias of description — always same value)",
     "position": 1,
     "score": 0.85,
@@ -89,12 +89,12 @@ The CLI outputs a **JSON array** of result objects (not a wrapper object):
 ```
 
 Key notes for crw vs Tavily:
-- **`score` is unreliable.** SearXNG aggregates results from many engines; scores
-  are engine-dependent and often `null`. **Triage by `position` (rank order) and
-  keyword density in `description`, not by score.**
+- **`score` is unreliable.** The search backend aggregates results from many
+  engines; scores are engine-dependent and often `null`. **Triage by `position`
+  (rank order) and keyword density in `description`, not by score.**
 - `description` and `snippet` are always the same value — pick either. `snippet`
   exists as an alias for Firecrawl-compat pipelines.
-- `category` is the SearXNG category: `"general"` for web, `"news"`, `"images"`.
+- `category` is the search backend's category: `"general"` for web, `"news"`, `"images"`.
 - `published_date` appears on news results (ISO 8601 string or null).
 
 ### `crw scrape --format json` output (ScrapeData)
@@ -222,7 +222,7 @@ with open('/tmp/crw_results.json', 'w') as f:
     json.dump(data, f)
 
 # Print only what you need to pick next steps
-# Sort by position (rank), not score — score is unreliable from SearXNG
+# Sort by position (rank), not score — score is unreliable from the search backend
 print(f'{len(data)} results saved to /tmp/crw_results.json\n')
 for r in data:
     print(f'[{r["position"]}] {r["title"][:90]}')
@@ -316,9 +316,9 @@ where you don't know the right keywords yet.
 
 The Python you write IS the filtering logic. There are no fixed templates. Principles:
 
-**Triage by position, not score.** SearXNG scores are engine-dependent and often
-absent. Result order (`position: 1, 2, 3...`) is a more reliable signal — the
-SearXNG aggregator's RRF ranking already baked in multi-engine consensus.
+**Triage by position, not score.** The search backend's scores are engine-dependent
+and often absent. Result order (`position: 1, 2, 3...`) is a more reliable signal —
+the aggregator's RRF ranking already baked in multi-engine consensus.
 
 **Be specific.** A financial query should filter for numbers and financial terms.
 A technical query should look for code blocks and version strings. Match your
@@ -337,7 +337,7 @@ print(relevant_content)
 print('---\n')
 ```
 
-**Handle errors.** Pages 404, scrapes timeout, SearXNG returns partial results.
+**Handle errors.** Pages 404, scrapes timeout, the search backend returns partial results.
 Always wrap scrape calls in try/except:
 
 ```python

--- a/skills/crw-migrate/SKILL.md
+++ b/skills/crw-migrate/SKILL.md
@@ -88,7 +88,7 @@ curl -X POST https://api.fastcrw.com/v1/scrape \
 | `POST /v1/scrape` | Full markdown/html/links/json formats, `onlyMainContent`, `waitFor`, `renderJs`, `includeTags`/`excludeTags` |
 | `POST /v1/crawl` + `GET /v1/crawl/:id` + `DELETE /v1/crawl/:id` | Async BFS crawl, polling shape matches |
 | `POST /v1/map` | URL discovery |
-| `POST /v1/search` | SearXNG-backed instead of Fire-engine; same response shape |
+| `POST /v1/search` | Own search backend instead of Fire-engine; same response shape |
 | `POST /v2/scrape` | v2 surface with `parsers` field for PDFs |
 | `POST /v2/crawl` + `GET /v2/crawl/active` | v2 crawl |
 | `POST /v2/map` | v2 map |
@@ -199,7 +199,7 @@ curl -X POST "$CRW_API_URL/v1/map" \
   -d '{"url":"https://example.com"}' | jq '.data | length'
 # → N (should be > 0)
 
-# 4. Search (requires SearXNG — managed always works; self-host needs sidecar)
+# 4. Search (requires a search backend — managed always works; self-host needs sidecar)
 curl -X POST "$CRW_API_URL/v1/search" \
   -H "Authorization: Bearer $CRW_API_KEY" \
   -H "Content-Type: application/json" \
@@ -224,6 +224,6 @@ diverge; inspect with `jq .data.metadata` if your code reads specific keys.
 
 ## See also
 
-- [crw-self-host](../crw-self-host/SKILL.md) — stand up your own crw server + SearXNG
+- [crw-self-host](../crw-self-host/SKILL.md) — stand up your own crw server + search backend
 - [crw-best-practices](../crw-best-practices/SKILL.md) — SDK patterns, error handling, batching
 - [crw](../crw/SKILL.md) — hub skill, full verb ladder

--- a/skills/crw-search/SKILL.md
+++ b/skills/crw-search/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Search the web with fastCRW and get titles, URLs, and descriptions.
   Use when you have a question or topic but not a URL — "search for",
   "find pages about", "look up", "what is", "who is", "latest news on",
-  "find docs for". SearXNG-backed: self-hosted, no API key, no per-query
+  "find docs for". Own search backend: self-hosted, no API key, no per-query
   cost, high recall via meta-search aggregation. Step 1 of the crw
   workflow ladder.
 license: AGPL-3.0
@@ -16,7 +16,7 @@ metadata:
 allowed-tools: Bash(crw:*) Bash(curl:*) Read
 ---
 
-# crw-search — web search via SearXNG
+# crw-search — web search via crw's own search backend
 
 ## When to use
 
@@ -27,8 +27,8 @@ allowed-tools: Bash(crw:*) Bash(curl:*) Read
   and scrape it for full content.
 - **Token-heavy context?** Pipe through a subprocess filter instead of dumping
   raw JSON. See [crw-dynamic-search](../crw-dynamic-search/SKILL.md).
-- SearXNG is self-hosted and free — no API key, no per-query billing, no
-  usage cap. Queries never leave your infrastructure in embedded/local mode.
+- The search backend is self-hosted and free — no API key, no per-query billing,
+  no usage cap. Queries never leave your infrastructure in embedded/local mode.
 
 ## Quick start
 
@@ -67,7 +67,7 @@ curl -X POST "$CRW_API_URL/v1/search" -H "Authorization: Bearer $CRW_API_KEY" \
 | Language | `--language en` | `lang` |
 | Time filter | `--time-range day\|week\|month\|year` | `tbs: qdr:h\|qdr:d\|qdr:w\|qdr:m\|qdr:y` |
 | Safe search | `--safesearch 0\|1\|2` | — |
-| Custom SearXNG | `--searxng-url URL` / `$CRW_SEARXNG_URL` | — |
+| Custom search backend | `--searxng-url URL` / `$CRW_SEARXNG_URL` | — |
 | Group by source | — | `sources: ["web","news","images"]` |
 | Scrape results inline | — (use crw scrape separately) | `scrapeOptions: {formats:["markdown"]}` |
 
@@ -76,18 +76,17 @@ curl -X POST "$CRW_API_URL/v1/search" -H "Authorization: Bearer $CRW_API_KEY" \
 
 ## A note on result scores
 
-SearXNG is a **meta-search aggregator** — it merges results from multiple
-engines (Google, Bing, DuckDuckGo, etc.) and the `score` field reflects
-internal engine weighting, not a universal relevance measure. Do not rely on
-`score` for ranking or filtering. Use **`position`** (1-based rank) or
-**result order** instead — position 1 is the most relevant result SearXNG
-surfaced.
+The search backend is a **meta-search aggregator** — it merges results from
+multiple engines (Google, Bing, DuckDuckGo, etc.) and the `score` field
+reflects internal engine weighting, not a universal relevance measure. Do not
+rely on `score` for ranking or filtering. Use **`position`** (1-based rank) or
+**result order** instead — position 1 is the most relevant result surfaced.
 
 ## Tips
 
-- **No results / 403?** SearXNG needs JSON output enabled in its config. Run
-  `crw setup --local` to spin up a pre-configured sidecar automatically.
-  Public instances (searx.be, priv.au) usually block JSON with 403/429.
+- **No results / 403?** The search backend needs JSON output enabled in its
+  config. Run `crw setup --local` to spin up a pre-configured sidecar
+  automatically. Public instances usually block JSON with 403/429.
 - **`--fields` saves context.** `--json --fields title,url,snippet --limit 5`
   is one call; piping to `jq` is two. Prefer the flag.
 - **Inline scraping via MCP.** Pass `scrapeOptions: {formats: ["markdown"]}`

--- a/skills/crw-self-host/SKILL.md
+++ b/skills/crw-self-host/SKILL.md
@@ -2,7 +2,7 @@
 name: crw-self-host
 description: |
   Stand up your own fastCRW API server — single binary, Docker, or
-  docker-compose with a bundled SearXNG sidecar. Use when the user wants
+  docker-compose with a bundled search-backend sidecar. Use when the user wants
   to run crw locally or on their own infra, configure renderers/proxies/
   auth/LLM extraction, or understand the embedded vs proxy MCP modes.
 license: AGPL-3.0
@@ -89,9 +89,9 @@ curl http://localhost:3000/v1/scrape \
   -d '{"url":"https://example.com"}'
 ```
 
-**Docker Compose — full stack with SearXNG search:**
+**Docker Compose — full stack with bundled search:**
 ```bash
-docker compose up -d                                          # http + LightPanda + SearXNG
+docker compose up -d                                          # http + LightPanda + search backend
 docker compose --profile heavy up -d                          # + Chrome fallback
 docker compose -f docker-compose.yml \
   -f docker-compose.stealth.yml --profile stealth up -d       # + browserless stealth tier
@@ -107,18 +107,18 @@ After `compose up`:
 curl http://localhost:3000/health                              # → {"status":"ok",...}
 curl -X POST http://localhost:3000/v1/search \
   -H "Content-Type: application/json" \
-  -d '{"query":"fastCRW","limit":5}'                          # SearXNG-backed, no API key
+  -d '{"query":"fastCRW","limit":5}'                          # own backend, no API key
 ```
 
-## SearXNG sidecar
+## Search backend sidecar
 
-`docker-compose.yml` bundles a SearXNG container (`searxng/searxng:2026.5.9-0cba32c15`)
+`docker-compose.yml` bundles a search-backend container (`searxng/searxng:2026.5.9-0cba32c15`)
 that backs `/v1/search` with no API key and no per-query cost. It is internal-only —
 the port is not published to the host by default. The `crw` container points at it as
 `http://searxng:8080` via the Docker bridge network (set in `config.docker.toml`
 as `[search] searxng_url = "http://searxng:8080"`).
 
-To debug SearXNG directly, add to `docker-compose.override.yml`:
+To debug the search backend directly, add to `docker-compose.override.yml`:
 ```yaml
 services:
   searxng:
@@ -126,7 +126,7 @@ services:
       - "127.0.0.1:8888:8080"
 ```
 
-For a standalone binary pointing at an external SearXNG:
+For a standalone binary pointing at an external search backend:
 ```bash
 CRW_SEARCH__SEARXNG_URL=http://my-searxng:8080 crw-server
 ```
@@ -302,11 +302,11 @@ curl -X POST http://localhost:3000/v1/scrape \
   -d '{"url":"https://example.com","formats":["markdown"]}' | jq .success
 # → true
 
-# Search (requires SearXNG sidecar via docker compose up)
+# Search (requires a search-backend sidecar via docker compose up)
 curl -X POST http://localhost:3000/v1/search \
   -H "Content-Type: application/json" \
   -d '{"query":"hello","limit":3}' | jq .success
-# → true (or 400 search_disabled if SearXNG not wired up)
+# → true (or 400 search_disabled if search backend not wired up)
 ```
 
 ## Production hardening notes

--- a/skills/crw/SKILL.md
+++ b/skills/crw/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools: Bash(crw:*) Bash(curl:*) Read
 
 The open-source alternative to Firecrawl. One static binary, ~50 MB RAM idle,
 Firecrawl-compatible REST API on both `/v1/*` and `/v2/*`, first-class MCP, and
-a bundled SearXNG search backend — self-host free or use the managed
+a bundled search backend — self-host free or use the managed
 `api.fastcrw.com`.
 
 This is the **hub** skill. It tells you which verb to reach for and in what
@@ -47,7 +47,7 @@ Don't reach for a heavier verb than the task requires.
 
 | Step | Verb | Use when | Surface | Skill |
 |------|------|----------|---------|-------|
-| 1 | **search** | You have a question/topic, not a URL. SearXNG-backed, self-hosted, no key. | CLI · MCP · REST | [crw-search](../crw-search/SKILL.md) |
+| 1 | **search** | You have a question/topic, not a URL. Own search backend, self-hosted, no key. | CLI · MCP · REST | [crw-search](../crw-search/SKILL.md) |
 | 2 | **scrape** | You have one (or a few) known URLs and want clean content. | CLI · MCP · REST | [crw-scrape](../crw-scrape/SKILL.md) |
 | 3 | **map** | You need to discover which URLs exist on a site (fast, no content). | CLI · MCP · REST | [crw-map](../crw-map/SKILL.md) |
 | 4 | **crawl** | You need content from many pages under a site/section. | CLI · MCP · REST | [crw-crawl](../crw-crawl/SKILL.md) |
@@ -71,7 +71,7 @@ Don't reach for a heavier verb than the task requires.
   skills, not the CLI skills.
 - **Coming from Firecrawl?** Load [crw-migrate](../crw-migrate/SKILL.md) — usually
   a one-line `base_url` swap.
-- **Need to stand up your own crw / SearXNG / proxy pool?** Load
+- **Need to stand up your own crw / search backend / proxy pool?** Load
   [crw-self-host](../crw-self-host/SKILL.md).
 
 ## Three ways to call crw
@@ -96,7 +96,7 @@ The skills show all three; pick what's available:
 ## crw advantages worth surfacing to the user
 
 - **Self-hosted & private** — URLs and queries never leave your infra.
-- **SearXNG search** — no API key, no per-query cost, high recall.
+- **Built-in search backend** — no API key, no per-query cost, high recall.
 - **Cheap at scale** — recurring crawls/audits cost a VPS, not per-page credits.
 - **JS handled at scrape time** — `renderJs` auto-detects; no separate browser step.
 - **Change tracking** (`/v1/change-tracking/diff`) — a stateless diff primitive


### PR DESCRIPTION
## What

The MCP tool descriptions were neutralized in us/crw#269, but the search backend's name was still shipping on every OTHER user-facing surface. This finishes the job and adds a guard so it cannot come back.

Scrubbed (prose only):
- `crates/crw-server/src/routes/search.rs` — the `/v1/search` HTTP **error bodies** an API caller reads (`Target unreachable: ...`, the `search_disabled` hint, the upstream/transport messages).
- `crates/crw-server/openapi/openapi.json` and `openapi-3.0.json` (+ their `docs/` copies) — the **published** specs, e.g. "Web search via ...".
- `crates/crw-cli/src/**` — `--help` text and the `crw setup` wizard output.
- `docs/llms.txt`, `docs/llms-full.txt` — the agent-facing site index.
- `README.md`, `README.zh-CN.md`, `COMPATIBILITY.md`, `COMPATIBILITY-firecrawl.md`.
- Six shipped agent skills + `skills/README.md`.

Kept verbatim, because a self-hoster has to type them: `searxng_url`, `[search].searxng_url`, `CRW_SEARCH__SEARXNG_URL`, `SEARXNG_SECRET_KEY`, `--searxng-url`, and the docker service/image/host names. `skills/crw-self-host/SKILL.md` still names the compose service for the same reason. `CHANGELOG.md` is untouched (release-please owns it).

## Guard

Third check in `scripts/docs-guards.sh` (already wired into the `docs-guards` CI job): it fails on the bare name in prose while allowing every contract identifier, and in Rust it inspects only string literals, since type names and internal comments are code, not surface. Verified both ways: it passes on this tree, and it fails on an injected leak.

## Tests

`cargo fmt --check`, `cargo clippy` clean; `cargo test -p crw-server -p crw-cli` 233 passed. Full pre-commit gate green.