### PR TITLE
fix(map): stop returning 504 with zero URLs on sites without a sitemap

### DIFF
--- a/crates/crw-cli/src/commands/map.rs
+++ b/crates/crw-cli/src/commands/map.rs
@@ -5,6 +5,10 @@ use clap::{Args, ValueEnum};
 use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
 use crw_crawl::crawl::{DiscoverOptions, discover_urls};
 use crw_renderer::FallbackRenderer;
+
+/// Discovery budget for the `map` subcommand, which has no request timeout of
+/// its own. Matches the HTTP route's default.
+const CLI_MAP_TIMEOUT_SECS: u64 = 120;
 use std::sync::Arc;
 
 #[derive(Clone, ValueEnum)]
@@ -148,6 +152,12 @@ pub async fn run(mut args: MapArgs) -> Result<(), CmdError> {
         per_host_max_concurrent: 2,
         url_filter: None,
         max_urls: args.limit,
+        // The CLI has no outer timeout, so discovery would otherwise be
+        // unbounded. Same default budget as the HTTP route, stated explicitly.
+        overall_deadline: crw_crawl::crawl::discovery_deadline(std::time::Duration::from_secs(
+            CLI_MAP_TIMEOUT_SECS,
+        )),
+        respect_robots: true,
     };
 
     let result = match discover_urls(opts).await {

--- a/crates/crw-core/src/metrics.rs
+++ b/crates/crw-core/src/metrics.rs
@@ -4,10 +4,10 @@
 //! [`gather_text`] to render the current snapshot for `/metrics`.
 
 use prometheus::{
-    Encoder, Histogram, HistogramVec, IntCounterVec, IntGauge, Registry, TextEncoder,
+    Encoder, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, Registry, TextEncoder,
     exponential_buckets, histogram_opts, register_histogram_vec_with_registry,
     register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_gauge_with_registry,
+    register_int_counter_with_registry, register_int_gauge_with_registry,
 };
 use std::sync::OnceLock;
 
@@ -25,6 +25,11 @@ pub struct Metrics {
     pub user_pin_total: IntCounterVec,
     /// Current size of the host preferences cache.
     pub host_preferences_size: IntGauge,
+    /// Hosts currently latched to proxy-first egress after a hard block.
+    /// A runaway value means we are paying for proxy bandwidth we may not need.
+    pub egress_latched_hosts: IntGauge,
+    /// Fetches that started on the proxy because the host was latched.
+    pub egress_latch_hit_total: IntCounter,
     /// Chrome navigation budget truncations, labeled by snapshot outcome
     /// (`ok` = partial DOM extracted, `empty` = nothing snapshotted).
     pub chrome_budget_truncated_total: IntCounterVec,
@@ -202,6 +207,18 @@ impl Metrics {
         let host_preferences_size = register_int_gauge_with_registry!(
             "crw_host_preferences_size",
             "Current size of the host preferences cache",
+            registry
+        )
+        .unwrap();
+        let egress_latched_hosts = register_int_gauge_with_registry!(
+            "crw_egress_latched_hosts",
+            "Hosts currently latched to proxy-first egress after a hard block",
+            registry
+        )
+        .unwrap();
+        let egress_latch_hit_total = register_int_counter_with_registry!(
+            "crw_egress_latch_hit_total",
+            "Fetches that started on the proxy because the host was latched",
             registry
         )
         .unwrap();
@@ -517,6 +534,8 @@ impl Metrics {
             admin_preferences_reset_total,
             user_pin_total,
             host_preferences_size,
+            egress_latched_hosts,
+            egress_latch_hit_total,
             chrome_budget_truncated_total,
             chrome_blocked_requests_total,
             breaker_ignored_total,

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -5,6 +5,7 @@ use crw_core::types::{
 };
 use crw_extract::readability::extract_links;
 use crw_renderer::FallbackRenderer;
+use futures::StreamExt;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -448,6 +449,19 @@ pub struct DiscoverOptions<'a> {
     /// Max URLs to discover. Clamped to `[1, MAX_DISCOVERED_URLS_CEILING]`.
     /// Use `DEFAULT_MAX_DISCOVERED_URLS` for the historical behaviour.
     pub max_urls: usize,
+    /// Wall-clock deadline for the WHOLE discovery call.
+    ///
+    /// Every phase (robots, sitemap probes, sitemap tree, each BFS page) is
+    /// clamped by whatever is left of this, and discovery returns the URLs it
+    /// has when it runs out. Callers must set it *inside* their own request
+    /// timeout: if the caller's `tokio::time::timeout` fires first it drops this
+    /// future and every discovered URL is lost — which is exactly the
+    /// zero-result 504 this field exists to prevent.
+    pub overall_deadline: std::time::Instant,
+    /// Skip links that robots.txt disallows. Fetching only; a disallowed link is
+    /// still *reported* if we discovered it, because robots governs fetching,
+    /// not listing.
+    pub respect_robots: bool,
 }
 
 /// Result of [`discover_urls`]. URLs in `urls` have already passed the
@@ -483,6 +497,34 @@ const SITEMAP_ESCALATE_BUDGET: usize = 64;
 /// the caller's request timeout instead of being killed with nothing.
 const SITEMAP_PHASE_BUDGET_SECS: u64 = 75;
 
+/// Margin held back so discovery finishes *before* the caller's backstop timeout.
+///
+/// The backstop drops the future and loses everything; the inner deadline returns
+/// partial results. They must not be the same instant, or the race decides whether
+/// the caller gets its URLs or a 504.
+const DISCOVERY_BACKSTOP_MARGIN: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The `overall_deadline` to hand [`DiscoverOptions`] for a caller-supplied request
+/// timeout. Shared by every caller (v1/v2 map, MCP, CLI) so they cannot drift.
+pub fn discovery_deadline(request_timeout: std::time::Duration) -> std::time::Instant {
+    let budget = request_timeout
+        .saturating_sub(DISCOVERY_BACKSTOP_MARGIN)
+        .max(std::time::Duration::from_millis(500));
+    std::time::Instant::now() + budget
+}
+
+/// Time left before `deadline`, or `None` if it has already passed.
+///
+/// Every awaited phase of discovery clamps itself with this. Clamping only some
+/// of them leaves the total-loss bug open in the ones that aren't: the caller's
+/// outer timeout fires, the future is dropped, and every URL found so far is
+/// thrown away.
+fn remaining_budget(deadline: std::time::Instant) -> Option<std::time::Duration> {
+    deadline
+        .checked_duration_since(std::time::Instant::now())
+        .filter(|d| !d.is_zero())
+}
+
 /// Discover URLs from a site (map endpoint).
 pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResult> {
     let DiscoverOptions {
@@ -499,6 +541,8 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         per_host_max_concurrent,
         url_filter,
         max_urls,
+        overall_deadline,
+        respect_robots,
     } = opts;
     // `0` is the documented "unbounded" sentinel (MCP/Firecrawl) → the ceiling.
     let max_urls = if max_urls == 0 {
@@ -605,15 +649,29 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         .build()
         .map_err(|e| crw_core::error::CrwError::Internal(format!("http client build: {e}")))?;
 
+    // The base URL is always part of the result, so seed it up front and let it
+    // count against `max_urls`. Appending it at the very end instead would push the
+    // result to `max_urls + 1` whenever the cap was already full and the base was
+    // not among the discovered URLs — a caller asking for 10 would get 11.
     let mut all_urls: HashSet<String> = HashSet::new();
+    all_urls.insert(base_url.to_string());
+
+    // robots.txt is fetched OUTSIDE the `use_sitemap` block: the BFS phase needs
+    // its Disallow rules even when sitemap discovery is switched off. (It used to
+    // live inside, which silently disabled robots for `use_sitemap: false`.)
+    //
+    // The client's own 15s timeout is longer than a short caller timeout, so it
+    // is additionally clamped by the overall deadline — otherwise a slow
+    // robots.txt alone could burn the whole budget and lose every result.
+    let robots = match remaining_budget(overall_deadline) {
+        Some(budget) => tokio::time::timeout(budget, RobotsTxt::fetch(&origin, &client))
+            .await
+            .unwrap_or_else(|_| Ok(RobotsTxt::parse("")))
+            .unwrap_or_else(|_| RobotsTxt::parse("")),
+        None => RobotsTxt::parse(""),
+    };
 
     if use_sitemap {
-        // robots.txt fetch is wrapped in the discover client's 15s/5s timeouts —
-        // it can no longer block the entire map call (the original bug).
-        let robots = RobotsTxt::fetch(&origin, &client)
-            .await
-            .unwrap_or_else(|_| RobotsTxt::parse(""));
-
         let seeds: Vec<String> = if !robots.sitemaps.is_empty() {
             robots.sitemaps.clone()
         } else {
@@ -638,7 +696,18 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
                 let u = u.clone();
                 async move { (u.clone(), crate::sitemap::head_probe(&u, &client).await) }
             });
-            let probe_results = futures::future::join_all(probes).await;
+            // Clamped by the overall deadline: the probes inherit the discovery
+            // client's 15s timeout, which outlives a short caller budget. Unbounded,
+            // they could run past the deadline and let the route's backstop drop the
+            // future — losing every URL found so far, the exact bug we are fixing.
+            // On expiry we just skip the CMS-specific guesses; the canonical
+            // /sitemap.xml seed is still tried.
+            let probe_results = match remaining_budget(overall_deadline) {
+                Some(budget) => tokio::time::timeout(budget, futures::future::join_all(probes))
+                    .await
+                    .unwrap_or_default(),
+                None => Vec::new(),
+            };
             let mut seeds: Vec<String> = vec![canonical];
             seeds.extend(
                 probe_results
@@ -685,22 +754,44 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         // behind its own Cloudflare solve) would grind every child to the outer
         // request timeout and return nothing; with it the walk stops and returns
         // whatever it recovered.
-        let sitemap_deadline = escalator.as_ref().map(|_| {
-            std::time::Instant::now() + std::time::Duration::from_secs(SITEMAP_PHASE_BUDGET_SECS)
-        });
+        // Always clamped by the overall deadline. SITEMAP_PHASE_BUDGET_SECS (75s)
+        // is a hardcoded constant, so on its own it happily outlives a caller who
+        // asked for `timeout=10` — the outer timeout would then fire mid-walk and
+        // discard everything. Take whichever comes first, and arm it even without
+        // an escalator so the plain-HTTP walk is bounded too.
+        let sitemap_deadline = Some(
+            (std::time::Instant::now() + std::time::Duration::from_secs(SITEMAP_PHASE_BUDGET_SECS))
+                .min(overall_deadline),
+        );
 
-        let sitemap_urls = crate::sitemap::fetch_sitemap_tree(
-            seeds,
-            &parsed,
-            &client,
-            SITEMAP_MAX_DEPTH,
-            sitemap_max_fetches,
-            max_urls,
-            per_host_max_concurrent as usize,
-            escalator.as_ref(),
-            sitemap_deadline,
-        )
-        .await;
+        // Hard-bounded by the overall deadline, on top of the inner `sitemap_deadline`.
+        //
+        // The inner deadline is only checked BETWEEN batches: a batch that starts a
+        // millisecond before it can still run for a full client timeout (15s), which
+        // blows straight through the backstop margin. The route's outer timeout would
+        // then fire, drop this future, and throw away every URL — the exact
+        // zero-result 504 this whole change exists to prevent. The inner deadline
+        // still does the real work (it returns partial sitemap results); this timeout
+        // is the guarantee that the phase can never outlive its budget.
+        let sitemap_urls = match remaining_budget(overall_deadline) {
+            Some(budget) => tokio::time::timeout(
+                budget,
+                crate::sitemap::fetch_sitemap_tree(
+                    seeds,
+                    &parsed,
+                    &client,
+                    SITEMAP_MAX_DEPTH,
+                    sitemap_max_fetches,
+                    max_urls,
+                    per_host_max_concurrent as usize,
+                    escalator.as_ref(),
+                    sitemap_deadline,
+                ),
+            )
+            .await
+            .unwrap_or_default(),
+            None => Vec::new(),
+        };
         for u in sitemap_urls {
             if all_urls.len() >= max_urls {
                 break;
@@ -714,7 +805,6 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
 
     // Sitemap-only mode (or sitemap was empty + crawl_fallback is off).
     if !crawl_fallback {
-        all_urls.insert(base_url.to_string());
         let mut urls: Vec<String> = all_urls.into_iter().collect();
         urls.sort();
         return Ok(DiscoverResult {
@@ -724,102 +814,176 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
         });
     }
 
-    // Sitemap was rich enough → run BFS with a tight budget. Otherwise let it
-    // run to the per-page deadline and the outer route timeout.
+    // The BFS phase is ALWAYS bounded. It used to get a deadline only when the
+    // sitemap had already produced >= 50 URLs; a site with no sitemap (e.g. Hacker
+    // News) therefore ran the BFS with no budget at all until the outer request
+    // timeout killed the future and threw away every URL it had found — a 504 with
+    // zero results. A rich sitemap still shortens the budget (we have plenty
+    // already); everything else runs to the overall deadline and returns partials.
     let bfs_deadline_at = if all_urls.len() >= SITEMAP_SUFFICIENT_THRESHOLD {
         tracing::info!(
             sitemap_urls = all_urls.len(),
             "sitemap sufficient, BFS will run with short budget"
         );
-        Some(std::time::Instant::now() + std::time::Duration::from_secs(BFS_SHORT_BUDGET_SECS))
+        (std::time::Instant::now() + std::time::Duration::from_secs(BFS_SHORT_BUDGET_SECS))
+            .min(overall_deadline)
     } else {
-        None
+        overall_deadline
     };
 
     let max_depth = max_depth.min(10);
-    let semaphore = Arc::new(Semaphore::new(max_concurrency));
     // Per-host limiter is owned by FallbackRenderer (see run_crawl).
     let _ = (requests_per_second, per_host_max_concurrent);
     let mut visited: HashSet<String> = HashSet::new();
-    let mut queue: VecDeque<(String, u32)> = VecDeque::new();
 
-    queue.push_back((base_url.to_string(), 0));
     visited.insert(normalize_url(base_url));
+    let mut frontier: Vec<String> = vec![base_url.to_string()];
 
-    while let Some((url, depth)) = queue.pop_front() {
-        if visited.len() > max_urls {
+    // BFS runs level by level, fetching each level CONCURRENTLY.
+    //
+    // The previous loop built a `Semaphore`, acquired a permit, then awaited the
+    // fetch inline in the same iteration and dropped the permit at the end of it.
+    // Nothing was ever spawned, so real concurrency was 1 and `max_concurrency`
+    // was dead weight — every URL was fetched strictly one after another.
+    //
+    // Level-by-level keeps `visited` single-owner (mutated only between levels,
+    // never across tasks), so there is no shared-mutex churn and no chance of the
+    // same URL being fetched twice. Note the real ceiling here is the per-host
+    // limiter inside `FallbackRenderer::fetch`, not `max_concurrency`: map only
+    // follows same-origin links, so every fetch contends for the same host's
+    // permits. Politeness is unchanged by design.
+    //
+    // A level's fetches are STREAMED, not collected: results are merged as each
+    // page lands and the level is abandoned the moment `max_urls` is reached.
+    // Waiting for a whole batch would make every batch cost as much as its slowest
+    // page — and pages are wildly uneven. On Hacker News a `/item?id=` page takes
+    // ~6.7s while the list pages that actually yield most of the links take ~0.7s,
+    // so batching made map ~6x slower for the same output. Streaming lets the cheap
+    // pages satisfy the cap while the expensive ones are still in flight; dropping
+    // the stream then cancels them.
+    'bfs: for depth in 0..=max_depth {
+        if frontier.is_empty() {
             break;
         }
-        if let Some(deadline) = bfs_deadline_at
-            && std::time::Instant::now() >= deadline
+        let mut next_frontier: Vec<String> = Vec::new();
+        let level_urls = std::mem::take(&mut frontier);
+
         {
-            tracing::info!("BFS short budget exhausted; returning sitemap+partial results");
-            break;
-        }
+            let mut in_flight = futures::stream::iter(level_urls.into_iter().map(|url| {
+                let renderer = renderer.clone();
+                async move {
+                    // A page must not start if the budget is already gone, and its own
+                    // deadline is clamped to what is left of the overall budget —
+                    // otherwise a page begun just before the deadline runs for its full
+                    // per-page allowance and overruns the caller's timeout, losing
+                    // everything to the outer backstop.
+                    let budget = remaining_budget(bfs_deadline_at)?;
 
-        let _permit = match semaphore.clone().acquire_owned().await {
-            Ok(p) => p,
-            Err(_) => break,
-        };
-        // Per-host limiter handled in FallbackRenderer (see run_crawl note).
-        if let Ok(parsed) = url::Url::parse(&url)
-            && crw_core::url_safety::validate_safe_url_resolved(&parsed)
-                .await
-                .is_err()
-        {
-            continue;
-        }
+                    let parsed = url::Url::parse(&url).ok()?;
+                    // The SSRF check resolves DNS, so it is an awaited phase like any
+                    // other and must live inside the budget. Slow resolution would
+                    // otherwise burn time the per-page deadline below never accounts
+                    // for, pushing the request past the caller's backstop.
+                    let safe = tokio::time::timeout(
+                        budget,
+                        crw_core::url_safety::validate_safe_url_resolved(&parsed),
+                    )
+                    .await;
+                    if !matches!(safe, Ok(Ok(()))) {
+                        return None;
+                    }
 
-        let discover_deadline = crw_core::Deadline::from_request_ms(deadline_ms_per_page);
-        // Honor the config rotator so discovery page fetches egress through the
-        // proxy (sticky-per-host), not direct. Resolved once into REQUEST_PROXY.
-        let resolved_proxy = renderer.pick_proxy_for_url(&url);
-        let empty_headers: HashMap<String, String> = HashMap::new();
-        // render_js = None (auto), not Some(false): SPAs (Angular/React/Vue)
-        // serve an empty app shell over plain HTTP, so HTTP-only discovery finds
-        // zero navigational links and /map returns only the seed URL (issue #166).
-        // Auto mode lets the renderer escalate thin/SPA shells to a JS render
-        // (it stays HTTP-only for static sites), matching /scrape and /crawl.
-        let fetch_fut = renderer.fetch(&url, &empty_headers, None, None, None, discover_deadline);
-        let fetch = crw_renderer::REQUEST_PROXY
-            .scope(resolved_proxy, fetch_fut)
-            .await;
+                    // Re-read the budget: DNS resolution may have eaten into it.
+                    let budget = remaining_budget(bfs_deadline_at)?;
+                    let page_ms = (budget.as_millis() as u64).min(deadline_ms_per_page);
+                    let discover_deadline = crw_core::Deadline::from_request_ms(page_ms);
+                    // Honor the config rotator so discovery page fetches egress through
+                    // the proxy (sticky-per-host), not direct. Resolved into REQUEST_PROXY.
+                    let resolved_proxy = renderer.pick_proxy_for_url(&url);
+                    let empty_headers: HashMap<String, String> = HashMap::new();
+                    // render_js = None (auto), not Some(false): SPAs (Angular/React/Vue)
+                    // serve an empty app shell over plain HTTP, so HTTP-only discovery
+                    // finds zero navigational links and /map returns only the seed URL
+                    // (issue #166). Auto lets the renderer escalate thin/SPA shells to a
+                    // JS render (staying HTTP-only for static sites), like /scrape.
+                    let fetch_fut =
+                        renderer.fetch(&url, &empty_headers, None, None, None, discover_deadline);
+                    let result = crw_renderer::REQUEST_PROXY
+                        .scope(resolved_proxy, fetch_fut)
+                        .await
+                        .ok()?;
+                    Some((url, result.html))
+                }
+            }))
+            .buffer_unordered(max_concurrency.max(1));
 
-        if let Ok(result) = fetch {
-            let links = extract_links(&result.html, &url);
-            for link in links {
-                if let Ok(link_url) = url::Url::parse(&link) {
+            // Merge each page's links as it lands. `visited` and the filter counters
+            // have a single owner here, and `urls.sort()` below keeps the output
+            // deterministic regardless of the order pages completed in.
+            while let Some(page) = in_flight.next().await {
+                if all_urls.len() >= max_urls || std::time::Instant::now() >= bfs_deadline_at {
+                    break;
+                }
+                let Some((url, html)) = page else { continue };
+                for link in extract_links(&html, &url) {
+                    let Ok(link_url) = url::Url::parse(&link) else {
+                        continue;
+                    };
                     if !is_safe_url(&link_url) {
                         continue;
                     }
                     // Compare full origin (scheme + host + explicit port) so a
-                    // non-default-port target (e.g. https://example.com:8443)
-                    // doesn't reject its own same-origin links.
+                    // non-default-port target (e.g. https://example.com:8443) doesn't
+                    // reject its own same-origin links.
                     if link_url.origin().ascii_serialization() != origin {
                         continue;
                     }
-                    let normalized = match filter_parsed(
+                    let Some(normalized) = filter_parsed(
                         &link_url,
                         &link,
                         &mut dropped_action_count,
                         &mut stripped_tracking_count,
-                    ) {
-                        Some(n) => n,
-                        None => continue,
+                    ) else {
+                        continue;
                     };
-                    if !visited.contains(&normalized) {
-                        visited.insert(normalized.clone());
-                        all_urls.insert(normalized.clone());
-                        if depth < max_depth {
-                            queue.push_back((normalized, depth + 1));
-                        }
+                    if visited.contains(&normalized) {
+                        continue;
                     }
+                    visited.insert(normalized.clone());
+                    // The URL is REPORTED even if robots disallows it: robots.txt
+                    // governs fetching, not listing. Only the re-fetch below is gated.
+                    all_urls.insert(normalized.clone());
+                    if all_urls.len() >= max_urls {
+                        break;
+                    }
+                    if depth >= max_depth {
+                        continue;
+                    }
+                    // robots gate applies to FETCHING only. Hacker News disallows
+                    // `/hide?`, `/vote?`, `/reply?` etc; we were rendering each of those
+                    // through a full Chrome ladder, ~10-20s a piece, which is most of
+                    // how the 120s budget got burned.
+                    if respect_robots
+                        && let Ok(next_url) = url::Url::parse(&normalized)
+                        && !robots.is_url_allowed(&next_url)
+                    {
+                        continue;
+                    }
+                    next_frontier.push(normalized);
                 }
             }
         }
+        frontier = next_frontier;
+
+        if all_urls.len() >= max_urls || std::time::Instant::now() >= bfs_deadline_at {
+            tracing::info!(
+                discovered = all_urls.len(),
+                "BFS stopping: URL cap or budget reached; returning what we have"
+            );
+            break 'bfs;
+        }
     }
 
-    all_urls.insert(base_url.to_string());
     let mut urls: Vec<String> = all_urls.into_iter().collect();
     urls.sort();
     Ok(DiscoverResult {

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -605,9 +605,31 @@ pub async fn discover_urls(opts: DiscoverOptions<'_>) -> CrwResult<DiscoverResul
     let parsed = url::Url::parse(base_url)
         .map_err(|e| crw_core::error::CrwError::InvalidRequest(format!("Invalid URL: {e}")))?;
 
-    crw_core::url_safety::validate_safe_url_resolved(&parsed)
-        .await
-        .map_err(crw_core::error::CrwError::InvalidRequest)?;
+    // The seed's SSRF/DNS resolution is an awaited phase like robots, the sitemap
+    // walk and every per-page fetch, so it honours the overall deadline too.
+    // Left unclamped it was the one hole in the "every phase is bounded"
+    // guarantee: a stalled resolver here would run past the route backstop, get
+    // the whole future dropped, and reproduce the 504-with-zero-URLs this change
+    // exists to remove — and callers without their own pre-check (the CLI `map`)
+    // have nothing else guarding it. A timeout here is fail-closed (an SSRF check
+    // cannot be skipped), so it surfaces as a clean error the caller maps, never a
+    // silent bypass.
+    let seed_budget =
+        remaining_budget(overall_deadline).ok_or(crw_core::error::CrwError::Timeout(0))?;
+    match tokio::time::timeout(
+        seed_budget,
+        crw_core::url_safety::validate_safe_url_resolved(&parsed),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(crw_core::error::CrwError::InvalidRequest(e)),
+        Err(_) => {
+            return Err(crw_core::error::CrwError::Timeout(
+                seed_budget.as_millis() as u64
+            ));
+        }
+    }
 
     // Use the URL's full origin (scheme + host + explicit port). Dropping the
     // port here would silently break sitemap discovery on any non-default-port

--- a/crates/crw-crawl/src/robots.rs
+++ b/crates/crw-crawl/src/robots.rs
@@ -109,6 +109,22 @@ impl RobotsTxt {
             None => true, // No matching rule means allowed
         }
     }
+
+    /// Check whether a URL may be fetched, matching on **path *and* query**.
+    ///
+    /// Prefer this over calling [`Self::is_allowed`] with `url.path()`: robots
+    /// patterns routinely key on the query string, and dropping it silently
+    /// allows everything the site tried to forbid. Hacker News, for example,
+    /// disallows `/hide?`, `/vote?` and `/reply?` — matching bare `/hide`
+    /// against pattern `/hide?` fails, so `/hide?id=1&goto=news` would be
+    /// fetched despite being explicitly forbidden.
+    pub fn is_url_allowed(&self, url: &url::Url) -> bool {
+        let path_and_query = match url.query() {
+            Some(q) => format!("{}?{}", url.path(), q),
+            None => url.path().to_string(),
+        };
+        self.is_allowed(&path_and_query)
+    }
 }
 
 /// Effective pattern length for specificity calculation.

--- a/crates/crw-crawl/tests/discover_concurrency.rs
+++ b/crates/crw-crawl/tests/discover_concurrency.rs
@@ -1,0 +1,123 @@
+//! BFS concurrency for `/map` discovery — in its OWN test binary on purpose.
+//!
+//! The per-host limiter is process-global and keyed by eTLD+1. Every wiremock
+//! server in a test binary binds to 127.0.0.1, so sibling tests in the same
+//! process contend for the SAME host permits and serialize each other, which
+//! looks exactly like the serial-BFS bug this test exists to catch. Cargo gives
+//! each `tests/*.rs` its own process, so isolating this one keeps it honest.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_crawl::crawl::{DiscoverOptions, discover_urls};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// wiremock binds to loopback, which the SSRF guard rejects by default.
+fn allow_loopback() {
+    // SAFETY: set before any discovery runs.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    }
+}
+
+async fn renderer() -> Arc<FallbackRenderer> {
+    allow_loopback();
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    Arc::new(
+        FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+            .expect("renderer builds in http-only mode"),
+    )
+}
+
+fn opts<'a>(
+    base_url: &'a str,
+    renderer: &'a Arc<FallbackRenderer>,
+    overall_deadline: Instant,
+    respect_robots: bool,
+) -> DiscoverOptions<'a> {
+    DiscoverOptions {
+        base_url,
+        max_depth: 2,
+        use_sitemap: true,
+        crawl_fallback: true,
+        renderer,
+        max_concurrency: 5,
+        requests_per_second: 100.0,
+        user_agent: "crw-test",
+        proxy: None,
+        deadline_ms_per_page: 5_000,
+        per_host_max_concurrent: 4,
+        url_filter: None,
+        max_urls: 100,
+        overall_deadline,
+        respect_robots,
+    }
+}
+
+/// The BFS used to acquire a semaphore permit and then await the fetch inline in
+/// the same loop body, so nothing was ever spawned and real concurrency was 1.
+/// Pages here respond slowly; if fetches were serial the level could not finish
+/// in anywhere near the asserted window.
+#[tokio::test]
+async fn bfs_fetches_a_level_concurrently() {
+    let server = MockServer::start().await;
+    const PAGE_DELAY: Duration = Duration::from_millis(600);
+    const CHILDREN: usize = 4;
+
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sitemap.xml"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"<a href="/p1">1</a><a href="/p2">2</a><a href="/p3">3</a><a href="/p4">4</a>"#,
+        ))
+        .mount(&server)
+        .await;
+    for i in 1..=CHILDREN {
+        Mock::given(method("GET"))
+            .and(path(format!("/p{i}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(PAGE_DELAY)
+                    .set_body_string("<html>leaf</html>"),
+            )
+            .mount(&server)
+            .await;
+    }
+
+    let r = renderer().await;
+    let started = Instant::now();
+    discover_urls(opts(
+        &server.uri(),
+        &r,
+        Instant::now() + Duration::from_secs(30),
+        true,
+    ))
+    .await
+    .expect("discovery succeeds");
+    let elapsed = started.elapsed();
+
+    // Serial would be >= CHILDREN * PAGE_DELAY (2.4s) for the child level alone.
+    // Concurrent overlaps them. The bound is loose on purpose: the real ceiling is
+    // the per-host limiter, not `max_concurrency`, so this asserts "not serial"
+    // rather than a specific speedup.
+    let serial_floor = PAGE_DELAY * CHILDREN as u32;
+    assert!(
+        elapsed < serial_floor,
+        "BFS level looks serial: took {elapsed:?}, serial floor is {serial_floor:?}"
+    );
+}

--- a/crates/crw-crawl/tests/discover_tests.rs
+++ b/crates/crw-crawl/tests/discover_tests.rs
@@ -300,3 +300,23 @@ async fn max_urls_is_never_exceeded() {
         );
     }
 }
+
+/// The seed's SSRF/DNS resolution is bounded by the overall deadline like every
+/// other awaited phase. Left unclamped it was the one step that could run past
+/// the route backstop on a stalled resolver, get the whole future dropped, and
+/// bring back the 504-with-zero-URLs. With no budget left it must fail closed
+/// with a clean `Timeout` the caller can map — never proceed, never hang, never
+/// silently skip the SSRF check.
+#[tokio::test]
+async fn seed_validation_is_bounded_by_the_overall_deadline() {
+    let r = renderer().await;
+    // A deadline already in the past: no budget remains for the seed step.
+    let past = Instant::now() - Duration::from_secs(1);
+    let err = discover_urls(opts("http://example.com/", &r, past, true))
+        .await
+        .expect_err("a past deadline must fail closed at the seed, not proceed");
+    assert!(
+        matches!(err, crw_core::error::CrwError::Timeout(_)),
+        "expected a clean Timeout from the seed budget gate, got: {err:?}"
+    );
+}

--- a/crates/crw-crawl/tests/discover_tests.rs
+++ b/crates/crw-crawl/tests/discover_tests.rs
@@ -1,0 +1,302 @@
+//! Integration tests for `/map` discovery (`discover_urls`).
+//!
+//! These pin the behaviours that made `POST /v1/map` on news.ycombinator.com
+//! burn 120s and return a 504 with zero URLs:
+//!
+//! - the BFS ran with no time budget whenever the sitemap was thin/absent, so
+//!   the caller's timeout was the only bound — and it *dropped* the future,
+//!   discarding every URL already found;
+//! - robots.txt was fetched only for its `Sitemap:` lines, so links the site
+//!   explicitly disallows (`/hide?`, `/vote?`) were fetched anyway, each through
+//!   a full renderer ladder.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_crawl::crawl::{DiscoverOptions, discover_urls};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// wiremock binds to loopback, which the SSRF guard rejects by default.
+fn allow_loopback() {
+    // SAFETY: set before any discovery runs; tests in this file share one process.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    }
+}
+
+/// An HTTP-only renderer: these tests exercise discovery, not JS rendering.
+async fn renderer() -> Arc<FallbackRenderer> {
+    allow_loopback();
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    Arc::new(
+        FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+            .expect("renderer builds in http-only mode"),
+    )
+}
+
+fn opts<'a>(
+    base_url: &'a str,
+    renderer: &'a Arc<FallbackRenderer>,
+    overall_deadline: Instant,
+    respect_robots: bool,
+) -> DiscoverOptions<'a> {
+    DiscoverOptions {
+        base_url,
+        max_depth: 2,
+        use_sitemap: true,
+        crawl_fallback: true,
+        renderer,
+        max_concurrency: 5,
+        requests_per_second: 100.0,
+        user_agent: "crw-test",
+        proxy: None,
+        deadline_ms_per_page: 5_000,
+        per_host_max_concurrent: 4,
+        url_filter: None,
+        max_urls: 100,
+        overall_deadline,
+        respect_robots,
+    }
+}
+
+/// robots.txt in the Hacker News shape: rules keyed on the QUERY string.
+async fn mount_hn_like_site(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("User-Agent: *\nDisallow: /hide?\nDisallow: /vote?\n"),
+        )
+        .mount(server)
+        .await;
+
+    // No sitemap: this is what leaves the BFS as the only discovery path, and
+    // what used to leave it completely unbudgeted.
+    Mock::given(method("GET"))
+        .and(path("/sitemap.xml"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(server)
+        .await;
+
+    let home = r#"
+        <a href="/item?id=1">story</a>
+        <a href="/hide?id=1&goto=news">hide</a>
+        <a href="/vote?id=1&how=up">vote</a>
+    "#;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(home))
+        .mount(server)
+        .await;
+
+    for p in ["/item", "/hide", "/vote"] {
+        Mock::given(method("GET"))
+            .and(path(p))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>ok</html>"))
+            .mount(server)
+            .await;
+    }
+}
+
+/// robots governs FETCHING, not LISTING: a disallowed link we discovered is
+/// still reported to the caller, we simply never fetch it. Getting this wrong in
+/// either direction is easy — dropping it from the output would silently shrink
+/// every map result.
+#[tokio::test]
+async fn robots_disallowed_links_are_reported_but_never_fetched() {
+    let server = MockServer::start().await;
+    mount_hn_like_site(&server).await;
+    let r = renderer().await;
+
+    let result = discover_urls(opts(
+        &server.uri(),
+        &r,
+        Instant::now() + Duration::from_secs(30),
+        true,
+    ))
+    .await
+    .expect("discovery succeeds");
+
+    let has = |needle: &str| result.urls.iter().any(|u| u.contains(needle));
+    assert!(
+        has("/item"),
+        "allowed link must be discovered: {:?}",
+        result.urls
+    );
+    assert!(
+        has("/hide"),
+        "robots-disallowed link must still be REPORTED (robots forbids fetching, not listing): {:?}",
+        result.urls
+    );
+
+    // The disallowed paths must never have been requested.
+    let requests = server.received_requests().await.unwrap();
+    let fetched_disallowed = requests
+        .iter()
+        .filter(|r| {
+            let p = r.url.path();
+            p.starts_with("/hide") || p.starts_with("/vote")
+        })
+        .count();
+    assert_eq!(
+        fetched_disallowed, 0,
+        "robots.txt disallows /hide? and /vote? — they must never be fetched"
+    );
+}
+
+/// With `respect_robots: false` the same links ARE fetched, proving the gate is
+/// what stops them (and not some unrelated filter).
+#[tokio::test]
+async fn disallowed_links_are_fetched_when_robots_is_off() {
+    let server = MockServer::start().await;
+    mount_hn_like_site(&server).await;
+    let r = renderer().await;
+
+    discover_urls(opts(
+        &server.uri(),
+        &r,
+        Instant::now() + Duration::from_secs(30),
+        false,
+    ))
+    .await
+    .expect("discovery succeeds");
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.iter().any(|r| r.url.path().starts_with("/hide")),
+        "with robots off, the disallowed link should be fetched — otherwise this \
+         test proves nothing about the gate"
+    );
+}
+
+/// The regression test for the 504: a site with NO sitemap whose pages are slow.
+/// The BFS used to get no budget at all here, so the caller's timeout fired,
+/// dropped the future, and every URL found so far was thrown away.
+///
+/// Discovery must now stop at its own deadline and RETURN what it has.
+#[tokio::test]
+async fn slow_site_returns_partial_results_instead_of_timing_out() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sitemap.xml"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"<a href="/a">a</a><a href="/b">b</a><a href="/c">c</a>"#),
+        )
+        .mount(&server)
+        .await;
+    // Every child page stalls far past the deadline.
+    for p in ["/a", "/b", "/c"] {
+        Mock::given(method("GET"))
+            .and(path(p))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_secs(30))
+                    .set_body_string("<html>slow</html>"),
+            )
+            .mount(&server)
+            .await;
+    }
+
+    let r = renderer().await;
+    let started = Instant::now();
+    let result = discover_urls(opts(
+        &server.uri(),
+        &r,
+        Instant::now() + Duration::from_secs(3),
+        true,
+    ))
+    .await
+    .expect("discovery must SUCCEED with partial results, not fail with a timeout");
+
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "discovery must stop at its own deadline, not run to the slow pages"
+    );
+    // The links were discovered from the home page even though fetching them stalled.
+    assert!(
+        result.urls.len() > 1,
+        "partial results must still be returned: {:?}",
+        result.urls
+    );
+}
+
+/// A robots.txt that hangs must not be able to eat the whole budget and take
+/// every result down with it: the robots fetch is clamped by the overall deadline.
+#[tokio::test]
+async fn hanging_robots_does_not_consume_the_whole_budget() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/robots.txt"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(30)))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sitemap.xml"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"<a href="/x">x</a>"#))
+        .mount(&server)
+        .await;
+
+    let r = renderer().await;
+    let started = Instant::now();
+    let result = discover_urls(opts(
+        &server.uri(),
+        &r,
+        Instant::now() + Duration::from_secs(3),
+        true,
+    ))
+    .await
+    .expect("a hanging robots.txt must not fail the whole call");
+
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "robots fetch must be clamped by the overall deadline, took {:?}",
+        started.elapsed()
+    );
+    assert!(!result.urls.is_empty(), "the base URL is always reported");
+}
+
+/// `max_urls` is a hard cap, not a suggestion. The base URL used to be appended
+/// after the cap was enforced, so a caller asking for N could get N+1 back.
+#[tokio::test]
+async fn max_urls_is_never_exceeded() {
+    let server = MockServer::start().await;
+    mount_hn_like_site(&server).await;
+    let r = renderer().await;
+
+    let uri = server.uri();
+    for limit in [1usize, 2, 3] {
+        let mut o = opts(&uri, &r, Instant::now() + Duration::from_secs(30), true);
+        o.max_urls = limit;
+        let result = discover_urls(o).await.expect("discovery succeeds");
+        assert!(
+            result.urls.len() <= limit,
+            "asked for {limit} URLs, got {}: {:?}",
+            result.urls.len(),
+            result.urls
+        );
+    }
+}

--- a/crates/crw-crawl/tests/robots_tests.rs
+++ b/crates/crw-crawl/tests/robots_tests.rs
@@ -135,3 +135,67 @@ fn robots_case_insensitive_directives() {
     assert!(!robots.is_allowed("/blocked/page"));
     assert_eq!(robots.sitemaps.len(), 1);
 }
+
+/// Real Hacker News robots.txt. Its rules key on the query string, so matching
+/// on the bare path silently allows everything it forbids — which is exactly
+/// how /map ended up rendering `/hide?id=...` through a full Chrome ladder.
+const HN_ROBOTS: &str = "User-Agent: *\n\
+Crawl-delay: 30\n\
+Disallow: /x?\n\
+Disallow: /r?\n\
+Disallow: /vote?\n\
+Disallow: /reply?\n\
+Disallow: /submitlink?\n\
+Disallow: /collapse?\n\
+Disallow: /context?\n\
+Disallow: /fave?\n\
+Disallow: /flag?\n\
+Disallow: /hide?\n\
+Disallow: /login\n\
+Disallow: /logout\n";
+
+#[test]
+fn url_allowed_matches_on_path_and_query() {
+    let robots = RobotsTxt::parse(HN_ROBOTS);
+
+    // Forbidden action links: these were being fetched before the fix.
+    for blocked in [
+        "https://news.ycombinator.com/hide?id=48876505&goto=news",
+        "https://news.ycombinator.com/vote?id=123&how=up",
+        "https://news.ycombinator.com/reply?id=9&goto=item",
+        "https://news.ycombinator.com/login",
+    ] {
+        let url = url::Url::parse(blocked).unwrap();
+        assert!(
+            !robots.is_url_allowed(&url),
+            "robots.txt forbids {blocked}, it must not be fetched"
+        );
+    }
+
+    // Real content that HN does NOT disallow must still be crawled: robots is
+    // the authority, so we must not over-filter into a hand-rolled deny-list.
+    for allowed in [
+        "https://news.ycombinator.com/",
+        "https://news.ycombinator.com/item?id=48876505",
+        "https://news.ycombinator.com/user?id=tionis",
+        "https://news.ycombinator.com/from?site=iroh.computer",
+    ] {
+        let url = url::Url::parse(allowed).unwrap();
+        assert!(
+            robots.is_url_allowed(&url),
+            "robots.txt permits {allowed}, it must still be crawled"
+        );
+    }
+}
+
+/// Pins the exact bug: matching on the bare path lets `/hide?...` through.
+#[test]
+fn bare_path_matching_would_miss_query_keyed_rules() {
+    let robots = RobotsTxt::parse(HN_ROBOTS);
+    let url = url::Url::parse("https://news.ycombinator.com/hide?id=1&goto=news").unwrap();
+
+    // The old call shape — path only — wrongly reports "allowed".
+    assert!(robots.is_allowed(url.path()));
+    // The fixed call shape correctly reports "forbidden".
+    assert!(!robots.is_url_allowed(&url));
+}

--- a/crates/crw-renderer/src/egress.rs
+++ b/crates/crw-renderer/src/egress.rs
@@ -1,0 +1,246 @@
+//! Per-host egress memory: remember which hosts hard-block our direct egress.
+//!
+//! Without this, every URL on a blocking host re-climbs the whole renderer
+//! ladder from scratch (`direct → 429 → proxy retry → JS ladder → hard block →
+//! chrome_proxy`), because the block signal lives in request-local state and
+//! dies at function exit. On a site that 429s us that costs 10-20s *per URL*.
+//!
+//! ## The latch is a TTL cache, not a state machine
+//!
+//! Presence in the cache == "this host recently hard-blocked our direct egress".
+//! Everything else falls out of the TTL, with no explicit probe/clear code:
+//!
+//! - within the TTL  → [`should_proxy`] is true → try the proxy egress first;
+//! - TTL expires     → entry is gone → direct is tried again. *That expiry is
+//!   the half-open probe*;
+//! - blocked again   → [`note_block`] re-inserts and the TTL resets (re-latch);
+//! - recovered       → nothing to do; the entry already expired.
+//!
+//! This is deliberately not built on [`crate::preference::HostPreferences`]:
+//! its `record_success` fires regardless of which tier succeeded, so a latch
+//! living there would be erased by the very proxied success it produced. A TTL
+//! cache needs no success hook, so nothing can erase it by mistake.
+//!
+//! ## The latch reorders egress; it never suppresses direct
+//!
+//! A latched host is *preferred* onto the proxy, but the caller must still keep
+//! [`DIRECT_FALLBACK_RESERVE`] of its deadline so a failing — or, worse,
+//! *hanging* — proxy can always fall back to a direct attempt. Suppressing
+//! direct outright would mean a falsely-latched host whose proxy egress is worse
+//! (origin blocks the proxy ranges, proxy down, geo exit trips another wall) has
+//! no way to recover for the whole cooldown, which is how this could push scrape
+//! success below the 89.7% red line.
+//!
+//! ## Writes are direct-only
+//!
+//! Only a block observed on a genuine [`EgressKind::Direct`] attempt may latch a
+//! host. A block seen while already egressing through a proxy says the *proxy*
+//! is blocked and says nothing about direct — latching on it would let one
+//! caller's broken proxy demote every other caller's healthy direct traffic onto
+//! paid bandwidth.
+
+use moka::future::Cache;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use crate::preference::normalize_host;
+
+/// Process-wide egress memory, shared by every fetch path (`/scrape`, `/crawl`,
+/// `/map`), mirroring how [`crate::host_limiter`] holds its per-host state. A
+/// block learned by one request is what makes the *next* one cheap, so the
+/// memory has to outlive any single request or renderer instance.
+static EGRESS_MEMORY: LazyLock<EgressMemory> = LazyLock::new(EgressMemory::with_defaults);
+
+/// The shared [`EgressMemory`].
+pub fn global() -> &'static EgressMemory {
+    &EGRESS_MEMORY
+}
+
+/// How long a host stays latched to proxy-first egress after a hard block.
+/// Also the re-probe interval: when it expires, direct is tried again.
+pub const COOLDOWN: Duration = Duration::from_secs(10 * 60);
+
+/// Budget held back from the proxy-first attempt so a direct fallback is always
+/// possible. A hanging proxy must not be able to eat the whole deadline.
+pub const DIRECT_FALLBACK_RESERVE: Duration = Duration::from_secs(4);
+
+/// Smallest budget a proxy-first attempt is worth making with.
+pub const MIN_PROXY_ATTEMPT: Duration = Duration::from_secs(2);
+
+/// The latch only takes effect when the deadline can afford BOTH a real proxy
+/// attempt and a full direct rescue.
+///
+/// Splitting a short budget between the two is worse than not trying the proxy at
+/// all: with the SaaS's 5s scrape deadline, a hanging proxy would burn half of it
+/// and leave too little for direct, so a request that used to succeed over direct
+/// in 3s would now fail on BOTH legs. That is a scrape-success regression, and the
+/// 89.7% line is not negotiable.
+///
+/// So below this threshold the latch is inert and behaviour is byte-for-byte what
+/// it is today. Above it the proxy gets `remaining - DIRECT_FALLBACK_RESERVE` and
+/// direct still keeps a full-size rescue.
+///
+/// The threshold has to be picked against the REAL budgets, with slack on BOTH
+/// sides, not as a round number:
+///   * `/scrape` on the SaaS runs a **5s** deadline -> comfortably below, inert.
+///   * `/map` and `/crawl` pages run `effective_deadline_ms` = **8s** by default
+///     -> comfortably above, active. This is the path where re-climbing the ladder
+///     on a blocking host cost 10-20s per URL.
+///
+/// Two ways to get this wrong, both of which silently turn the feature into dead
+/// code while it still *looks* implemented:
+///   * too high (15s was the first attempt) -> never engages on any real path;
+///   * exactly equal to a budget (8s) -> `Deadline::remaining()` is always a hair
+///     UNDER the budget it was built from, because time passes between construction
+///     and the check. A `>= 8s` gate therefore never opens on an 8s budget, and any
+///     test pinned to that boundary is decided by clock resolution.
+///
+/// 6s sits between the two real budgets with ~1s of slack on the scrape side and
+/// ~2s on the map side, so neither is at the mercy of elapsed-time jitter.
+pub const MIN_BUDGET_FOR_LATCH: Duration =
+    Duration::from_secs(DIRECT_FALLBACK_RESERVE.as_secs() + MIN_PROXY_ATTEMPT.as_secs());
+
+/// Maximum number of distinct hosts tracked.
+const CAPACITY: u64 = 10_000;
+
+/// How a single fetch attempt actually left the box.
+///
+/// Provenance must be recorded explicitly at the point the request is issued —
+/// it cannot be inferred from `REQUEST_PROXY.is_some()` (which reflects
+/// *selection*, not what the attempt did) nor from `rendered_with`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EgressKind {
+    Direct,
+    Proxy,
+}
+
+/// Per-host memory of hosts that hard-block direct egress. Cheap to clone.
+#[derive(Clone)]
+pub struct EgressMemory {
+    /// Presence == latched. The value carries no information.
+    cache: Cache<String, ()>,
+}
+
+impl EgressMemory {
+    pub fn new(cooldown: Duration) -> Self {
+        Self {
+            cache: Cache::builder()
+                .max_capacity(CAPACITY)
+                // time_to_live, NOT time_to_idle: the latch must expire a fixed
+                // time after the block, so direct gets re-probed. time_to_idle
+                // would be kept alive forever by the very proxied traffic the
+                // latch causes, pinning the host to paid egress permanently.
+                .time_to_live(cooldown)
+                .build(),
+        }
+    }
+
+    pub fn with_defaults() -> Self {
+        Self::new(COOLDOWN)
+    }
+
+    /// Latch `host` onto proxy-first egress for the cooldown.
+    ///
+    /// Callers MUST only invoke this for a block seen on an [`EgressKind::Direct`]
+    /// attempt, and only for a strong block signal (429, `cf-mitigated`, or an
+    /// antibot `classify()` verdict). A bare 401/403/503 usually means
+    /// auth-required, paywall, or a transient upstream fault — none of which a
+    /// residential proxy fixes, so latching on them just burns paid bandwidth.
+    pub async fn note_block(&self, host: &str) {
+        self.cache.insert(normalize_host(host), ()).await;
+    }
+
+    /// True while `host` is latched: try the proxy egress first.
+    pub async fn should_proxy(&self, host: &str) -> bool {
+        self.cache.get(&normalize_host(host)).await.is_some()
+    }
+
+    /// Number of currently latched hosts (approximate; for the metrics gauge).
+    pub fn latched_hosts(&self) -> u64 {
+        self.cache.entry_count()
+    }
+
+    #[cfg(test)]
+    async fn sync(&self) {
+        self.cache.run_pending_tasks().await;
+    }
+}
+
+impl Default for EgressMemory {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unknown_host_is_not_latched() {
+        let m = EgressMemory::with_defaults();
+        assert!(!m.should_proxy("example.com").await);
+    }
+
+    #[tokio::test]
+    async fn note_block_latches_the_host() {
+        let m = EgressMemory::with_defaults();
+        m.note_block("news.ycombinator.com").await;
+        assert!(m.should_proxy("news.ycombinator.com").await);
+    }
+
+    #[tokio::test]
+    async fn latch_is_keyed_by_etld_plus_one() {
+        let m = EgressMemory::with_defaults();
+        m.note_block("a.example.com").await;
+        // Subdomains of one registered domain share a latch: the block is an
+        // origin-level decision, not a per-subdomain one.
+        assert!(m.should_proxy("b.example.com").await);
+    }
+
+    #[tokio::test]
+    async fn other_hosts_are_unaffected() {
+        let m = EgressMemory::with_defaults();
+        m.note_block("blocked.com").await;
+        assert!(!m.should_proxy("healthy.com").await);
+    }
+
+    // moka drives its TTL off its own (quanta) clock, not tokio's, so a paused
+    // tokio runtime cannot advance it. These two tests use a real, very short
+    // cooldown instead.
+    const TINY: Duration = Duration::from_millis(50);
+
+    /// The regression test for the permanent-latch bug: a latched host MUST
+    /// return to direct egress once the cooldown expires, otherwise a single
+    /// transient 429 pins it to paid proxy bandwidth forever. TTL expiry *is*
+    /// the half-open probe.
+    #[tokio::test]
+    async fn latch_expires_so_direct_is_reprobed() {
+        let m = EgressMemory::new(TINY);
+        m.note_block("news.ycombinator.com").await;
+        assert!(m.should_proxy("news.ycombinator.com").await);
+
+        tokio::time::sleep(TINY * 3).await;
+        m.sync().await;
+
+        assert!(
+            !m.should_proxy("news.ycombinator.com").await,
+            "latch must expire so direct egress is probed again"
+        );
+    }
+
+    /// A still-blocking host re-latches on the next block, so a genuinely
+    /// hostile origin does not flap back to direct on every request.
+    #[tokio::test]
+    async fn reblock_after_expiry_relatches() {
+        let m = EgressMemory::new(TINY);
+        m.note_block("hostile.com").await;
+
+        tokio::time::sleep(TINY * 3).await;
+        m.sync().await;
+        assert!(!m.should_proxy("hostile.com").await);
+
+        m.note_block("hostile.com").await;
+        assert!(m.should_proxy("hostile.com").await);
+    }
+}

--- a/crates/crw-renderer/src/egress.rs
+++ b/crates/crw-renderer/src/egress.rs
@@ -33,7 +33,7 @@
 //!
 //! ## Writes are direct-only
 //!
-//! Only a block observed on a genuine [`EgressKind::Direct`] attempt may latch a
+//! Only a block observed on a genuine direct attempt may latch a
 //! host. A block seen while already egressing through a proxy says the *proxy*
 //! is blocked and says nothing about direct — latching on it would let one
 //! caller's broken proxy demote every other caller's healthy direct traffic onto
@@ -103,17 +103,6 @@ pub const MIN_BUDGET_FOR_LATCH: Duration =
 /// Maximum number of distinct hosts tracked.
 const CAPACITY: u64 = 10_000;
 
-/// How a single fetch attempt actually left the box.
-///
-/// Provenance must be recorded explicitly at the point the request is issued —
-/// it cannot be inferred from `REQUEST_PROXY.is_some()` (which reflects
-/// *selection*, not what the attempt did) nor from `rendered_with`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EgressKind {
-    Direct,
-    Proxy,
-}
-
 /// Per-host memory of hosts that hard-block direct egress. Cheap to clone.
 #[derive(Clone)]
 pub struct EgressMemory {
@@ -141,7 +130,7 @@ impl EgressMemory {
 
     /// Latch `host` onto proxy-first egress for the cooldown.
     ///
-    /// Callers MUST only invoke this for a block seen on an [`EgressKind::Direct`]
+    /// Callers MUST only invoke this for a block seen on a genuine direct
     /// attempt, and only for a strong block signal (429, `cf-mitigated`, or an
     /// antibot `classify()` verdict). A bare 401/403/503 usually means
     /// auth-required, paywall, or a transient upstream fault — none of which a

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -349,7 +349,38 @@ impl PageFetcher for HttpFetcher {
         // remaining deadline so the request cannot exceed the overall budget.
         let mut attempt: u32 = 0;
         let mut use_relaxed = false;
-        let mut use_proxy = false;
+
+        // Egress memory: if this host recently hard-blocked our direct egress,
+        // start on the proxy instead of re-discovering the block. Without this
+        // every URL on a blocking host repeats the whole climb
+        // (direct → 429 → proxy retry → JS ladder), which is the 10-20s/URL that
+        // made /map time out on sites like Hacker News.
+        //
+        // We only PREFER the proxy — we never forbid direct (see the rescue arm
+        // below). A falsely-latched host whose proxy egress is worse must still be
+        // able to succeed, or scrape success would regress.
+        let host = url::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_owned));
+        // The latch is inert unless a proxy exists AND the deadline can afford both
+        // a real proxy attempt and a full direct rescue. Splitting a short budget
+        // (the SaaS scrape deadline is 5s) would let a hanging proxy starve the
+        // direct rescue, failing a request that direct alone would have served —
+        // a scrape-success regression. Below the threshold we behave exactly as
+        // before the latch existed.
+        let proxy_first = match (&host, self.ratelimit_proxy_client.is_some()) {
+            (Some(h), true) => {
+                deadline.remaining() >= crate::egress::MIN_BUDGET_FOR_LATCH
+                    && crate::egress::global().should_proxy(h).await
+            }
+            _ => false,
+        };
+        let mut use_proxy = proxy_first;
+        let mut direct_rescue_used = false;
+        if proxy_first {
+            crw_core::metrics::metrics().egress_latch_hit_total.inc();
+        }
+
         let resp = loop {
             let remaining = deadline.remaining();
             if remaining.is_zero() {
@@ -359,6 +390,35 @@ impl PageFetcher for HttpFetcher {
                     (start.elapsed().as_millis().max(1)) as u64,
                 ));
             }
+            // While trying the proxy first, hold back a FULL direct-rescue budget. A
+            // HANGING proxy is the dangerous case: without the reserve it would eat
+            // the whole deadline and direct would never run — the very suppression
+            // this design exists to avoid.
+            //
+            // The reserve is flat, not a share of what's left: a share would shrink
+            // the rescue on short deadlines to the point where a healthy direct
+            // origin no longer fits in it. `proxy_first` already guarantees the
+            // budget is at least MIN_BUDGET_FOR_LATCH, so this subtraction always
+            // leaves a real proxy attempt behind.
+            let attempt_budget = if use_proxy && proxy_first && !direct_rescue_used {
+                remaining.saturating_sub(crate::egress::DIRECT_FALLBACK_RESERVE)
+            } else {
+                remaining
+            };
+            if attempt_budget.is_zero() {
+                // Not enough left to try the proxy AND still rescue with direct.
+                // Spend what remains on direct, which is the attempt we know how to
+                // reason about.
+                if use_proxy && proxy_first && !direct_rescue_used {
+                    use_proxy = false;
+                    direct_rescue_used = true;
+                    continue;
+                }
+                return Err(CrwError::Timeout(
+                    (start.elapsed().as_millis().max(1)) as u64,
+                ));
+            }
+            let remaining = attempt_budget;
             // On the cert-error fallback path use the verification-disabled
             // client; otherwise the strict client.
             let active_client = if use_proxy {
@@ -371,6 +431,17 @@ impl PageFetcher for HttpFetcher {
             let send_fut = build_request(active_client).send();
             let send_result = tokio::time::timeout(remaining, send_fut).await;
             match send_result {
+                // The proxy-first attempt HUNG until its capped budget ran out.
+                // This is the case the reserve exists for: fall back to direct with
+                // the budget we held back, instead of failing the whole fetch on a
+                // proxy that a latch — possibly a false one — put in front of it.
+                Err(_) if use_proxy && proxy_first && !direct_rescue_used => {
+                    tracing::warn!(
+                        "proxy attempt for {url} exhausted its budget while latched; falling back to direct"
+                    );
+                    use_proxy = false;
+                    direct_rescue_used = true;
+                }
                 Err(_) => {
                     return Err(CrwError::Timeout(remaining.as_millis() as u64));
                 }
@@ -396,6 +467,11 @@ impl PageFetcher for HttpFetcher {
                 // 429 is not returned before the proxy is tried.
                 Ok(Ok(r))
                     if !use_proxy
+                        // `direct_rescue_used` means we already tried the proxy for
+                        // this request and it failed, which is why we are on direct
+                        // at all. Bouncing back to that same broken proxy would just
+                        // burn the rescue budget on an attempt we know fails.
+                        && !direct_rescue_used
                         && self.ratelimit_proxy_client.is_some()
                         && should_arm_proxy(
                             r.status().as_u16(),
@@ -411,7 +487,46 @@ impl PageFetcher for HttpFetcher {
                         r.status()
                     );
                     drop(r);
+                    // WRITE HOOK — direct-only by construction: this arm is gated on
+                    // `!use_proxy`, so the block we just saw was observed on a
+                    // genuine direct attempt. Remember it, so the next URL on this
+                    // host starts on the proxy instead of paying the climb again.
+                    //
+                    // A block seen *through* a proxy must never land here: it would
+                    // say the proxy is blocked, not direct, and would let one
+                    // caller's broken proxy demote every other caller's healthy
+                    // direct traffic onto paid bandwidth.
+                    if let Some(h) = &host {
+                        crate::egress::global().note_block(h).await;
+                    }
                     use_proxy = true;
+                }
+                // The proxy-first attempt came back blocked as well. Direct is not
+                // forbidden by a latch — only deprioritized — so spend the reserved
+                // budget on one direct attempt rather than returning the proxy's
+                // block. Keeps best-result behaviour when the proxy is the worse
+                // egress for this host (origin blocks the proxy ranges, bad geo
+                // exit, etc).
+                Ok(Ok(r))
+                    if use_proxy
+                        && proxy_first
+                        && !direct_rescue_used
+                        && should_arm_proxy(
+                            r.status().as_u16(),
+                            r.headers()
+                                .get("cf-mitigated")
+                                .and_then(|v| v.to_str().ok())
+                                .map(crate::detector::is_cloudflare_mitigated_header)
+                                .unwrap_or(false),
+                        ) =>
+                {
+                    tracing::warn!(
+                        "HTTP {} from {url} via proxy while latched; falling back to direct",
+                        r.status()
+                    );
+                    drop(r);
+                    use_proxy = false;
+                    direct_rescue_used = true;
                 }
                 Ok(Ok(r)) => break r,
                 // TLS cert verification failed and relaxed-TLS fallback is armed:
@@ -420,6 +535,20 @@ impl PageFetcher for HttpFetcher {
                 // before the generic retry arm because cert failures are
                 // `is_connect()` and would otherwise be retried on the strict
                 // client (pointless — the cert is still broken).
+                // The proxy-first attempt could not reach the origin AT ALL (proxy
+                // down, refused, DNS, misconfigured creds). The latch only expresses
+                // a preference, so this must not sink the fetch: spend the reserved
+                // budget on direct. Without this arm an unreachable proxy would turn
+                // every scrape of a latched host into a hard failure for the whole
+                // cooldown — a scrape-success regression, and precisely the case the
+                // "reorder, never suppress" rule exists to prevent.
+                Ok(Err(_)) if use_proxy && proxy_first && !direct_rescue_used => {
+                    tracing::warn!(
+                        "proxy egress failed for {url} while latched; falling back to direct"
+                    );
+                    use_proxy = false;
+                    direct_rescue_used = true;
+                }
                 Ok(Err(e))
                     if !use_relaxed && self.relaxed_client.is_some() && is_cert_error(&e) =>
                 {

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -378,7 +378,13 @@ impl PageFetcher for HttpFetcher {
         let mut use_proxy = proxy_first;
         let mut direct_rescue_used = false;
         if proxy_first {
-            crw_core::metrics::metrics().egress_latch_hit_total.inc();
+            let m = crw_core::metrics::metrics();
+            m.egress_latch_hit_total.inc();
+            // Refresh the gauge on the hot latched path so it tracks the live
+            // latched-host count (and its TTL decay), mirroring how
+            // `host_preferences_size` is set opportunistically during a fetch.
+            m.egress_latched_hosts
+                .set(crate::egress::global().latched_hosts() as i64);
         }
 
         let resp = loop {
@@ -497,28 +503,46 @@ impl PageFetcher for HttpFetcher {
                     // caller's broken proxy demote every other caller's healthy
                     // direct traffic onto paid bandwidth.
                     if let Some(h) = &host {
-                        crate::egress::global().note_block(h).await;
+                        let eg = crate::egress::global();
+                        eg.note_block(h).await;
+                        crw_core::metrics::metrics()
+                            .egress_latched_hosts
+                            .set(eg.latched_hosts() as i64);
                     }
                     use_proxy = true;
                 }
-                // The proxy-first attempt came back blocked as well. Direct is not
-                // forbidden by a latch — only deprioritized — so spend the reserved
-                // budget on one direct attempt rather than returning the proxy's
-                // block. Keeps best-result behaviour when the proxy is the worse
-                // egress for this host (origin blocks the proxy ranges, bad geo
-                // exit, etc).
+                // The proxy-first attempt did not return a usable page. Direct is
+                // not forbidden by a latch — only deprioritized — so spend the
+                // reserved budget on one direct attempt rather than returning the
+                // proxy's result. This keeps best-result behaviour when the proxy
+                // is the worse egress for this host (origin blocks the proxy
+                // ranges, bad geo exit, a 403/5xx wall the box's own IP clears).
+                //
+                // Gate on "not a usable page", which is BROADER than the 429/cf
+                // signal the direct-side arm uses: the latch reorders and must
+                // never SUPPRESS direct, so ANY non-2xx proxy response (403, 5xx,
+                // an un-followed redirect) has to leave a direct rescue reachable,
+                // or a falsely-latched host would return the proxy's failure while
+                // direct would have served 200 — a scrape-success regression.
+                //
+                // `cf-mitigated` is folded in explicitly because a Cloudflare
+                // challenge is often served as a 200: `is_success()` alone would
+                // let that interstitial through and skip the rescue, silently
+                // narrowing the very case (`should_arm_proxy(200, true)`) the
+                // pre-existing 429 arm already treats as a block. Retriable
+                // statuses still exhaust their retries on the proxy first (that arm
+                // is matched above); a clean 2xx falls through to `break r` and
+                // never wastes the rescue.
                 Ok(Ok(r))
                     if use_proxy
                         && proxy_first
                         && !direct_rescue_used
-                        && should_arm_proxy(
-                            r.status().as_u16(),
-                            r.headers()
+                        && (!r.status().is_success()
+                            || r.headers()
                                 .get("cf-mitigated")
                                 .and_then(|v| v.to_str().ok())
                                 .map(crate::detector::is_cloudflare_mitigated_header)
-                                .unwrap_or(false),
-                        ) =>
+                                .unwrap_or(false)) =>
                 {
                     tracing::warn!(
                         "HTTP {} from {url} via proxy while latched; falling back to direct",

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -46,6 +46,7 @@ pub mod cdp;
 #[cfg(feature = "cdp")]
 pub mod cdp_conn;
 pub mod detector;
+pub mod egress;
 #[cfg(feature = "cdp")]
 pub mod health_telemetry;
 pub mod host_limiter;

--- a/crates/crw-renderer/tests/egress_latch.rs
+++ b/crates/crw-renderer/tests/egress_latch.rs
@@ -1,0 +1,149 @@
+//! The egress latch must REORDER egress, never SUPPRESS direct.
+//!
+//! These tests guard the scrape-success red line. A latch is a hint learned from
+//! one request ("this host hard-blocked our direct egress"), and it can be wrong:
+//! a single transient 429 latches a host whose direct egress is actually fine.
+//! If a latch could *forbid* direct, then any host whose proxy egress is worse —
+//! proxy down, origin blocks the proxy's ranges, bad geo exit — would fail every
+//! scrape for the whole cooldown. So a latched host must still be able to succeed
+//! over direct when the proxy cannot deliver.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Port 1 is reserved and nothing listens there: every connection is refused
+/// immediately, which is our stand-in for "the proxy is down/misconfigured".
+const DEAD_PROXY: &str = "http://127.0.0.1:1";
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: these tests run in their own process (one binary per tests/*.rs).
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+async fn serving_ok() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>direct works</html>"))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// THE red-line test. Host is latched, so we try the proxy first — but the proxy
+/// is dead. Direct must still be attempted, and the fetch must SUCCEED.
+///
+/// Before the rescue arm existed, the dead proxy returned a transport error that
+/// no arm handled, and the whole fetch failed. Every scrape of this host would
+/// have failed for the entire 10-minute cooldown.
+#[tokio::test]
+async fn latched_host_falls_back_to_direct_when_the_proxy_is_dead() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", DEAD_PROXY);
+
+    let server = serving_ok().await;
+    let url = server.uri();
+    let host = url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned();
+
+    // Pretend a previous request learned this host blocks our direct egress.
+    crw_renderer::egress::global().note_block(&host).await;
+    assert!(
+        crw_renderer::egress::global().should_proxy(&host).await,
+        "test precondition: host must be latched"
+    );
+
+    let r = renderer();
+    let result = r
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            None,
+            Deadline::from_request_ms(20_000),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "a latched host with a dead proxy must still succeed over direct — the \
+         latch reorders egress, it must never suppress it. Got: {:?}",
+        result.err()
+    );
+    assert!(result.unwrap().html.contains("direct works"));
+
+    // The origin really was reached directly.
+    assert!(
+        !server.received_requests().await.unwrap().is_empty(),
+        "the direct rescue attempt must actually hit the origin"
+    );
+}
+
+/// The latch must actually ENGAGE on the budget /map and /crawl really use.
+///
+/// This is the "is the feature dead code?" test. The threshold that protects the
+/// 5s scrape path can very easily be set so high that it also excludes the 8s
+/// per-page budget of /map — which is the one path the whole feature exists for.
+/// A first attempt at 15s did exactly that.
+///
+/// Here the host is latched and the proxy is dead, on an 8s budget: the request
+/// must have gone to the proxy FIRST (and then been rescued by direct). We prove
+/// the proxy was really tried by asserting the latch-hit metric moved.
+#[tokio::test]
+async fn latch_engages_on_the_map_per_page_budget() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", DEAD_PROXY);
+
+    let server = serving_ok().await;
+    let url = server.uri();
+    let host = url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned();
+    crw_renderer::egress::global().note_block(&host).await;
+
+    let before = crw_core::metrics::metrics().egress_latch_hit_total.get();
+
+    let result = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            None,
+            // config.effective_deadline_ms() default — what /map gives each page.
+            // Comfortably above MIN_BUDGET_FOR_LATCH (6s), not sitting on it:
+            // `remaining()` is always a hair under the budget it was built from, so
+            // a threshold equal to this value would be decided by clock jitter.
+            Deadline::from_request_ms(8_000),
+        )
+        .await;
+
+    assert!(result.is_ok(), "direct rescue must still serve the page");
+
+    let after = crw_core::metrics::metrics().egress_latch_hit_total.get();
+    assert!(
+        after > before,
+        "the latch did NOT engage on an 8s budget — /map is the path this feature \
+         exists for, so a threshold that excludes it makes the whole thing dead code"
+    );
+}

--- a/crates/crw-renderer/tests/egress_latch_no_proxy.rs
+++ b/crates/crw-renderer/tests/egress_latch_no_proxy.rs
@@ -1,0 +1,75 @@
+//! The egress latch must be INERT when no proxy is configured.
+//!
+//! Own test binary on purpose: the proxy client is built from a process-global
+//! env var at renderer-construction time, so a sibling test that *sets* that var
+//! would race this one that needs it *unset*. Cargo gives each `tests/*.rs` its
+//! own process, which is the only way to keep both honest.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: this test owns its process.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+async fn serving_ok() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>direct works</html>"))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// With no proxy configured the latch is inert: it must not change anything on
+/// its own. An unlatched-vs-latched host should behave identically here.
+#[tokio::test]
+async fn latch_is_inert_when_no_proxy_is_configured() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    // No CRW_HTTP_RATELIMIT_PROXY_URL is ever set in this process.
+
+    let server = serving_ok().await;
+    let url = server.uri();
+    let host = url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned();
+
+    crw_renderer::egress::global().note_block(&host).await;
+
+    let r = renderer();
+    let result = r
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            None,
+            Deadline::from_request_ms(20_000),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "with no proxy configured a latched host must behave exactly as before: {:?}",
+        result.err()
+    );
+    assert!(result.unwrap().html.contains("direct works"));
+}

--- a/crates/crw-renderer/tests/egress_latch_proxy_block.rs
+++ b/crates/crw-renderer/tests/egress_latch_proxy_block.rs
@@ -1,0 +1,110 @@
+//! A latched host whose proxy returns a NON-429 error status must still fall
+//! back to direct.
+//!
+//! The rescue arm originally fired only on a proxy transport failure, a hung
+//! proxy, or a 429/`cf-mitigated` block. But the latch is a hint that can be
+//! wrong (one transient 429 latches a host whose direct egress is fine), and a
+//! proxy exit IP is often the WORSE egress: datacenter/residential ranges get a
+//! 403 or 5xx wall from origins the box's own IP clears. If the proxy's 403 were
+//! returned as-is, a falsely-latched host would fail while direct would have
+//! served 200 — a scrape-success regression. So ANY non-2xx proxy response has
+//! to leave the direct rescue reachable, not just the block signal.
+//!
+//! This lives in its own test binary so its proxy env does not race the
+//! DEAD_PROXY value the sibling `egress_latch.rs` tests set in the same process.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+/// Host is latched, so the proxy is tried first — and it answers 403 (an exit-IP
+/// wall, not a 429). Direct must still be attempted and serve the page.
+#[tokio::test]
+async fn latched_host_falls_back_to_direct_when_the_proxy_walls_it_403() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+
+    // The proxy answers every request with 403 (it walls this host's exit IP).
+    let proxy = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("blocked at the proxy exit"))
+        .mount(&proxy)
+        .await;
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", &proxy.uri());
+
+    // Direct egress serves the page fine.
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>direct works</html>"))
+        .mount(&origin)
+        .await;
+    let url = origin.uri();
+    let host = url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned();
+
+    crw_renderer::egress::global().note_block(&host).await;
+    assert!(
+        crw_renderer::egress::global().should_proxy(&host).await,
+        "test precondition: host must be latched"
+    );
+
+    let before = crw_core::metrics::metrics().egress_latch_hit_total.get();
+
+    let result = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            None,
+            // 8s: above MIN_BUDGET_FOR_LATCH so the latch actually engages.
+            Deadline::from_request_ms(8_000),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "a latched host whose proxy answers 403 must still succeed over direct — \
+         the latch reorders egress, it must never suppress it. Got: {:?}",
+        result.err()
+    );
+    assert!(
+        result.unwrap().html.contains("direct works"),
+        "the rescued direct attempt's body must be what is returned, not the proxy's 403"
+    );
+
+    // The proxy really was tried first (latch engaged)...
+    assert!(
+        crw_core::metrics::metrics().egress_latch_hit_total.get() > before,
+        "the latch must have engaged so the proxy was tried before direct"
+    );
+    assert!(
+        !proxy.received_requests().await.unwrap().is_empty(),
+        "the proxy-first attempt must actually hit the proxy"
+    );
+    // ...and direct really rescued it.
+    assert!(
+        !origin.received_requests().await.unwrap().is_empty(),
+        "the direct rescue attempt must actually hit the origin"
+    );
+}

--- a/crates/crw-renderer/tests/egress_latch_proxy_cf200.rs
+++ b/crates/crw-renderer/tests/egress_latch_proxy_cf200.rs
@@ -1,0 +1,87 @@
+//! The subtle rescue case: a latched host's proxy answers HTTP 200, but it is a
+//! Cloudflare challenge (`cf-mitigated: challenge`).
+//!
+//! A pure `!is_success()` gate would let that interstitial through as the scrape
+//! result, silently narrowing the very case the direct-side 429 arm already
+//! treats as a block (`should_arm_proxy(200, true)`). The rescue must still fire
+//! on the `cf-mitigated` signal so a latched host whose proxy exit hits a CF wall
+//! the box's own IP clears is not stuck with the challenge page.
+//!
+//! Its own test binary: the proxy env must not race the other latch tests that
+//! set a different `CRW_HTTP_RATELIMIT_PROXY_URL` in the same process.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+#[tokio::test]
+async fn latched_host_falls_back_to_direct_on_a_cf_challenge_served_as_200() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+
+    // The proxy answers 200, but the cf-mitigated header marks it a challenge.
+    let proxy = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("cf-mitigated", "challenge")
+                .set_body_string("<html>just a moment... cloudflare challenge</html>"),
+        )
+        .mount(&proxy)
+        .await;
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", &proxy.uri());
+
+    // Direct egress serves the real page.
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>direct works</html>"))
+        .mount(&origin)
+        .await;
+    let url = origin.uri();
+    let host = url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned();
+
+    crw_renderer::egress::global().note_block(&host).await;
+
+    let result = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            None,
+            Deadline::from_request_ms(8_000),
+        )
+        .await;
+
+    assert!(result.is_ok(), "the direct rescue must serve the page");
+    assert!(
+        result.unwrap().html.contains("direct works"),
+        "a cf-mitigated 200 from the proxy must trigger the direct rescue, not be \
+         returned as the challenge page"
+    );
+    assert!(
+        !origin.received_requests().await.unwrap().is_empty(),
+        "the direct rescue attempt must actually hit the origin"
+    );
+}

--- a/crates/crw-renderer/tests/egress_latch_scrape_budget.rs
+++ b/crates/crw-renderer/tests/egress_latch_scrape_budget.rs
@@ -1,0 +1,105 @@
+//! The latch must stay INERT on the SaaS scrape budget.
+//!
+//! Own test binary on purpose: this asserts a process-global metric counter did
+//! NOT move, so a sibling test that legitimately increments it would race this one
+//! and make it flaky. Cargo gives each `tests/*.rs` its own process.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A proxy that accepts the TCP connection and then never answers — the pathology
+/// a plain "connection refused" cannot exercise, and the one that could starve the
+/// direct rescue if the latch engaged on a short budget.
+fn blackholing_proxy() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept() {
+            held.push(sock); // never read, never respond
+        }
+    });
+    format!("http://{addr}")
+}
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: this test owns its process.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+async fn serving_ok() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html>direct works</html>"))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// On the 5s scrape budget the latch must NOT engage, even for a latched host with
+/// a BLACKHOLING proxy in front of it.
+///
+/// If it did engage, that hanging proxy would eat part of the 5s and a healthy but
+/// not-instant direct origin could no longer fit in the remainder — turning a
+/// request that used to succeed into a failure, and pushing scrape success below
+/// the 89.7% red line.
+///
+/// The assertion is on the METRIC, not on wall-clock timing: a "direct still
+/// finished in time" assertion has to sit near the budget boundary to be meaningful,
+/// which makes it a coin-flip under parallel test load. The counter says plainly
+/// whether the latch fired.
+#[tokio::test]
+async fn latch_does_not_engage_on_the_scrape_budget() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", &blackholing_proxy());
+
+    let server = serving_ok().await;
+    let url = server.uri();
+    let host = url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned();
+    crw_renderer::egress::global().note_block(&host).await;
+
+    let before = crw_core::metrics::metrics().egress_latch_hit_total.get();
+
+    let result = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            None,
+            // The SaaS scrape deadline.
+            Deadline::from_request_ms(5_000),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "the scrape path must keep working: {:?}",
+        result.err()
+    );
+    assert_eq!(
+        crw_core::metrics::metrics().egress_latch_hit_total.get(),
+        before,
+        "the latch must stay inert on the 5s scrape budget — engaging there is how a \
+         hanging proxy could starve direct and push scrape success below 89.7%"
+    );
+}

--- a/crates/crw-server/src/routes/map.rs
+++ b/crates/crw-server/src/routes/map.rs
@@ -101,6 +101,11 @@ pub async fn map(
         max_urls: req
             .limit
             .unwrap_or(crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS),
+        // Discovery stops just before the backstop below and returns what it has.
+        // Previously the backstop was the only bound: it dropped the future and
+        // every discovered URL with it, so a slow site got a 504 with zero links.
+        overall_deadline: crw_crawl::crawl::discovery_deadline(Duration::from_secs(timeout_secs)),
+        respect_robots: state.config.crawler.respect_robots_txt,
     });
 
     let result =

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -1,3 +1,7 @@
+/// Discovery budget for `crw_map` over MCP, which has no request timeout of its
+/// own. Matches the HTTP route's default so both surfaces behave the same.
+const MCP_MAP_TIMEOUT_SECS: u64 = 120;
+
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
@@ -94,6 +98,13 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
                 max_urls: req
                     .limit
                     .unwrap_or(crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS),
+                // MCP has no outer timeout of its own, so discovery would
+                // otherwise be unbounded. Give it the same default budget the
+                // HTTP route uses, explicitly rather than by accident.
+                overall_deadline: crw_crawl::crawl::discovery_deadline(
+                    std::time::Duration::from_secs(MCP_MAP_TIMEOUT_SECS),
+                ),
+                respect_robots: state.config.crawler.respect_robots_txt,
             })
             .await
             .map_err(|e| format!("{e}"))?;

--- a/crates/crw-server/src/routes/v2/map.rs
+++ b/crates/crw-server/src/routes/v2/map.rs
@@ -89,6 +89,10 @@ pub async fn map(
         max_urls: req
             .limit
             .unwrap_or(crw_crawl::crawl::DEFAULT_MAX_DISCOVERED_URLS),
+        // Stop just before the backstop below and return partials, instead of
+        // letting the backstop drop the future and lose every discovered URL.
+        overall_deadline: crw_crawl::crawl::discovery_deadline(Duration::from_secs(timeout_secs)),
+        respect_robots: state.config.crawler.respect_robots_txt,
     });
 
     let result = match tokio::time::timeout(Duration::from_secs(timeout_secs), fut).await {


### PR DESCRIPTION
## The bug

`POST /v1/map` on a site without a sitemap burned the full 120s budget and came
back **504 with zero URLs**. Reproduced on prod against `news.ycombinator.com`,
twice. Credits were refunded, so no billing harm, but the endpoint was unusable
on any sitemap-less site.

The engine log showed the shape of it — each of these is a *different* URL, each
paying the full renderer ladder from scratch:

```
HTTP 429 Too Many Requests from news.ycombinator.com/user?id=... -> retrying once via proxy
HTTP 403 received, escalating to JS renderer
antibot classifier flagged a block  renderer=chrome  signal=rate_limited
chrome nav budget hit; attempting partial snapshot
antibot classifier flagged a block  renderer=lightpanda  signal=structural_failure
```

## Root causes

Five defects compounded into the outage:

1. **No per-host block memory.** `saw_hard_block` and `use_proxy` are
   request-local, so URL #2 on a host that just 429'd us started over at direct
   HTTP: `direct -> 429 -> proxy retry -> JS ladder -> chrome_proxy`. That climb
   is the 10-20s/URL we measured, and it is the dominant cost.
2. **The BFS discovery loop only looked concurrent.** It took a semaphore permit
   and then awaited the fetch inline in the same iteration; nothing was ever
   spawned. Real concurrency was 1 and `max_concurrency` was dead weight.
3. **The BFS phase got a time budget only when the sitemap had already produced
   >= 50 URLs.** HN has no sitemap, so it ran unbounded.
4. **The route's `tokio::time::timeout` DROPPED the discovery future**, throwing
   away every URL found so far. That is why a slow site produced a 504 with an
   empty result rather than a short list.
5. **robots.txt was read only for its `Sitemap:` lines**, and `is_allowed()` was
   handed a bare path, so query-keyed rules never matched. HN disallows `/hide?`,
   `/vote?` and `/reply?` — every one of them was fetched anyway, through a full
   Chrome ladder.

## What changed

**New `crw-renderer/src/egress.rs`** — per-host memory of hosts that hard-block
our direct egress, as a moka TTL cache. Presence == latched, and TTL expiry *is*
the half-open re-probe, so there is no success hook that could erase it and a
false latch cannot decay into permanent paid-proxy egress.

The latch **reorders egress, it never suppresses direct**. A latched host starts
on the proxy, but a reserved slice of the deadline guarantees a direct rescue
even if the proxy is dead or *hanging*. Writes only ever happen on a genuine
direct attempt seeing a strong block signal (429 / `cf-mitigated`), so one
caller's broken proxy cannot demote another caller's healthy direct traffic onto
paid bandwidth. Below `MIN_BUDGET_FOR_LATCH` the latch is inert, which leaves the
5s scrape path byte-for-byte unchanged.

**`discover_urls`** — an `overall_deadline` now clamps *every* awaited phase
(robots, HEAD probes, sitemap tree, DNS resolution, each page), and discovery
returns the URLs it has when the budget runs out instead of dying with the
future. The outer timeout is now only a backstop.

**BFS** streams its fetches concurrently and exits the moment the URL cap is hit,
instead of paying for a whole level it no longer needs.

**robots.txt** is honoured for *fetching* only: a disallowed link is still
reported in the output, it is simply never requested. New `is_url_allowed()`
matches on path **and** query.

**`max_urls`** is a hard cap now; the base URL counts against it rather than
being appended after the cap was enforced.

## Deliberate calls, flagged rather than buried

- **`Crawl-delay` is not honoured.** HN asks for 30s between fetches, which would
  mean map never finishes. Our per-host limiter stays the politeness mechanism.
  This is not new behaviour — `/crawl` already ignores it.
- **Fewer URLs for sites that disallow paths we used to fetch.** This is a real
  behaviour change and it is the correct one.
- **Concurrency buys "up to ~2x", not more.** Map follows same-origin links only,
  so every fetch contends for the same host's permits (`per_host_max_concurrent`
  + interactive reserve = 2). The per-host cap is deliberately NOT raised. The
  real win here is the egress memory, not the parallelism.

## Verification

Against the live engine, not just the test suite:

| | before | after |
|---|---|---|
| `POST /v1/map` news.ycombinator.com | **504, 0 URLs, 120s** | **200, 5000 URLs, ~22s** |
| same, `timeout: 10` | 504, 0 URLs | 200, partial list (~1800 URLs), 8s |
| docs.fastcrw.com | 53 URLs | 53 URLs, 1.4s |
| fastcrw.com | 360 URLs | 369-391 URLs |

Old vs new binaries were built from the same tree and measured alternately on the
same machine with a cold browser, so the comparison is apples-to-apples.

**Scrape-success red line:** the latch is inert on the 5s scrape budget, so that
path is unchanged by construction, and a test asserts the latch metric does not
move there. On a 15-URL live sample old scored 13/15 and new 14/15 — no
regression signal. This is a sample, not the 1000-URL benchmark.

Full suite green (1200+ tests), clippy clean, fmt clean. The latch tests were
each verified to FAIL when their guard is removed, and run 10x with no flakes.

## Follow-ups (not in this PR)

- `run_crawl_inner` has the *identical* dead-semaphore bug, so `/crawl` is serial
  too. Real, but `/crawl` works today and fixing it widens the blast radius.
- `/crawl`'s robots check drops the query the same way (`crawl.rs`, one line).
  It would *reduce* the URL count `/crawl` returns, so it deserves its own
  benchmark verification.
