### PR TITLE
fix(engine): detect large Cloudflare challenge pages and return clean blocks

### DIFF
--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -708,6 +708,26 @@ pub struct ScrapeData {
     pub block: Option<BlockOutcome>,
 }
 
+impl ScrapeData {
+    /// Clear the page-content fields (markdown, HTML, text, links, and any
+    /// LLM-derived outputs), keeping `metadata`, `block`, warnings, and the
+    /// screenshot. Used on the block-response path so a detected anti-bot
+    /// interstitial returns a clean block (success:false + error + metadata)
+    /// instead of the challenge shell text as content.
+    pub fn clear_body(&mut self) {
+        self.markdown = None;
+        self.source_hash = None;
+        self.html = None;
+        self.raw_html = None;
+        self.plain_text = None;
+        self.links = None;
+        self.json = None;
+        self.basis = None;
+        self.summary = None;
+        self.chunks = None;
+    }
+}
+
 /// Typed anti-bot block verdict. `vendor` is the antibot `class_name`
 /// (cloudflare|datadome|perimeterx|generic_block|structural_failure|…);
 /// `reason` is the detector's human-readable explanation.
@@ -881,6 +901,68 @@ pub fn resolve_pinned_renderer(req: Option<RequestedRenderer>) -> Option<&'stati
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clear_body_drops_content_keeps_metadata_and_block() {
+        let mut data = ScrapeData {
+            markdown: Some("Just a moment... Humans only".into()),
+            source_hash: Some("sha256:abc".into()),
+            html: Some("<html>challenge</html>".into()),
+            raw_html: Some("<html>challenge</html>".into()),
+            plain_text: Some("challenge text".into()),
+            links: Some(vec!["https://help.example.com".into()]),
+            json: Some(serde_json::json!({"junk": true})),
+            summary: Some("a summary of junk".into()),
+            llm_usage: None,
+            chunks: None,
+            warning: Some("blocked".into()),
+            warnings: vec!["blocked".into()],
+            render_decision: None,
+            credit_cost: 0,
+            basis: None,
+            basis_warnings: Vec::new(),
+            llm_input_hash: None,
+            metadata: PageMetadata {
+                title: None,
+                description: None,
+                og_title: None,
+                og_description: None,
+                og_image: None,
+                canonical_url: None,
+                source_url: "https://www.glassdoor.com/Reviews/x.htm".into(),
+                language: None,
+                status_code: 200,
+                rendered_with: None,
+                elapsed_ms: 0,
+                page_count: None,
+                source_filename: None,
+                extra: Default::default(),
+            },
+            debug_extraction: None,
+            content_type: Some("text/html".into()),
+            change_tracking: None,
+            screenshot: Some("data:image/png;base64,AA".into()),
+            block: Some(BlockOutcome {
+                vendor: "cloudflare".into(),
+                reason: "cloudflare challenge interstitial".into(),
+            }),
+        };
+        data.clear_body();
+        // content-shell + LLM outputs cleared
+        assert!(data.markdown.is_none());
+        assert!(data.source_hash.is_none());
+        assert!(data.html.is_none());
+        assert!(data.raw_html.is_none());
+        assert!(data.plain_text.is_none());
+        assert!(data.links.is_none());
+        assert!(data.json.is_none());
+        assert!(data.summary.is_none());
+        // block verdict, metadata, warnings, screenshot kept for the caller
+        assert!(data.block.is_some());
+        assert_eq!(data.metadata.status_code, 200);
+        assert_eq!(data.warnings, vec!["blocked".to_string()]);
+        assert!(data.screenshot.is_some());
+    }
 
     fn usage(input: u32, output: u32) -> LlmUsage {
         LlmUsage {

--- a/crates/crw-renderer/src/detector.rs
+++ b/crates/crw-renderer/src/detector.rs
@@ -502,23 +502,37 @@ fn strip_tag_blocks(html: &str, tag: &str) -> String {
 /// `cf-mitigated` response header — that signal is independent of body
 /// content and is the most reliable indicator.
 pub fn looks_like_cloudflare_challenge(html: &str) -> bool {
+    // Strong markers appear ONLY on the interstitial and can sit deep in the
+    // body of a large managed-challenge page — measured at byte ~128k of a 275k
+    // Glassdoor "Just a moment" page, inside a
+    // `<script src="/cdn-cgi/challenge-platform/…/orchestrate/…">`. So scan them
+    // regardless of the 80KB weak-marker cap, bounded to the first 512KB. The
+    // markers are fixed-lowercase ASCII CF tokens, so match case-sensitively on
+    // the raw bytes (no allocation on the hot per-attempt path; mirrors
+    // `crw_crawl::single::classify_block`).
+    const STRONG_SCAN_LIMIT: usize = 512 * 1024;
+    let mut strong_end = STRONG_SCAN_LIMIT.min(html.len());
+    while strong_end > 0 && !html.is_char_boundary(strong_end) {
+        strong_end -= 1;
+    }
+    let strong_src = &html[..strong_end];
+    const STRONG: [&str; 5] = [
+        "cf-browser-verification",
+        "cf-challenge-running",
+        "/cdn-cgi/challenge-platform/",
+        "_cf_chl_opt", // substring of window._cf_chl_opt / __cf_chl_managed_tk__
+        "__cf_chl_managed_tk__",
+    ];
+    if STRONG.iter().any(|m| strong_src.contains(m)) {
+        return true;
+    }
+
+    // Weak markers can appear on legitimate Cloudflare-fronted pages, so they
+    // keep the size guard: a large page is real content, not an interstitial.
     if html.len() > 80_000 {
         return false;
     }
     let lower = html.to_lowercase();
-
-    // Strong markers: appear ONLY on the interstitial.
-    let strong = [
-        "cf-browser-verification",
-        "cf-challenge-running",
-        "/cdn-cgi/challenge-platform/",
-        "_cf_chl_opt",
-        "__cf_chl_managed_tk__",
-        "window._cf_chl_opt",
-    ];
-    if strong.iter().any(|m| lower.contains(m)) {
-        return true;
-    }
 
     // Weak markers: each can appear on legitimate Cloudflare-fronted pages.
     // "ray id:" + "cloudflare" co-occur on most CF-fronted error pages and
@@ -737,6 +751,39 @@ mod tests {
     }
 
     #[test]
+    fn cf_strong_marker_detected_on_large_page() {
+        // Modern Cloudflare managed challenge: a large (>80KB) HTML whose only
+        // machine marker is a challenge-platform <script src> deep in the body
+        // (Glassdoor served a 275KB page with the marker at byte ~128k). The old
+        // 80KB size cap made this evade detection.
+        let mut html = String::from("<html><head><title>Just a moment...</title></head><body>");
+        html.push_str(&"<p>verifying you are human, one moment please.</p>".repeat(3_000));
+        html.push_str(
+            r#"<script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=abc"></script>"#,
+        );
+        html.push_str("</body></html>");
+        assert!(
+            html.len() > 80_000,
+            "fixture must exceed the weak-marker cap"
+        );
+        assert!(looks_like_cloudflare_challenge(&html));
+    }
+
+    #[test]
+    fn cf_large_real_page_with_footer_mention_not_flagged() {
+        // A large real page that merely mentions Cloudflare in a footer (no
+        // challenge markers) must NOT be flagged — the weak-marker path stays
+        // size-guarded.
+        let mut html = String::from("<html><body><article>");
+        html.push_str(&"<p>Real article content about web performance.</p>".repeat(3_000));
+        html.push_str(
+            "<footer>Hosted via Cloudflare. Ray ID: abc123</footer></article></body></html>",
+        );
+        assert!(html.len() > 80_000);
+        assert!(!looks_like_cloudflare_challenge(&html));
+    }
+
+    #[test]
     fn cf_single_weak_marker_not_enough() {
         // A page that just mentions "Cloudflare" should not trigger.
         let html = r#"<html><body><article><h1>Why we use Cloudflare</h1><p>Performance benefits.</p></article></body></html>"#;
@@ -776,11 +823,14 @@ mod tests {
     }
 
     #[test]
-    fn cf_huge_page_not_scanned() {
-        let mut html = String::from(r#"<html><body><div id="cf-browser-verification">"#);
-        html.push_str(&"<p>x</p>".repeat(20_000));
-        html.push_str("</div></body></html>");
-        assert!(html.len() > 80_000);
+    fn cf_strong_marker_beyond_scan_limit_not_flagged() {
+        // Perf bound: strong markers are scanned only within the first 512KB.
+        // A marker past that (pathologically large page) is not scanned — real
+        // CF challenge markers sit well within the first few hundred KB.
+        let mut html = String::from("<html><body>");
+        html.push_str(&"<p>x</p>".repeat(80_000)); // ~640KB of filler > 512KB
+        html.push_str(r#"<div id="cf-browser-verification"></div></body></html>"#);
+        assert!(html.len() > 512 * 1024);
         assert!(!looks_like_cloudflare_challenge(&html));
     }
 

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -1293,6 +1293,12 @@ impl FallbackRenderer {
         let failed_render = detector::looks_like_failed_render(&result.html);
         let is_bot_wall = detector::looks_like_generic_bot_wall(&result.html);
         let vendor_block = detector::looks_like_vendor_block(&result.html);
+        // Size-independent Cloudflare interstitial check: modern managed
+        // challenges are 100-300KB with the challenge marker deep in the body,
+        // which the size-capped `vendor_block`/`bot_wall`/`antibot` detectors all
+        // miss. Without this a CF challenge slips through as "thin" (not a hard
+        // block), so the chrome_proxy egress-recovery arm never fires.
+        let cf_challenge = detector::looks_like_cloudflare_challenge(&result.html);
         let is_status_blocked = matches!(
             result.status_code,
             401 | 403 | 404 | 405 | 406 | 410 | 412 | 429 | 451 | 500 | 503
@@ -1308,12 +1314,14 @@ impl FallbackRenderer {
             || (520..=530).contains(&result.status_code)
             || is_bot_wall
             || vendor_block.is_some()
+            || cf_challenge
             || antibot.signal.is_blocked();
         let acceptable = text_len >= Self::MIN_RENDERED_TEXT_LEN
             && !is_placeholder
             && failed_render.is_none()
             && !is_bot_wall
             && vendor_block.is_none()
+            && !cf_challenge
             && !is_status_blocked
             && !antibot_blocked;
         JsAttemptClass {
@@ -1875,6 +1883,11 @@ impl FallbackRenderer {
                     let failed_render = detector::looks_like_failed_render(&result.html);
                     let is_bot_wall = detector::looks_like_generic_bot_wall(&result.html);
                     let vendor_block = detector::looks_like_vendor_block(&result.html);
+                    // Size-independent Cloudflare interstitial check (see
+                    // `classify_js_attempt`): large managed-challenge pages evade
+                    // the size-capped detectors above, so a CF challenge would
+                    // otherwise slip through as "thin" and never arm chrome_proxy.
+                    let cf_challenge = detector::looks_like_cloudflare_challenge(&result.html);
                     // Mirrors the HTTP-tier escalation set (lib.rs:658). A JS
                     // renderer can return 200 with bot HTML or 403 with content
                     // — without this check, both slip through as "valid".
@@ -1904,6 +1917,7 @@ impl FallbackRenderer {
                         || (520..=530).contains(&result.status_code)
                         || is_bot_wall
                         || vendor_block.is_some()
+                        || cf_challenge
                         || antibot.signal.is_blocked()
                     {
                         saw_hard_block = true;
@@ -1913,6 +1927,7 @@ impl FallbackRenderer {
                         && failed_render.is_none()
                         && !is_bot_wall
                         && vendor_block.is_none()
+                        && !cf_challenge
                         && !is_status_blocked
                         && !antibot_blocked
                     {
@@ -2255,9 +2270,13 @@ impl FallbackRenderer {
                         let is_placeholder = detector::looks_like_loading_placeholder(&result.html);
                         let failed_render = detector::looks_like_failed_render(&result.html);
                         let truncated = result.truncated;
+                        // A large CF challenge shell has body text > 50 and no
+                        // placeholder/failed marker, so guard it explicitly or it
+                        // would leak through this path as success.
                         let content_ok = text_len >= Self::MIN_RENDERED_TEXT_LEN
                             && !is_placeholder
-                            && failed_render.is_none();
+                            && failed_render.is_none()
+                            && !detector::looks_like_cloudflare_challenge(&result.html);
                         let outcome = classify_outcome(content_ok, truncated, false, &attempt_ctx);
                         // Record host only — global stays untouched so the
                         // existing trip can finish its cooldown naturally.

--- a/crates/crw-server/src/routes/scrape.rs
+++ b/crates/crw-server/src/routes/scrape.rs
@@ -108,6 +108,11 @@ pub async fn scrape(
     // md_empty path) so credit-refund logic is unchanged.
     if let Some(b) = data.block.clone() {
         let error_msg = b.message();
+        // Drop the interstitial/challenge shell so the caller gets a clean block
+        // instead of the "Just a moment / Humans only" wall as markdown. Runs
+        // after the http_error gate above, which reads the content lengths.
+        let mut data = data;
+        data.clear_body();
         return Ok(Json(ApiResponse {
             success: false,
             data: Some(data),

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -240,11 +240,19 @@ pub async fn scrape(
     // Anti-bot verdict from the choke: a blocked page is `success:false` with an
     // error string, matching v1's behaviour. Read before `to_v2_document`
     // consumes `data`.
+    // Mirror v1: the anti-bot block path is reached only when the http_error
+    // gate did not fire. Drop the challenge shell there so the caller gets a
+    // clean block instead of the interstitial text as content.
+    let is_anti_bot_block = http_error.is_none() && data.block.is_some();
     let (success, error) = match (http_error, data.block.as_ref()) {
         (Some(msg), _) => (false, Some(msg)),
         (None, Some(b)) => (false, Some(b.message())),
         (None, None) => (true, None),
     };
+    let mut data = data;
+    if is_anti_bot_block {
+        data.clear_body();
+    }
     let doc = to_v2_document(data, &tier, Uuid::new_v4().to_string());
     Ok(Json(V2ScrapeResponse {
         success,


### PR DESCRIPTION
## What

Large Cloudflare managed-challenge pages (100-300KB, served with HTTP 200 — e.g.
the multilingual "Just a moment / Humans only" interstitial) evaded every
renderer-layer block detector because of size caps, so the challenge slipped
through as thin content and its interstitial text was returned as `markdown`.
The marker (`/cdn-cgi/challenge-platform/…`) sits deep in the body (byte ~128k of
a 275KB page), past every scan window.

## Changes

- `looks_like_cloudflare_challenge` scans the strong CF markers regardless of
  page size (first 512KB, case-sensitive on raw bytes, mirroring
  `crw_crawl::single::classify_block`); the 80KB guard is kept only for the
  weak-marker heuristic.
- A CF challenge is treated as a hard block in `classify_js_attempt`, the serial
  loop, and the leak-through path, so a genuine block arms the recovery arm and
  is never accepted as content.
- On the anti-bot block response path (after the `http_error` gate that reads
  the content lengths), the content-shell fields are cleared via
  `ScrapeData::clear_body`, so v1/v2 return a clean block (`success:false` +
  error + metadata) instead of the challenge text.

## Tests

- New detector tests for large-page strong-marker detection + the 512KB scan
  bound + a large real page that only mentions Cloudflare (must not flag).
- New `ScrapeData::clear_body` unit test.
- Verified against the real 275KB challenge page.