### PR TITLE
fix(extract): return empty + selector_no_match when a selector matches nothing

### DIFF
--- a/crates/crw-extract/src/clean.rs
+++ b/crates/crw-extract/src/clean.rs
@@ -4,11 +4,49 @@ use std::collections::HashSet;
 
 /// Clean HTML by stripping scripts, styles, and optionally non-content elements.
 /// Then apply include_tags/exclude_tags via scraper.
+///
+/// Soft-failure warnings (e.g. `selector_no_match`) are discarded. Use
+/// [`clean_html_with_warnings`] when the caller wants to surface them.
 pub fn clean_html(
     html: &str,
     only_main_content: bool,
     include_tags: &[String],
     exclude_tags: &[String],
+) -> Result<String, String> {
+    clean_html_impl(
+        html,
+        only_main_content,
+        include_tags,
+        exclude_tags,
+        &mut Vec::new(),
+    )
+}
+
+/// Like [`clean_html`], but collects soft-failure warnings into `warnings`.
+/// Currently the only warning is `selector_no_match`, emitted when one or more
+/// `include_tags` are supplied but none match any element.
+pub fn clean_html_with_warnings(
+    html: &str,
+    only_main_content: bool,
+    include_tags: &[String],
+    exclude_tags: &[String],
+    warnings: &mut Vec<String>,
+) -> Result<String, String> {
+    clean_html_impl(
+        html,
+        only_main_content,
+        include_tags,
+        exclude_tags,
+        warnings,
+    )
+}
+
+fn clean_html_impl(
+    html: &str,
+    only_main_content: bool,
+    include_tags: &[String],
+    exclude_tags: &[String],
+    warnings: &mut Vec<String>,
 ) -> Result<String, String> {
     // Phase 1: lol_html streaming removal of always-unwanted tags.
     let mut handlers = vec![
@@ -222,7 +260,7 @@ pub fn clean_html(
 
     // Phase 2: If include_tags specified, only keep content matching those selectors.
     if !include_tags.is_empty() {
-        result = keep_only_selectors(&result, include_tags);
+        result = keep_only_selectors(&result, include_tags, warnings);
     }
 
     // Phase 3: Apply exclude_tags — parse again and collect text/html without excluded.
@@ -234,7 +272,12 @@ pub fn clean_html(
 }
 
 /// Keep only the HTML of elements matching any of the given CSS selectors.
-fn keep_only_selectors(html: &str, selectors: &[String]) -> String {
+///
+/// When none of the selectors match (or all are invalid), returns an empty
+/// string and pushes `selector_no_match` into `warnings`. Previously this fell
+/// back to the entire `html`, which silently dumped the full page into the
+/// output — a footgun for LLM agents whose context fills up.
+fn keep_only_selectors(html: &str, selectors: &[String], warnings: &mut Vec<String>) -> String {
     let doc = Html::parse_document(html);
     let mut parts = Vec::new();
 
@@ -252,7 +295,8 @@ fn keep_only_selectors(html: &str, selectors: &[String]) -> String {
     }
 
     if parts.is_empty() {
-        return html.to_string();
+        warnings.push("selector_no_match".to_string());
+        return String::new();
     }
 
     parts.join("\n")
@@ -426,5 +470,23 @@ mod tests {
         assert!(result.contains("Article"));
         assert!(!result.contains("Nav"));
         assert!(!result.contains("Foot"));
+    }
+
+    #[test]
+    fn include_tags_no_match_returns_empty_and_warns() {
+        let html =
+            r#"<body><nav>Nav</nav><article><p>Article</p></article><footer>Foot</footer></body>"#;
+        let mut warnings = Vec::new();
+        let result =
+            clean_html_with_warnings(html, false, &[".does-not-exist".into()], &[], &mut warnings)
+                .unwrap();
+        assert!(
+            result.trim().is_empty(),
+            "a non-matching include_tags selector must not fall back to the whole page"
+        );
+        assert!(
+            warnings.iter().any(|w| w == "selector_no_match"),
+            "expected selector_no_match warning, got {warnings:?}"
+        );
     }
 }

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -500,6 +500,11 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     let meta = readability::extract_metadata(raw_html);
 
     // Step 2: Clean HTML (remove boilerplate, nav, ads, etc.).
+    // `include_tags` narrowing happens inside clean_html; when it matches
+    // nothing, clean_html empties the output and pushes `selector_no_match`.
+    // Capture that here (via the warning delta this call produced) so the rest
+    // of the pipeline can treat it exactly like an unmatched css/xpath selector.
+    let warns_before = warnings.len();
     let cleaned = clean::clean_html_with_warnings(
         raw_html,
         only_main_content,
@@ -508,16 +513,28 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         &mut warnings,
     )
     .unwrap_or_else(|_| raw_html.to_string());
+    let include_tags_no_match = warnings[warns_before..]
+        .iter()
+        .any(|w| w == "selector_no_match");
 
     // Step 3: Apply CSS/XPath selector if provided (narrows to a specific element).
     let selected_html = apply_selector(&cleaned, css_selector, xpath)?;
-    // A user-supplied selector that matched nothing must NOT fall back to the
-    // whole page (a silent context-bloat footgun: an unmatched `--css`/
-    // `includeTags` previously returned the entire document). Treat it as an
-    // intentional narrow extraction that yielded empty output and warn.
+    // A user-requested narrowing that matched nothing must NOT fall back to the
+    // whole page (a silent context-bloat footgun: an unmatched `--css`/`--xpath`
+    // or `includeTags` previously returned the entire document). Treat it as an
+    // intentional narrow extraction that yielded empty output. `Some("")` also
+    // short-circuits the alternates ladder below, so the whole page can't sneak
+    // back in via basic_clean / structural fallbacks.
     // Domain-configured default selectors are excluded: a host default that
-    // doesn't apply should still show the page.
-    let selected_html = if user_selected && selected_html.is_none() {
+    // doesn't apply should still show the page (its no-match sets neither flag).
+    let selected_html = if include_tags_no_match {
+        // include_tags matched nothing, so `cleaned` is already empty. This
+        // takes precedence over any css/xpath applied afterwards: an xpath
+        // scalar like `count(//x)` would otherwise evaluate to "0" against the
+        // empty document and leak a bogus value. clean_html already pushed the
+        // `selector_no_match` warning, so don't push it again.
+        Some(String::new())
+    } else if user_selected && selected_html.is_none() {
         warnings.push("selector_no_match".to_string());
         Some(String::new())
     } else {
@@ -658,7 +675,9 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // present in the markdown — otherwise downstream recall scoring loses the
     // most important phrase on the page (the title itself).
     let md = md.map(|m| {
-        if user_selected {
+        // A narrowing that matched nothing is intentionally empty; padding it
+        // with the page title would re-leak content the caller narrowed away.
+        if user_selected || include_tags_no_match {
             return m;
         }
         let title = meta
@@ -716,7 +735,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // is already substantial, the description is short or already present,
     // or it duplicates the page title.
     let md = md.map(|m| {
-        if user_selected {
+        if user_selected || include_tags_no_match {
             return m;
         }
         if m.len() >= 1500 {

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -464,7 +464,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         elapsed_ms,
         render_decision,
         credit_cost,
-        warnings,
+        mut warnings,
         formats,
         only_main_content,
         include_tags,
@@ -500,11 +500,29 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     let meta = readability::extract_metadata(raw_html);
 
     // Step 2: Clean HTML (remove boilerplate, nav, ads, etc.).
-    let cleaned = clean::clean_html(raw_html, only_main_content, include_tags, exclude_tags)
-        .unwrap_or_else(|_| raw_html.to_string());
+    let cleaned = clean::clean_html_with_warnings(
+        raw_html,
+        only_main_content,
+        include_tags,
+        exclude_tags,
+        &mut warnings,
+    )
+    .unwrap_or_else(|_| raw_html.to_string());
 
     // Step 3: Apply CSS/XPath selector if provided (narrows to a specific element).
     let selected_html = apply_selector(&cleaned, css_selector, xpath)?;
+    // A user-supplied selector that matched nothing must NOT fall back to the
+    // whole page (a silent context-bloat footgun: an unmatched `--css`/
+    // `includeTags` previously returned the entire document). Treat it as an
+    // intentional narrow extraction that yielded empty output and warn.
+    // Domain-configured default selectors are excluded: a host default that
+    // doesn't apply should still show the page.
+    let selected_html = if user_selected && selected_html.is_none() {
+        warnings.push("selector_no_match".to_string());
+        Some(String::new())
+    } else {
+        selected_html
+    };
     let after_selection = selected_html.as_deref().unwrap_or(&cleaned);
 
     // Step 4: If only_main_content, try to narrow further with readability scoring.
@@ -555,8 +573,14 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
             }
 
             // Alt 2: basic clean without only_main_content (no readability narrowing).
-            let basic_cleaned = clean::clean_html(raw_html, false, include_tags, exclude_tags)
-                .unwrap_or_else(|_| raw_html.to_string());
+            let basic_cleaned = clean::clean_html_with_warnings(
+                raw_html,
+                false,
+                include_tags,
+                exclude_tags,
+                &mut warnings,
+            )
+            .unwrap_or_else(|_| raw_html.to_string());
             let basic_md = markdown::html_to_markdown(&basic_cleaned);
             let basic_q = quality::analyze_md_only(&basic_md);
             candidates.push(("basic_clean", basic_md, basic_q));

--- a/crates/crw-extract/tests/clean_tests.rs
+++ b/crates/crw-extract/tests/clean_tests.rs
@@ -44,11 +44,16 @@ fn clean_html_unicode_content() {
 
 #[test]
 fn clean_html_invalid_css_selector() {
-    // Invalid selector should warn but not crash
+    // Invalid selector should warn but not crash. It no longer falls back to
+    // the whole page (that was a footgun: an unmatched/invalid include_tags
+    // selector silently returned the entire document). It now yields empty
+    // output; clean_html_with_warnings surfaces a `selector_no_match` warning.
     let html = "<body><p>Content</p></body>";
     let result = clean_html(html, false, &["[[[invalid".into()], &[]).unwrap();
-    // Falls back to original since no valid selector matched
-    assert!(result.contains("Content"));
+    assert!(
+        result.trim().is_empty(),
+        "invalid selector must not fall back to the whole page"
+    );
 }
 
 #[test]

--- a/crates/crw-extract/tests/extract_tests.rs
+++ b/crates/crw-extract/tests/extract_tests.rs
@@ -475,3 +475,129 @@ fn prepends_title_when_only_domain_selector_applies() {
         "domain-default selector must not suppress title prepend: {md:?}"
     );
 }
+
+// Content-rich page (title + meta description + a 2-row table + a 5-item list)
+// so every re-leak vector is live: title-prepend, description-append, AND the
+// `structural` / `basic_clean` alternates (which need >=2 table rows or >=5
+// list items to fire). Used by the selector no-match regression tests below.
+const NO_MATCH_PAGE: &str = "<html><head><title>My Page Title</title>\
+    <meta name=\"description\" content=\"A long meta description that would otherwise be appended to short output and re-leak page context to the caller.\"></head>\
+    <body><nav>Nav</nav><article><h1>Real Heading</h1><p>Real body paragraph.</p>\
+    <table><tr><td>Row1A</td><td>Row1B</td></tr><tr><td>Row2A</td><td>Row2B</td></tr></table>\
+    <ul><li>Item one</li><li>Item two</li><li>Item three</li><li>Item four</li><li>Item five</li></ul>\
+    </article><footer>Foot</footer></body></html>";
+
+fn extract_markdown(
+    include_tags: &[String],
+    css_selector: Option<&str>,
+    xpath: Option<&str>,
+) -> crw_core::types::ScrapeData {
+    crw_extract::extract(ExtractOptions {
+        raw_html: NO_MATCH_PAGE,
+        source_url: "https://example.com",
+        status_code: 200,
+        rendered_with: None,
+        elapsed_ms: 100,
+        render_decision: None,
+        credit_cost: 0,
+        warnings: Vec::new(),
+        formats: &[OutputFormat::Markdown],
+        only_main_content: true,
+        include_tags,
+        exclude_tags: &[],
+        css_selector,
+        xpath,
+        chunk_strategy: None,
+        query: None,
+        filter_mode: None,
+        top_k: None,
+        domain_selectors: None,
+        captured_responses: &[],
+        llm_fallback: None,
+        debug: false,
+        debug_sink: None,
+    })
+    .unwrap()
+}
+
+fn no_match_warning_count(data: &crw_core::types::ScrapeData) -> usize {
+    data.warnings
+        .iter()
+        .filter(|w| *w == "selector_no_match")
+        .count()
+}
+
+// A user-supplied `include_tags` selector that matches nothing must yield empty
+// output through the *full* extract pipeline (not just clean_html), and warn
+// exactly once. Regression guard: title-prepend, description-append, and the
+// alternates ladder (basic_clean / structural) previously re-leaked the page
+// and double-pushed the warning. See issue #291.
+#[test]
+fn include_tags_no_match_extract_returns_empty_single_warning() {
+    let data = extract_markdown(&[".does-not-exist".to_string()], None, None);
+    let md = data.markdown.clone().unwrap_or_default();
+    assert!(
+        md.trim().is_empty(),
+        "unmatched include_tags must not re-leak title/description/tables/lists: {md:?}"
+    );
+    assert_eq!(
+        no_match_warning_count(&data),
+        1,
+        "expected exactly one selector_no_match, got {:?}",
+        data.warnings
+    );
+}
+
+// include_tags no-match takes precedence over a later css/xpath selector applied
+// to the (now-empty) document: an xpath scalar like `count(//x)` must not leak a
+// bogus "0", and the two paths must not stack a second warning.
+#[test]
+fn include_tags_no_match_beats_trailing_xpath_scalar() {
+    let data = extract_markdown(
+        &[".does-not-exist".to_string()],
+        None,
+        Some("count(//article)"),
+    );
+    let md = data.markdown.clone().unwrap_or_default();
+    assert!(
+        md.trim().is_empty(),
+        "include_tags no-match must win over an xpath scalar: {md:?}"
+    );
+    assert_eq!(
+        no_match_warning_count(&data),
+        1,
+        "warnings: {:?}",
+        data.warnings
+    );
+}
+
+// include_tags AND css both matching nothing must still warn exactly once, not
+// once per path.
+#[test]
+fn include_tags_and_css_both_no_match_warn_once() {
+    let data = extract_markdown(&[".does-not-exist".to_string()], Some("#missing"), None);
+    let md = data.markdown.clone().unwrap_or_default();
+    assert!(md.trim().is_empty(), "both no-match must be empty: {md:?}");
+    assert_eq!(
+        no_match_warning_count(&data),
+        1,
+        "warnings: {:?}",
+        data.warnings
+    );
+}
+
+// A css selector that matches nothing (no include_tags) stays empty + one
+// warning — the behavior the base PR established, guarded here against the
+// refactor above.
+#[test]
+fn css_no_match_extract_returns_empty_single_warning() {
+    let data = extract_markdown(&[], Some(".does-not-exist"), None);
+    let md = data.markdown.clone().unwrap_or_default();
+    assert!(md.trim().is_empty(), "unmatched css must be empty: {md:?}");
+    assert_eq!(
+        no_match_warning_count(&data),
+        1,
+        "warnings: {:?}",
+        data.warnings
+    );
+}


### PR DESCRIPTION
## What

Fixes #291.

When a **user-supplied** content selector matches no elements, crw now returns **empty content** and adds `selector_no_match` to `metadata.warnings`, instead of silently returning the entire page.

Applies to all three selector inputs:

- `includeTags` (MCP `crw_scrape` / REST `/v1/scrape`)
- `--css` (CLI)
- `--xpath` (CLI)

## Why

An unmatched selector falling back to the whole page is a footgun for the LLM-agent use case: the output looks normal so it gets trusted, but the full document is dumped into the model's context. I hit this directly when it exhausted an agent's context window mid-session. Repro and root cause in #291.

## Changes

- `crates/crw-extract/src/clean.rs`
  - `keep_only_selectors`: on no match, push `selector_no_match` and return an empty string instead of the whole `html`.
  - Non-breaking split: `clean_html` keeps its 4-arg signature (discards warnings) via `clean_html_impl`; new `clean_html_with_warnings` surfaces the warning.
- `crates/crw-extract/src/lib.rs`
  - `extract()` uses `clean_html_with_warnings` at the two production call sites that carry `include_tags`.
  - CSS/XPath no-match: when `user_selected` and `apply_selector` returns `None`, push `selector_no_match` and use empty content instead of falling back to the whole cleaned page. Domain-configured default selectors are excluded (a host default that doesn't apply still shows the page).

## Behavior change to flag

`include_tags` with an **invalid** selector (parse error) previously fell back to the whole page too; it now yields empty + `selector_no_match`, consistent with the valid-but-no-match case. The existing `clean_html_invalid_css_selector` test was updated to reflect this.

## Testing

`cargo test -p crw-extract` → 173 lib + 17 `clean_tests` + 11 `extract_tests`, all green. Added `include_tags_no_match_returns_empty_and_warns`; updated `clean_html_invalid_css_selector`.

`clean_html`'s public signature is unchanged, so other crates (e.g. `crw-server` security tests that call `clean_html`) compile without modification.
