### PR TITLE
feat(engine): opt-in cloak Turnstile-solver recovery tier (default-off)

### DIFF
--- a/crates/crw-cli/Cargo.toml
+++ b/crates/crw-cli/Cargo.toml
@@ -30,6 +30,7 @@ browse = ["dep:crw-browse", "dep:rmcp", "dep:anyhow"]
 # to crw-renderer/camoufox and, when the embedded server is present, to
 # crw-server/camoufox.
 camoufox = ["crw-renderer/camoufox", "crw-server?/camoufox"]
+cloak = ["crw-renderer/cloak", "crw-server?/cloak"]
 
 [dependencies]
 # Core crates

--- a/crates/crw-core/Cargo.toml
+++ b/crates/crw-core/Cargo.toml
@@ -23,6 +23,7 @@ cdp = []
 # auto ladder and deadline math stay byte-identical to a lean build. The
 # workspace binary enables this transitively via `crw-renderer/camoufox`.
 camoufox = []
+cloak = []
 
 [dependencies]
 crw-mcp-proto = { workspace = true }

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -197,6 +197,23 @@ pub const MAX_WAIT_FOR_MS: u64 = 60_000;
 /// and must never be charged CDP overhead.
 pub const CAMOUFOX_DEFAULT_TIMEOUT_MS: u64 = 60_000;
 
+/// Default cloak (Turnstile-solver sidecar) per-request budget (ms) — the
+/// per-attempt solve budget bounding one sidecar mirror call. A cold interactive
+/// Turnstile solve is ~21s; 35s leaves margin for the browser solve + curl_cffi
+/// replay. Used by [`RendererConfig::cloak_timeout`].
+pub const CLOAK_DEFAULT_TIMEOUT_MS: u64 = 35_000;
+
+/// Minimum remaining request budget for the cloak recovery arm to fire (ms),
+/// DECOUPLED from [`CLOAK_DEFAULT_TIMEOUT_MS`]: one cold solve (~21s) + margin.
+/// Reusing the full per-attempt budget as the floor was a design bug — the
+/// serial ladder does not short-circuit on CF detection and burns ~18s first,
+/// so a 35s floor could never be cleared under any legal deadline. `pub const`
+/// (not `pub(crate)`) so a lean build referencing it only under `#[cfg(cloak)]`
+/// does not trip `dead_code` — mirrors [`CAMOUFOX_DEFAULT_TIMEOUT_MS`].
+/// NOTE: the 24s margin assumes `chrome_challenge_max_retries` stays OFF (prod
+/// default); enabling it grows the ladder tax and this floor must be revisited.
+pub const CLOAK_ARM_FLOOR_MS: u64 = 24_000;
+
 /// Configuration for the `/v1/search` endpoint and its SearXNG backend.
 ///
 /// When `searxng_url` is unset the endpoint returns HTTP 503 with
@@ -539,6 +556,10 @@ pub enum RendererMode {
     /// build feature; a build without it rejects this mode at renderer
     /// construction time.
     Camoufox,
+    /// Opt-in cloak Turnstile-solver tier (REST recovery arm). See
+    /// [`CloakEndpoint`]. Requires the `cloak` build feature; a build without it
+    /// rejects this mode at renderer construction time.
+    Cloak,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -652,6 +673,16 @@ pub struct RendererConfig {
     /// [`CAMOUFOX_DEFAULT_TIMEOUT_MS`] when unset.
     #[serde(default)]
     pub camoufox_timeout_ms: Option<u64>,
+    /// Opt-in cloak Turnstile-solver sidecar endpoint. See [`CloakEndpoint`].
+    /// `None` = not configured (default) → the tier is never constructed and the
+    /// engine is byte-identical to a build without it. Fired only as a
+    /// CF-challenge recovery arm, never in the normal ladder.
+    #[serde(default)]
+    pub cloak: Option<CloakEndpoint>,
+    /// Per-attempt cloak solve budget override (ms). Falls back to
+    /// [`CLOAK_DEFAULT_TIMEOUT_MS`] when unset.
+    #[serde(default)]
+    pub cloak_timeout_ms: Option<u64>,
     /// Enable Chrome resource interception (`Fetch.enable` blocking of media,
     /// fonts, trackers). Default `false`; flipped after the CDP-fake suite
     /// validates pump + cleanup behaviour. See plan Phase 2.
@@ -892,6 +923,8 @@ impl Default for RendererConfig {
             chrome_proxy_timeout_ms: None,
             camoufox: None,
             camoufox_timeout_ms: None,
+            cloak: None,
+            cloak_timeout_ms: None,
             chrome_intercept_resources: false,
             chrome_intercept_stylesheets: false,
             chrome_host_intercept_disable: Vec::new(),
@@ -938,6 +971,34 @@ impl RendererConfig {
     pub fn camoufox_timeout(&self) -> u64 {
         self.camoufox_timeout_ms
             .unwrap_or(CAMOUFOX_DEFAULT_TIMEOUT_MS)
+    }
+    /// Per-attempt cloak solve budget (ms). Unconditional (no `#[cfg]`) so
+    /// `tier_timeouts_from` can reference it in every build, like
+    /// [`Self::camoufox_timeout`].
+    pub fn cloak_timeout(&self) -> u64 {
+        self.cloak_timeout_ms.unwrap_or(CLOAK_DEFAULT_TIMEOUT_MS)
+    }
+
+    /// True when the cloak REST tier participates in the *auto* ladder for the
+    /// current mode. Mirrors [`Self::camoufox_in_ladder`] exactly, including the
+    /// leading `!cfg!(feature = "cloak")` short-circuit (compiled to a constant
+    /// and dead-code-eliminated in a lean build) that keeps the unconditional
+    /// `RendererMode::Cloak` variant inert without the feature. Do NOT remove
+    /// that early return. (The cloak tier is normally a recovery arm, not a
+    /// ladder tier, so this is `true` only when explicitly pinned or opted in.)
+    pub fn cloak_in_ladder(&self) -> bool {
+        if !cfg!(feature = "cloak") || matches!(self.mode, RendererMode::None) {
+            return false;
+        }
+        let configured = |c: &CloakEndpoint| !c.base_url.trim().is_empty();
+        match self.mode {
+            RendererMode::Cloak => self.cloak.as_ref().is_some_and(configured),
+            RendererMode::Auto => self
+                .cloak
+                .as_ref()
+                .is_some_and(|c| c.include_in_auto && configured(c)),
+            _ => false,
+        }
     }
 
     /// True when the Camoufox REST tier participates in the *auto* ladder for
@@ -1061,6 +1122,14 @@ impl RendererConfig {
             sum = sum.saturating_add(self.camoufox_timeout());
         }
 
+        // Cloak REST contribution, symmetric to camoufox. `cloak_in_ladder()` is
+        // always `false` in the lean build, so this line is inert there. (The
+        // cloak tier is normally a recovery arm, not a ladder tier, so this only
+        // contributes when explicitly pinned / opted into the auto ladder.)
+        if self.cloak_in_ladder() {
+            sum = sum.saturating_add(self.cloak_timeout());
+        }
+
         // CDP tiers only contribute when the binary was built with the `cdp`
         // feature; otherwise no JS renderer is constructable at runtime and
         // including their budgets would over-extend the deadline.
@@ -1109,6 +1178,23 @@ pub struct CamoufoxEndpoint {
     /// Whether this tier joins the Auto fallback ladder. Default `false`:
     /// configured-but-not-in-auto, reachable only via an explicit pin or
     /// `mode = "camoufox"`.
+    #[serde(default)]
+    pub include_in_auto: bool,
+}
+
+/// Endpoint for the "cloak" Turnstile-solver sidecar (a `cloudflarebypassforscraping`
+/// / CloakBrowser REST server). Mirrors [`CamoufoxEndpoint`]. Absent config
+/// (`cloak = None`) means the tier is never constructed — see
+/// [`RendererConfig::cloak_in_ladder`]. The cloak tier is a CF-challenge recovery
+/// arm, not an auto-ladder tier, so `include_in_auto` is normally left `false`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct CloakEndpoint {
+    /// Base URL of the cloak sidecar's mirror endpoint, e.g. `http://cloak-sidecar:8000`.
+    pub base_url: String,
+    /// Optional bearer token sent as `Authorization: Bearer <key>`. Empty = no auth.
+    #[serde(default)]
+    pub api_key: String,
+    /// Whether this tier joins the Auto fallback ladder. Default `false`.
     #[serde(default)]
     pub include_in_auto: bool,
 }
@@ -1680,7 +1766,10 @@ impl AppConfig {
         // its 60s budget would be clamped to the strict default and starved.
         // `camoufox_in_ladder()` is always `false` in the lean build, so
         // HTTP-only deployments keep byte-identical behaviour here.
-        if self.renderer.cdp_tier_count() == 0 && !self.renderer.camoufox_in_ladder() {
+        if self.renderer.cdp_tier_count() == 0
+            && !self.renderer.camoufox_in_ladder()
+            && !self.renderer.cloak_in_ladder()
+        {
             return default_ms;
         }
         let ladder_min = self.renderer.min_deadline_for_full_ladder_ms();
@@ -1902,6 +1991,33 @@ mod tests {
             ..Default::default()
         };
         assert!(!c.camoufox_in_ladder());
+    }
+
+    #[test]
+    fn cloak_absent_config_is_none_and_not_in_ladder() {
+        // Default config: no [renderer.cloak] → cloak is None and never in the
+        // ladder (byte-identical to a build without the tier).
+        let c = RendererConfig::default();
+        assert!(c.cloak.is_none());
+        assert!(!c.cloak_in_ladder());
+        assert_eq!(c.cloak_timeout(), CLOAK_DEFAULT_TIMEOUT_MS);
+    }
+
+    #[cfg(not(feature = "cloak"))]
+    #[test]
+    fn cloak_in_ladder_always_false_without_feature() {
+        // Without the feature the tier can never join the ladder, even if a
+        // (deserialized) endpoint is present and mode is pinned to cloak.
+        let c = RendererConfig {
+            mode: RendererMode::Cloak,
+            cloak: Some(CloakEndpoint {
+                base_url: "http://cloak-sidecar:8000".into(),
+                api_key: String::new(),
+                include_in_auto: true,
+            }),
+            ..Default::default()
+        };
+        assert!(!c.cloak_in_ladder());
     }
 
     #[cfg(feature = "camoufox")]

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -128,6 +128,9 @@ pub enum RequestedRenderer {
     /// `"camoufox"`, matching the internal renderer name and
     /// `RendererKind::Camoufox`.
     Camoufox,
+    /// Opt-in cloak Turnstile-solver tier. `rename_all = "lowercase"` yields
+    /// `"cloak"`, matching the internal renderer name and `RendererKind::Cloak`.
+    Cloak,
 }
 
 impl RequestedRenderer {
@@ -141,6 +144,7 @@ impl RequestedRenderer {
             RequestedRenderer::ChromeProxy => Some("chrome_proxy"),
             RequestedRenderer::Playwright => Some("playwright"),
             RequestedRenderer::Camoufox => Some("camoufox"),
+            RequestedRenderer::Cloak => Some("cloak"),
         }
     }
 }
@@ -1667,6 +1671,10 @@ pub enum RendererKind {
     /// the variant is inert in lean builds since no camoufox renderer is ever
     /// constructed there.
     Camoufox,
+    /// Opt-in cloak Turnstile-solver recovery tier (REST). `rename_all =
+    /// "lowercase"` yields `"cloak"`. Unconditional like every other kind; inert
+    /// in lean builds since no cloak renderer is ever constructed there.
+    Cloak,
 }
 
 impl RendererKind {
@@ -1677,6 +1685,7 @@ impl RendererKind {
             RendererKind::Chrome => "chrome",
             RendererKind::ChromeProxy => "chrome_proxy",
             RendererKind::Camoufox => "camoufox",
+            RendererKind::Cloak => "cloak",
         }
     }
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -128,9 +128,9 @@ pub enum RequestedRenderer {
     /// `"camoufox"`, matching the internal renderer name and
     /// `RendererKind::Camoufox`.
     Camoufox,
-    /// Opt-in cloak Turnstile-solver tier. `rename_all = "lowercase"` yields
-    /// `"cloak"`, matching the internal renderer name and `RendererKind::Cloak`.
-    Cloak,
+    // NOTE: there is deliberately NO `Cloak` variant here. The cloak tier is an
+    // internal CF-challenge recovery arm (RendererKind::Cloak), fired
+    // automatically — never a user-pinnable per-request `renderer`.
 }
 
 impl RequestedRenderer {
@@ -144,7 +144,6 @@ impl RequestedRenderer {
             RequestedRenderer::ChromeProxy => Some("chrome_proxy"),
             RequestedRenderer::Playwright => Some("playwright"),
             RequestedRenderer::Camoufox => Some("camoufox"),
-            RequestedRenderer::Cloak => Some("cloak"),
         }
     }
 }

--- a/crates/crw-renderer/Cargo.toml
+++ b/crates/crw-renderer/Cargo.toml
@@ -18,6 +18,9 @@ auto-browser = ["dep:dirs"]
 # lean build is byte-identical. Forwards to `crw-core/camoufox` for the
 # config-level predicate and deadline math.
 camoufox = ["crw-core/camoufox"]
+# Opt-in cloak Turnstile-solver recovery tier (REST). Feature-gated + config-gated;
+# absent from all defaults, so the lean build is byte-identical.
+cloak = ["crw-core/cloak"]
 
 [dependencies]
 crw-core = { workspace = true }

--- a/crates/crw-renderer/src/breaker.rs
+++ b/crates/crw-renderer/src/breaker.rs
@@ -494,7 +494,7 @@ const REGISTRY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 #[derive(Clone)]
 pub struct BreakerRegistry {
     config: BreakerConfig,
-    global: Arc<[(RendererKind, Arc<CircuitBreaker>); 5]>,
+    global: Arc<[(RendererKind, Arc<CircuitBreaker>); 6]>,
     host: Cache<(String, RendererKind), Arc<CircuitBreaker>>,
 }
 
@@ -518,6 +518,9 @@ impl BreakerRegistry {
                 RendererKind::Camoufox,
                 Arc::new(CircuitBreaker::new(config)),
             ),
+            // Unconditional (like every other kind). Harmless dead capacity in
+            // lean builds; a cloak failure trips only the Cloak breaker.
+            (RendererKind::Cloak, Arc::new(CircuitBreaker::new(config))),
         ]);
         let host = Cache::builder()
             .max_capacity(REGISTRY_CAPACITY)
@@ -544,7 +547,9 @@ impl BreakerRegistry {
                 return Arc::clone(breaker);
             }
         }
-        unreachable!("RendererKind is closed: Http | Lightpanda | Chrome | ChromeProxy | Camoufox")
+        unreachable!(
+            "RendererKind is closed: Http | Lightpanda | Chrome | ChromeProxy | Camoufox | Cloak"
+        )
     }
 
     pub async fn host_for(&self, host: &str, renderer: RendererKind) -> Arc<CircuitBreaker> {

--- a/crates/crw-renderer/src/cloak.rs
+++ b/crates/crw-renderer/src/cloak.rs
@@ -1,0 +1,449 @@
+//! Cloak Turnstile-solver recovery tier (opt-in, REST — not CDP).
+//!
+//! Backed by a `cloudflarebypassforscraping` / CloakBrowser REST sidecar. Fired
+//! ONLY as a Cloudflare-managed-challenge recovery arm (see `lib.rs`), never in
+//! the normal ladder. Model B: the sidecar owns the stealth browser (mint), the
+//! `cf_clearance` cache, and the curl_cffi warm replay; this tier just calls its
+//! **mirror endpoint** and gets back the real upstream HTML.
+//!
+//! ## Request (mirror endpoint)
+//! `GET {base}/{path}{?query}` with headers:
+//! - `x-hostname: <host>` (required — the sidecar mirrors to `https://<host>/…`)
+//! - `x-proxy: http://<user>__cr.<cc>;sessid.stick<id>:<pass>@<host:port>`
+//!   (DataImpulse sticky exit; a **stable per-host sessid** for warm reuse, a
+//!   **fresh** one per retry for a new IP)
+//! - `x-bypass-cache: true` on the retry (force a fresh solve)
+//!
+//! The returned body is the real upstream response; a still-challenged body is
+//! re-checked with the shared [`crate::detector::looks_like_cloudflare_challenge`]
+//! accept-gate and surfaced as a retryable [`CrwError::RendererError`].
+
+use async_trait::async_trait;
+use crw_core::Deadline;
+use crw_core::error::{CrwError, CrwResult};
+use crw_core::types::FetchResult;
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::traits::PageFetcher;
+
+/// Budget for the `is_available` health probe.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Fail-fast connect timeout so a down sidecar errors quickly instead of
+/// eating the full per-request budget.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+/// How long a proven-good sticky sessid is remembered per host. Under the
+/// sidecar's `cf_clearance` cache TTL (29 min) so we re-mint before it dies.
+const SESSID_TTL: Duration = Duration::from_secs(29 * 60);
+/// Max solve attempts per fetch (1 sticky + 1 fresh-IP). A second COLD attempt
+/// rarely fits the recovery budget, so this mainly recovers the warm/poison
+/// case; best-result-wins leaves a clean block on exhaustion.
+const MAX_ATTEMPTS: usize = 2;
+
+/// Opt-in cloak recovery renderer. Construct via [`CloakRenderer::new`].
+pub struct CloakRenderer {
+    name: String,
+    /// Trimmed base URL, no trailing slash (e.g. `http://cloak-sidecar:8000`).
+    base_url: String,
+    /// Bearer token; empty string means no `Authorization` header is sent.
+    api_key: String,
+    /// Per-attempt solve budget (`config.cloak_timeout()`).
+    timeout: Duration,
+    /// DataImpulse base credentials `(user, pass)` from config
+    /// (`proxy_base_user`/`proxy_base_pass`). `None` on a self-host without a
+    /// proxy → the sidecar egresses direct.
+    proxy_base: Option<(String, String)>,
+    /// Default country for the `__cr.<cc>` suffix (`config.proxy_default_country`).
+    default_country: Option<String>,
+    client: reqwest::Client,
+    /// host → (proven-good sessid, minted_at). Lets a host that only works on a
+    /// fresh IP promote that sessid to the primary attempt so it warms.
+    sessid_map: Arc<Mutex<HashMap<String, (String, Instant)>>>,
+}
+
+impl CloakRenderer {
+    pub fn new(
+        name: &str,
+        base_url: &str,
+        api_key: &str,
+        timeout_ms: u64,
+        proxy_base: Option<(String, String)>,
+        default_country: Option<String>,
+    ) -> Self {
+        let client = reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .unwrap_or_default();
+        Self {
+            name: name.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            timeout: Duration::from_millis(timeout_ms),
+            proxy_base,
+            default_country,
+            client,
+            sessid_map: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn auth(&self, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if self.api_key.is_empty() {
+            rb
+        } else {
+            rb.bearer_auth(&self.api_key)
+        }
+    }
+
+    fn call_budget(&self, deadline: &Deadline) -> Duration {
+        deadline.remaining().min(self.timeout)
+    }
+
+    /// Stable per-host sessid for the primary attempt (deterministic hash), so a
+    /// repeat request to the same host reuses the same sidecar cache key + exit
+    /// IP → warm replay.
+    fn deterministic_sessid(host: &str) -> String {
+        let mut h = DefaultHasher::new();
+        host.hash(&mut h);
+        format!("crwd{:016x}", h.finish())
+    }
+
+    /// Compose the DataImpulse sticky proxy URL for one attempt, injecting the
+    /// country suffix + `;sessid.stick<id>` into the base credentials, and the
+    /// creds into the proxy `scheme://host:port`. Returns `None` when no proxy
+    /// is configured (self-host → sidecar egresses direct). Mirrors the
+    /// `<user>__cr.<cc>` composition in `cdp.rs`.
+    fn sticky_proxy_url(&self, sessid: &str) -> Option<String> {
+        let (user, pass) = self.proxy_base.as_ref()?;
+        // Host:port comes from the request's REQUEST_PROXY entry (creds-free).
+        let server = crate::REQUEST_PROXY
+            .try_with(|p| p.as_ref().map(|e| e.chrome_proxy_server().to_string()))
+            .ok()
+            .flatten()?;
+        let cc = crate::REQUEST_COUNTRY
+            .try_with(|c| c.clone())
+            .ok()
+            .flatten()
+            .or_else(|| self.default_country.clone())
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| s.len() == 2 && s.chars().all(|c| c.is_ascii_alphabetic()));
+        let username = match cc {
+            Some(cc) => format!("{user}__cr.{cc};sessid.stick{sessid}"),
+            None => format!("{user};sessid.stick{sessid}"),
+        };
+        // server is "scheme://host:port" (no creds); inject "user:pass@".
+        Some(server.replacen("://", &format!("://{username}:{pass}@"), 1))
+    }
+
+    /// One mirror call. `bypass_cache` forces a fresh sidecar solve.
+    async fn mirror_once(
+        &self,
+        host: &str,
+        path_and_query: &str,
+        sessid: &str,
+        bypass_cache: bool,
+        deadline: &Deadline,
+    ) -> CrwResult<(u16, String)> {
+        let budget = self.call_budget(deadline);
+        if budget.is_zero() {
+            return Err(CrwError::Timeout(
+                deadline.overrun().as_millis().max(1) as u64
+            ));
+        }
+        let url = format!("{}{}", self.base_url, path_and_query);
+        let mut rb = self.auth(self.client.get(&url)).header("x-hostname", host);
+        if let Some(px) = self.sticky_proxy_url(sessid) {
+            rb = rb.header("x-proxy", px);
+        }
+        if bypass_cache {
+            rb = rb.header("x-bypass-cache", "true");
+        }
+        let resp = tokio::time::timeout(budget, rb.send())
+            .await
+            .map_err(|_| CrwError::Timeout(budget.as_millis() as u64))?
+            .map_err(|e| CrwError::RendererError(format!("cloak GET {path_and_query}: {e}")))?;
+        let status = resp.status().as_u16();
+        let body = resp.text().await.map_err(|e| {
+            CrwError::RendererError(format!("cloak GET {path_and_query} body: {e}"))
+        })?;
+        Ok((status, body))
+    }
+}
+
+#[async_trait]
+impl PageFetcher for CloakRenderer {
+    async fn fetch(
+        &self,
+        url: &str,
+        _headers: &HashMap<String, String>,
+        _wait_for_ms: Option<u64>,
+        deadline: Deadline,
+    ) -> CrwResult<FetchResult> {
+        if deadline.expired() {
+            return Err(CrwError::Timeout(
+                deadline.overrun().as_millis().max(1) as u64
+            ));
+        }
+        let start = Instant::now();
+        let parsed = url::Url::parse(url)
+            .map_err(|e| CrwError::RendererError(format!("cloak: bad url {url}: {e}")))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| CrwError::RendererError(format!("cloak: url has no host: {url}")))?
+            .to_string();
+        let path_and_query = match parsed.query() {
+            Some(q) => format!("{}?{}", parsed.path(), q),
+            None => parsed.path().to_string(),
+        };
+
+        // Primary sessid: a proven-good one for this host if we have it (and it
+        // hasn't aged out), else the deterministic per-host sessid.
+        let primary_sessid = {
+            let mut map = self.sessid_map.lock().expect("cloak sessid map poisoned");
+            match map.get(&host) {
+                Some((s, at)) if at.elapsed() < SESSID_TTL => s.clone(),
+                _ => {
+                    map.remove(&host);
+                    Self::deterministic_sessid(&host)
+                }
+            }
+        };
+
+        let mut last_err: Option<CrwError> = None;
+        for attempt in 0..MAX_ATTEMPTS {
+            if deadline.remaining() < crate::MIN_TIER_BUDGET {
+                break;
+            }
+            let (sessid, bypass) = if attempt == 0 {
+                (primary_sessid.clone(), false)
+            } else {
+                // Fresh random sessid = new exit IP + new sidecar cache key,
+                // with x-bypass-cache to force a fresh solve.
+                let n: u64 = rand::random();
+                (format!("crwr{n:016x}"), true)
+            };
+            match self
+                .mirror_once(&host, &path_and_query, &sessid, bypass, &deadline)
+                .await
+            {
+                // Accept any body that is NOT itself a CF challenge — the ONLY
+                // reject criterion (matches the module contract). Do NOT gate on
+                // 2xx: after the sidecar clears the challenge, the real upstream
+                // may legitimately return 403/451 (paywall/geo) with usable
+                // content, which the caller's own `r_ok` (content-quality, not
+                // status) accepts. The status is preserved in `status_code`.
+                Ok((status, body)) if !crate::detector::looks_like_cloudflare_challenge(&body) => {
+                    // Success: remember the winning sessid so future requests to
+                    // this host reuse the working exit IP (warm the cache).
+                    {
+                        let mut map = self.sessid_map.lock().expect("cloak sessid map poisoned");
+                        map.retain(|_, (_, at)| at.elapsed() < SESSID_TTL);
+                        map.insert(host.clone(), (sessid, Instant::now()));
+                    }
+                    return Ok(FetchResult {
+                        url: url.to_string(),
+                        final_url: None,
+                        status_code: status,
+                        html: body,
+                        content_type: None,
+                        raw_bytes: None,
+                        rendered_with: Some(self.name.clone()),
+                        elapsed_ms: start.elapsed().as_millis() as u64,
+                        warning: None,
+                        render_decision: None,
+                        credit_cost: 0,
+                        warnings: Vec::new(),
+                        truncated: false,
+                        deadline_exceeded: deadline.remaining().is_zero(),
+                        captured_responses: Vec::new(),
+                        screenshot: None,
+                    });
+                }
+                Ok((status, _)) => {
+                    last_err = Some(CrwError::RendererError(format!(
+                        "cloak: still challenged (HTTP {status}) for {host}"
+                    )));
+                }
+                Err(e) => last_err = Some(e),
+            }
+        }
+        // Fallback: if the loop broke before any attempt (deadline pressure),
+        // surface a Timeout so the breaker classifies it as deadline-clamped
+        // rather than a render failure — mirrors the ladder's budget-drained idiom.
+        Err(last_err
+            .unwrap_or_else(|| CrwError::Timeout(deadline.overrun().as_millis().max(1) as u64)))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn supports_js(&self) -> bool {
+        true
+    }
+
+    /// Health probe against `GET {base}/cache/stats` (the sidecar has no
+    /// `/health` route — its catch-all mirror would 400 without `x-hostname`).
+    async fn is_available(&self) -> bool {
+        let url = format!("{}/cache/stats", self.base_url);
+        let fut = self.auth(self.client.get(&url)).send();
+        matches!(
+            tokio::time::timeout(PROBE_TIMEOUT, fut).await,
+            Ok(Ok(r)) if r.status().is_success()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // A body carrying a Cloudflare strong marker → looks_like_cloudflare_challenge==true.
+    const CHALLENGE_BODY: &str = "<html><head><title>Just a moment...</title></head><body>\
+        <script src=\"/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1\"></script></body></html>";
+    const REAL_BODY: &str = "<html><body><h1>Northwestern Mutual Reviews</h1>\
+        <p>real review content that is definitely not a challenge page</p></body></html>";
+
+    fn renderer(base_url: &str) -> CloakRenderer {
+        // No proxy_base → no x-proxy header (sidecar egresses direct in tests).
+        CloakRenderer::new("cloak", base_url, "", 30_000, None, None)
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_upstream_html() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/page"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(REAL_BODY))
+            .mount(&server)
+            .await;
+        let r = renderer(&server.uri())
+            .fetch(
+                &format!("{}/page", server.uri()),
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(30_000),
+            )
+            .await
+            .expect("cloak fetch should succeed");
+        assert_eq!(r.status_code, 200);
+        assert!(r.html.contains("Northwestern Mutual"));
+        assert_eq!(r.rendered_with.as_deref(), Some("cloak"));
+    }
+
+    #[tokio::test]
+    async fn persistent_challenge_body_is_retryable_error() {
+        let server = MockServer::start().await;
+        // Every attempt gets a 200 challenge shell → the accept-gate rejects it.
+        Mock::given(method("GET"))
+            .and(path("/page"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(CHALLENGE_BODY))
+            .expect(2) // both attempts fire
+            .mount(&server)
+            .await;
+        let err = renderer(&server.uri())
+            .fetch(
+                &format!("{}/page", server.uri()),
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(30_000),
+            )
+            .await
+            .expect_err("a persistent challenge must surface as an error, never fake success");
+        assert!(matches!(err, CrwError::RendererError(_)));
+    }
+
+    #[tokio::test]
+    async fn recovers_on_fresh_sessid_retry_with_bypass_cache() {
+        let server = MockServer::start().await;
+        // Attempt 1 carries x-bypass-cache → real body (higher priority wins).
+        Mock::given(method("GET"))
+            .and(path("/page"))
+            .and(header("x-bypass-cache", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(REAL_BODY))
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        // Attempt 0 (no bypass header) → challenge.
+        Mock::given(method("GET"))
+            .and(path("/page"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(CHALLENGE_BODY))
+            .with_priority(5)
+            .mount(&server)
+            .await;
+        let r = renderer(&server.uri())
+            .fetch(
+                &format!("{}/page", server.uri()),
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(30_000),
+            )
+            .await
+            .expect("second attempt (fresh sessid + bypass) should recover");
+        assert!(r.html.contains("real review content"));
+    }
+
+    #[tokio::test]
+    async fn non_2xx_real_content_is_accepted_not_rejected() {
+        // After the sidecar clears CF, a legit upstream 403 (paywall/geo) with
+        // usable content must be RETURNED (status preserved), not discarded — the
+        // caller's r_ok judges content, not status.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/page"))
+            .respond_with(ResponseTemplate::new(403).set_body_string(REAL_BODY))
+            .expect(1) // accepted on attempt 0, no retry
+            .mount(&server)
+            .await;
+        let r = renderer(&server.uri())
+            .fetch(
+                &format!("{}/page", server.uri()),
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(30_000),
+            )
+            .await
+            .expect("non-2xx real content must be accepted");
+        assert_eq!(r.status_code, 403);
+        assert!(r.html.contains("real review content"));
+    }
+
+    #[tokio::test]
+    async fn expired_deadline_short_circuits_without_http() {
+        // No mock mounted: if it made an HTTP call it would error differently.
+        let r = renderer("http://127.0.0.1:1") // unroutable
+            .fetch(
+                "http://example.com/page",
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(0),
+            )
+            .await;
+        assert!(matches!(r, Err(CrwError::Timeout(_))));
+    }
+
+    #[tokio::test]
+    async fn is_available_probes_cache_stats() {
+        let up = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/cache/stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "cached_entries": 0
+            })))
+            .mount(&up)
+            .await;
+        assert!(renderer(&up.uri()).is_available().await);
+
+        let down = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/cache/stats"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&down)
+            .await;
+        assert!(!renderer(&down.uri()).is_available().await);
+    }
+}

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -45,6 +45,8 @@ pub mod camoufox;
 pub mod cdp;
 #[cfg(feature = "cdp")]
 pub mod cdp_conn;
+#[cfg(feature = "cloak")]
+pub mod cloak;
 pub mod detector;
 #[cfg(feature = "cdp")]
 pub mod health_telemetry;
@@ -162,6 +164,7 @@ fn renderer_kind_for(name: &str) -> Option<RendererKind> {
         "chrome" => Some(RendererKind::Chrome),
         "chrome_proxy" => Some(RendererKind::ChromeProxy),
         "camoufox" => Some(RendererKind::Camoufox),
+        "cloak" => Some(RendererKind::Cloak),
         _ => None,
     }
 }
@@ -216,6 +219,13 @@ fn tier_timeouts_from(
     m.insert(
         RendererKind::Camoufox,
         std::time::Duration::from_millis(config.camoufox_timeout()),
+    );
+    // Unconditional, same rationale as camoufox: `cloak_timeout()` exists in
+    // every build; the entry is consulted only when a cloak renderer is in the
+    // pool, so it is harmless dead capacity in lean.
+    m.insert(
+        RendererKind::Cloak,
+        std::time::Duration::from_millis(config.cloak_timeout()),
     );
     m
 }
@@ -334,6 +344,14 @@ fn is_origin_navigation_failure(e: &CrwError) -> bool {
 /// and the HTTP tier's proxy retry (`http_only`).
 pub(crate) const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
 
+/// Concurrency permits for the cloak recovery arm — sized to the sidecar's
+/// cold-solve browser cap (`CF_MAX_CONCURRENT_BROWSERS`, default 4) so the
+/// engine sheds excess with a fast clean block instead of queuing headed
+/// Turnstile solves that hold the request budget. `pub const` so it never trips
+/// `dead_code` in a lean build (referenced only under `#[cfg(feature="cloak")]`).
+#[cfg(feature = "cloak")]
+pub const CLOAK_SEM_PERMITS: usize = 4;
+
 /// Composite renderer that tries multiple backends in order.
 pub struct FallbackRenderer {
     http: Arc<dyn PageFetcher>,
@@ -399,6 +417,16 @@ pub struct FallbackRenderer {
     /// only by an explicit `renderer = "camoufox"` pin, never the auto chain.
     #[cfg(feature = "camoufox")]
     camoufox_in_auto: bool,
+    /// Cloak Turnstile-solver recovery arm, held OUT of the normal ladder and
+    /// fired only on a detected CF challenge. `None` when unconfigured. Gated so
+    /// a lean build has no such field (byte-identical).
+    #[cfg(feature = "cloak")]
+    cloak_arm: Option<Arc<dyn PageFetcher>>,
+    /// Concurrency shed for the cloak arm — sized to the sidecar's cold-solve
+    /// browser cap so the engine returns a fast clean block instead of queuing
+    /// headed-Chromium solves. Acquired non-blocking (`try_acquire_owned`).
+    #[cfg(feature = "cloak")]
+    cloak_sem: Arc<tokio::sync::Semaphore>,
 }
 
 impl std::fmt::Debug for FallbackRenderer {
@@ -468,6 +496,16 @@ impl FallbackRenderer {
             ));
         }
 
+        #[cfg(not(feature = "cloak"))]
+        if matches!(config.mode, RendererMode::Cloak) {
+            return Err(CrwError::ConfigError(
+                "renderer.mode = \"cloak\" requires the 'cloak' feature, but this build \
+                 was compiled without it. Rebuild with --features cloak or set mode = \
+                 \"auto\"/\"none\"."
+                    .into(),
+            ));
+        }
+
         #[allow(unused_mut)]
         let mut js_renderers: Vec<Arc<dyn PageFetcher>> = Vec::new();
 
@@ -504,6 +542,11 @@ impl FallbackRenderer {
                 // the (empty) ladder.
                 #[cfg(feature = "camoufox")]
                 camoufox_in_auto: false,
+                // mode=none never recovers — no cloak arm.
+                #[cfg(feature = "cloak")]
+                cloak_arm: None,
+                #[cfg(feature = "cloak")]
+                cloak_sem: Arc::new(tokio::sync::Semaphore::new(CLOAK_SEM_PERMITS)),
             });
         }
 
@@ -731,6 +774,44 @@ impl FallbackRenderer {
             }
         }
 
+        // Cloak Turnstile-solver recovery tier — held OUT of `js_renderers` (it
+        // is a CF-challenge recovery arm, not a ladder tier). Constructed with
+        // the DataImpulse base creds + default country threaded from config, so
+        // it can mint per-request sticky-sessid proxy URLs itself.
+        #[cfg(feature = "cloak")]
+        let cloak_arm: Option<Arc<dyn PageFetcher>> = {
+            if let Some(ck) = config
+                .cloak
+                .as_ref()
+                .filter(|c| !c.base_url.trim().is_empty())
+            {
+                let proxy_base = config
+                    .proxy_base_user
+                    .clone()
+                    .zip(config.proxy_base_pass.clone());
+                tracing::info!(
+                    base_url = %ck.base_url,
+                    proxy_auth = proxy_base.is_some(),
+                    "cloak recovery tier enabled"
+                );
+                Some(Arc::new(cloak::CloakRenderer::new(
+                    "cloak",
+                    &ck.base_url,
+                    &ck.api_key,
+                    config.cloak_timeout(),
+                    proxy_base,
+                    config.proxy_default_country.clone(),
+                )) as Arc<dyn PageFetcher>)
+            } else if matches!(config.mode, RendererMode::Cloak) {
+                return Err(CrwError::ConfigError(
+                    "renderer.mode = \"cloak\" but [renderer.cloak] base_url is not configured"
+                        .into(),
+                ));
+            } else {
+                None
+            }
+        };
+
         // Spawn the process-wide CDP telemetry sampler. Idempotent —
         // OnceLock guarantees a single task across all FallbackRenderer
         // instances. No-op on the `mode = none` early-return path above.
@@ -771,6 +852,10 @@ impl FallbackRenderer {
             // configured-but-not-opted-in endpoint stays out of the auto chain.
             #[cfg(feature = "camoufox")]
             camoufox_in_auto: config.camoufox_in_ladder(),
+            #[cfg(feature = "cloak")]
+            cloak_arm,
+            #[cfg(feature = "cloak")]
+            cloak_sem: Arc::new(tokio::sync::Semaphore::new(CLOAK_SEM_PERMITS)),
         })
     }
 
@@ -2316,6 +2401,30 @@ impl FallbackRenderer {
         // causes a timeout the baseline wouldn't have — the failure mode the
         // naive always-on ladder tier showed: success −2pp, p90 +69%).
         // best-result-wins: never replace usable content with an empty retry.
+        //
+        // CF-challenge routing: a managed Turnstile challenge cannot be cleared
+        // by chrome_proxy (default Chrome fingerprint), so route it STRAIGHT to
+        // the cloak recovery arm and suppress chrome_proxy for it. Re-detect the
+        // signal once from `thin_result` (the richest-HTML thin body; a CF
+        // challenge is 100-300KB so it wins the size race) — this covers both
+        // the serial and hedge paths without threading a new bool. `route_to_cloak`
+        // is a cfg-const that folds to `false` in a lean build → chrome_proxy
+        // firing is byte-identical there.
+        #[cfg(feature = "cloak")]
+        let saw_cf_challenge = thin_result
+            .as_ref()
+            .map(|r| detector::looks_like_cloudflare_challenge(&r.html))
+            .unwrap_or(false);
+        let route_to_cloak = {
+            #[cfg(feature = "cloak")]
+            {
+                saw_cf_challenge && self.cloak_arm.is_some()
+            }
+            #[cfg(not(feature = "cloak"))]
+            {
+                false
+            }
+        };
         if let Some(arm) = auto_egress_arm {
             let kind = RendererKind::ChromeProxy;
             let tier_budget = self
@@ -2327,7 +2436,7 @@ impl FallbackRenderer {
             // to chrome_timeout + 15s), but an operator can configure it lower. Take the
             // stricter of the two so no JS dispatch path can run on a degenerate budget.
             let arm_floor = tier_budget.max(MIN_TIER_BUDGET);
-            if saw_hard_block && deadline.remaining() >= arm_floor {
+            if saw_hard_block && !route_to_cloak && deadline.remaining() >= arm_floor {
                 chain.push(kind);
                 let entry = self.pick_proxy_for_url(url);
                 let attempt = REQUEST_PROXY
@@ -2381,6 +2490,78 @@ impl FallbackRenderer {
                                 target: "latency_breakdown",
                                 url, tier = "chrome_proxy", error = %e,
                                 "auto_egress fired (error)"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // Cloak Turnstile recovery arm — fired ONLY on a detected CF challenge,
+        // with a DECOUPLED floor (`CLOAK_ARM_FLOOR_MS`, one cold solve) so it can
+        // arm even though the per-attempt budget is larger. Load-shed via
+        // `cloak_sem` (non-blocking); pre-fire read-only breaker check; and
+        // best-result-wins IDENTICAL to the chrome_proxy arm above so an Err/thin
+        // cloak result never turns the baseline CF-block into Ok(empty).
+        #[cfg(feature = "cloak")]
+        if route_to_cloak && let Some(arm) = &self.cloak_arm {
+            let kind = RendererKind::Cloak;
+            let floor = std::time::Duration::from_millis(crw_core::config::CLOAK_ARM_FLOOR_MS);
+            let permit = if deadline.remaining() >= floor
+                && !self.breakers.host_for(&host, kind).await.is_open()
+            {
+                self.cloak_sem.clone().try_acquire_owned().ok()
+            } else {
+                None
+            };
+            if let Some(_permit) = permit {
+                chain.push(kind);
+                let entry = self.pick_proxy_for_url(url);
+                let attempt = REQUEST_PROXY
+                    .scope(entry, arm.fetch(url, headers, wait_for_ms, deadline))
+                    .await;
+                match attempt {
+                    Ok(r) => {
+                        let r_ok = html_body_text_len(&r.html) >= Self::MIN_RENDERED_TEXT_LEN
+                            && detector::looks_like_failed_render(&r.html).is_none()
+                            && !detector::looks_like_loading_placeholder(&r.html)
+                            && !detector::looks_like_cloudflare_challenge(&r.html);
+                        if !host.is_empty() {
+                            let outcome = if r_ok {
+                                BreakerOutcome::Success
+                            } else {
+                                BreakerOutcome::RenderError
+                            };
+                            self.breakers.record_outcome(&host, kind, outcome).await;
+                        }
+                        let better = r_ok
+                            && match &thin_result {
+                                Some(prev) => r.html.len() > prev.html.len(),
+                                None => true,
+                            };
+                        if self.latency_breakdown {
+                            tracing::info!(
+                                target: "latency_breakdown",
+                                url, tier = "cloak",
+                                ok = r_ok, consumed = better,
+                                "cloak recovery fired"
+                            );
+                        }
+                        if better {
+                            thin_result = Some(r);
+                        }
+                    }
+                    Err(e) => {
+                        if !host.is_empty() {
+                            self.breakers
+                                .record_outcome(&host, kind, BreakerOutcome::ConnectionError)
+                                .await;
+                        }
+                        if self.latency_breakdown {
+                            tracing::info!(
+                                target: "latency_breakdown",
+                                url, tier = "cloak", error = %e,
+                                "cloak recovery fired (error)"
                             );
                         }
                     }

--- a/crates/crw-server/Cargo.toml
+++ b/crates/crw-server/Cargo.toml
@@ -15,6 +15,7 @@ cdp = ["crw-renderer/cdp"]
 # Opt-in Camoufox stealth renderer tier (REST). Default OFF — the lean build is
 # byte-identical. Forwards to crw-renderer/camoufox (→ crw-core/camoufox).
 camoufox = ["crw-renderer/camoufox"]
+cloak = ["crw-renderer/cloak"]
 test-utils = []
 
 [dependencies]


### PR DESCRIPTION
## What

A feature-gated, config-gated recovery tier that clears Cloudflare **managed
Turnstile** challenges (Glassdoor-class sites) which the HTTP/LightPanda/Chrome/
chrome_proxy ladder cannot solve. Fired ONLY on a detected CF challenge, routed
straight to cloak (chrome_proxy, being default-fingerprint Chrome, cannot clear
Turnstile). Empirically verified: a stealth-browser sidecar + our residential
proxy returns real Glassdoor content where every off-the-shelf stealth tool froze.

## Design (Model B)

The sidecar owns the stealth browser (mint), the `cf_clearance` cache, and the
curl_cffi warm replay. The engine's `CloakRenderer` just calls the sidecar's
mirror endpoint (`x-hostname` + `x-proxy`) with a DataImpulse **sticky-sessid**
proxy: a stable per-host sessid for warm reuse (~1-2s), a fresh one per retry for
a new exit IP. cf_clearance is IP+UA+TLS-bound, so keeping mint+replay in one
process (the sidecar) is strictly more robust than an engine-side replay.

- decoupled `CLOAK_ARM_FLOOR_MS` (arm-firing floor) from the per-attempt solve budget
- pre-fire circuit breaker + non-blocking concurrency shed (`cloak_sem`) + bounded 2-attempt retry
- own `RendererKind::Cloak` so a cloak failure never trips other tiers
- shared `looks_like_cloudflare_challenge` accept-gate (a still-challenged body is retryable)

## Zero-impact guarantee

Off by default at **every** layer, mirroring the `camoufox` tier:
- Cargo `cloak` feature **absent from every `default`** set
- `[renderer.cloak]` is `Option<CloakEndpoint> = None` when unconfigured
- `cloak_in_ladder()`'s `!cfg!(feature="cloak")` first line folds to constant `false` in lean
- `route_to_cloak` cfg-const folds to `false` in lean → chrome_proxy firing byte-identical

A build/config without cloak is byte-identical to today. Verified: lean
`cargo clippy --workspace --all-targets -- -D warnings` + full lean test suite pass.

## Tests

- New `cloak.rs` unit tests (happy path, persistent-challenge → retryable error,
  fresh-sessid+bypass-cache recovery, non-2xx real content accepted, expired
  deadline → Timeout, `/cache/stats` health).
- New config gating tests (absent config → None + not-in-ladder; `mode=cloak`
  without the feature → clean ConfigError).

## Follow-ups (not in this PR)

- SaaS paid-plan gate + recovery-budget grant (separate crw-saas PR, env-flag default-off).
- Sidecar deployment (`cloak-sidecar` compose service) + live end-to-end enable.