### PR TITLE
fix: multibyte byte-index panics on the extract and browse paths

### DIFF
--- a/crates/crw-browse/src/tools/goto.rs
+++ b/crates/crw-browse/src/tools/goto.rs
@@ -28,20 +28,28 @@ pub struct GotoData {
     pub status: u16,
 }
 
+/// What precedes the first ':' in a rejected url, bounded to 32 bytes, for
+/// logging. The url is attacker-controlled via an LLM and could carry auth
+/// tokens, injection payloads or multi-megabyte garbage, so the query and path
+/// never reach the log; for anything url-shaped this is just the scheme. The
+/// bound keeps a percent-encoded or malformed prefix (`http%3A//`, or a 65KB
+/// non-url with no ':' at all) from ballooning the log line. Note an input with
+/// no ':' has no scheme to isolate, so it is logged as-is up to the bound.
+///
+/// The bound lands on a char boundary: the url is arbitrary text, so byte 32 can
+/// fall inside a multibyte char, and slicing there would turn a rejected url
+/// into a panic on the way to logging it.
+fn scheme_for_log(url: &str) -> &str {
+    let raw_prefix = url.split(':').next().unwrap_or("unknown");
+    &raw_prefix[..raw_prefix.floor_char_boundary(32)]
+}
+
 pub async fn handle(server: &CrwBrowse, input: GotoInput) -> Result<CallToolResult, McpError> {
     let started = Instant::now();
 
     if let Err(msg) = validate_goto_url(&input.url) {
-        // Log the scheme only, never the full URL: the URL is attacker-
-        // controlled via an LLM and could contain auth tokens, injection
-        // payloads, or multi-megabyte garbage. Even the pre-parse scheme
-        // slice is bounded to 32 bytes so a percent-encoded or malformed
-        // prefix (e.g. `http%3A//` or a 65KB non-URL with no ':' at all)
-        // can't balloon the log line.
-        let raw_prefix = input.url.split(':').next().unwrap_or("unknown");
-        let scheme_for_log = &raw_prefix[..raw_prefix.len().min(32)];
         tracing::warn!(
-            scheme = scheme_for_log,
+            scheme = scheme_for_log(&input.url),
             "goto rejected — disallowed scheme or malformed url"
         );
         return Ok(err_result(&ErrorResponse::new(ErrorCode::InvalidArgs, msg)));
@@ -385,5 +393,47 @@ mod tests {
                 "error message must not echo the bad URL: {msg}"
             );
         }
+    }
+
+    /// The rejection path logs a bounded prefix of the url. The url is arbitrary
+    /// LLM-supplied text, so that bound must not split a multibyte char — and the
+    /// "no ':' at all" case the bound exists for is exactly where it lands
+    /// mid-char.
+    ///
+    /// The char has to be placed deliberately: a repeated char only straddles
+    /// byte 32 when its width does not divide 32, so `"é".repeat(n)` (2 bytes)
+    /// and `"😀".repeat(n)` (4) land on a boundary and would pass unpatched. Pad
+    /// with ASCII instead so each width crosses the bound at every interior
+    /// offset, and assert the straddle so a fixture cannot go quietly vacuous.
+    #[test]
+    fn rejected_multibyte_url_prefix_is_bounded_on_a_char_boundary() {
+        for (c, offset) in [
+            ('é', 1),
+            ('ハ', 1),
+            ('ハ', 2),
+            ('😀', 1),
+            ('😀', 2),
+            ('😀', 3),
+        ] {
+            // No ':' anywhere, so the whole url is the prefix to be bounded.
+            let mut url = "a".repeat(32 - offset);
+            url.push(c);
+            url.push_str("tail");
+            assert!(
+                !url.is_char_boundary(32),
+                "{c:?}/{offset}: byte 32 must be mid-char"
+            );
+            assert!(validate_goto_url(&url).is_err(), "{url} must be rejected");
+
+            let logged = scheme_for_log(&url);
+            assert!(logged.len() <= 32, "{c:?}/{offset}: bound must hold");
+            assert!(url.starts_with(logged), "{c:?}/{offset}: must be a prefix");
+        }
+    }
+
+    #[test]
+    fn scheme_for_log_keeps_the_scheme_of_an_ordinary_url() {
+        assert_eq!(scheme_for_log("https://example.com/a"), "https");
+        assert_eq!(scheme_for_log("no-colon-at-all"), "no-colon-at-all");
     }
 }

--- a/crates/crw-extract/src/basis.rs
+++ b/crates/crw-extract/src/basis.rs
@@ -340,7 +340,12 @@ fn contains_word(hay: &str, needle: &str, dot_joins: bool) -> bool {
         if boundary(start.checked_sub(1).map(|i| &hb[i])) && boundary(hb.get(end)) {
             return true;
         }
-        from = start + 1;
+        // Retry past this match, advancing one CHAR: `start + 1` lands inside the
+        // match's first char whenever it is multibyte, and the next iteration
+        // slices `hay[from..]` there, which panics. Both sides are page text, so
+        // a value like "日本語" embedded in a larger token ("x日本語y") reaches
+        // this on an ordinary extract.
+        from = start + hay[start..].chars().next().map_or(1, char::len_utf8);
         if from >= hay.len() {
             break;
         }
@@ -1165,5 +1170,63 @@ mod tests {
         let p = prompt_section(URL);
         assert!(p.contains(URL), "the model cannot echo a url it never saw");
         assert!(p.contains("basis"));
+    }
+
+    /// A value embedded in a larger token fails the word-boundary check, so the
+    /// scan retries past the match — and every retry must land on a char
+    /// boundary. Both the excerpt and the value are page text, so a multibyte
+    /// first char here is ordinary (CJK, accented Latin, emoji), not an edge
+    /// case. The whole ladder is exercised: no match, an embedded-only match,
+    /// and an embedded match followed by a real standalone one.
+    ///
+    /// Every value must still START with a multibyte char after
+    /// `collapse_ws_lower`, or it never reaches the hazard: Turkish 'İ'
+    /// lowercases to ASCII 'i' plus a combining dot, so an "İstanbul" row would
+    /// pass whether or not the retry is char-aware. 2-, 3- and 4-byte first
+    /// chars are all covered.
+    #[test]
+    fn a_multibyte_value_embedded_in_a_token_does_not_panic_the_scan() {
+        for (value, embedded, standalone) in [
+            ("日本語", "x日本語y", "日本語 の"),
+            ("Ölçek", "xÖlçekli", "Ölçek değeri"),
+            ("😀", "x😀y", "😀 tag"),
+        ] {
+            let needle = collapse_ws_lower(value);
+            // Embedded only: the retry path runs to exhaustion and finds nothing.
+            assert!(
+                !contains_word(&collapse_ws_lower(embedded), &needle, false),
+                "{value} is only embedded in {embedded}, so it is not carried"
+            );
+            // Embedded first, then standalone: the retry must survive the first
+            // match and still reach the second.
+            let both = collapse_ws_lower(&format!("{embedded} {standalone}"));
+            assert!(
+                contains_word(&both, &needle, false),
+                "{value} stands alone later in {both} and must be found"
+            );
+        }
+    }
+
+    /// The same retry path, reached through the real grounding entry point.
+    ///
+    /// The value must still start with a multibyte char *after* `collapse_ws_lower`
+    /// to reach the hazard: Turkish 'İ' lowercases to ASCII 'i' plus a combining
+    /// dot, so an "İstanbul" fixture here would pass whether or not the retry is
+    /// char-aware. '日' lowercases to itself.
+    #[test]
+    fn value_carried_survives_a_multibyte_value_embedded_in_the_excerpt() {
+        // The value is short, so the whole-source fallback never applies and the
+        // verdict rests purely on the excerpt scan.
+        let source = "a document that happens to mention 日本語 somewhere";
+        assert!(!value_carried(
+            &json!("日本語"),
+            "x日本語y is not the language",
+            source
+        ));
+        assert!(value_carried(
+            &json!("日本語"),
+            "x日本語y, then 日本語 itself",
+            source
+        ));
     }
 }


### PR DESCRIPTION
Two live panics of the same class the multibyte scan-cap fix (#297) surfaced: a raw byte index into a `&str` holding page or LLM text, which panics when it lands inside a multibyte char. Both were reproduced against unpatched code first, then confirmed closed.

Neither is an edge case. The text on both sides is page content, so non-ASCII is ordinary input.

### `fix(extract)` — `crw-extract/src/basis.rs`

`contains_word` retries past a match that failed the word-boundary check by advancing one **byte** (`start + 1`). When the match's first char is multibyte, that index lands inside it and the next iteration's `hay[from..]` panics.

```
contains_word("x日本語y", "日本語", false)
  -> start byte index 2 is not a char boundary; it is inside '日' (bytes 1..4)
```

Live on the `/extract` grounding path: `align_basis` -> `value_carried` -> `contains_word`, where `hay` is the model's excerpt and `needle` the extracted value. Any extract whose value is embedded in a larger token reaches it. Fixed by advancing one char.

### `fix(browse)` — `crw-browse/src/tools/goto.rs`

The `goto` rejection path logs a 32-byte-bounded url prefix so a malformed url can't balloon the log line. The bound was a raw byte index, so a url with a multibyte char across byte 32 panicked *while being rejected* — and the "65KB non-URL with no ':' at all" case the bound exists for is exactly the one that reaches it. The url is LLM-supplied via MCP. Fixed with `floor_char_boundary`, matching #297.

### Notes

- The prefix logic moved into `scheme_for_log` so its test exercises the real expression rather than a copy; `handle` is async and needs a `CrwBrowse`, so a fn is the only way to cover it honestly.
- Both fixes are strict no-ops for ASCII (verified by differential test: 1.6M cases for `contains_word`, 200K urls for `scheme_for_log`, zero diffs).
- Test fixtures are built to actually reach the hazard, which is fiddly in both cases and worth stating: `İ` lowercases to ASCII `i` plus a combining dot, so an "İstanbul" fixture never panics; and a repeated char only straddles byte 32 when its width does not divide 32, so `"é".repeat(n)` and `"😀".repeat(n)` sit on a boundary. Both tests assert the straddle so a fixture cannot go quietly vacuous.

### Deliberately out of scope

- `crw-cli` `mask_api_key` (x2): same class, but interactive `crw setup` only, and fixing it means choosing char- vs byte-semantics for its length gate.
- `basis.rs` word-boundary check reads raw bytes, so a multibyte neighbour reads as a boundary and can over-accept a value as carried. Pre-existing and orthogonal — it returns at the first match, before the line touched here. The Unicode-aware form would move `supported`/`unsupported` verdicts on every non-ASCII page and needs its own bench; a panic fix should not silently shift the grounding gate.

ref #297