### PR TITLE
chore: sync Cargo.lock with the 0.25.0 workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "base64",
  "clap",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "axum",
  "axum-test",


### PR DESCRIPTION
release-please bumps the workspace manifests through `extra-files` but does not touch `Cargo.lock`, so after the 0.25.0 release the 11 workspace members stayed pinned at `0.24.1` while `Cargo.toml` reads `0.25.0`.

Any cargo invocation re-syncs them, so the lock shows up dirty in every contributor's tree and leaks into their diffs as unrelated churn. It bit the review of both #297 and #299.

Version lines only — 11 crates, 22 lines, no dependency resolution changed:

```
-version = "0.24.1"
+version = "0.25.0"
```

CI doesn't build with `--locked`, so this was never a build failure — just churn. Regenerated with `cargo metadata`, not `cargo update`, so no dependency was touched.