### PR TITLE
fix(release): stop the mcp-registry verify failing on a published version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,10 +485,21 @@ jobs:
       - name: Publish to MCP Registry
         # The registry intermittently returns 5xx (504 seen on v0.13.2). Retry
         # so a transient gateway error doesn't fail an otherwise-green release.
+        #
+        # "cannot publish duplicate version" (400) is not transient — it means the
+        # version is already there, which is the state we want. Retrying it burns
+        # four attempts and reports a red job for a release that is fine, and it
+        # makes the job impossible to re-run once a later step (e.g. Verify) has
+        # failed. Treat it as success so the job is idempotent.
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4; do
-            if mcp-publisher publish; then exit 0; fi
+            out="$(mcp-publisher publish 2>&1)" && { echo "$out"; exit 0; }
+            echo "$out"
+            if grep -qi "cannot publish duplicate version" <<<"$out"; then
+              echo "::notice::version already present in the registry; nothing to do"
+              exit 0
+            fi
             echo "::warning::mcp-publisher publish attempt ${attempt}/4 failed (transient registry error); retrying in $((attempt * 20))s"
             sleep "$((attempt * 20))"
           done

--- a/scripts/release/verify_mcp_registry.sh
+++ b/scripts/release/verify_mcp_registry.sh
@@ -10,13 +10,15 @@ source "$SCRIPT_DIR/lib.sh"
 v="${1:?version required}"
 name="${2:-io.github.us/crw}"
 
-# The bare /v0/servers list is paginated (~30 per page, cursor-based), so our
-# server is almost never on page 1 — that check could never pass. Use the
-# search filter, which returns every version of just this server, and read the
-# nested `.server.*` schema fields.
+# Ask for the ONE version we just published. `search=` alone is still paginated
+# (30 per page, oldest first), so it returns our earliest 30 releases and the new
+# one is never on page 1 — the check then fails for a version that IS published.
+# It held only while we had <=30 releases: v0.25.0 passed as the 30th and last row
+# on page 1, and v0.25.1 became the 31st and failed. `limit=` would just move the
+# cliff to 100 (the cap). Filtering by version is O(1) and cannot page out.
 end=$((SECONDS + 180))
 while (( SECONDS < end )); do
-  if curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=$name" 2>/dev/null \
+  if curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=$name&version=$v" 2>/dev/null \
       | jq -e --arg n "$name" --arg v "$v" \
         'any(.servers[]?; .server.name == $n and .server.version == $v)' >/dev/null 2>&1; then
     notice "mcp-registry $name@$v present"


### PR DESCRIPTION
The v0.25.1 release published fine to all eight targets, but `publish-mcp-registry` and `verify-publish` both went red with:

```
mcp-registry io.github.us/crw@0.25.1 not visible after 3min
```

The version was live in the registry the whole time. It reads like a propagation timeout; it isn't.

### The bug

`verify_mcp_registry.sh` queried `?search=<name>` and scanned the result for the new version. That endpoint is **paginated at 30, oldest first** — so it returns our earliest 30 releases, and the version we just published is never on page 1:

```
$ curl ".../v0/servers?search=io.github.us/crw"
count: 30
first 3: 0.10.0, 0.11.0, 0.12.1
last 3:  0.24.0, 0.24.1, 0.25.0      <- page 1 ends here
nextCursor: "io.github.us/crw:0.25.0"
0.25.1 present: False
```

It held only while we had <=30 releases. **v0.25.0 passed as the 30th and last row on page 1. v0.25.1 became the 31st and failed** — and every release from here would have failed the same way, for a version that published correctly.

The script's own comment claimed the search filter "returns every version of just this server". It returns the first 30 of them.

`&limit=100` would work today but only moves the cliff to 100 (the cap — `limit=200` is rejected), so this filters by version instead: O(1), and it cannot page out.

### Verified against the live registry

| | old script | new script |
|---|---|---|
| 0.25.1 (today's failure) | spins 3min, dies | **found** |
| 0.25.0 (was 30th) | found | found |
| 0.10.0 (was 1st) | found | found |
| 9.9.9 (nonexistent) | rejected | rejected |

### Also: the publish step is now idempotent

`release.yml`'s retry loop was written for the intermittent 5xx (504 seen on v0.13.2), but it retried **any** failure — including `400 cannot publish duplicate version`, which is not transient. It means the version is already there, which is the state we want. Retrying burned four attempts over ~2min and reported a red job for a fine release, and it made the job impossible to re-run once a later step had failed. Now treated as success.

No behavior change to a normal first publish.