### PR TITLE
ci: give each job its own cargo cache and stop fuzzing every PR

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,13 +2,36 @@ name: ClusterFuzzLite PR
 on:
   pull_request:
     branches: [main]
+    # This is the critical path of every PR: 678s wall, of which 519s (76%) is an
+    # uncached container build and 123s is the actual fuzzing. It has no business
+    # gating a docs or SDK PR.
+    #
+    # Excluding rather than listing the crates that feed the harness: the target
+    # reaches crw-extract -> crw-core -> crw-mcp-proto, and the fuzzed function is
+    # `htmd::convert`, whose version lives in the ROOT Cargo.toml — so an allowlist
+    # would silently skip fuzzing on a dep bump, the single most fuzz-relevant
+    # change we get. There is no cron leg to catch what a PR filter drops, so the
+    # filter must not be able to go quietly wrong. Everything below contains no
+    # Rust that can reach the harness.
+    paths-ignore:
+      - "docs/**"
+      - "sdks/**"
+      - "mcp/**" # npm packages; the crate is crates/crw-mcp-proto
+      - "conformance/**" # python
+      - "bench/**"
+      - "**.md"
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fuzzing:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,24 @@ on:
 permissions:
   contents: read
 
+# A force-push (our normal rebase flow) otherwise leaves the superseded run to
+# finish, burning ~26 runner-min and writing cache entries that compete for the
+# 10GB quota. Only cancel PR runs; main-push runs must not cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Debug info is the largest part of a debug target dir, and this job stacks
+      # a 12-16GB target on a runner with ~20GB free — see the cache note below.
+      # `line-tables-only` keeps file:line in panic backtraces (how we diagnose a
+      # CI-only failure) while dropping the rest. Env form, so local builds are
+      # untouched. `cargo test` uses the test profile, which inherits dev.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -20,15 +35,34 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      # Was `actions/cache` on `target/` with a key shared with `conformance` and
+      # a bare `-cargo-` restore-key. Two bugs came out of that:
+      #
+      #  1. actions/cache does not save on an exact key hit, so whichever job
+      #     finished first defined the contents. conformance won, so the cache
+      #     held a RELEASE target — which this job cannot use. Measured on one
+      #     commit: conformance compiled 10 crates, `check` compiled 616, from
+      #     proc-macro2 up, every run. It then stacked a 12-16GB debug target on
+      #     the restored release one, on ~20GB of runner disk, and died with
+      #     "No space left on device" / "ld terminated with signal 7".
+      #  2. The bare restore-key resurrected the previous lock's target and saved
+      #     the union. actions/cache never prunes and cargo never GCs target/, so
+      #     it grew monotonically (491MB -> 819MB in 16h).
+      #
+      # rust-cache keys per job, prunes stale artifacts before saving, and skips
+      # workspace crates. `save-if` keeps PR refs from each minting their own
+      # copy: caches are branch-scoped, so saving on every ref is what blew the
+      # quota. PRs still restore main's cache, which is the whole win.
+      #
+      # `shared-key` because release.yml's `check` runs the same dev/test build
+      # and wants this exact cache. Both jobs are literally named `check`, so
+      # rust-cache's job-id default would have shared it by accident; naming it
+      # makes that a decision, and one that survives renaming either job.
       - name: Cache cargo registry & build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          shared-key: dev-check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -74,6 +108,7 @@ jobs:
 
   sdk-ts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -113,21 +148,23 @@ jobs:
   # deterministic. (Run `compare` locally with a SearXNG up to gate search too.)
   conformance:
     runs-on: ubuntu-latest
+    # Generous: the first run after a cache-key change rebuilds the whole tree
+    # with `lto = true, codegen-units = 1`, i.e. a single-threaded fat-LTO link.
+    # The uncached release binaries measure ~10 min, so this is ~2.5x that.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
+      # See the note on `check`: these two jobs shared one key while building
+      # different profiles. rust-cache keys on the job id, so they no longer
+      # collide, and this job stops handing `check` a release target it can't use.
       - name: Cache cargo registry & build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -141,6 +178,10 @@ jobs:
           echo $! > /tmp/crw.pid
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000/health >/dev/null; then echo "crw up"; break; fi
+            # Without this the loop just falls through after 30 failed probes and
+            # `compare` runs against a dead server, reporting a confusing diff
+            # instead of "the server never came up".
+            if [ "$i" -eq 30 ]; then echo "::error::crw serve never became healthy"; exit 1; fi
             sleep 1
           done
 

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -36,10 +36,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   openapi-drift:
     name: OpenAPI spec drift check
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,17 +52,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
+      # Was actions/cache with a bare `-cargo-` fallback restore-key, which pulled
+      # in ci.yml's shared entry and saved the union back — the same unpruned
+      # growth as there (375MB -> 730MB in 27h). The job id `openapi-drift` is
+      # unique, so rust-cache's default job-scoped key is enough here.
       - name: Cache cargo registry & build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-openapi-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-openapi-
-            ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build release binary
         run: cargo build --release -p crw-server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Must match ci.yml's `check`: rust-cache hashes CARGO_*/RUST_* env into the
+      # key, so a mismatch here would silently miss the shared cache below.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -65,15 +69,24 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      # This job runs the same dev/test build as ci.yml's `check`, so it wants
+      # exactly that cache — `shared-key` says so instead of leaving it to
+      # rust-cache's job-id default (both jobs are literally named `check`, so the
+      # default would collide by accident rather than share by intent).
+      #
+      # It used to restore the old `Linux-cargo-` key, which conformance filled
+      # with a RELEASE target this job cannot use — so it rebuilt the dev tree from
+      # scratch every release while still paying to download 815MB. Restoring main's
+      # dev cache instead is a straight win on the release critical path
+      # (publish-crates/binaries/docker all `needs: check`).
+      #
+      # save-if is false because this only ever runs on a tag ref, and tag-scoped
+      # caches can never be restored by a later run — saving one is pure quota burn.
       - name: Cache cargo registry & build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          shared-key: dev-check
+          save-if: false
 
       - name: Install uv (for preflight scripts)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2


### PR DESCRIPTION
Five CI failures across four PRs in one day, all `No space left on device` / `ld terminated with signal 7 [Bus error]`, all on `check`, all passing on re-run. Both error strings are the same failure: `ld` mmaps its output, so a full filesystem raises SIGBUS instead of ENOSPC.

### The bug

`ci.yml`'s `check` (debug) and `conformance` (release) shared one cache key, and **`actions/cache` does not save on an exact key hit** — so whichever job finishes first defines the contents. conformance (361s) beats check (401s), so the cache holds a **release** target.

From the job logs of one run, same commit, same cache:

```
conformance: Cache saved with key: Linux-cargo-8b096cc...
check:       Cache hit occurred on the primary key Linux-cargo-8b096cc..., not saving cache.
```

| job | crates compiled | first crate | 
|---|---|---|
| conformance | **10** | `crw-mcp-proto` (first-party) |
| check | **616** | `proc-macro2` (the whole dep tree) |

So `check` downloads 815MB it cannot use, rebuilds 616 crates **every run**, and stacks a 12-16GB debug target on the restored release one. `ubuntu-latest` has ~20GB free (GitHub guarantees 14GB). It fits, or it doesn't — hence the randomness.

The bare `-cargo-` restore-keys compound it: they resurrect the previous lock's target and save the union. actions/cache never prunes, cargo never GCs `target/`, so entries grow monotonically — measured `Linux-cargo-*` 491MB → 819MB in 16h, `Linux-cargo-openapi-*` 375MB → 730MB in 27h — against a 10GB repo quota that is currently **over** (11,453 MiB / 10,240 MiB).

### The fix

`Swatinem/rust-cache` keys on the job id (kills the collision), prunes stale artifacts before saving (kills the growth), and skips workspace crates. `save-if: main` matters: caches are **branch-scoped**, so saving on every PR ref is what blew the quota. PRs still restore main's cache, which is the entire win. (A Cargo.lock-changing PR is not left cold — the lock hash is only in the exact key, never the restore key.)

### Fuzzing was the critical path of every PR

678s wall: **519s (76%) uncached container build, 123s actual fuzzing**, for one 191-byte harness, on every PR including docs and SDK ones.

Now skipped for trees that cannot reach it. Deliberately `paths-ignore` rather than an allowlist of crates: the target reaches `crw-extract → crw-core → crw-mcp-proto` and fuzzes `htmd::convert`, whose version lives in the **root `Cargo.toml`** — so an allowlist would silently skip fuzzing on a dependency bump, the most fuzz-relevant change we get, and there is no cron leg to catch what a PR filter drops. Verified every path that feeds the harness (root Cargo.toml/lock, all three crates, `.clusterfuzzlite/`, `fuzz/`, the workflow itself) still triggers it.

### Also

- **concurrency groups** — a force-push (our normal rebase flow) left the superseded run to finish, burning ~26 runner-min and writing cache entries that compete for the quota. Guarded so main-push runs never cancel each other; `release.yml` already had one and is untouched.
- **timeouts** — there were none anywhere (default 360). conformance gets 40 because the first run on a new cache key is a full `lto = true, codegen-units = 1` build; the uncached release binaries measure ~10 min, so that is ~2.5x.
- **`CARGO_PROFILE_DEV_DEBUG=line-tables-only`** on `check` only — keeps file:line in panic backtraces (how we diagnose a CI-only failure) while dropping the rest. A true no-op for the release-building jobs (`strip = true` already).
- **conformance's readiness loop** fell through after 30 failed probes and ran the comparison against a dead server, reporting a confusing diff instead of "the server never came up".

### Expected

PR wall clock **11m18s → ~6m30s** on PRs that skip fuzzing, and lower again once `check` stops rebuilding 616 crates. The `~4m` figure is extrapolated from the 616-vs-10 crate delta, not measured — the crate delta is measured.

### Not in this PR

`release.yml` is untouched on purpose. Its `buildkit-blob` cache (`cache-to: type=gha,mode=max`) writes into the **tag ref's** scope — verified live: 1896 MiB under `refs/tags/v0.25.0`, 1896 MiB under `refs/tags/v0.25.1`, **zero under main**, so no tag run can ever read another's and the 3.8GB is write-only. Dropping it, sharing the dev-profile cache between the two `check` jobs, and giving `publish-crates` a barrier so nothing irreversible publishes before the killable work lands, are a separate PR — they need measuring, not reasoning.

Legacy `Linux-cargo-*` caches get swept after this merges; nothing restores them once these four blocks are gone.