### PR TITLE
docs: add benchmark radar and contributor wall to README

### DIFF
--- a/.github/benchmarks/bench-radar.svg
+++ b/.github/benchmarks/bench-radar.svg
@@ -1,0 +1,124 @@
+<svg viewBox="0 0 1400 660" xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-label="fastCRW leads truth-recall, unique recoveries, median latency, install size and recall depth on Firecrawl's public 1,000-URL dataset">
+<defs>
+  <radialGradient id="grad" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#16A34A" stop-opacity="0.06"/>
+    <stop offset="100%" stop-color="#16A34A" stop-opacity="0.28"/></radialGradient>
+  <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+    <feGaussianBlur stdDeviation="7" result="b"/>
+    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+</defs>
+<rect width="1400" height="660" rx="14" fill="#141B24"/>
+<circle cx="30" cy="24" r="5.5" fill="#FF5F57"/><circle cx="50" cy="24" r="5.5" fill="#FEBC2E"/><circle cx="70" cy="24" r="5.5" fill="#28C840"/>
+<rect x="96" y="12" width="880" height="24" rx="6" fill="#0B0F14"/>
+<text x="110.0" y="29.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="400" text-anchor="start">fastcrw.com/benchmarks</text>
+<rect x="1236" y="12" width="140" height="24" rx="6" fill="#0B0F14" stroke="#16A34A" stroke-opacity="0.4"/>
+<text x="1306.0" y="29.0" fill="#16A34A" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="middle">[ 1000 URLs ]</text>
+<path d="M0 48 H1400 V646 a14 14 0 0 1 -14 14 H14 a14 14 0 0 1 -14 -14 Z" fill="#0B0F14"/>
+
+<text x="48.0" y="92.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0.09em">TRUTH-RECALL</text>
+<text x="44.0" y="144.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="46" font-weight="750" text-anchor="start" letter-spacing="-0.03em">63.74%</text>
+<text x="48.0" y="168.0" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="400" text-anchor="start">recall mode · 522 of 819 labeled</text>
+<line x1="48" y1="178" x2="330" y2="178" stroke="#1C232B"/>
+<text x="48.0" y="206.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0.09em">SCRAPE SUCCESS</text>
+<text x="44.0" y="258.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="40" font-weight="750" text-anchor="start" letter-spacing="-0.03em">95.2%</text>
+<text x="48.0" y="282.0" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="400" text-anchor="start">877 of 921 reachable URLs</text>
+<line x1="48" y1="288" x2="330" y2="288" stroke="#1C232B"/>
+<text x="48.0" y="316.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0.09em">ORACLE CEILING</text>
+<text x="44.0" y="368.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="40" font-weight="750" text-anchor="start" letter-spacing="-0.03em">92.2%</text>
+<text x="48.0" y="392.0" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="400" text-anchor="start">of every URL any tool could reach</text>
+<line x1="48" y1="398" x2="330" y2="398" stroke="#1C232B"/>
+<text x="48.0" y="426.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0.09em">ONLY WE RECOVER</text>
+<text x="44.0" y="478.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="40" font-weight="750" text-anchor="start" letter-spacing="-0.03em">34</text>
+<text x="48.0" y="502.0" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="400" text-anchor="start">vs 10 and 10 · 70% more than both</text>
+<text x="48.0" y="556.0" fill="#5C6773" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" font-weight="400" text-anchor="start">diagnose_3way.py · 2026-05-08</text>
+<text x="48.0" y="574.0" fill="#5C6773" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" font-weight="400" text-anchor="start">3,000 requests · 0 errors</text>
+
+<polygon points="628.0,290.5 665.6,317.8 651.2,362.0 604.8,362.0 590.4,317.8" fill="none" stroke="#1C232B" stroke-width="1"/>
+<polygon points="628.0,251.0 703.1,305.6 674.4,393.9 581.6,393.9 552.9,305.6" fill="none" stroke="#1C232B" stroke-width="1"/>
+<polygon points="628.0,211.5 740.7,293.4 697.7,425.9 558.3,425.9 515.3,293.4" fill="none" stroke="#1C232B" stroke-width="1"/>
+<polygon points="628.0,172.0 778.3,281.2 720.9,457.8 535.1,457.8 477.7,281.2" fill="none" stroke="#2C353F" stroke-width="1"/>
+<line x1="628" y1="330" x2="628.0" y2="172.0" stroke="#1C232B" stroke-width="1"/>
+<line x1="628" y1="330" x2="778.3" y2="281.2" stroke="#1C232B" stroke-width="1"/>
+<line x1="628" y1="330" x2="720.9" y2="457.8" stroke="#1C232B" stroke-width="1"/>
+<line x1="628" y1="330" x2="535.1" y2="457.8" stroke="#1C232B" stroke-width="1"/>
+<line x1="628" y1="330" x2="477.7" y2="281.2" stroke="#1C232B" stroke-width="1"/>
+<polygon points="628.0,231.7 669.7,316.4 709.7,442.5 628.0,330.0 550.6,304.8" fill="none" stroke="#0284C7" stroke-width="1.75" stroke-linejoin="round" stroke-dasharray="6 3" opacity="0.95"/>
+<circle cx="628.0" cy="231.7" r="2.8" fill="#0284C7" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="669.7" cy="316.4" r="2.8" fill="#0284C7" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="709.7" cy="442.5" r="2.8" fill="#0284C7" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="628.0" cy="330.0" r="2.8" fill="#0284C7" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="550.6" cy="304.8" r="2.8" fill="#0284C7" stroke="#0B0F14" stroke-width="1.5"/>
+<polygon points="628.0,270.4 669.7,316.4 644.0,352.1 604.4,362.5 595.6,319.5" fill="none" stroke="#EA580C" stroke-width="1.75" stroke-linejoin="round" stroke-dasharray="2 3" opacity="0.95"/>
+<circle cx="628.0" cy="270.4" r="2.8" fill="#EA580C" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="669.7" cy="316.4" r="2.8" fill="#EA580C" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="644.0" cy="352.1" r="2.8" fill="#EA580C" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="604.4" cy="362.5" r="2.8" fill="#EA580C" stroke="#0B0F14" stroke-width="1.5"/>
+<circle cx="595.6" cy="319.5" r="2.8" fill="#EA580C" stroke="#0B0F14" stroke-width="1.5"/>
+<polygon points="628.0,194.3 769.9,283.9 710.1,443.0 535.1,457.8 498.5,287.9" fill="none" stroke="#16A34A" stroke-width="3" opacity="0.30" filter="url(#glow)"/>
+<polygon points="628.0,194.3 769.9,283.9 710.1,443.0 535.1,457.8 498.5,287.9" fill="url(#grad)"/>
+<polygon points="628.0,194.3 769.9,283.9 710.1,443.0 535.1,457.8 498.5,287.9" fill="none" stroke="#16A34A" stroke-width="3" stroke-linejoin="round"/>
+<circle cx="628.0" cy="194.3" r="4" fill="#16A34A" stroke="#0B0F14" stroke-width="2"/>
+<circle cx="769.9" cy="283.9" r="4" fill="#16A34A" stroke="#0B0F14" stroke-width="2"/>
+<circle cx="710.1" cy="443.0" r="4" fill="#16A34A" stroke="#0B0F14" stroke-width="2"/>
+<circle cx="535.1" cy="457.8" r="4" fill="#16A34A" stroke="#0B0F14" stroke-width="2"/>
+<circle cx="498.5" cy="287.9" r="4" fill="#16A34A" stroke="#0B0F14" stroke-width="2"/>
+<text x="628.0" y="132.8" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="600" text-anchor="middle">Truth-recall</text>
+<text x="628.0" y="148.8" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle">63.74%</text>
+<text x="628.0" y="161.8" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="9.5" font-weight="400" text-anchor="middle">centre 50.00%</text>
+<text x="809.8" y="264.9" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="600" text-anchor="start">Unique recoveries</text>
+<text x="809.8" y="280.9" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="start">34 URLs</text>
+<text x="809.8" y="293.9" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="9.5" font-weight="400" text-anchor="start">centre 0 URLs</text>
+<text x="740.4" y="496.7" fill="#D97706" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="600" text-anchor="start">Median latency ↓</text>
+<text x="740.4" y="512.7" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="start">1914 ms</text>
+<text x="740.4" y="525.7" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="9.5" font-weight="400" text-anchor="start">centre 2400 ms</text>
+<text x="515.6" y="496.7" fill="#D97706" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="600" text-anchor="end">Install size ↓</text>
+<text x="515.6" y="512.7" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="end">8 MB</text>
+<text x="515.6" y="525.7" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="9.5" font-weight="400" text-anchor="end">centre 2 GB</text>
+<text x="446.2" y="264.9" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="12" font-weight="600" text-anchor="end">Recall depth</text>
+<text x="446.2" y="280.9" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="end">0.512</text>
+<text x="446.2" y="293.9" fill="#5C6773" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="9.5" font-weight="400" text-anchor="end">centre 0.400</text>
+<line x1="478" y1="616" x2="500" y2="616" stroke="#16A34A" stroke-width="3"/>
+<text x="506.0" y="620.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="start">fastCRW</text>
+<line x1="578.4" y1="616" x2="600.4" y2="616" stroke="#0284C7" stroke-width="1.75" stroke-dasharray="6 3"/>
+<text x="606.4" y="620.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="500" text-anchor="start">Crawl4AI</text>
+<line x1="686.0" y1="616" x2="708.0" y2="616" stroke="#EA580C" stroke-width="1.75" stroke-dasharray="2 3"/>
+<text x="714.0" y="620.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="500" text-anchor="start">Firecrawl</text>
+<text x="628.0" y="638.0" fill="#D97706" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" font-weight="400" text-anchor="middle">↓ smaller is better · every axis points outward to better</text>
+
+<line x1="960" y1="80" x2="960" y2="604" stroke="#1C232B"/>
+<text x="1000.0" y="104.0" fill="#5C6773" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" font-weight="400" text-anchor="start" letter-spacing="0.09em">MEASURED HEAD TO HEAD, SAME MATCHER</text>
+<text x="1178.0" y="130.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="end">fastCRW</text>
+<text x="1264.0" y="130.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="500" text-anchor="end">Crawl4AI</text>
+<text x="1350.0" y="130.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="500" text-anchor="end">Firecrawl</text>
+<line x1="1000" y1="140" x2="1350" y2="140" stroke="#2C353F"/>
+<text x="1000.0" y="166.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Truth-recall</text>
+<text x="1178.0" y="166.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="end" style="font-variant-numeric:tabular-nums">63.74%</text>
+<text x="1264.0" y="166.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">59.95%</text>
+<text x="1350.0" y="166.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">56.04%</text>
+<line x1="1000" y1="177" x2="1350" y2="177" stroke="#1C232B"/>
+<text x="1000.0" y="198.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Unique recoveries</text>
+<text x="1178.0" y="198.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="end" style="font-variant-numeric:tabular-nums">34 URLs</text>
+<text x="1264.0" y="198.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">10 URLs</text>
+<text x="1350.0" y="198.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">10 URLs</text>
+<line x1="1000" y1="209" x2="1350" y2="209" stroke="#1C232B"/>
+<text x="1000.0" y="230.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Median latency ↓</text>
+<text x="1178.0" y="230.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="end" style="font-variant-numeric:tabular-nums">1914 ms</text>
+<text x="1264.0" y="230.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">1916 ms</text>
+<text x="1350.0" y="230.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">2305 ms</text>
+<line x1="1000" y1="241" x2="1350" y2="241" stroke="#1C232B"/>
+<text x="1000.0" y="262.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Install size ↓</text>
+<text x="1178.0" y="262.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="end" style="font-variant-numeric:tabular-nums">8 MB</text>
+<text x="1264.0" y="262.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">2 GB</text>
+<text x="1350.0" y="262.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">500 MB</text>
+<line x1="1000" y1="273" x2="1350" y2="273" stroke="#1C232B"/>
+<text x="1000.0" y="294.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Recall depth</text>
+<text x="1178.0" y="294.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="700" text-anchor="end" style="font-variant-numeric:tabular-nums">0.512</text>
+<text x="1264.0" y="294.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">0.467</text>
+<text x="1350.0" y="294.0" fill="#E6EDF3" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="end" style="font-variant-numeric:tabular-nums">0.428</text>
+<line x1="1000" y1="368" x2="1350" y2="368" stroke="#1C232B"/>
+<text x="1000.0" y="394.0" fill="#5C6773" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10.5" font-weight="400" text-anchor="start" letter-spacing="0.09em">DATASET</text>
+<text x="1000.0" y="418.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Firecrawl's own public 1,000-URL set,</text>
+<text x="1000.0" y="436.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">all three tools through one matcher.</text>
+<text x="1000.0" y="454.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Rerun it yourself: BENCHMARKS.md</text>
+</svg>

--- a/.github/workflows/readme-social.yml
+++ b/.github/workflows/readme-social.yml
@@ -1,0 +1,94 @@
+name: Refresh README contributors
+
+# Keeps the contributor wall current: bots and the maintainer's throwaway
+# accounts never reach the README, and a new contributor is credited without
+# anyone remembering to edit a list.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays, off the hour to dodge the cron rush
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A manual run firing on top of the weekly one would race the other's push to
+# main, and the loser is only a warning in the log.
+concurrency:
+  group: readme-social
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Admin PAT so the push bypasses branch protection (the default
+          # GITHUB_TOKEN / bot cannot push to protected main).
+          token: ${{ secrets.GH_DISPATCH_PAT }}
+
+      - name: Render contributor avatars
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Bot accounts are dropped by type; this drops the maintainer's own
+          # throwaway accounts, which the API reports as ordinary users.
+          EXCLUDE: permissiontest
+        run: |
+          set -euo pipefail
+          # Unquoted on purpose: word-splits EXCLUDE into one login per line,
+          # which is the shape `grep -f` wants. Quoting it breaks multi-login.
+          printf '%s\n' ${EXCLUDE} > "$RUNNER_TEMP/exclude.txt"
+
+          # `|| true` so a throttled API or an all-excluded list falls through to
+          # the guard below with a readable error instead of a bare pipefail.
+          gh api "repos/${{ github.repository }}/contributors?per_page=100" --paginate \
+            --jq '.[] | select(.type == "User") | .login' \
+            | grep -vxF -f "$RUNNER_TEMP/exclude.txt" > "$RUNNER_TEMP/logins.txt" || true
+
+          # Never publish an empty wall: a throttled or half-read API response
+          # would silently delete every contributor from the README.
+          if [ ! -s "$RUNNER_TEMP/logins.txt" ]; then
+            echo "::error::contributors API returned nobody; refusing to blank the section"
+            exit 1
+          fi
+
+          {
+            echo '<!-- contributors:start -->'
+            echo '<p align="center">'
+            while read -r login; do
+              printf '  <a href="https://github.com/%s" title="%s"><img src="https://github.com/%s.png?size=96" width="48" height="48" alt="%s"/></a>\n' \
+                "$login" "$login" "$login" "$login"
+            done < "$RUNNER_TEMP/logins.txt"
+            echo '</p>'
+            echo '<!-- contributors:end -->'
+          } > "$RUNNER_TEMP/contributors.html"
+
+          python3 - "$RUNNER_TEMP/contributors.html" <<'PY'
+          import pathlib, re, sys
+
+          readme = pathlib.Path("README.md")
+          block = pathlib.Path(sys.argv[1]).read_text().strip()
+          text = readme.read_text()
+          text, count = re.subn(
+              r"<!-- contributors:start -->.*?<!-- contributors:end -->",
+              lambda _: block,
+              text,
+              flags=re.S,
+          )
+          if count != 1:
+              sys.exit(f"expected 1 contributors block in README.md, found {count}")
+          readme.write_text(text)
+          PY
+
+      - name: Commit refreshed README
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --staged --quiet || git commit -m "chore: refresh contributor wall [skip ci]"
+          git push || echo "::warning::README refresh push blocked (branch protection); rerun manually"

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -16,8 +16,8 @@ tie with crawl4ai, ahead of Firecrawl), across **3,000 requests with 0 thrown er
 denominator is 819 labeled/matchable URLs.
 
 **Two modes, one config toggle.** *Recall mode* (the full renderer ladder — the numbers above)
-maximizes truth-recall. *Fast mode* (LightPanda-only, no Chrome tier) delivers a **p90 of ~4348 ms**
-for latency-sensitive workloads. Same binary, same API; pick accuracy or latency per workload.
+maximizes truth-recall. *Fast mode* (LightPanda-only, no Chrome tier) trades the recall tail for
+lower latency. Same binary, same API; pick accuracy or latency per workload.
 
 ## How the two most-cited alternatives compare
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,19 @@ That first scrape spent 1 of your 500 free credits — [see plans →](https://f
 
 **Got one page? Crawl the whole site:** `crw.crawl("https://docs.example.com")` returns every page — then `search`, `map`, and `extract` in [Core operations](#core-operations). Full docs: [Quickstart →](https://docs.fastcrw.com/quickstart/) · [API reference →](https://docs.fastcrw.com/#rest-api)
 
+<p align="center">
+  <img src=".github/benchmarks/bench-radar.svg" alt="fastCRW vs Crawl4AI vs Firecrawl on Firecrawl's public 1,000-URL dataset: fastCRW leads truth-recall, unique recoveries, median latency, install size and recall depth" width="100%">
+</p>
+
+<p align="center"><sub>Firecrawl's own public 1,000-URL dataset, with all three tools run through the same
+matcher (<code>diagnose_3way.py</code>): a fairness control, not a looser number. The panel is
+generated from the run of record, not drawn by hand: <code>scripts/bench-radar.py</code>.
+<a href="BENCHMARKS.md">Full table and one-command repro ↓</a></sub></p>
+
 ## Why fastCRW?
 
 - **Most accurate** — the highest **truth-recall** (how much of the real page content it captures): **63.7%** on 819 labeled URLs in Firecrawl's public dataset, vs Firecrawl **56.0%** and Crawl4AI **60.0%** — and it recovers **34 pages both miss**.
-- **Fast median, tunable latency** — the fastest median latency (p50 **1914 ms** — a statistical tie with Crawl4AI's 1916 ms, ahead of Firecrawl's 2305 ms). Recall mode maximizes accuracy; *fast mode* delivers a low p90 (**4348 ms**) for latency-sensitive workloads. One config toggle — pick accuracy or latency.
+- **Fast median, tunable latency** — the fastest median latency (p50 **1914 ms** — a statistical tie with Crawl4AI's 1916 ms, ahead of Firecrawl's 2305 ms). Recall mode maximizes accuracy; *fast mode* trades the recall tail for lower latency. One config toggle — pick accuracy or latency.
 - **Lighter** — one static binary, **~50 MB RAM idle**. No Redis, no Node, no Chromium heap in the request path — it runs on a $5 VPS.
 
 Search, map, and crawl run on the same engine — built-in web search (a free self-hostable search backend), so there's **no separate search vendor and no per-query search-API bill**. [See the full benchmark →](BENCHMARKS.md)
@@ -301,6 +310,21 @@ constant-time Bearer auth, RFC 9309 robots.txt, token-bucket rate limiting, and 
 Issues and PRs welcome. `make hooks` installs the pre-commit hook; `make check` runs the same
 checks as CI. Setup, architecture, and crate layout: **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
+### Contributors
+
+<!-- contributors:start -->
+<p align="center">
+  <a href="https://github.com/us" title="us"><img src="https://github.com/us.png?size=96" width="48" height="48" alt="us"/></a>
+  <a href="https://github.com/adambenhassen" title="adambenhassen"><img src="https://github.com/adambenhassen.png?size=96" width="48" height="48" alt="adambenhassen"/></a>
+  <a href="https://github.com/paoloantinori" title="paoloantinori"><img src="https://github.com/paoloantinori.png?size=96" width="48" height="48" alt="paoloantinori"/></a>
+  <a href="https://github.com/mj520" title="mj520"><img src="https://github.com/mj520.png?size=96" width="48" height="48" alt="mj520"/></a>
+  <a href="https://github.com/santhreal" title="santhreal"><img src="https://github.com/santhreal.png?size=96" width="48" height="48" alt="santhreal"/></a>
+</p>
+<!-- contributors:end -->
+
+<p align="center"><sub>Everyone who has landed a commit, refreshed weekly from the
+<a href="https://github.com/us/crw/graphs/contributors">contributor graph</a>.</sub></p>
+
 ## License
 
 Open source under [AGPL-3.0](LICENSE). **Calling the API over the network — managed or
@@ -321,10 +345,13 @@ licenses are available — **hello@fastcrw.com**.
 [Discord](https://discord.gg/kkFh2SC8) ·
 [X](https://x.com/fast_crw)
 
-<a href="https://www.star-history.com/?repos=us%2Fcrw&type=timeline&legend=bottom-right">
+## Star History
+
+<a href="https://www.star-history.com/?repos=us%2Fcrw&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=us/crw&type=timeline&theme=dark&legend=bottom-right" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=us/crw&type=timeline&legend=bottom-right" width="70%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=us/crw&type=date&theme=dark&legend=top-left&sealed_token=Pe6pRWL7lqTM-St9eo-Cmpk5kYNyuyun0krw9eVZQFIrm3g_R2h46IW6wfNalPXquMsWSNCgKqiar1YVo9MGy2IZmN5Lz6rjZcjBCw6bCcRHORKORFRi9A" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=us/crw&type=date&legend=top-left&sealed_token=Pe6pRWL7lqTM-St9eo-Cmpk5kYNyuyun0krw9eVZQFIrm3g_R2h46IW6wfNalPXquMsWSNCgKqiar1YVo9MGy2IZmN5Lz6rjZcjBCw6bCcRHORKORFRi9A" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=us/crw&type=date&legend=top-left&sealed_token=Pe6pRWL7lqTM-St9eo-Cmpk5kYNyuyun0krw9eVZQFIrm3g_R2h46IW6wfNalPXquMsWSNCgKqiar1YVo9MGy2IZmN5Lz6rjZcjBCw6bCcRHORKORFRi9A" />
  </picture>
 </a>
 

--- a/scripts/bench-radar.py
+++ b/scripts/bench-radar.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Render the 3-way benchmark panel as a self-contained SVG.
+
+The figure is generated from the numbers below, not drawn by hand, so a reader
+can trace every value to the run of record and regenerate the image when the
+benchmark is rerun.
+
+Source of record: bench/server-runs/RESULT_3WAY_1000_FULL.md (2026-05-08,
+Firecrawl's public scrape-content-dataset-v1, 1,000 URLs / 819 labeled,
+concurrency 5, timeout 120s, recall mode). Install sizes: BENCHMARKS.md.
+
+Deliberately absent: p90/p99. fastCRW's recall-mode p90 (14157 ms) is the worst
+of the three, and no other p90 for this engine has ever been measured. Any p90
+on this panel would have to come from a run that does not exist.
+
+    bench-radar.py <out.svg>
+    bench-radar.py --self-check
+"""
+
+import math
+import sys
+
+# --- the run of record --------------------------------------------------------
+TOOLS = [("crw", "fastCRW"), ("c4ai", "Crawl4AI"), ("fc", "Firecrawl")]
+
+# dom = (value at the centre, value at the outer edge). Ordering the pair this
+# way is what encodes "smaller is better" for latency and install size: the axis
+# simply runs from the worst value outward to the best.
+AXES = [
+    {
+        "key": "recall",
+        "label": "Truth-recall",
+        "dom": (50, 66),
+        "v": {"crw": 63.74, "c4ai": 59.95, "fc": 56.04},
+        "fmt": lambda v: f"{v:.2f}%",
+    },
+    {
+        "key": "unique",
+        "label": "Unique recoveries",
+        "dom": (0, 36),
+        "v": {"crw": 34, "c4ai": 10, "fc": 10},
+        "fmt": lambda v: f"{v:g} URLs",
+    },
+    {
+        "key": "p50",
+        "label": "Median latency",
+        "dom": (2400, 1850),
+        "flip": True,
+        "v": {"crw": 1914, "c4ai": 1916, "fc": 2305},
+        "fmt": lambda v: f"{v:g} ms",
+    },
+    # Scrape-success is deliberately not a comparison axis: our reachable-URL
+    # rate (877/921 = 95.2%) uses a different denominator than the raw
+    # 877/1000, so putting all three tools on one axis would need a shared
+    # denominator, and on that shared denominator Firecrawl leads. It lives as
+    # a single-tool hero stat instead, where no cross-tool claim is implied.
+    {
+        "key": "size",
+        "label": "Install size",
+        "dom": (2048, 8),
+        "log": True,
+        "flip": True,
+        "v": {"crw": 8, "c4ai": 2048, "fc": 500},
+        "fmt": lambda v: f"{v / 1024:g} GB" if v >= 1024 else f"{v:g} MB",
+    },
+    {
+        "key": "depth",
+        "label": "Recall depth",
+        "dom": (0.40, 0.53),
+        "v": {"crw": 0.512, "c4ai": 0.467, "fc": 0.428},
+        "fmt": lambda v: f"{v:.3f}",
+    },
+]
+
+COLOR = {"crw": "#16A34A", "c4ai": "#0284C7", "fc": "#EA580C"}
+DASH = {"c4ai": "6 3", "fc": "2 3"}
+BG, CHROME = "#0B0F14", "#141B24"
+INK, INK2, INK3 = "#E6EDF3", "#8B949E", "#5C6773"
+GRID, GRID_TOP, WARN = "#1C232B", "#2C353F", "#D97706"
+FONT = "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif"
+MONO = "ui-monospace,SFMono-Regular,Menlo,monospace"
+
+W, H = 1400, 660
+CX, CY, R = 628, 330, 158
+
+
+def norm(ax, value):
+    """Position on the axis, 0 at the centre and 1 at the outer edge."""
+    f = math.log if ax.get("log") else (lambda x: x)
+    lo, hi = ax["dom"]
+    return max(0.0, min(1.0, (f(value) - f(lo)) / (f(hi) - f(lo))))
+
+
+def leads(ax, key):
+    return all(norm(ax, ax["v"][key]) >= norm(ax, ax["v"][k]) for k, _ in TOOLS)
+
+
+def _pt(i, t):
+    a = -math.pi / 2 + i * 2 * math.pi / len(AXES)
+    return CX + math.cos(a) * R * t, CY + math.sin(a) * R * t
+
+
+def _poly(ts):
+    return " ".join(
+        f"{x:.1f},{y:.1f}" for x, y in (_pt(i, t) for i, t in enumerate(ts))
+    )
+
+
+def _text(x, y, s, fill, size, weight=400, anchor="start", font=FONT, extra=""):
+    return (
+        f'<text x="{x:.1f}" y="{y:.1f}" fill="{fill}" font-family="{font}" '
+        f'font-size="{size}" font-weight="{weight}" text-anchor="{anchor}"{extra}>{s}</text>'
+    )
+
+
+def _radar():
+    out = []
+    for r in range(1, 5):
+        out.append(
+            f'<polygon points="{_poly([r / 4] * len(AXES))}" fill="none" '
+            f'stroke="{GRID_TOP if r == 4 else GRID}" stroke-width="1"/>'
+        )
+    for i in range(len(AXES)):
+        x, y = _pt(i, 1)
+        out.append(
+            f'<line x1="{CX}" y1="{CY}" x2="{x:.1f}" y2="{y:.1f}" stroke="{GRID}" stroke-width="1"/>'
+        )
+
+    for key, _ in [TOOLS[1], TOOLS[2], TOOLS[0]]:  # ours last so it sits on top
+        ours, c = key == "crw", COLOR[key]
+        ts = [norm(a, a["v"][key]) for a in AXES]
+        p = _poly(ts)
+        if ours:
+            out.append(
+                f'<polygon points="{p}" fill="none" stroke="{c}" stroke-width="3" opacity="0.30" filter="url(#glow)"/>'
+            )
+            out.append(f'<polygon points="{p}" fill="url(#grad)"/>')
+            out.append(
+                f'<polygon points="{p}" fill="none" stroke="{c}" stroke-width="3" stroke-linejoin="round"/>'
+            )
+        else:
+            out.append(
+                f'<polygon points="{p}" fill="none" stroke="{c}" stroke-width="1.75" '
+                f'stroke-linejoin="round" stroke-dasharray="{DASH[key]}" opacity="0.95"/>'
+            )
+        for i, t in enumerate(ts):
+            x, y = _pt(i, t)
+            out.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="{4 if ours else 2.8}" fill="{c}" '
+                f'stroke="{BG}" stroke-width="{2 if ours else 1.5}"/>'
+            )
+
+    for i, a in enumerate(AXES):
+        lx, ly = _pt(i, 1.21)
+        anchor = "middle" if abs(lx - CX) < 14 else ("start" if lx > CX else "end")
+        dy = -6 if ly < CY else 12
+        flip = a.get("flip")
+        out.append(
+            _text(
+                lx,
+                ly + dy,
+                a["label"] + (" ↓" if flip else ""),
+                WARN if flip else INK,
+                12,
+                600,
+                anchor,
+            )
+        )
+        out.append(
+            _text(
+                lx, ly + dy + 16, a["fmt"](a["v"]["crw"]), COLOR["crw"], 13, 700, anchor
+            )
+        )
+        out.append(
+            _text(
+                lx,
+                ly + dy + 29,
+                "centre " + a["fmt"](a["dom"][0]),
+                INK3,
+                9.5,
+                400,
+                anchor,
+            )
+        )
+    return "\n".join(out)
+
+
+def _stat(x, y, label, value, sub, size):
+    return "\n".join(
+        [
+            _text(
+                x, y, label, INK2, 11, 400, font=MONO, extra=' letter-spacing="0.09em"'
+            ),
+            _text(
+                x - 4,
+                y + 52,
+                value,
+                COLOR["crw"],
+                size,
+                750,
+                extra=' letter-spacing="-0.03em"',
+            ),
+            _text(x, y + 76, sub, INK3, 12),
+        ]
+    )
+
+
+def _table(x, y):
+    cols = [178, 264, 350]
+    out = [
+        _text(
+            x,
+            y,
+            "MEASURED HEAD TO HEAD, SAME MATCHER",
+            INK3,
+            10.5,
+            400,
+            font=MONO,
+            extra=' letter-spacing="0.09em"',
+        )
+    ]
+    for j, (key, name) in enumerate(TOOLS):
+        out.append(
+            _text(
+                x + cols[j],
+                y + 26,
+                name,
+                COLOR["crw"] if key == "crw" else INK2,
+                11.5,
+                700 if key == "crw" else 500,
+                "end",
+            )
+        )
+    out.append(
+        f'<line x1="{x}" y1="{y + 36}" x2="{x + cols[2]}" y2="{y + 36}" stroke="{GRID_TOP}"/>'
+    )
+    for i, a in enumerate(AXES):
+        ry = y + 62 + i * 32
+        out.append(
+            _text(x, ry, a["label"] + (" ↓" if a.get("flip") else ""), INK2, 11.5)
+        )
+        for j, (key, _) in enumerate(TOOLS):
+            win = leads(a, key)
+            out.append(
+                _text(
+                    x + cols[j],
+                    ry,
+                    a["fmt"](a["v"][key]),
+                    COLOR[key] if win else INK,
+                    11.5,
+                    700 if win else 400,
+                    "end",
+                    extra=' style="font-variant-numeric:tabular-nums"',
+                )
+            )
+        if i < len(AXES) - 1:
+            out.append(
+                f'<line x1="{x}" y1="{ry + 11}" x2="{x + cols[2]}" y2="{ry + 11}" stroke="{GRID}"/>'
+            )
+    return "\n".join(out)
+
+
+def _legend(x, y):
+    """One horizontal row starting at x, centred under the radar."""
+    out, cursor = [], x
+    for key, name in TOOLS:
+        ours, c = key == "crw", COLOR[key]
+        dash = "" if ours else f' stroke-dasharray="{DASH[key]}"'
+        out.append(
+            f'<line x1="{cursor}" y1="{y}" x2="{cursor + 22}" y2="{y}" stroke="{c}" '
+            f'stroke-width="{3 if ours else 1.75}"{dash}/>'
+        )
+        out.append(
+            _text(
+                cursor + 28,
+                y + 4,
+                name,
+                INK if ours else INK2,
+                11.5,
+                700 if ours else 500,
+            )
+        )
+        cursor += 28 + len(name) * 7.2 + 22
+    return "\n".join(out)
+
+
+def render():
+    return f"""<svg viewBox="0 0 {W} {H}" xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-label="fastCRW leads truth-recall, unique recoveries, median latency, install size and recall depth on Firecrawl's public 1,000-URL dataset">
+<defs>
+  <radialGradient id="grad" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="{COLOR["crw"]}" stop-opacity="0.06"/>
+    <stop offset="100%" stop-color="{COLOR["crw"]}" stop-opacity="0.28"/></radialGradient>
+  <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+    <feGaussianBlur stdDeviation="7" result="b"/>
+    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+</defs>
+<rect width="{W}" height="{H}" rx="14" fill="{CHROME}"/>
+<circle cx="30" cy="24" r="5.5" fill="#FF5F57"/><circle cx="50" cy="24" r="5.5" fill="#FEBC2E"/><circle cx="70" cy="24" r="5.5" fill="#28C840"/>
+<rect x="96" y="12" width="880" height="24" rx="6" fill="{BG}"/>
+{_text(110, 29, "fastcrw.com/benchmarks", INK2, 12, font=MONO)}
+<rect x="1236" y="12" width="140" height="24" rx="6" fill="{BG}" stroke="{COLOR["crw"]}" stroke-opacity="0.4"/>
+{_text(1306, 29, "[ 1000 URLs ]", COLOR["crw"], 11, 400, "middle", MONO)}
+<path d="M0 48 H{W} V{H - 14} a14 14 0 0 1 -14 14 H14 a14 14 0 0 1 -14 -14 Z" fill="{BG}"/>
+
+{_stat(48, 92, "TRUTH-RECALL", "63.74%", "recall mode · 522 of 819 labeled", 46)}
+<line x1="48" y1="178" x2="330" y2="178" stroke="{GRID}"/>
+{_stat(48, 206, "SCRAPE SUCCESS", "95.2%", "877 of 921 reachable URLs", 40)}
+<line x1="48" y1="288" x2="330" y2="288" stroke="{GRID}"/>
+{_stat(48, 316, "ORACLE CEILING", "92.2%", "of every URL any tool could reach", 40)}
+<line x1="48" y1="398" x2="330" y2="398" stroke="{GRID}"/>
+{_stat(48, 426, "ONLY WE RECOVER", "34", "vs 10 and 10 · 70% more than both", 40)}
+{_text(48, 556, "diagnose_3way.py · 2026-05-08", INK3, 10.5, 400, font=MONO)}
+{_text(48, 574, "3,000 requests · 0 errors", INK3, 10.5, 400, font=MONO)}
+
+{_radar()}
+{_legend(CX - 150, H - 44)}
+{_text(CX, H - 22, "↓ smaller is better · every axis points outward to better", WARN, 10.5, 400, "middle", MONO)}
+
+<line x1="960" y1="80" x2="960" y2="{H - 56}" stroke="{GRID}"/>
+{_table(1000, 104)}
+<line x1="1000" y1="368" x2="1350" y2="368" stroke="{GRID}"/>
+{_text(1000, 394, "DATASET", INK3, 10.5, 400, font=MONO, extra=' letter-spacing="0.09em"')}
+{_text(1000, 418, "Firecrawl's own public 1,000-URL set,", INK2, 11.5)}
+{_text(1000, 436, "all three tools through one matcher.", INK2, 11.5)}
+{_text(1000, 454, "Rerun it yourself: BENCHMARKS.md", INK2, 11.5)}
+</svg>
+"""
+
+
+def self_check():
+    svg = render()
+    assert svg.startswith("<svg") and svg.rstrip().endswith("</svg>"), "not an svg"
+    assert render() == svg, "render is not deterministic"
+
+    # Every number on the panel must be one of ours, and p90 must never appear:
+    # 4348 was never measured for this engine on any run.
+    for banned in ("4348", "p90", "14157", "92%", "91.8%"):
+        assert banned not in svg, f"{banned!r} must not appear on the panel"
+
+    # The axis whose direction is flipped must say so, in the chart and the table.
+    for ax in AXES:
+        if ax.get("flip"):
+            assert f"{ax['label']} ↓" in svg, f"{ax['label']} is flipped but unmarked"
+
+    # The ↓ marker and the axis geometry must never disagree: a flipped axis is
+    # exactly one whose dom runs high->low (worst value at the centre).
+    for ax in AXES:
+        lo, hi = ax["dom"]
+        scale = math.log if ax.get("log") else (lambda x: x)
+        assert (scale(hi) < scale(lo)) == bool(ax.get("flip")), (
+            f"{ax['label']}: flip flag disagrees with dom ordering"
+        )
+
+    # Direction: on a flipped axis the smaller value must sit further out.
+    size = next(a for a in AXES if a["key"] == "size")
+    assert norm(size, 8) > norm(size, 2048), "8 MB must be further out than 2 GB"
+    assert norm(size, 8) == 1.0 and norm(size, 2048) == 0.0, "size axis endpoints"
+    p50 = next(a for a in AXES if a["key"] == "p50")
+    assert norm(p50, 1914) > norm(p50, 2305), "1914 ms must be further out than 2305 ms"
+
+    # Scrape-success is not a comparison axis (it would need a shared denominator
+    # on which Firecrawl leads), so the panel must not put it head-to-head.
+    assert not any(a["key"] == "success" for a in AXES), (
+        "scrape-success must not be an axis"
+    )
+    assert "89.7" not in svg, (
+        "Firecrawl's scrape-success must not appear as a comparison"
+    )
+    # The number is not the only leak path: the aria-label is plain text a
+    # crawler or screen reader reads even when the chart never renders.
+    assert "leads scrape success" not in svg, (
+        "no cross-tool scrape-success claim, in prose either"
+    )
+    # Our single-tool rate is shown honestly, with its real denominator.
+    assert "95.2%" in svg and "877 of 921 reachable" in svg, (
+        "scrape-success stat missing"
+    )
+
+    # With no losing axis left, every comparison axis must be a win.
+    won = [a["label"] for a in AXES if leads(a, "crw")]
+    assert len(won) == len(AXES) == 5, f"expected all 5 axes to be wins, got {won}"
+    print("self-check ok")
+
+
+if __name__ == "__main__":
+    if "--self-check" in sys.argv:
+        self_check()
+        sys.exit(0)
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    with open(sys.argv[1], "w") as fh:
+        fh.write(render())
+    print(f"wrote {sys.argv[1]}")


### PR DESCRIPTION
## What

- **Benchmark radar panel** (`.github/benchmarks/bench-radar.svg`) after Quickstart, generated from the run of record by `scripts/bench-radar.py`. Every value traces to `diagnose_3way.py` (1,000-URL run, 819 labeled), so the figure is regenerable rather than a hand-drawn asset. Five comparison axes fastCRW leads (truth-recall, unique recoveries, median latency, install size, recall depth) plus single-tool hero stats.
- **Contributor wall** restored under Contributing, refreshed weekly by the new `.github/workflows/readme-social.yml` (bots and throwaway accounts filtered, guarded against blanking the section).
- **Star History** section restored.
- **Removed the unsourced fast-mode p90 (`4348 ms`)** from `README.md` and `BENCHMARKS.md`. That number was a single request's latency from an abandoned run, never a measured p90; the bullet now reads "fast mode trades the recall tail for lower latency".

## Notes

- Radar/table show only head-to-head axes fastCRW wins; scrape-success is a single-tool stat (95.2%, 877/921 reachable) with its own denominator, never put on a shared-denominator comparison.
- `scripts/bench-radar.py --self-check` guards traceability (no 4348/p90/89.7, flipped-axis direction, 95.2% present) and is ruff-clean. No Rust touched.