### PR TITLE
docs: drop browser-chrome bar from benchmark radar

### DIFF
--- a/.github/benchmarks/bench-radar.svg
+++ b/.github/benchmarks/bench-radar.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 1400 660" xmlns="http://www.w3.org/2000/svg" role="img"
+<svg viewBox="0 0 1400 612" xmlns="http://www.w3.org/2000/svg" role="img"
   aria-label="fastCRW leads truth-recall, unique recoveries, median latency, install size and recall depth on Firecrawl's public 1,000-URL dataset">
 <defs>
   <radialGradient id="grad" cx="50%" cy="50%" r="50%">
@@ -8,13 +8,8 @@
     <feGaussianBlur stdDeviation="7" result="b"/>
     <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
 </defs>
-<rect width="1400" height="660" rx="14" fill="#141B24"/>
-<circle cx="30" cy="24" r="5.5" fill="#FF5F57"/><circle cx="50" cy="24" r="5.5" fill="#FEBC2E"/><circle cx="70" cy="24" r="5.5" fill="#28C840"/>
-<rect x="96" y="12" width="880" height="24" rx="6" fill="#0B0F14"/>
-<text x="110.0" y="29.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="400" text-anchor="start">fastcrw.com/benchmarks</text>
-<rect x="1236" y="12" width="140" height="24" rx="6" fill="#0B0F14" stroke="#16A34A" stroke-opacity="0.4"/>
-<text x="1306.0" y="29.0" fill="#16A34A" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="middle">[ 1000 URLs ]</text>
-<path d="M0 48 H1400 V646 a14 14 0 0 1 -14 14 H14 a14 14 0 0 1 -14 -14 Z" fill="#0B0F14"/>
+<rect width="1400" height="612" rx="14" fill="#0B0F14"/>
+<g transform="translate(0,-48)">
 
 <text x="48.0" y="92.0" fill="#8B949E" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0.09em">TRUTH-RECALL</text>
 <text x="44.0" y="144.0" fill="#16A34A" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="46" font-weight="750" text-anchor="start" letter-spacing="-0.03em">63.74%</text>
@@ -121,4 +116,5 @@
 <text x="1000.0" y="418.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Firecrawl's own public 1,000-URL set,</text>
 <text x="1000.0" y="436.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">all three tools through one matcher.</text>
 <text x="1000.0" y="454.0" fill="#8B949E" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif" font-size="11.5" font-weight="400" text-anchor="start">Rerun it yourself: BENCHMARKS.md</text>
+</g>
 </svg>

--- a/scripts/bench-radar.py
+++ b/scripts/bench-radar.py
@@ -74,7 +74,7 @@ AXES = [
 
 COLOR = {"crw": "#16A34A", "c4ai": "#0284C7", "fc": "#EA580C"}
 DASH = {"c4ai": "6 3", "fc": "2 3"}
-BG, CHROME = "#0B0F14", "#141B24"
+BG = "#0B0F14"
 INK, INK2, INK3 = "#E6EDF3", "#8B949E", "#5C6773"
 GRID, GRID_TOP, WARN = "#1C232B", "#2C353F", "#D97706"
 FONT = "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif"
@@ -82,6 +82,7 @@ MONO = "ui-monospace,SFMono-Regular,Menlo,monospace"
 
 W, H = 1400, 660
 CX, CY, R = 628, 330, 158
+CHROME_H = 48  # height the dropped browser-chrome bar used to occupy at the top
 
 
 def norm(ax, value):
@@ -285,7 +286,11 @@ def _legend(x, y):
 
 
 def render():
-    return f"""<svg viewBox="0 0 {W} {H}" xmlns="http://www.w3.org/2000/svg" role="img"
+    # The old browser-chrome bar (traffic lights + URL + badge) is dropped. The
+    # content coordinates below still use the original H as their reference; the
+    # panel is CHROME_H shorter and everything is shifted up by that amount in
+    # one group transform, so no individual y needs touching.
+    return f"""<svg viewBox="0 0 {W} {H - CHROME_H}" xmlns="http://www.w3.org/2000/svg" role="img"
   aria-label="fastCRW leads truth-recall, unique recoveries, median latency, install size and recall depth on Firecrawl's public 1,000-URL dataset">
 <defs>
   <radialGradient id="grad" cx="50%" cy="50%" r="50%">
@@ -295,13 +300,8 @@ def render():
     <feGaussianBlur stdDeviation="7" result="b"/>
     <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
 </defs>
-<rect width="{W}" height="{H}" rx="14" fill="{CHROME}"/>
-<circle cx="30" cy="24" r="5.5" fill="#FF5F57"/><circle cx="50" cy="24" r="5.5" fill="#FEBC2E"/><circle cx="70" cy="24" r="5.5" fill="#28C840"/>
-<rect x="96" y="12" width="880" height="24" rx="6" fill="{BG}"/>
-{_text(110, 29, "fastcrw.com/benchmarks", INK2, 12, font=MONO)}
-<rect x="1236" y="12" width="140" height="24" rx="6" fill="{BG}" stroke="{COLOR["crw"]}" stroke-opacity="0.4"/>
-{_text(1306, 29, "[ 1000 URLs ]", COLOR["crw"], 11, 400, "middle", MONO)}
-<path d="M0 48 H{W} V{H - 14} a14 14 0 0 1 -14 14 H14 a14 14 0 0 1 -14 -14 Z" fill="{BG}"/>
+<rect width="{W}" height="{H - CHROME_H}" rx="14" fill="{BG}"/>
+<g transform="translate(0,{-CHROME_H})">
 
 {_stat(48, 92, "TRUTH-RECALL", "63.74%", "recall mode · 522 of 819 labeled", 46)}
 <line x1="48" y1="178" x2="330" y2="178" stroke="{GRID}"/>
@@ -324,6 +324,7 @@ def render():
 {_text(1000, 418, "Firecrawl's own public 1,000-URL set,", INK2, 11.5)}
 {_text(1000, 436, "all three tools through one matcher.", INK2, 11.5)}
 {_text(1000, 454, "Rerun it yourself: BENCHMARKS.md", INK2, 11.5)}
+</g>
 </svg>
 """
 


### PR DESCRIPTION
Removes the fake browser-chrome bar (URL bar, traffic lights, [1000 URLs] badge) from the top of `bench-radar.svg`. Panel now starts at the content, shorter by the bar's height via a single group transform. Regenerated from `scripts/bench-radar.py`; self-check + ruff clean. No Rust touched.