### PR TITLE
chore: add contributor license agreement and CLA bot

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -152,12 +152,16 @@ convert arbitrary file URLs to Markdown without a separate HTTP call.
 4. **CI must be green** — the `check` and `sdk-ts` jobs in CI are required. A PR
    with a red CI will not be reviewed.
 
-5. **One approval required** — a maintainer will review. Address feedback by pushing
+5. **Sign the CLA** — on your first PR a bot asks you to sign our
+   [Contributor License Agreement](../CLA.md). It takes one comment and covers all
+   of your future contributions. PRs can't be merged until it's signed.
+
+6. **One approval required** — a maintainer will review. Address feedback by pushing
    new commits (no force-pushes to open PRs, please).
 
-6. **Merge** — maintainers merge with rebase-and-merge to keep a linear history.
+7. **Merge** — maintainers merge with rebase-and-merge to keep a linear history.
 
-7. **Releases** — release-please opens a Release PR automatically as commits
+8. **Releases** — release-please opens a Release PR automatically as commits
    accumulate on `main`. Merging that PR creates the tag and GitHub Release. You
    do not need to do anything version-related.
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write # store signatures in the signatures branch
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/us/crw/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: us,dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: |
+            Thanks for the pull request. Before we can merge it, please read our [Contributor License Agreement](https://github.com/us/crw/blob/main/CLA.md) and sign it by posting the comment below in this PR.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,79 @@
+# fastCRW Contributor License Agreement
+
+Thank you for your interest in contributing to fastCRW (the "Project"), maintained
+by Recep Ahmet Sarıtekin (the "Maintainer").
+
+This Contributor License Agreement ("Agreement") sets out the terms under which
+Your contributions are made to the Project. It protects You, the Maintainer, and
+everyone who relies on the Project. You accept and agree to these terms for Your
+present and future Contributions submitted to the Project. Except for the license
+granted here, You retain all right, title, and interest in and to Your Contributions.
+
+You sign this Agreement once, by commenting on your first pull request as prompted
+by the CLA bot. Signing covers all of your future Contributions to the Project.
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) means the individual, or the legal entity on whose
+  behalf the individual is authorized to act, that submits a Contribution. For a
+  legal entity, all entities that control, are controlled by, or are under common
+  control with that entity are considered a single Contributor.
+- **"Contribution"** means any original work of authorship, including any
+  modification or addition to existing work, that You intentionally submit to the
+  Project for inclusion in, or documentation of, the Project. "Submit" means any
+  form of electronic, verbal, or written communication sent to the Project,
+  including but not limited to pull requests, issues, and patches.
+
+## 2. Copyright license
+
+You grant to the Maintainer and to recipients of software distributed by the
+Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative works.
+
+You agree that the Maintainer may license Your Contributions, and derivative works
+of Your Contributions, **under any license terms of the Maintainer's choosing,
+including open source, proprietary, and commercial licenses**. This allows the
+Project to be offered under the AGPL-3.0 and, in the future, under separate
+commercial terms, without requiring further permission from You.
+
+## 3. Patent license
+
+You grant to the Maintainer and to recipients of software distributed by the
+Project a perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer Your Contributions, where such license applies
+only to those patent claims licensable by You that are necessarily infringed by
+Your Contributions alone or by combination of Your Contributions with the Project.
+If any entity institutes patent litigation against You or any other entity alleging
+that Your Contribution, or the Project to which You contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Project terminate as of the
+date such litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+1. Each of Your Contributions is Your original creation, and You have the legal
+   right to grant the licenses above.
+2. If Your employer has rights to intellectual property that You create, You have
+   received permission to make the Contributions on behalf of that employer, or
+   Your employer has waived such rights for Your Contributions to the Project.
+3. Your Contributions do not, to Your knowledge, violate any third party's
+   copyrights, trademarks, patents, or other intellectual property rights.
+4. Should You wish to submit work that is not Your original creation, You may
+   submit it separately, clearly identifying the source and any license or other
+   restriction of which You are aware.
+
+## 5. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to do so. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" basis, without warranties or
+conditions of any kind, either express or implied.
+
+## 6. Agreement
+
+By signing, You accept and agree to the terms of this Agreement for Your present
+and future Contributions to the Project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Contributions are welcome — issues and PRs both.
 
+## Contributor License Agreement
+
+On your first pull request a bot will ask you to sign our
+[Contributor License Agreement](CLA.md). It takes one comment and covers all of
+your future contributions. We can't merge PRs until it's signed.
+
 ## Development setup
 
 1. Fork the repository


### PR DESCRIPTION
Adds a Contributor License Agreement and automated enforcement so external contributions carry a clear license grant going forward.

## What's in here

- **`CLA.md`** — combined individual/entity CLA. The copyright grant lets the maintainer relicense contributions under any terms (including commercial), keeping a future dual-license option open alongside AGPL-3.0. Includes patent grant and originality representations (Apache ICLA derived).
- **`.github/workflows/cla.yml`** — `contributor-assistant/github-action` (SHA-pinned v2.6.1). On a contributor's first PR the bot asks for a one-comment signature; signatures are stored in-repo on a `cla-signatures` branch. Uses the built-in `GITHUB_TOKEN`, no external service or secret to configure.
- **`CONTRIBUTING.md` / `.github/CONTRIBUTING.md`** — short note pointing contributors at the CLA.

## After merge

The bot only activates once the workflow is on `main`. Optional but recommended: add the `CLA Assistant` status check as a required check in `main` branch protection so unsigned PRs are blocked from merging.