### PR TITLE
fix: recover HTTP-200 datacenter block shells (Wikimedia) via residential egress

### DIFF
--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -1028,6 +1028,23 @@ fn classify_block(
             reason: "cloudflare challenge interstitial".to_string(),
         });
     }
+    // Wikimedia serves its datacenter-IP ban as an HTTP-200 static error shell
+    // whose error prose extracts to ~110 bytes of markdown — over the guard
+    // below — so the antibot classifier (which runs after the guard) never sees
+    // it and the block leaks as success:true. This footer sentence is unique to
+    // the Wikimedia error page, so treat it as a strong marker and classify
+    // ahead of the markdown-substantial guard, mirroring the CF markers above.
+    // Case-sensitive like CF_STRONG_MARKERS: the sentence is a fixed literal in
+    // Wikimedia's Varnish/ops error template (below the app layer, language- and
+    // wiki-independent), so its casing does not vary across requests.
+    // ponytail: one canonical sentence keeps false positives ~nil; a real
+    // article never carries it.
+    if html.contains("report this error to the Wikimedia System Administrators") {
+        return Some(BlockOutcome {
+            vendor: "generic_block".to_string(),
+            reason: "wikimedia datacenter-ip block".to_string(),
+        });
+    }
     if markdown.map(|m| m.trim().len()).unwrap_or(0) >= threshold {
         return None;
     }
@@ -1120,6 +1137,27 @@ mod tests {
         let b = classify_block(403, Some("text/html"), html, None, false, THRESH)
             .expect("DataDome block must be flagged");
         assert_eq!(b.vendor, "datadome");
+    }
+
+    #[test]
+    fn classify_block_wikimedia_200_shell_over_markdown_guard() {
+        // Regression for the silent-success bug: Wikimedia's HTTP-200 datacenter
+        // ban extracts to ~110 bytes of error prose (> THRESH), so the
+        // markdown-substantial guard would suppress the antibot verdict. The
+        // strong-marker check must classify it as a block regardless, mirroring
+        // the CF strong-marker path.
+        let html = r#"<!DOCTYPE html><html lang="en"><title>Wikimedia Error</title>
+<div class="content"><h1>Error</h1><p>Contabo networks are forbidden due to abuse.</p></div>
+<div class="footer"><p>If you report this error to the Wikimedia System Administrators, please include the details below.</p></div></html>"#;
+        // Matches what crw_extract::extract() yields for this shell (~114 bytes).
+        let md = "# Wikimedia Error\n\n# Error\n\nContabo networks are forbidden due to abuse. Contact noc@wikimedia.org for assistance.";
+        assert!(
+            md.len() >= THRESH,
+            "fixture must exceed the guard to be meaningful"
+        );
+        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
+            .expect("wikimedia datacenter block must be flagged even with substantial markdown");
+        assert_eq!(b.vendor, "generic_block");
     }
 
     #[test]

--- a/crates/crw-renderer/src/detector.rs
+++ b/crates/crw-renderer/src/detector.rs
@@ -98,7 +98,23 @@ pub fn looks_like_generic_bot_wall(html: &str) -> bool {
         return false;
     }
     let lower = html.to_lowercase();
-    let body_stripped = body_html_without_scripts_lower(&lower);
+    // Most block shells wrap their text in <body>; extracting body-only text
+    // keeps a phrase buried in a JS bundle from false-positiving. A few shells
+    // (Wikimedia's Varnish error page) omit <body> entirely — the text sits in
+    // <div>s directly under <html>, so body-only extraction returns "" and no
+    // phrase can ever match. When an HTML document has no <body> tag, fall back
+    // to the whole document with <script>/<style> stripped. The fallback is
+    // gated on an <html>/<!doctype html> marker so a directly-scraped JSON / XML
+    // / plain-text response (which never carries <body>) is NOT scanned — else a
+    // small `{"error":"access_denied"}` payload would trip an existing phrase.
+    // The 600-char cap below still guards against real articles.
+    let body_stripped = if lower.contains("<body") {
+        body_html_without_scripts_lower(&lower)
+    } else if lower.contains("<html") || lower.contains("<!doctype html") {
+        strip_tag_blocks(&strip_tag_blocks(&lower, "script"), "style")
+    } else {
+        return false;
+    };
     let body_text = visible_text_from_stripped_html(&body_stripped);
     if body_text.chars().filter(|c| !c.is_whitespace()).count() > 600 {
         return false;
@@ -120,6 +136,10 @@ pub fn looks_like_generic_bot_wall(html: &str) -> bool {
         // Akamai / AWS-style geo-block phrasing — also surfaces on some
         // origin-side firewall pages that don't say "blocked" outright.
         "configured to block access",
+        // Wikimedia serves its datacenter-IP ban as an HTTP-200 static error
+        // shell (no <body> tag). This canonical footer sentence is unique to
+        // that page — a real article never carries it.
+        "if you report this error to the wikimedia system administrators",
     ];
     phrases.iter().any(|p| body_text.contains(p))
 }
@@ -850,6 +870,62 @@ mod tests {
         let html = r#"<html><body><h1>403</h1>
             <p>Our firewall is configured to block access from this region.</p></body></html>"#;
         assert!(looks_like_generic_bot_wall(html));
+    }
+
+    /// The Wikimedia Varnish error shell, reproducing the real structure: an
+    /// HTTP-200 static page with NO <body>/<head> tags, one inline <style>, and
+    /// the content in <div>s directly under <html> (source: Wikimedia
+    /// operations/puppet error templates).
+    fn wikimedia_block_html() -> &'static str {
+        r#"<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>Wikimedia Error</title>
+<style>body{font-family:sans-serif}</style>
+<meta name="color-scheme" content="light dark">
+<div class="content" role="main">
+<h1>Error</h1>
+<p>Contabo networks are forbidden due to abuse. Contact noc@wikimedia.org for assistance.</p>
+</div>
+<div class="footer">
+<p>If you report this error to the Wikimedia System Administrators, please include the details below.</p>
+<p class="text-muted"><code>Request served via cp6016, Varnish XID 12345<br>Error: 403, Contabo networks are forbidden due to abuse.<br><details><summary>Sensitive client information</summary>IP address: 207.180.230.151</details></code></p>
+</div>
+</html>"#
+    }
+
+    #[test]
+    fn wikimedia_http200_block_shell_is_bot_wall() {
+        // Regression for the silent-success bug: the Wikimedia error page is
+        // HTTP-200, scriptless, and crucially has NO <body> tag. Body-only text
+        // extraction returned "" here, so the phrase list never matched. The
+        // no-<body> fallback must let the canonical footer phrase trip.
+        assert!(looks_like_generic_bot_wall(wikimedia_block_html()));
+    }
+
+    #[test]
+    fn json_api_error_without_body_is_not_bot_wall() {
+        // Regression: a directly-scraped JSON/plain-text error response has no
+        // <body> AND no <html> marker, so the no-<body> fallback must not scan
+        // it — otherwise the existing "access denied" phrase would wrongly flag
+        // a legitimate small API payload as a block.
+        let json = r#"{"error":"access_denied","message":"Access Denied: insufficient permissions for this resource"}"#;
+        assert!(!looks_like_generic_bot_wall(json));
+        let xml = r#"<?xml version="1.0"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"#;
+        assert!(!looks_like_generic_bot_wall(xml));
+    }
+
+    #[test]
+    fn real_wikipedia_article_is_not_bot_wall() {
+        // A real article (>600 visible chars, normal <body>) must NOT trip.
+        let html = format!(
+            "<html><body><article><h1>Radcliffe College</h1>{}</article></body></html>",
+            "<p>Radcliffe College was a women's liberal arts college in Cambridge, \
+             Massachusetts, and functioned as the female coordinate institution for \
+             the all-male Harvard College.</p>"
+                .repeat(6)
+        );
+        assert!(!looks_like_generic_bot_wall(&html));
     }
 
     #[test]

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -313,11 +313,33 @@ struct JsAttemptClass {
 /// residential egress DOES recover — those still fire the arm. The `vendor_block`
 /// "cloudflare" arm is deliberately excluded (CF is matched via `cf_challenge`)
 /// so a CF error-1020 IP block is NOT wrongly suppressed.
-fn is_fingerprint_vendor_wall(cf_challenge: bool, vendor_block: Option<&str>) -> bool {
+fn is_fingerprint_vendor_wall(
+    cf_challenge: bool,
+    vendor_block: Option<&str>,
+    antibot_signal: crw_extract::antibot::AntibotSignal,
+) -> bool {
+    use crw_extract::antibot::AntibotSignal;
     cf_challenge
         || matches!(
             vendor_block,
             Some("datadome" | "perimeterx" | "kasada" | "akamai" | "imperva")
+        )
+        // `antibot::classify` recognises these vendors from visible text alone
+        // (a PerimeterX/Imperva page without its SDK marker, or a CF page with a
+        // single weak marker) that `looks_like_vendor_block` misses — yet those
+        // feed `saw_hard_block` via `antibot.signal.is_blocked()`, so without
+        // this arm the residential tier would fire on a wall it can't clear.
+        // Sucuri / NetworkSecurity / GenericBlock / RateLimited /
+        // StructuralFailure stay OUT (IP-reputation blocks a residential egress
+        // recovers).
+        || matches!(
+            antibot_signal,
+            AntibotSignal::Cloudflare
+                | AntibotSignal::Datadome
+                | AntibotSignal::PerimeterX
+                | AntibotSignal::Akamai
+                | AntibotSignal::Imperva
+                | AntibotSignal::Kasada
         )
 }
 
@@ -1441,7 +1463,8 @@ impl FallbackRenderer {
             && !cf_challenge
             && !is_status_blocked
             && !antibot_blocked;
-        let unrecoverable_wall = is_fingerprint_vendor_wall(cf_challenge, vendor_block);
+        let unrecoverable_wall =
+            is_fingerprint_vendor_wall(cf_challenge, vendor_block, antibot.signal);
         JsAttemptClass {
             text_len,
             is_placeholder,
@@ -2045,7 +2068,7 @@ impl FallbackRenderer {
                     // Phase 2: track hard-block (egress-recoverable) outcomes for
                     // the gated chrome_proxy arm. Hard-block status subset only
                     // (not 404/410/412/451/500) + interstitial walls.
-                    if is_fingerprint_vendor_wall(cf_challenge, vendor_block) {
+                    if is_fingerprint_vendor_wall(cf_challenge, vendor_block, antibot.signal) {
                         saw_unrecoverable_wall = true;
                     }
                     if matches!(result.status_code, 401 | 403 | 429 | 503)
@@ -4041,6 +4064,56 @@ mod tests {
         assert!(
             !result.html.contains("PROXY-"),
             "chrome_proxy must be suppressed on a DataDome wall, got proxy output"
+        );
+        if let Some(RenderDecision::Failover { chain, .. }) = &result.render_decision {
+            assert!(
+                !chain.contains(&RendererKind::ChromeProxy),
+                "chain must not include chrome_proxy on a DataDome wall: {chain:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn chrome_proxy_suppressed_on_antibot_only_vendor_wall() {
+        // Regression: a PerimeterX wall recognised ONLY by antibot::classify from
+        // visible text (no `window._pxAppId` SDK marker, so `looks_like_vendor_block`
+        // returns None and `looks_like_cloudflare_challenge` is false). It still
+        // sets saw_hard_block via `antibot.signal.is_blocked()`, so the arm must
+        // suppress it off the antibot signal — else the residential tier burns the
+        // deadline on a fingerprint wall it can't clear.
+        let px = format!(
+            "<html><body><h1>Access to This Page Has Been Blocked</h1>{}</body></html>",
+            "x".repeat(200)
+        );
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::OkStatus(403, px.clone()),
+        }) as Arc<dyn PageFetcher>;
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::OkStatus(403, px),
+        }) as Arc<dyn PageFetcher>;
+        let chrome_proxy = Arc::new(MockFetcher {
+            name: "chrome_proxy",
+            behavior: MockBehavior::Ok(rich_html("PROXY-")),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![lp, chrome, chrome_proxy]);
+        r.auto_egress_escalation = true; // pull chrome_proxy into the gated arm
+
+        let result = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                Some("auto"),
+                tdl(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.html.contains("PROXY-"),
+            "chrome_proxy must be suppressed on an antibot-detected PerimeterX wall"
         );
     }
 

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -298,18 +298,39 @@ struct JsAttemptClass {
     antibot_blocked: bool,
     /// Egress-recoverable hard-block (drives the gated chrome_proxy recovery arm).
     hard_block: bool,
+    /// A fingerprint-vendor wall chrome_proxy cannot clear (suppresses the arm).
+    unrecoverable_wall: bool,
     /// Passes the success accept-gate (return as-is, don't escalate).
     acceptable: bool,
+}
+
+/// A fingerprint-vendor wall that chrome_proxy's default Chrome fingerprint
+/// cannot clear (it needs the camoufox/cloak stealth tier): a Cloudflare managed
+/// challenge, DataDome, PerimeterX, Kasada, Akamai, or Imperva. Firing the slow
+/// residential tier on one just burns the deadline (the p90 regression the arm
+/// was tuned against), so it suppresses the arm. Distinct from IP-reputation
+/// blocks (429 / IP-ban 403 / generic bot walls / CF error-1020) that a
+/// residential egress DOES recover — those still fire the arm. The `vendor_block`
+/// "cloudflare" arm is deliberately excluded (CF is matched via `cf_challenge`)
+/// so a CF error-1020 IP block is NOT wrongly suppressed.
+fn is_fingerprint_vendor_wall(cf_challenge: bool, vendor_block: Option<&str>) -> bool {
+    cf_challenge
+        || matches!(
+            vendor_block,
+            Some("datadome" | "perimeterx" | "kasada" | "akamai" | "imperva")
+        )
 }
 
 /// Result of the conditional hedge (race lightpanda+chrome).
 enum HedgeOutcome {
     /// A tier passed the accept-gate — return as-is (terminal).
     Accepted(FetchResult),
-    /// Both tiers thin/failed — best-thin result + whether a hard-block was seen
-    /// (so the caller can fire the gated auto-egress recovery arm). Mirrors the
-    /// serial loop's `thin_result` + `saw_hard_block` fall-through.
-    Thin(FetchResult, bool),
+    /// Both tiers thin/failed — best-thin result, whether a hard-block was seen
+    /// (so the caller can fire the gated auto-egress recovery arm), and whether
+    /// any attempt was a fingerprint-vendor wall (so the arm is suppressed even
+    /// if the size-race stitch dropped that attempt's HTML). Mirrors the serial
+    /// loop's `thin_result` + `saw_hard_block` + `saw_unrecoverable_wall`.
+    Thin(FetchResult, bool, bool),
 }
 
 /// Did this renderer error come from failing to reach/navigate the ORIGIN, as
@@ -344,6 +365,16 @@ fn is_origin_navigation_failure(e: &CrwError) -> bool {
 /// Guards the main ladder loop, the hedge dispatch, the breaker leak-through arm,
 /// and the HTTP tier's proxy retry (`http_only`).
 pub(crate) const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
+
+/// Minimum remaining deadline to dispatch the `chrome_proxy` auto-egress
+/// recovery arm. Deliberately decoupled from `chrome_proxy_timeout()` (the
+/// per-attempt ceiling ≈ `chrome_timeout + 15s` = 45s on prod): that ceiling
+/// exceeds the ~15-20s request deadline, so gating on it kept the arm
+/// permanently inert (the residential-egress recovery never fired). The arm's
+/// fetch is already deadline-bounded, so this floor only refuses a residential
+/// dispatch too small to plausibly complete. ~8s fires under both the 15s and
+/// 20s prod deadlines once the ladder has failed fast; tune via the p90 bench.
+pub(crate) const CHROME_PROXY_ARM_FLOOR_MS: u64 = 8_000;
 
 /// Concurrency permits for the cloak recovery arm — sized to the sidecar's
 /// cold-solve browser cap (`CF_MAX_CONCURRENT_BROWSERS`, default 4) so the
@@ -1410,6 +1441,7 @@ impl FallbackRenderer {
             && !cf_challenge
             && !is_status_blocked
             && !antibot_blocked;
+        let unrecoverable_wall = is_fingerprint_vendor_wall(cf_challenge, vendor_block);
         JsAttemptClass {
             text_len,
             is_placeholder,
@@ -1420,6 +1452,7 @@ impl FallbackRenderer {
             antibot,
             antibot_blocked,
             hard_block,
+            unrecoverable_wall,
             acceptable,
         }
     }
@@ -1537,9 +1570,11 @@ impl FallbackRenderer {
         }
         // lightpanda completed thin → record it (serial would have).
         let mut saw_hard_block = false;
+        let mut saw_unrecoverable_wall = false;
         if let Some(Ok(res)) = &lp_res {
             let cls = self.classify_js_attempt(res);
             saw_hard_block |= cls.hard_block;
+            saw_unrecoverable_wall |= cls.unrecoverable_wall;
             self.record_hedge_thin(host, RendererKind::Lightpanda, &cls, &mut lp_guard)
                 .await;
         }
@@ -1558,6 +1593,7 @@ impl FallbackRenderer {
         if let Some(Ok(res)) = &ch_res {
             let cls = self.classify_js_attempt(res);
             saw_hard_block |= cls.hard_block;
+            saw_unrecoverable_wall |= cls.unrecoverable_wall;
             self.record_hedge_thin(host, RendererKind::Chrome, &cls, &mut ch_guard)
                 .await;
         }
@@ -1569,7 +1605,11 @@ impl FallbackRenderer {
             .filter_map(|r| r.ok())
             .max_by_key(|r| r.html.len());
         match thin {
-            Some(r) => Ok(Some(HedgeOutcome::Thin(r, saw_hard_block))),
+            Some(r) => Ok(Some(HedgeOutcome::Thin(
+                r,
+                saw_hard_block,
+                saw_unrecoverable_wall,
+            ))),
             // Both tiers errored — let the caller fall back to serial for its
             // richer error handling rather than inventing an error here.
             None => Ok(None),
@@ -1778,6 +1818,11 @@ impl FallbackRenderer {
         // Drives the gated chrome_proxy recovery arm below. Excludes
         // 404/410/412/451/500 (a different egress IP won't fix those).
         let mut saw_hard_block = false;
+        // Was any attempt a fingerprint-vendor wall chrome_proxy can't clear?
+        // Tracked at detection time (not re-detected from the stitched
+        // `thin_result`, whose largest-HTML keeper can drop a small vendor shell
+        // in a multi-hop chain) so the arm is reliably suppressed on those.
+        let mut saw_unrecoverable_wall = false;
         // Snapshot for the leak-through fallback below. The main loop
         // consumes `renderers`; we keep a parallel reference list so a
         // single skipped renderer can still get a shot when its host
@@ -1814,9 +1859,10 @@ impl FallbackRenderer {
                 .await
             {
                 Ok(Some(HedgeOutcome::Accepted(r))) => return Ok(r),
-                Ok(Some(HedgeOutcome::Thin(r, hb))) => {
+                Ok(Some(HedgeOutcome::Thin(r, hb, uw))) => {
                     thin_result = Some(r);
                     saw_hard_block |= hb;
+                    saw_unrecoverable_wall |= uw;
                     chain.push(RendererKind::Lightpanda);
                     chain.push(RendererKind::Chrome);
                     hedge_done = true;
@@ -1999,6 +2045,9 @@ impl FallbackRenderer {
                     // Phase 2: track hard-block (egress-recoverable) outcomes for
                     // the gated chrome_proxy arm. Hard-block status subset only
                     // (not 404/410/412/451/500) + interstitial walls.
+                    if is_fingerprint_vendor_wall(cf_challenge, vendor_block) {
+                        saw_unrecoverable_wall = true;
+                    }
                     if matches!(result.status_code, 401 | 403 | 429 | 503)
                         || (520..=530).contains(&result.status_code)
                         || is_bot_wall
@@ -2428,16 +2477,26 @@ impl FallbackRenderer {
         };
         if let Some(arm) = auto_egress_arm {
             let kind = RendererKind::ChromeProxy;
-            let tier_budget = self
-                .tier_timeouts
-                .get(&kind)
-                .copied()
-                .unwrap_or_else(|| std::time::Duration::from_secs(30));
-            // `tier_budget` is normally far above MIN_TIER_BUDGET (chrome_proxy defaults
-            // to chrome_timeout + 15s), but an operator can configure it lower. Take the
-            // stricter of the two so no JS dispatch path can run on a degenerate budget.
-            let arm_floor = tier_budget.max(MIN_TIER_BUDGET);
-            if saw_hard_block && !route_to_cloak && deadline.remaining() >= arm_floor {
+            let arm_floor = std::time::Duration::from_millis(CHROME_PROXY_ARM_FLOOR_MS);
+            // chrome_proxy is default-Chrome + residential IP: it recovers
+            // IP-reputation blocks (429 / IP-ban 403 / generic bot walls / CF
+            // error-1020 / Wikimedia origin bans) but CANNOT clear a
+            // fingerprint-vendor challenge — CF managed challenge, DataDome,
+            // PerimeterX, Kasada, Akamai, Imperva — which needs the stealth
+            // (camoufox/cloak) tier. Firing the slow residential tier on those
+            // just burns the deadline (the p90 regression this arm was tuned
+            // against: success −2pp, p90 +69%), so suppress it there.
+            // `saw_unrecoverable_wall` is tracked at detection time across the
+            // serial and hedge paths (see `is_fingerprint_vendor_wall`); it works
+            // in a lean (no-cloak) build where `route_to_cloak` is always false,
+            // and unlike re-detecting from `thin_result` it can't miss a small
+            // vendor shell that the largest-HTML stitch dropped mid-chain.
+            if saw_hard_block
+                && !route_to_cloak
+                && !saw_unrecoverable_wall
+                && deadline.remaining() >= arm_floor
+                && !self.breakers.host_for(&host, kind).await.is_open()
+            {
                 chain.push(kind);
                 let entry = self.pick_proxy_for_url(url);
                 let attempt = REQUEST_PROXY
@@ -2947,6 +3006,23 @@ mod tests {
             "<html><body><article>{}{}</article></body></html>",
             marker,
             "x".repeat(200)
+        )
+    }
+
+    /// Wikimedia's HTTP-200 datacenter-IP block shell (no <body>, scriptless).
+    fn wikimedia_block_html() -> String {
+        String::from(
+            r#"<!DOCTYPE html>
+<html lang="en">
+<title>Wikimedia Error</title>
+<div class="content" role="main">
+<h1>Error</h1>
+<p>Contabo networks are forbidden due to abuse. Contact noc@wikimedia.org for assistance.</p>
+</div>
+<div class="footer">
+<p>If you report this error to the Wikimedia System Administrators, please include the details below.</p>
+</div>
+</html>"#,
         )
     }
 
@@ -3720,6 +3796,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn js_tier_escalates_on_wikimedia_block_with_200() {
+        // Wikimedia serves its datacenter-IP ban as an HTTP-200 scriptless error
+        // shell with NO <body> tag. The chain must escalate off it instead of
+        // returning the shell as a successful render.
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(wikimedia_block_html()),
+        }) as Arc<dyn PageFetcher>;
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Ok(rich_html("CHROME-")),
+        }) as Arc<dyn PageFetcher>;
+        let r = make_renderer_with_mocks(vec![lp, chrome]);
+
+        let result = r
+            .fetch(
+                "https://en.wikipedia.org/wiki/Radcliffe_College",
+                &HashMap::new(),
+                Some(true),
+                None,
+                Some("auto"),
+                tdl(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.html.contains("CHROME-"),
+            "expected chrome output after lightpanda wikimedia block, got: {}",
+            result.html
+        );
+    }
+
+    #[tokio::test]
     async fn js_tier_accepts_200_clean_response() {
         // Regression: a clean 200 from the first renderer must still be
         // accepted — no false escalation triggered by the new gates.
@@ -3801,6 +3910,137 @@ mod tests {
                 ],
                 reason: FailoverErrorKind::AntibotBlock,
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn chrome_proxy_arm_fires_under_realistic_deadline() {
+        // Regression lock for the budget-gate bug: a non-CF hard block under a
+        // realistic 15s deadline must still reach chrome_proxy. The old floor
+        // (chrome_proxy_timeout ≈ 45s) exceeded the deadline and kept the
+        // residential-egress recovery arm permanently inert.
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(network_security_block_html()),
+        }) as Arc<dyn PageFetcher>;
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Ok(network_security_block_html()),
+        }) as Arc<dyn PageFetcher>;
+        // Recovered content must out-size the thin block for best-result-wins.
+        let chrome_proxy = Arc::new(MockFetcher {
+            name: "chrome_proxy",
+            behavior: MockBehavior::Ok(format!(
+                "<html><body><article>PROXY-RECOVERED{}</article></body></html>",
+                "y".repeat(400)
+            )),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![lp, chrome, chrome_proxy]);
+        r.auto_egress_escalation = true; // pull chrome_proxy into the gated arm
+
+        let result = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                Some("auto"),
+                crw_core::Deadline::from_request_ms(15_000),
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.html.contains("PROXY-"),
+            "chrome_proxy must fire under a 15s deadline, got: {}",
+            result.html
+        );
+    }
+
+    #[tokio::test]
+    async fn chrome_proxy_suppressed_on_cloudflare_challenge() {
+        // chrome_proxy (default Chrome fingerprint) cannot clear a CF managed
+        // challenge, so the arm must NOT fire on it — it would only burn the
+        // deadline. The chain stops at chrome and returns the honest block.
+        // 60s deadline isolates the suppression from the budget floor.
+        let cf = format!(
+            "<html><body><div id=\"cf-browser-verification\">Just a moment...</div>{}</body></html>",
+            "x".repeat(200)
+        );
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(cf.clone()),
+        }) as Arc<dyn PageFetcher>;
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Ok(cf),
+        }) as Arc<dyn PageFetcher>;
+        let chrome_proxy = Arc::new(MockFetcher {
+            name: "chrome_proxy",
+            behavior: MockBehavior::Ok(rich_html("PROXY-")),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![lp, chrome, chrome_proxy]);
+        r.auto_egress_escalation = true; // pull chrome_proxy into the gated arm
+
+        let result = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                Some("auto"),
+                tdl(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.html.contains("PROXY-"),
+            "chrome_proxy must be suppressed on a CF challenge, got proxy output"
+        );
+        if let Some(RenderDecision::Failover { chain, .. }) = &result.render_decision {
+            assert!(
+                !chain.contains(&RendererKind::ChromeProxy),
+                "chain must not include chrome_proxy on a CF challenge: {chain:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn chrome_proxy_suppressed_on_datadome_wall() {
+        // DataDome is a fingerprint wall like CF — chrome_proxy can't clear it,
+        // so the arm must suppress it rather than burn the deadline.
+        let dd = format!(
+            "<html><body><iframe src=\"https://geo.captcha-delivery.com/captcha/?cid=x\"></iframe>{}</body></html>",
+            "x".repeat(200)
+        );
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(dd.clone()),
+        }) as Arc<dyn PageFetcher>;
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Ok(dd),
+        }) as Arc<dyn PageFetcher>;
+        let chrome_proxy = Arc::new(MockFetcher {
+            name: "chrome_proxy",
+            behavior: MockBehavior::Ok(rich_html("PROXY-")),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![lp, chrome, chrome_proxy]);
+        r.auto_egress_escalation = true; // pull chrome_proxy into the gated arm
+
+        let result = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                Some("auto"),
+                tdl(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.html.contains("PROXY-"),
+            "chrome_proxy must be suppressed on a DataDome wall, got proxy output"
         );
     }
 


### PR DESCRIPTION
Two related fixes so a Wikipedia scrape from a blocked datacenter IP recovers real content instead of silently returning a block as success.

## 1. Detect & surface the HTTP-200 Wikimedia block shell
Wikipedia serves its datacenter-IP ban as an HTTP-200 static error shell (no `<body>` tag, scriptless). It slipped through detection and was returned as `success:true` with the ~260-char shell as content.

- `looks_like_generic_bot_wall`: when an HTML document has no `<body>`, scan the whole doc (scripts/styles stripped) so a shell whose text sits in `<div>`s under `<html>` is inspected. Gated on an `<html>`/`<!doctype html>` marker so a directly-scraped JSON/XML/plain-text response is NOT scanned (avoids false-positiving a small `{"error":"access_denied"}` payload on the existing phrase list). Adds the canonical Wikimedia footer phrase.
- `classify_block`: matches the Wikimedia strong marker ahead of the markdown-substantial guard (mirroring the CF markers) so the block is surfaced (`blocked=true`, no billing) even though the shell yields ~110 bytes of markdown that would otherwise suppress the antibot verdict.

## 2. Fire the chrome_proxy residential recovery arm under the default deadline
The residential-egress recovery tier was gated on `chrome_proxy_timeout` (`chrome_timeout + 15s` = 45s), which exceeds the ~15-20s request deadline, so the arm never fired on prod (verified: a hard block returns `chain:["lightpanda","chrome"]`, and only `timeout:90000` reaches `chrome_proxy`).

- Floor lowered to `CHROME_PROXY_ARM_FLOOR_MS` (8s); the arm's fetch is deadline-bounded, so the full ceiling only kept it inert.
- Suppress the arm on fingerprint-vendor walls its default-Chrome fingerprint cannot clear (CF managed challenge, DataDome, PerimeterX, Kasada, Akamai, Imperva) so the slow residential tier does not burn the deadline; keep firing on IP-reputation blocks (429 / IP-ban 403 / generic bot walls / CF error-1020 / Wikimedia origin bans) it can recover.
- The vendor-wall signal is tracked at detection time (serial + hedge) so the largest-HTML thin stitch cannot drop a small vendor shell mid-chain.
- Adds a ChromeProxy breaker guard (parity with the cloak arm).

## Deploy / validation notes
- opencore is the engine: Docker images build only on releases, so a merge to `main` is not live on prod until the next release-please release.
- The Wikimedia block only reproduces from the blocked Contabo prod IP; logic verified via unit + integration tests and the real `crw_extract::extract()` pipeline (measured ~114 bytes markdown).
- The chrome_proxy floor (8s) is benchmark-sensitive. Current prod p90 baseline ~5.5s; the design is p90-safe by construction (fingerprint-vendor walls are suppressed, so the common wasteful case does not fire). The "no p90 regression" confirmation is a post-deploy step — re-run the p90 bench against prod after release and tune the floor if needed.
- Managed-CF sites (e.g. wikiwand) are correctly detected and now fail fast/honestly; actually scraping them needs the camoufox/cloak stealth tier (separate work), not this change.

Tests: full workspace green (1286 passed), `cargo fmt`/`clippy` clean on both lean and `--features cloak`.