### PR TITLE
ci: gate crates.io on assets, drop dead docker cache, bump Node off EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [22, 24]
     defaults:
       run:
         working-directory: sdks/typescript

--- a/.github/workflows/deprecate-npm.yml
+++ b/.github/workflows/deprecate-npm.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Deprecate

--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [22, 24]
     defaults:
       run:
         working-directory: sdks/typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,13 @@ jobs:
         run: cargo test --workspace
 
   publish-crates:
-    needs: [release-context, check]
+    # Gate on asset-gate, like every other publisher (pypi/npm/apt/homebrew), not
+    # on `check` alone. crates.io is the one irreversible publish that cannot be
+    # unpublished, and firing it on `check` meant it raced the binary build: a
+    # failed Windows/ARM leg would leave the release live on crates.io with no
+    # binaries and no other registry — a broken half-release. Waiting for
+    # asset-gate costs the binary-build time but never ships crates.io alone.
+    needs: [release-context, asset-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -328,7 +334,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Download platform release assets
@@ -470,8 +476,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No `cache-to: type=gha`: it writes into the tag ref's cache scope, and a
+          # tag run can only read its own ref plus the default branch. main carries
+          # no buildkit-blob, so no release could ever read another's — ~2.2GB was
+          # written every release and never restored (build times are flat across a
+          # patch release, confirming the cold rebuild). `cache-from` is dropped
+          # with it since there is now nothing to read.
 
   publish-mcp-registry:
     needs: [release-context, publish-docker]
@@ -571,7 +581,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Build + test

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -32,7 +32,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && node scripts/postbuild.mjs",


### PR DESCRIPTION
Follows #304 (per-job rust-cache, concurrency, timeouts, fuzzing paths-ignore). That PR deliberately left the release publish tier alone; this is that work, cut to the three items three independent reviews (2 agents + Codex) unanimously cleared.

### 1. Gate `publish-crates` on `asset-gate`

`publish-crates` was the **only** irreversible publisher gated on `check` alone — every other one (pypi/npm/npm-sdk/apt/homebrew) waits for `asset-gate`. So crates.io published the moment `check` passed, racing the binary build. A failed Windows/ARM leg would leave the release **live on crates.io with no binaries and no other registry** — the one release failure that cannot be undone. Now gated on `asset-gate` like the rest. Verified no cycle (`asset-gate → publish-binaries → check`) and nothing depends on `publish-crates` except `verify-publish`, which already lists it by name.

### 2. Drop the write-only buildkit gha cache

`publish-docker`'s `cache-to: type=gha,mode=max` writes into the **tag ref's** cache scope. A tag run can read only its own ref plus the default branch, and `refs/heads/main` carries **zero** buildkit-blob entries (verified live) — so no release could ever restore another's. ~2.2GB was written every release and never read; build times are flat across a patch release, confirming the cold rebuild. Both `cache-from` and `cache-to` dropped.

### 3. Node off EOL

`ci.yml` and `examples-test.yml` matrixed `[18, 20]`. **Both** are past EOL (Node 18: 2025-04-30, Node 20: 2026-04-30). Moved to `[22, 24]` (Maintenance + Active LTS) and the SDK `engines` floor to `>=22`.

### Cut from this PR after review (kept honest)

- **docker-build.yml release trigger**: reviewers split — it runs `push:false` in parallel with `publish-docker` and gave an independent multi-arch signal on v0.25.1 even when release.yml failed for an unrelated reason. Left as the canary its own comment says it is.
- **`[skip ci]` on the docs-sync commit**: `[skip ci]` is push-event-global, so it would also suppress `google-indexing.yml`'s changelog reindex on the exact files that commit writes. Net regression; dropped.
- **CodeQL js-ts / sdk-ts path filters**: `paths:` is workflow-level only, not per-job — a raw filter on ci.yml would strand the required `check`, and doing it right needs a workflow split not worth this PR.