### PR TITLE
feat(server): Kimi Code compat routes (/kimi/search, /kimi/fetch)

### DIFF
--- a/crates/crw-server/src/app.rs
+++ b/crates/crw-server/src/app.rs
@@ -55,6 +55,7 @@ pub fn create_app(state: AppState) -> Router {
     let api_routes = routes::v1::router()
         .merge(routes::v2::router(max_upload_bytes))
         .merge(firecrawl_compat)
+        .merge(routes::kimi::router())
         .route(
             "/mcp",
             post(routes::mcp::mcp_handler).fallback(method_not_allowed),

--- a/crates/crw-server/src/routes/kimi.rs
+++ b/crates/crw-server/src/routes/kimi.rs
@@ -1,0 +1,160 @@
+//! `/kimi/*` compatibility surface for Kimi Code's built-in `moonshot_search`
+//! and `moonshot_fetch` tools. Two thin translators that reshape the native
+//! `/v1` search/scrape into Kimi's snake_case wire format:
+//!
+//! - `POST /kimi/search` `{text_query}` → `{search_results:[{title,url,snippet,date,site_name}]}`
+//! - `POST /kimi/fetch`  `{url}` → raw `text/markdown` body; a failure surfaces
+//!   as a non-200 (fetch inherits scrape's `http_error`/anti-bot heuristic, not a
+//!   bare HTTP-status check, so a large soft-error page can still return 200).
+//!
+//! No new business logic: search reuses `search::search_inner`, fetch reuses
+//! the `scrape::scrape` handler verbatim (SSRF `validate_safe_url_resolved` +
+//! anti-bot envelope). The snake_case wire is a deliberate foreign shape,
+//! isolated in the `Kimi*` structs so the camelCase native types stay untouched.
+
+use axum::extract::State;
+use axum::extract::rejection::JsonRejection;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crw_core::error::CrwError;
+use crw_core::types::{ScrapeRequest, SearchData, SearchRequest, SearchResult};
+
+use crate::error::AppError;
+use crate::state::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/kimi/search",
+            post(kimi_search).fallback(crate::routes::method_not_allowed),
+        )
+        .route(
+            "/kimi/fetch",
+            post(kimi_fetch).fallback(crate::routes::method_not_allowed),
+        )
+}
+
+/// Kimi search request. `text_query` required; `limit` honored (kimi-cli sends
+/// it). Unknown fields (`enable_page_crawling`, `timeout_seconds`) are ignored
+/// by serde's default permissive parsing.
+#[derive(Deserialize)]
+struct KimiSearchBody {
+    text_query: String,
+    #[serde(default)]
+    limit: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct KimiSearchResult {
+    title: String,
+    url: String,
+    snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    date: Option<String>,
+    site_name: String,
+}
+
+#[derive(Serialize)]
+struct KimiSearchResponse {
+    search_results: Vec<KimiSearchResult>,
+}
+
+#[derive(Deserialize)]
+struct KimiFetchBody {
+    url: String,
+}
+
+/// Host of `url` with a leading `www.` stripped; empty string if unparseable.
+fn site_name(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_ascii_lowercase))
+        .map(|h| h.strip_prefix("www.").map(str::to_string).unwrap_or(h))
+        .unwrap_or_default()
+}
+
+async fn kimi_search(
+    State(state): State<AppState>,
+    body: Result<Json<KimiSearchBody>, JsonRejection>,
+) -> Result<Json<KimiSearchResponse>, AppError> {
+    let Json(body) = body.map_err(AppError::from)?;
+    let limit = body.limit.unwrap_or(10);
+    let req: SearchRequest =
+        serde_json::from_value(json!({ "query": body.text_query, "limit": limit }))
+            .map_err(|e| CrwError::InvalidRequest(format!("Invalid search request: {e}")))?;
+
+    let resp = crate::routes::search::search_inner(&state, req).await?;
+
+    // Kimi search is flat; grouped never occurs (we never set `sources`) but
+    // flatten defensively to the `web` bucket.
+    let rows: Vec<SearchResult> = match resp.data.map(|d| d.results) {
+        Some(SearchData::Flat(v)) => v,
+        Some(SearchData::Grouped(g)) => g.web.unwrap_or_default(),
+        None => Vec::new(),
+    };
+
+    let search_results = rows
+        .into_iter()
+        .map(|r| {
+            let site = site_name(&r.url);
+            let snippet = if r.snippet.is_empty() {
+                r.description
+            } else {
+                r.snippet
+            };
+            KimiSearchResult {
+                title: r.title,
+                url: r.url,
+                snippet,
+                date: r.published_date,
+                site_name: site,
+            }
+        })
+        .collect();
+
+    Ok(Json(KimiSearchResponse { search_results }))
+}
+
+async fn kimi_fetch(
+    State(state): State<AppState>,
+    body: Result<Json<KimiFetchBody>, JsonRejection>,
+) -> Response {
+    let req = match body {
+        Ok(Json(b)) => b,
+        Err(e) => return AppError::from(e).into_response(),
+    };
+
+    let scrape_req: ScrapeRequest =
+        match serde_json::from_value(json!({ "url": req.url, "formats": ["markdown"] })) {
+            Ok(r) => r,
+            Err(e) => {
+                return AppError::from(CrwError::InvalidRequest(format!(
+                    "Invalid fetch request: {e}"
+                )))
+                .into_response();
+            }
+        };
+
+    // Reuse the scrape handler verbatim: SSRF validation + anti-bot envelope.
+    match crate::routes::scrape::scrape(State(state), Ok(Json(scrape_req))).await {
+        Err(e) => e.into_response(),
+        Ok(Json(resp)) => match resp.data.and_then(|d| d.markdown) {
+            Some(md) if resp.success && !md.is_empty() => (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/markdown; charset=utf-8")],
+                md,
+            )
+                .into_response(),
+            // success:false (block/http_error) or empty/missing markdown → error.
+            _ => {
+                let err = resp.error.unwrap_or_else(|| "fetch failed".to_string());
+                (StatusCode::BAD_GATEWAY, err).into_response()
+            }
+        },
+    }
+}

--- a/crates/crw-server/src/routes/mod.rs
+++ b/crates/crw-server/src/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod change_tracking;
 pub mod crawl;
 pub mod extract;
 pub mod health;
+pub mod kimi;
 pub mod map;
 pub mod mcp;
 pub mod metrics;

--- a/crates/crw-server/tests/kimi_route.rs
+++ b/crates/crw-server/tests/kimi_route.rs
@@ -1,0 +1,200 @@
+//! Integration tests for the `/kimi/*` compatibility surface (Kimi Code's
+//! `moonshot_search` + `moonshot_fetch` tools).
+//!
+//! `search` is exercised against a `wiremock` SearXNG (like `search_route.rs`);
+//! `fetch` is exercised against a `wiremock` HTTP page over the HTTP-only
+//! renderer, gated by the `CRW_ALLOW_LOOPBACK_FOR_TESTS` opt-in so SSRF
+//! validation permits the loopback mock (same pattern as `map_filter.rs`).
+
+use axum_test::TestServer;
+use crw_core::config::AppConfig;
+use crw_server::app::create_app;
+use crw_server::state::AppState;
+use serde_json::{Value, json};
+use std::sync::Once;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+static INIT_TEST_ENV: Once = Once::new();
+fn allow_loopback_for_tests() {
+    INIT_TEST_ENV.call_once(|| {
+        // SAFETY: set once before any tokio worker spawns its own thread.
+        unsafe {
+            std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        }
+    });
+}
+
+fn test_app_with_searxng(url: &str) -> TestServer {
+    let toml = format!(
+        r#"
+[search]
+enabled = true
+searxng_url = "{url}"
+timeout_ms = 5000
+"#
+    );
+    let config: AppConfig = toml::from_str(&toml).unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    TestServer::new(create_app(state))
+}
+
+fn test_app_with_auth_and_searxng(url: &str) -> TestServer {
+    let toml = format!(
+        r#"
+[auth]
+api_keys = ["secret-key"]
+
+[search]
+enabled = true
+searxng_url = "{url}"
+timeout_ms = 5000
+"#
+    );
+    let config: AppConfig = toml::from_str(&toml).unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    TestServer::new(create_app(state))
+}
+
+fn test_app_plain() -> TestServer {
+    let config: AppConfig = toml::from_str("").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    TestServer::new(create_app(state))
+}
+
+/// Two results; the higher-scoring one uses a `www.` host so the top result
+/// (surviving `limit: 1`) exercises the `site_name` www-strip.
+fn searxng_response() -> Value {
+    json!({
+        "query": "rust async",
+        "number_of_results": 2,
+        "results": [
+            {
+                "url": "https://www.tokio.rs/",
+                "title": "Tokio",
+                "engine": "google",
+                "content": "An asynchronous runtime for Rust",
+                "score": 2.0,
+                "category": "general",
+                "template": "default.html"
+            },
+            {
+                "url": "https://docs.rs/async-std/",
+                "title": "async-std",
+                "engine": "duckduckgo",
+                "content": "An async standard library",
+                "score": 1.0,
+                "category": "general",
+                "template": "default.html"
+            }
+        ],
+        "answers": [],
+        "corrections": [],
+        "infoboxes": [],
+        "suggestions": [],
+        "unresponsive_engines": []
+    })
+}
+
+const FETCH_HTML: &str = r#"<!doctype html>
+<html><head><title>Kimi Fetch Fixture</title></head>
+<body><main><h1>Hello Kimi</h1>
+<p>This page is scraped by the kimi fetch adapter into markdown.</p></main></body></html>"#;
+
+#[tokio::test]
+async fn kimi_search_shapes_results_and_honors_limit() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(searxng_response()))
+        .mount(&mock)
+        .await;
+
+    let server = test_app_with_searxng(&mock.uri());
+    // Unknown fields (`enable_page_crawling`, `timeout_seconds`) must be tolerated.
+    let resp = server
+        .post("/kimi/search")
+        .json(&json!({
+            "text_query": "rust async",
+            "limit": 1,
+            "enable_page_crawling": true,
+            "timeout_seconds": 5
+        }))
+        .await;
+    resp.assert_status_ok();
+
+    let body: Value = resp.json();
+    let results = body["search_results"]
+        .as_array()
+        .expect("search_results should be an array");
+    assert_eq!(results.len(), 1, "limit=1 must be honored");
+    assert_eq!(results[0]["url"], "https://www.tokio.rs/");
+    assert_eq!(results[0]["site_name"], "tokio.rs", "www. must be stripped");
+    assert_eq!(results[0]["snippet"], "An asynchronous runtime for Rust");
+    assert_eq!(results[0]["title"], "Tokio");
+}
+
+#[tokio::test]
+async fn kimi_search_requires_auth_when_configured() {
+    let mock = MockServer::start().await;
+    let server = test_app_with_auth_and_searxng(&mock.uri());
+    let resp = server
+        .post("/kimi/search")
+        .json(&json!({"text_query": "rust async"}))
+        .await;
+    resp.assert_status(axum::http::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn kimi_fetch_returns_markdown() {
+    allow_loopback_for_tests();
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .set_body_string(FETCH_HTML),
+        )
+        .mount(&mock)
+        .await;
+
+    let server = test_app_plain();
+    let resp = server
+        .post("/kimi/fetch")
+        .json(&json!({"url": format!("{}/", mock.uri())}))
+        .await;
+    resp.assert_status_ok();
+
+    let content_type = resp.header("content-type").to_str().unwrap().to_string();
+    assert!(
+        content_type.starts_with("text/markdown"),
+        "expected text/markdown, got: {content_type}"
+    );
+    let text = resp.text();
+    assert!(text.contains("Hello Kimi"), "markdown body was: {text}");
+}
+
+#[tokio::test]
+async fn kimi_fetch_non200_target_is_error() {
+    allow_loopback_for_tests();
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .set_body_string("<html><body>not found</body></html>"),
+        )
+        .mount(&mock)
+        .await;
+
+    let server = test_app_plain();
+    let resp = server
+        .post("/kimi/fetch")
+        .json(&json!({"url": format!("{}/", mock.uri())}))
+        .await;
+    assert_ne!(
+        resp.status_code(),
+        axum::http::StatusCode::OK,
+        "a blocked/404 fetch must be a non-200 error for Kimi"
+    );
+}


### PR DESCRIPTION
Adds a `/kimi/*` compatibility surface so Kimi Code users can point its built-in
`moonshot_search` / `moonshot_fetch` tools at a self-hosted crw engine.

## What
- `POST /kimi/search` `{text_query}` -> `{search_results:[{title,url,snippet,date,site_name}]}`. Reuses `search::search_inner`; honors an optional `limit` (default 10); tolerates unknown fields.
- `POST /kimi/fetch` `{url}` -> raw `text/markdown` body; a failure surfaces as a non-200. Calls the existing `scrape` handler verbatim, so SSRF validation (`validate_safe_url_resolved`) and the anti-bot envelope are reused, not duplicated.
- Mounted via a one-line `.merge(routes::kimi::router())` into `api_routes`, so `/kimi/*` inherits the shared Bearer auth, rate limit, 1MB body cap and timeout, mirroring the `/firecrawl/*` compat pattern.

## Notes
- No native `/v1` or `/firecrawl` shape is touched; no new business logic.
- `cargo fmt` / `clippy --workspace -D warnings` / `cargo test --workspace` (1282 passed) all green; adds `tests/kimi_route.rs` (4 integration tests).
- Engine Docker images build on release, so this is not live on prod until the next release.