### PR TITLE
chore(mcp): add Smithery stdio config for crw-mcp

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,27 @@
+# Smithery configuration — https://smithery.ai/docs/build/publish
+# Local stdio server: Smithery launches `crw-mcp` from npm and clients run it
+# locally. The hosted remote endpoint (https://fastcrw.com/mcp, streamable HTTP
+# + OAuth) is listed separately via Smithery's URL method, no repo file needed.
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema for the config Smithery collects from the user at install time.
+    type: object
+    properties:
+      crwApiKey:
+        type: string
+        title: fastCRW API key
+        description: >-
+          API key from https://fastcrw.com for the hosted API. Optional — the
+          free tier works without one. Self-hosters can leave it blank and set
+          CRW_API_URL in their own environment.
+  commandFunction:
+    # Produces the CLI command Smithery runs to start the MCP server on stdio.
+    |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'crw-mcp'],
+      env: config.crwApiKey ? { CRW_API_KEY: config.crwApiKey } : {}
+    })
+  exampleConfig:
+    crwApiKey: crw_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -21,7 +21,13 @@ startCommand:
     (config) => ({
       command: 'npx',
       args: ['-y', 'crw-mcp'],
-      env: config.crwApiKey ? { CRW_API_KEY: config.crwApiKey } : {}
+      // A key alone is inert: crw-mcp picks cloud vs embedded mode on
+      // CRW_API_URL being set (crw-mcp/src/main.rs), so a key with no URL
+      // silently runs local mode. Pair them, exactly as the canonical
+      // installer does (mcp/crw-mcp/bin/install.js).
+      env: config.crwApiKey
+        ? { CRW_API_KEY: config.crwApiKey, CRW_API_URL: 'https://api.fastcrw.com' }
+        : {}
     })
   exampleConfig:
     crwApiKey: crw_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Adds a repo-root `smithery.yaml` so crw-mcp can be listed and installed via Smithery (smithery.ai).

## What
- `smithery.yaml` with a `startCommand.type: stdio` block that launches the published `crw-mcp` npm package: `npx -y crw-mcp`.
- `configSchema` exposes one optional field `crwApiKey`, mapped to the `CRW_API_KEY` env var the binary already reads. Optional because the free tier and self-host work without a key.
- `exampleConfig` uses a placeholder key (no secret committed).

## Why
Smithery has two publish paths: the URL method (a hosted streamable-HTTP + OAuth endpoint, already served at `https://fastcrw.com/mcp`) and the local stdio path. This file enables the local stdio install; the remote endpoint is listed separately via Smithery`s URL method and needs no repo file.

## Notes
- File must live at repo root for Smithery to find it; matches the stdio schema used across published Smithery servers.
- No Rust/config touched, so the pre-commit Rust suite is a no-op for this change.
- Publishing the listing itself is a one-time manual step on smithery.ai (GitHub-OAuth connect / URL submit); this PR only lands the config.