### PR TITLE
fix(server): add success envelope to /v1/extract responses so MCP extract tools validate

### DIFF
--- a/crates/crw-server/openapi/openapi-3.0.json
+++ b/crates/crw-server/openapi/openapi-3.0.json
@@ -1407,11 +1407,15 @@
       "ExtractAccepted": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "urls"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },
@@ -1481,6 +1485,7 @@
       "ExtractStatus": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "results",
@@ -1489,6 +1494,9 @@
           "tokensUsed"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -2027,11 +2027,15 @@
       "ExtractAccepted": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "urls"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },
@@ -2101,6 +2105,7 @@
       "ExtractStatus": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "results",
@@ -2109,6 +2114,9 @@
           "tokensUsed"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },

--- a/crates/crw-server/src/routes/extract.rs
+++ b/crates/crw-server/src/routes/extract.rs
@@ -3,7 +3,8 @@
 //! every URL's JSON into one object, last-write-wins), the native route returns
 //! a **per-URL array** (`results:[{url,status,data,error,llmUsage}]`) that keeps
 //! each URL's object distinct and carries per-URL LLM usage for downstream
-//! billing. No FC envelope (`success`/`urlTrace`/deprecation warning).
+//! billing. Carries the standard native `success` envelope (like every other
+//! `/v1` response), but none of the FC-legacy `urlTrace`/deprecation warning.
 
 use axum::Json;
 use axum::extract::rejection::JsonRejection;
@@ -18,7 +19,7 @@ use crw_core::types::{ExtractOptions, LlmUsage, OutputFormat, ScrapeRequest};
 
 use crate::error::AppError;
 use crate::routes::v2::adapters::system_time_rfc3339;
-use crate::state::{AppState, ExtractRecord, PreparedUrl, UrlResult};
+use crate::state::{AppState, ExtractRecord, ExtractStatus, PreparedUrl, UrlResult};
 
 /// Native extract request. camelCase like every other v1 public type.
 /// NOTE: no `#[derive(Debug)]` — `llm_api_key` is a secret and must never land
@@ -62,6 +63,10 @@ pub struct ExtractRequest {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtractStartResponse {
+    /// Response envelope carried by every native `/v1` response (and required by
+    /// the MCP `crw_extract` outputSchema, which the stdio/CLI proxies validate
+    /// this body against). Always `true` here — a rejected start is a 4xx error.
+    pub success: bool,
     pub id: String,
     pub status: String,
     /// Count of URLs actually enqueued for fetch (preflight-failed URLs are in
@@ -80,6 +85,7 @@ pub async fn start_extract(
         .start_extract_job(prepared.entries, prepared.template)
         .await;
     Ok(Json(ExtractStartResponse {
+        success: true,
         id: id.to_string(),
         status: "processing".to_string(),
         urls,
@@ -256,6 +262,11 @@ impl From<UrlResult> for ExtractUrlResult {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtractStatusResponse {
+    /// Response envelope carried by every native `/v1` response (and required by
+    /// the MCP `crw_check_extract_status` / `crw_cancel_extract` outputSchema,
+    /// which the stdio/CLI proxies validate this body against). `false` only when
+    /// the whole job failed.
+    pub success: bool,
     pub id: String,
     pub status: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -272,6 +283,7 @@ pub struct ExtractStatusResponse {
 pub(crate) fn serialize_extract_status(id: Uuid, rec: ExtractRecord) -> ExtractStatusResponse {
     let expires_at = system_time_rfc3339(rec.expires_at);
     ExtractStatusResponse {
+        success: rec.status != ExtractStatus::Failed,
         id: id.to_string(),
         status: rec.status.as_str().to_string(),
         results: rec
@@ -314,4 +326,31 @@ pub async fn cancel_extract(
     Path(id): Path<Uuid>,
 ) -> Result<Json<ExtractStatusResponse>, AppError> {
     Ok(Json(cancel_extract_status(&state, id).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The stdio/CLI MCP proxies ship the raw `/v1/extract` start body verbatim as
+    // `structuredContent`, so this serialized shape must satisfy the advertised
+    // `crw_extract` outputSchema — regression lock for issue #318 (a start body
+    // missing `success` failed strict-client validation).
+    #[test]
+    fn start_response_satisfies_mcp_output_schema() {
+        let body = serde_json::to_value(ExtractStartResponse {
+            success: true,
+            id: "d1e2f3".to_string(),
+            status: "processing".to_string(),
+            urls: 2,
+        })
+        .unwrap();
+        let schema = crw_core::mcp::tool_output_schema("crw_extract").unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let errors: Vec<String> = validator
+            .iter_errors(&body)
+            .map(|e| e.to_string())
+            .collect();
+        assert!(errors.is_empty(), "start body vs schema: {errors:#?}");
+    }
 }

--- a/crates/crw-server/src/routes/mcp.rs
+++ b/crates/crw-server/src/routes/mcp.rs
@@ -25,20 +25,9 @@ pub async fn validate_url(url: &str) -> Result<(), String> {
     crw_core::url_safety::validate_safe_url_resolved(&parsed).await
 }
 
-/// Serialize an extract lifecycle response for MCP, re-adding the `success`
-/// field MCP clients rely on. The shared HTTP `/v1` type omits it, so it is
-/// injected only here; `success` is false only when every URL failed.
-fn extract_status_value(
-    response: crate::routes::extract::ExtractStatusResponse,
-) -> Result<Value, String> {
-    let success = response.status != "failed";
-    let mut value = serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))?;
-    if let Some(obj) = value.as_object_mut() {
-        obj.insert("success".to_string(), Value::Bool(success));
-    }
-    Ok(value)
-}
-
+/// Dispatch an MCP `tools/call` to the matching engine operation and return its
+/// result value. Extract lifecycle responses carry `success` on the shared `/v1`
+/// struct itself, so no per-tool envelope patching happens here.
 pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result<Value, String> {
     match tool_name {
         "crw_scrape" => {
@@ -138,7 +127,7 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
             serde_json::to_value(&resp).map_err(|e| format!("serialize error: {e}"))
         }
         "crw_extract" => {
-            use crate::routes::extract::{ExtractRequest, prepare_extract};
+            use crate::routes::extract::{ExtractRequest, ExtractStartResponse, prepare_extract};
             let req: ExtractRequest =
                 serde_json::from_value(args).map_err(|e| format!("invalid arguments: {e}"))?;
             // Same validation + SSRF preflight + template as POST /v1/extract.
@@ -149,7 +138,15 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
             let id = state
                 .start_extract_job(prepared.entries, prepared.template)
                 .await;
-            Ok(json!({"success": true, "id": id.to_string(), "status": "processing", "urls": urls}))
+            // Same shape as POST /v1/extract (single source), so this in-server
+            // path and the proxy pass-through can never drift from the schema.
+            serde_json::to_value(ExtractStartResponse {
+                success: true,
+                id: id.to_string(),
+                status: "processing".to_string(),
+                urls,
+            })
+            .map_err(|e| format!("serialize error: {e}"))
         }
         "crw_check_extract_status" => {
             use crate::routes::extract::get_extract_status;
@@ -163,7 +160,7 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
             let response = get_extract_status(state, id)
                 .await
                 .map_err(|e| format!("{e}"))?;
-            extract_status_value(response)
+            serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))
         }
         "crw_cancel_extract" => {
             use crate::routes::extract::cancel_extract_status;
@@ -177,7 +174,7 @@ pub async fn call_tool(state: &AppState, tool_name: &str, args: Value) -> Result
             let response = cancel_extract_status(state, id)
                 .await
                 .map_err(|e| format!("{e}"))?;
-            extract_status_value(response)
+            serde_json::to_value(response).map_err(|e| format!("serialize error: {e}"))
         }
         "crw_parse_file" => {
             use base64::Engine;

--- a/crates/crw-server/tests/mcp.rs
+++ b/crates/crw-server/tests/mcp.rs
@@ -231,15 +231,68 @@ async fn mcp_extract_status_and_cancel_share_canonical_http_serializer() {
     assert_eq!(cancelled["success"], true);
 }
 
+/// The stdio/CLI MCP proxies ship the raw `GET /v1/extract/{id}` REST body
+/// verbatim as `structuredContent`, which strict clients validate against the
+/// advertised `crw_check_extract_status` outputSchema. Regression lock for issue
+/// #318: that REST body was missing the `success` envelope, so every poll failed
+/// client-side validation. Also pins `success = (status != failed)` across all
+/// five statuses. (The in-server `/mcp` path is covered above; this exercises the
+/// REST endpoint the proxies actually call.)
+#[tokio::test]
+async fn v1_extract_status_rest_body_matches_mcp_output_schema() {
+    let config: AppConfig = toml::from_str("").unwrap();
+    let state = AppState::new(config).unwrap();
+    let server = TestServer::new(create_app(state.clone()));
+    let schema = tool_output_schema("crw_check_extract_status").unwrap();
+    let validator = jsonschema::validator_for(&schema).expect("extract schema compiles");
+
+    for status in [
+        ExtractStatus::Processing,
+        ExtractStatus::Cancelling,
+        ExtractStatus::Completed,
+        ExtractStatus::Failed,
+        ExtractStatus::Cancelled,
+    ] {
+        let id = Uuid::new_v4();
+        let mut rec = pending_extract_record(Instant::now());
+        rec.status = status;
+        state.extract_jobs.write().await.insert(id, rec);
+
+        let body: Value = server.get(&format!("/v1/extract/{id}")).await.json();
+        let errors: Vec<String> = validator
+            .iter_errors(&body)
+            .map(|e| e.to_string())
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "{status:?} REST body vs schema: {errors:#?}"
+        );
+        assert_eq!(
+            body["success"],
+            Value::Bool(status != ExtractStatus::Failed),
+            "success mapping wrong for {status:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn mcp_extract_output_schemas_match_openapi_lifecycle_components() {
     let openapi: Value =
         serde_json::from_str(include_str!("../openapi/openapi.json")).expect("valid OpenAPI");
     let components = &openapi["components"]["schemas"];
 
-    // MCP responses carry the `success` envelope every MCP tool returns, which
-    // the native HTTP `/v1` (openapi) shape deliberately omits. Compare the data
-    // contract by ignoring that one envelope field on the MCP side.
+    // Both the MCP outputSchema and the native `/v1` (openapi) shape carry the
+    // `success` envelope (issue #318). Its presence+requiredness is asserted on
+    // every component below; the field is then stripped so the *rest* of the data
+    // contract must still match field-for-field between the two surfaces.
+    let has_required_success = |schema: &Value| -> bool {
+        schema["properties"]["success"]["type"] == "boolean"
+            && schema["required"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| v == "success")
+    };
     let required_without_success = |schema: &Value| -> Vec<String> {
         schema["required"]
             .as_array()
@@ -262,6 +315,14 @@ async fn mcp_extract_output_schemas_match_openapi_lifecycle_components() {
 
     let accepted = tool_output_schema("crw_extract").unwrap();
     let openapi_accepted = &components["ExtractAccepted"];
+    assert!(
+        has_required_success(&accepted),
+        "MCP crw_extract missing success"
+    );
+    assert!(
+        has_required_success(openapi_accepted),
+        "openapi ExtractAccepted missing success"
+    );
     assert_eq!(
         required_without_success(&accepted),
         required_without_success(openapi_accepted)
@@ -278,6 +339,14 @@ async fn mcp_extract_output_schemas_match_openapi_lifecycle_components() {
     let status = tool_output_schema("crw_check_extract_status").unwrap();
     assert_eq!(status, tool_output_schema("crw_cancel_extract").unwrap());
     let openapi_status = &components["ExtractStatus"];
+    assert!(
+        has_required_success(&status),
+        "MCP crw_check_extract_status missing success"
+    );
+    assert!(
+        has_required_success(openapi_status),
+        "openapi ExtractStatus missing success"
+    );
     assert_eq!(
         required_without_success(&status),
         required_without_success(openapi_status)

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -119,7 +119,7 @@ Parameters:
 - `llmProvider` — LLM provider (used with `llmApiKey`)
 - `llmModel` — LLM model (used with `llmApiKey`)
 
-Returns: `{ "id": "job-uuid" }` — use this ID with crw_check_extract_status.
+Returns: `{ "success": true, "id": "job-uuid", "status": "processing", "urls": 1 }` — use the ID with crw_check_extract_status.
 
 ### crw_check_extract_status
 

--- a/docs/docs/choose-endpoint.md
+++ b/docs/docs/choose-endpoint.md
@@ -87,7 +87,7 @@ of calling scrape N times:
 }
 ```
 
-It returns `{ "id", "status": "processing", "urls": 2 }`; poll `GET /v1/extract/{id}` for
+It returns `{ "success": true, "id", "status": "processing", "urls": 2 }`; poll `GET /v1/extract/{id}` for
 a `results` array (one `{ url, status, data, error }` per URL, in request order). Capped
 by `crawler.max_extract_urls` (default 50) since each URL triggers an LLM call.
 On the hosted service at `api.fastcrw.com` this is handled automatically.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -548,7 +548,7 @@ Parameters:
   llmProvider     string    opt       BYOK provider
   llmModel        string    opt       BYOK model
 
-Returns: {"id": "job-uuid", "status": "processing", "urls": N}
+Returns: {"success": true, "id": "job-uuid", "status": "processing", "urls": N}
 
 ────────────────────────────────────────────────────────────────────────────────
 ### Tool: crw_check_extract_status  →  GET /v1/extract/:id

--- a/docs/openapi-3.0.json
+++ b/docs/openapi-3.0.json
@@ -1407,11 +1407,15 @@
       "ExtractAccepted": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "urls"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },
@@ -1481,6 +1485,7 @@
       "ExtractStatus": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "results",
@@ -1489,6 +1494,9 @@
           "tokensUsed"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2027,11 +2027,15 @@
       "ExtractAccepted": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "urls"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },
@@ -2101,6 +2105,7 @@
       "ExtractStatus": {
         "type": "object",
         "required": [
+          "success",
           "id",
           "status",
           "results",
@@ -2109,6 +2114,9 @@
           "tokensUsed"
         ],
         "properties": {
+          "success": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },

--- a/mcp/crw-mcp/skills/SKILL.md
+++ b/mcp/crw-mcp/skills/SKILL.md
@@ -119,7 +119,7 @@ Parameters:
 - `llmProvider` — LLM provider (used with `llmApiKey`)
 - `llmModel` — LLM model (used with `llmApiKey`)
 
-Returns: `{ "id": "job-uuid" }` — use this ID with crw_check_extract_status.
+Returns: `{ "success": true, "id": "job-uuid", "status": "processing", "urls": 1 }` — use the ID with crw_check_extract_status.
 
 ### crw_check_extract_status
 


### PR DESCRIPTION
The stdio and CLI MCP proxies forward the raw `/v1/extract` REST body verbatim as `structuredContent`, which strict clients validate against each tool's advertised `outputSchema`. `ExtractStartResponse` and `ExtractStatusResponse` omitted the `success` field that the `crw_extract` / `crw_check_extract_status` / `crw_cancel_extract` schemas require, so every extract call over those transports failed client-side validation with `data must have required property 'success'`.

`success` is already carried by every other `/v1` response (scrape, search, map, crawl); the async extract lifecycle was the only one missing it. The in-server `/mcp` path compensated by injecting it manually, which is why only the proxied transports broke.

Changes:
- `ExtractStartResponse.success = true`; `ExtractStatusResponse.success = (status != failed)`, set in the one canonical `serialize_extract_status`.
- Drop the now-redundant `extract_status_value` success-injection helper in the in-server MCP handler; the start handler serializes `ExtractStartResponse` for a single source of truth.
- Add `success` to OpenAPI `ExtractAccepted` / `ExtractStatus` (both 3.1 and 3.0 specs, crate + docs copies kept byte-identical for the drift check).
- Regression test: the raw `GET /v1/extract/{id}` body validates against the advertised `crw_check_extract_status` schema across all five statuses; the contract test now asserts `success` is present and required on both surfaces instead of stripping it.

`/v2/extract` (Firecrawl-compat) is untouched.

ref #318