### PR TITLE
feat(renderer): send x-deadline-ms to the cloak sidecar mirror call

### DIFF
--- a/crates/crw-renderer/src/cloak.rs
+++ b/crates/crw-renderer/src/cloak.rs
@@ -160,6 +160,12 @@ impl CloakRenderer {
         if bypass_cache {
             rb = rb.header("x-bypass-cache", "true");
         }
+        // Propagate our per-call budget so the sidecar can deliver a slow cold
+        // solve in-band (up to what we will actually wait) instead of fail-opening
+        // at its conservative default. UNCONDITIONAL: must be sent on every mirror
+        // call, including attempt 0 (bypass=false) — the generous-deadline
+        // first-request case this exists for. `budget` is guarded non-zero above.
+        rb = rb.header("x-deadline-ms", budget.as_millis().to_string());
         let resp = tokio::time::timeout(budget, rb.send())
             .await
             .map_err(|_| CrwError::Timeout(budget.as_millis() as u64))?


### PR DESCRIPTION
Lets the cloak sidecar deliver a slow cold solve in-band instead of fail-opening at its conservative default. Pairs with the crw-saas sidecar PR that honors the header.

## What
One unconditional header on `mirror_once` (crw-renderer/src/cloak.rs): `x-deadline-ms = budget.as_millis()`, where `budget = deadline.remaining().min(CLOAK_DEFAULT_TIMEOUT_MS 35s)` (the exact time the engine will wait). Sent on every call including attempt 0 (bypass=false), which is the generous-deadline first-request case this exists for.

## Why
Today the sidecar cannot see how long the engine will wait, so it self-caps at a conservative ~23s and fail-opens even when the engine granted up to 35s. With the header, a ~24s cold solve returns real content in-band on the first request for cloak-entitled (generous-deadline) traffic; tight-deadline requests still fail-open gracefully.

## Safety
- Feature-gated (`cloak`): inert when the tier is compiled out or unconfigured; the whole function is under `#[cfg(feature = "cloak")]`.
- `budget` is guarded non-zero by the early return above, so `x-deadline-ms: 0` is never emitted.
- An older sidecar that ignores the header keeps working (falls back to its default); a newer sidecar reads it.
- +6 lines, no other change.

## Verification
`cargo fmt --check` + `clippy -D warnings` + `cargo test --workspace` (773 tests) all pass via the pre-commit hook. The paired sidecar was verified in-container honoring the header (generous-deadline first request returns in-band).

Ref: PLAN-cloak-deadline.md and the crw-saas cloak-sidecar PR.