### PR TITLE
fix(server): require auth on admin and metrics routes, restrict CORS default

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -17,9 +17,12 @@ GitHub release.
 
 **Please do not open a public GitHub issue for security vulnerabilities.**
 
-Report security issues by emailing the maintainers at:
+Report privately through either channel:
 
-**security@fastcrw.com**
+- **GitHub Private Vulnerability Reporting** (preferred): open a report from the
+  [Security tab](https://github.com/us/crw/security/advisories/new) of this
+  repository. This routes straight to the maintainers and keeps the details private.
+- **Email**: **security@fastcrw.com**
 
 Include as much detail as you can:
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ features instead of operating a scraper.
 | Cost | Free tier, then plans from **$11/mo** — [pricing](https://fastcrw.com/pricing) | $0 license — you pay for the infra and your team's time |
 | License | You call an API — **no copyleft on your code** | AGPL-3.0 — copyleft if you bundle the engine or run a modified public service |
 
+> **Air-gapped note:** the crw engine itself makes no telemetry calls. The default
+> Docker Compose stack disables the LightPanda renderer's third-party telemetry
+> (`LIGHTPANDA_DISABLE_TELEMETRY=true`). If you run a fully air-gapped deployment,
+> verify egress for any renderer sidecars you enable and pin their images to a digest.
+> See [self-hosting hardening](https://docs.fastcrw.com/self-hosting-hardening/).
+
 ### Self-host in one command
 
 ```bash

--- a/config.default.toml
+++ b/config.default.toml
@@ -9,6 +9,12 @@ port = 3000
 # the default ladder_min.
 request_timeout_secs = 120
 rate_limit_rps = 10              # Max requests/second (global). 0 = unlimited.
+# Cross-origin allowlist for browser callers. Empty (default) = NO CORS headers
+# are sent, so browsers block cross-origin JS access — the safe default for a
+# server-to-server API. Set explicit origins only if a browser app must call the
+# engine directly. A literal "*" is rejected (that is the permissive wildcard
+# this setting replaces). Env: CRW_SERVER__CORS_ALLOWED_ORIGINS="https://a,https://b".
+# cors_allowed_origins = ["https://app.example.com"]
 
 # [request]
 # deadline_ms_default = 8000

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -521,6 +521,15 @@ pub struct ServerConfig {
     /// Maximum requests per second (global). 0 = unlimited.
     #[serde(default = "default_rate_limit_rps")]
     pub rate_limit_rps: u64,
+    /// Cross-origin allowlist for browser callers. Empty (default) = NO CORS
+    /// headers are emitted, so browsers block cross-origin JS access — the safe
+    /// default for a server-to-server API. Populate only if a browser app must
+    /// call the engine directly (e.g. `["https://app.example.com"]`). A literal
+    /// `"*"` is rejected: wildcard CORS is exactly the permissive default this
+    /// setting replaces. Accepts a TOML array or a comma-separated env string via
+    /// `CRW_SERVER__CORS_ALLOWED_ORIGINS`.
+    #[serde(default, deserialize_with = "deserialize_string_vec")]
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl Default for ServerConfig {
@@ -530,6 +539,7 @@ impl Default for ServerConfig {
             port: default_port(),
             request_timeout_secs: default_request_timeout(),
             rate_limit_rps: default_rate_limit_rps(),
+            cors_allowed_origins: Vec::new(),
         }
     }
 }

--- a/crates/crw-server/src/app.rs
+++ b/crates/crw-server/src/app.rs
@@ -1,7 +1,7 @@
 use axum::Router;
 use axum::body::Body;
 use axum::extract::DefaultBodyLimit;
-use axum::http::{Request, StatusCode};
+use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -28,6 +28,7 @@ pub fn create_app(state: AppState) -> Router {
     // by the outer layer before the inner deadline fires. See issue #35.
     let timeout = Duration::from_secs(state.config.effective_request_timeout_secs());
     let rate_limit_rps = state.config.server.rate_limit_rps;
+    let cors_origins = state.config.server.cors_allowed_origins.clone();
 
     // Native vs Firecrawl-compat surface split.
     //
@@ -59,6 +60,23 @@ pub fn create_app(state: AppState) -> Router {
         .route(
             "/mcp",
             post(routes::mcp::mcp_handler).fallback(method_not_allowed),
+        )
+        // Ops + admin surfaces live INSIDE the auth boundary. When
+        // `[auth].api_keys` is set they require a valid Bearer token; with no
+        // keys configured (default self-host) they stay open, exactly like the
+        // scraper API. Previously these were mounted on the base router below,
+        // bypassing `auth_middleware` even on key-secured deployments.
+        .route(
+            "/metrics",
+            get(routes::metrics::metrics).fallback(method_not_allowed),
+        )
+        .route(
+            "/metrics/renderer-breakers",
+            get(routes::breakers::renderer_breakers).fallback(method_not_allowed),
+        )
+        .route(
+            "/admin/breakers/reset",
+            post(routes::breakers::reset_breakers).fallback(method_not_allowed),
         );
 
     let api_routes = if api_keys.is_empty() {
@@ -78,7 +96,10 @@ pub fn create_app(state: AppState) -> Router {
         None
     };
 
-    Router::new()
+    // Base router: only liveness + public schema stay OUTSIDE the auth boundary.
+    // Ops/admin routes now live in `api_routes` above. `health`/`ready` take
+    // `State<AppState>`, so `.with_state(state)` still belongs here.
+    let app = Router::new()
         .route(
             "/health",
             get(routes::health::health).fallback(method_not_allowed),
@@ -95,18 +116,6 @@ pub fn create_app(state: AppState) -> Router {
             "/ready",
             get(routes::health::ready).fallback(method_not_allowed),
         )
-        .route(
-            "/metrics",
-            get(routes::metrics::metrics).fallback(method_not_allowed),
-        )
-        .route(
-            "/metrics/renderer-breakers",
-            get(routes::breakers::renderer_breakers).fallback(method_not_allowed),
-        )
-        .route(
-            "/admin/breakers/reset",
-            post(routes::breakers::reset_breakers).fallback(method_not_allowed),
-        )
         .with_state(state)
         .merge(api_routes)
         .layer(axum::middleware::from_fn(move |req, next| {
@@ -119,15 +128,90 @@ pub fn create_app(state: AppState) -> Router {
             timeout,
         ))
         .layer(SetResponseHeaderLayer::overriding(
-            axum::http::header::X_CONTENT_TYPE_OPTIONS,
-            axum::http::HeaderValue::from_static("nosniff"),
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
         ))
         .layer(SetResponseHeaderLayer::overriding(
-            axum::http::header::X_FRAME_OPTIONS,
-            axum::http::HeaderValue::from_static("DENY"),
-        ))
-        .layer(CorsLayer::permissive())
-        .layer(TraceLayer::new_for_http())
+            header::X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ));
+
+    // CORS is opt-in via `server.cors_allowed_origins`. Empty (default) = no
+    // layer at all, so no `Access-Control-Allow-Origin` is emitted and browsers
+    // block cross-origin JS reads — the safe default for a server-to-server API,
+    // replacing the old blanket `CorsLayer::permissive()`. (The `/openapi*`
+    // handlers still set `ACAO: *` themselves — an intentional public-schema
+    // exception unaffected by this layer.)
+    let app = match build_cors_layer(&cors_origins) {
+        Some(cors) => app.layer(cors),
+        None => app,
+    };
+
+    app.layer(TraceLayer::new_for_http())
+}
+
+/// Build a CORS layer from the configured origin allowlist. Returns `None` when
+/// the allowlist is empty (or yields no valid origin), so the caller omits the
+/// layer entirely and no CORS headers are emitted. Only explicit
+/// `scheme://host` origins are accepted; `*`, `null`, and schemeless entries are
+/// rejected (see the inline notes) so the setting can never silently widen back
+/// into a permissive or opaque-origin allowance.
+fn build_cors_layer(origins: &[String]) -> Option<CorsLayer> {
+    let allow: Vec<HeaderValue> = origins
+        .iter()
+        .filter_map(|origin| {
+            let origin = origin.trim();
+            if origin.is_empty() {
+                return None;
+            }
+            // Reject footguns before building the allowlist entry:
+            //   `*`    — the wildcard permissive default this setting replaces;
+            //            `AllowOrigin::list(["*"])` also panics in tower-http.
+            //   `null` — the opaque-origin token; allowing it grants access to
+            //            sandboxed iframes and `file://` contexts.
+            //   no `://` — a real Origin is `scheme://host[:port]`, so a
+            //            schemeless entry can never match and would silently
+            //            leave CORS disabled.
+            let lower = origin.to_ascii_lowercase();
+            if lower == "*" || lower == "null" || !origin.contains("://") {
+                tracing::warn!(
+                    origin,
+                    "server.cors_allowed_origins: not a valid explicit origin \
+                     (expected scheme://host, never `*` or `null`); ignoring entry"
+                );
+                return None;
+            }
+            match HeaderValue::from_str(origin) {
+                Ok(value) => Some(value),
+                Err(_) => {
+                    tracing::warn!(
+                        origin,
+                        "server.cors_allowed_origins: invalid origin, ignoring"
+                    );
+                    None
+                }
+            }
+        })
+        .collect();
+
+    if allow.is_empty() {
+        if !origins.is_empty() {
+            // Configured but nothing survived (all blank/`*`/malformed) — warn so
+            // an operator who fat-fingered their only origin doesn't get a
+            // silently CORS-less server.
+            tracing::warn!(
+                "server.cors_allowed_origins was set but yielded no valid origin; no CORS layer applied"
+            );
+        }
+        return None;
+    }
+
+    Some(
+        CorsLayer::new()
+            .allow_origin(allow)
+            .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+            .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE]),
+    )
 }
 
 /// Simple token-bucket rate limiter using atomic counters.

--- a/crates/crw-server/tests/auth.rs
+++ b/crates/crw-server/tests/auth.rs
@@ -134,6 +134,209 @@ async fn auth_very_long_token() {
     resp.assert_status(axum::http::StatusCode::UNAUTHORIZED);
 }
 
+// ── Ops/admin routes are behind the auth boundary ──
+//
+// Regression guard for the pre-fix state where `/metrics`,
+// `/metrics/renderer-breakers`, and `/admin/breakers/reset` were mounted on the
+// base router OUTSIDE `auth_middleware` and were reachable with no credential
+// even on a key-secured deployment.
+
+#[tokio::test]
+async fn metrics_requires_auth_when_keys_set() {
+    let server = test_app_with_auth(vec!["ops-key".into()]);
+    server
+        .get("/metrics")
+        .await
+        .assert_status(axum::http::StatusCode::UNAUTHORIZED);
+    server
+        .get("/metrics")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer ops-key"),
+        )
+        .await
+        .assert_status_ok();
+}
+
+#[tokio::test]
+async fn renderer_breakers_requires_auth_when_keys_set() {
+    let server = test_app_with_auth(vec!["ops-key".into()]);
+    server
+        .get("/metrics/renderer-breakers")
+        .await
+        .assert_status(axum::http::StatusCode::UNAUTHORIZED);
+    server
+        .get("/metrics/renderer-breakers")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer ops-key"),
+        )
+        .await
+        .assert_status_ok();
+}
+
+#[tokio::test]
+async fn admin_reset_requires_auth_when_keys_set() {
+    let server = test_app_with_auth(vec!["ops-key".into()]);
+    // No credential → 401, and the breaker reset never runs.
+    server
+        .post("/admin/breakers/reset")
+        .await
+        .assert_status(axum::http::StatusCode::UNAUTHORIZED);
+    // Valid key → the admin action runs.
+    let resp = server
+        .post("/admin/breakers/reset")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer ops-key"),
+        )
+        .await;
+    resp.assert_status_ok();
+    let json: serde_json::Value = resp.json();
+    assert_eq!(json["ok"], true);
+}
+
+#[tokio::test]
+async fn ops_routes_open_when_no_keys() {
+    // Back-compat: with no keys configured the ops routes stay reachable,
+    // exactly like the scraper API (default self-host behavior).
+    let server = test_app_no_auth();
+    server.get("/metrics").await.assert_status_ok();
+    server
+        .get("/metrics/renderer-breakers")
+        .await
+        .assert_status_ok();
+    server
+        .post("/admin/breakers/reset")
+        .await
+        .assert_status_ok();
+}
+
+#[tokio::test]
+async fn liveness_and_schema_never_require_auth() {
+    // Health/ready/openapi must stay open even with keys set — they are how
+    // load balancers and SDK generators reach the service.
+    let server = test_app_with_auth(vec!["ops-key".into()]);
+    server.get("/health").await.assert_status_ok();
+    server.get("/ready").await.assert_status_ok();
+    server.get("/openapi.json").await.assert_status_ok();
+    server.get("/openapi-3.0.json").await.assert_status_ok();
+}
+
+// ── CORS defaults ──
+
+fn test_app_with_cors(origins: Vec<String>) -> TestServer {
+    let toml_str = format!(
+        r#"
+[server]
+cors_allowed_origins = {:?}
+"#,
+        origins
+    );
+    let config: AppConfig = toml::from_str(&toml_str).unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    TestServer::new(create_app(state))
+}
+
+#[tokio::test]
+async fn cors_absent_by_default() {
+    // Default config emits NO Access-Control-Allow-Origin on API/ops routes —
+    // browsers block cross-origin reads. (The old permissive layer set `*`.)
+    let server = test_app_no_auth();
+    let resp = server
+        .get("/metrics")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("https://evil.example"),
+        )
+        .await;
+    assert!(
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "default config must not emit ACAO on /metrics"
+    );
+}
+
+#[tokio::test]
+async fn cors_allowlist_echoes_configured_origin() {
+    let server = test_app_with_cors(vec!["https://app.example.com".into()]);
+    let resp = server
+        .get("/health")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("https://app.example.com"),
+        )
+        .await;
+    assert_eq!(
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|v| v.to_str().ok()),
+        Some("https://app.example.com"),
+    );
+}
+
+#[tokio::test]
+async fn cors_allowlist_rejects_unlisted_origin() {
+    // The property that actually makes it an allowlist: an origin NOT on the
+    // list is not echoed. Guards against a refactor to a mirror/permissive
+    // layer, which `cors_allowlist_echoes_configured_origin` alone would miss.
+    let server = test_app_with_cors(vec!["https://app.example.com".into()]);
+    let resp = server
+        .get("/health")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("https://evil.example"),
+        )
+        .await;
+    // Assert ACAO is absent (not merely "not the evil origin") — the strong
+    // guard: a mirror layer OR the old `permissive()` (`ACAO: *`) would both
+    // fail this, so it locks in true allowlist behavior.
+    assert!(
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "an unlisted origin must not receive any Access-Control-Allow-Origin"
+    );
+}
+
+#[tokio::test]
+async fn cors_null_origin_entry_is_rejected() {
+    // `null` is the opaque-origin token (sandboxed iframes, file://). It must be
+    // dropped like `*`, never turned into an allowed origin.
+    let server = test_app_with_cors(vec!["null".into()]);
+    let resp = server
+        .get("/health")
+        .add_header(axum::http::header::ORIGIN, HeaderValue::from_static("null"))
+        .await;
+    assert!(
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "`null` entry must not produce an allowed opaque origin"
+    );
+}
+
+#[tokio::test]
+async fn cors_wildcard_entry_is_rejected_not_panicking() {
+    // A literal "*" must be dropped (never re-enable wildcard CORS) and must not
+    // panic at startup — `AllowOrigin::list(["*"])` would panic in tower-http.
+    let server = test_app_with_cors(vec!["*".into()]);
+    let resp = server
+        .get("/health")
+        .add_header(
+            axum::http::header::ORIGIN,
+            HeaderValue::from_static("https://evil.example"),
+        )
+        .await;
+    assert!(
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "`*` entry must not produce a wildcard ACAO"
+    );
+}
+
 // ── Constant-time comparison tests ──
 
 #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,13 @@ services:
   # swap on small VPS instances.
   lightpanda:
     image: lightpanda/browser:latest
+    # LightPanda sends usage telemetry to a third-party endpoint by default.
+    # Disable it so the default stack makes no unexpected outbound connections —
+    # important for air-gapped / compliance deployments. Air-gapped operators who
+    # need byte-for-byte reproducibility should additionally pin this image to a
+    # digest (`lightpanda/browser@sha256:...`) instead of the `:latest` tag.
+    environment:
+      - LIGHTPANDA_DISABLE_TELEMETRY=true
     restart: unless-stopped
     mem_limit: 1g
     memswap_limit: 1g

--- a/docs/docs/self-hosting-hardening.md
+++ b/docs/docs/self-hosting-hardening.md
@@ -31,9 +31,9 @@ fastCRW validates every outbound URL before fetching it (`crw-core/src/url_safet
 
 The env var `CRW_ALLOW_LOOPBACK_FOR_TESTS=1` disables the loopback and private-range checks so integration tests can target mock servers at `127.0.0.1:<random>`. It is **not a runtime configuration option** — it exists solely to make integration tests pass in CI without a public network. Setting it in a production process removes the SSRF guard for all outbound fetches and is never safe to do.
 
-## Unauthenticated Admin and Ops Endpoints
+## Admin and Ops Endpoints
 
-Three endpoints are registered in `crates/crw-server/src/app.rs` **outside** the authenticated `api_routes` block and therefore bypass the `auth_middleware` entirely, even when `[auth].api_keys` is configured:
+Three operational endpoints expose internal state:
 
 | Endpoint | Method | Purpose |
 |---|---|---|
@@ -41,25 +41,36 @@ Three endpoints are registered in `crates/crw-server/src/app.rs` **outside** the
 | `/metrics/renderer-breakers` | `GET` | JSON snapshot of all circuit-breaker states |
 | `/admin/breakers/reset` | `POST` | Resets all circuit breakers; returns count of host entries cleared |
 
-These endpoints have no authentication built in. Anyone who can reach the process on its listen port can read internal metrics or reset circuit breakers.
+These endpoints sit **inside** the authentication boundary. When you configure `[auth].api_keys`, they require a valid `Authorization: Bearer <key>` header, exactly like the scraper API. With **no** keys configured (the default self-host case), they are open — same as every other route — so restrict the service by network in that mode.
 
-**How to protect them:**
+**Breaking change (key-secured deployments):** if you scrape `/metrics` with a Prometheus job and have `api_keys` set, the scrape now needs the token. Add it to your scrape config:
 
-Option 1 — network policy (preferred for most deployments): bind fastCRW to a non-public interface or port and allow only your monitoring system (Prometheus scraper, internal ops tooling) to reach it. In Docker Compose the default `ports` block should only publish to localhost (`127.0.0.1:<port>:<port>`), never `0.0.0.0`.
-
-Option 2 — reverse-proxy access control: if the process must be reachable on a shared interface, configure your reverse proxy to block or require HTTP Basic / mutual-TLS on the `/metrics` and `/admin` path prefixes before traffic reaches fastCRW. Example (nginx):
-
-```nginx
-location ~ ^/(metrics|admin)/ {
-    # Only allow your Prometheus scraper and ops CIDR
-    allow 10.0.0.0/8;
-    deny  all;
-}
+```yaml
+scrape_configs:
+  - job_name: crw
+    authorization:
+      type: Bearer
+      credentials: "<your-api-key>"
+    static_configs:
+      - targets: ["crw:3000"]
 ```
 
-Option 3 — firewall rule: drop inbound traffic to the fastCRW port except from trusted source IPs (iptables/nftables/cloud security group).
+**Defense in depth (recommended regardless of auth):**
 
-All three options can be layered.
+- Network policy: bind fastCRW to a non-public interface or port and allow only your monitoring system to reach it. In Docker Compose publish only to localhost (`127.0.0.1:<port>:<port>`), never `0.0.0.0`.
+- Reverse-proxy access control: block or require HTTP Basic / mutual-TLS on the `/metrics` and `/admin` path prefixes before traffic reaches fastCRW.
+- Firewall rule: drop inbound traffic to the fastCRW port except from trusted source IPs.
+
+## Cross-Origin (CORS)
+
+By default the engine sends **no** CORS headers, so browsers block cross-origin JavaScript from reading API responses — the safe posture for a server-to-server API. If a browser app must call the engine directly, set an explicit allowlist:
+
+```toml
+[server]
+cors_allowed_origins = ["https://app.example.com"]
+```
+
+or `CRW_SERVER__CORS_ALLOWED_ORIGINS="https://app.example.com,https://admin.example.com"`. A literal `"*"` is rejected — wildcard CORS is exactly what this setting replaces. (The `/openapi.json` schema endpoint is intentionally readable cross-origin so SDK generators can fetch it.)
 
 ## Runtime Isolation
 


### PR DESCRIPTION
Hardens the HTTP server's authentication boundary and default cross-origin policy.

## Auth boundary
`/metrics`, `/metrics/renderer-breakers`, and `/admin/breakers/reset` were mounted on the base router outside `auth_middleware`, so they were reachable with no credential even when `[auth].api_keys` was configured. They now live inside the `api_routes` group:
- with `api_keys` set → require `Authorization: Bearer <key>` (401 otherwise)
- with no keys (default self-host) → open, same as the rest of the API

Liveness/schema (`/health`, `/ready`, `/openapi.json`, `/openapi-3.0.json`) stay unauthenticated by design.

## CORS
Replaces blanket `CorsLayer::permissive()` with a config-gated allowlist `server.cors_allowed_origins`:
- default empty → no CORS headers emitted (browsers block cross-origin reads)
- `*`, `null`, and schemeless entries are rejected (never widens back to permissive; also avoids a tower-http startup panic on `*`)
- `/openapi*` keeps `ACAO: *` intentionally so SDK generators can fetch the schema

## Renderer telemetry
The default compose stack now sets `LIGHTPANDA_DISABLE_TELEMETRY=true` on the LightPanda sidecar, so the out-of-the-box stack makes no unexpected third-party outbound connections. The crw engine itself sends no telemetry.

## Docs
- `SECURITY.md`: adds GitHub private vulnerability reporting alongside email
- `self-hosting-hardening.md`: documents the auth boundary + CORS, including the Prometheus `Bearer` scrape-config **breaking change** for key-secured deployments

## Tests
Adds regression coverage in `crates/crw-server/tests/auth.rs`: ops/admin routes 401 without a key (and 200 with), stay open when no keys, liveness/schema always open, and CORS is absent by default / allowlist rejects unlisted, `null`, `*`, and schemeless origins.

Refs #333.
