### PR TITLE
fix(compose): make crw host port overridable via CRW_HOST_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,13 @@ services:
   crw:
     build: .
     ports:
-      - "3000:3000"
+      # Override the host port via `.env` (CRW_HOST_PORT) for boxes already
+      # using 3000. Namespaced to `crw` so it can't collide with a generic
+      # `HOST_PORT` in the operator's env. Despite the `CRW_` prefix this is
+      # Compose-only host-side interpolation — it is NOT passed into the
+      # container, so the engine's figment config never sees it. Container
+      # port stays 3000.
+      - "${CRW_HOST_PORT:-3000}:3000"
     depends_on:
       lightpanda:
         condition: service_started

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -31,7 +31,7 @@ The bundled `docker-compose.yml` starts these services:
 
 | Service | Internal Port | Published to host? | Default? | Description |
 |---------|---------------|--------------------|----------|-------------|
-| **crw** | 3000 | ✅ `0.0.0.0:3000` | ✅ | API server (loads `config.docker.toml`) |
+| **crw** | 3000 | ✅ `0.0.0.0:3000`³ | ✅ | API server (loads `config.docker.toml`) |
 | **searxng** | 8080 | ❌ internal only² | ✅ | SearXNG meta-search backend for `/v1/search` |
 | **lightpanda** | 9222 | ❌ internal only | ✅ | Lightweight headless browser for JS rendering |
 | **chrome** | 9222 | ❌ internal only | `--profile heavy` | Full Chromium fallback for complex SPAs |
@@ -40,6 +40,8 @@ The bundled `docker-compose.yml` starts these services:
 ¹ `chrome-stealth` listens on container port 3000 (browserless default) and is published to the host as `127.0.0.1:9224` — loopback only, for a host-run `crw-server` during development. The composed `crw` service reaches it via the Docker bridge as `chrome-stealth:3000` and does not use the host port.
 
 ² `searxng:8080` is internal to the Compose network only — `localhost:8080` on the host will not connect. Search traffic flows exclusively through crw's `/v1/search` endpoint. For direct debug access, add `ports: ["127.0.0.1:8888:8080"]` in `docker-compose.override.yml`.
+
+³ The host port defaults to `3000` but is overridable without editing the Compose file: set `CRW_HOST_PORT` in `.env` (e.g. `CRW_HOST_PORT=3055`) if something else already holds 3000 on the box. The container port stays `3000`. Note: Compose interpolates `CRW_HOST_PORT` on the host into the port mapping only; unlike the `CRW_*` config keys elsewhere it is not delivered into the container, so the engine never reads it.
 
 The `crw` service reads its configuration from the mounted `config.docker.toml` (via
 `CRW_CONFIG=config.docker`), which already points each renderer and the search backend at the matching


### PR DESCRIPTION
Resolves the hardcoded host port reported in #336.

## Problem
The `crw` service published a fixed host port:
```yaml
ports:
  - "3000:3000"
```
On a host already using 3000, `docker compose up` fails with `Bind for
0.0.0.0:3000 failed: port is already allocated`, and the host side can't be
remapped without editing the tracked compose file.

## Change
```yaml
ports:
  - "${CRW_HOST_PORT:-3000}:3000"
```
- Matches the existing `${VAR:-default}` convention already used for
  `SEARXNG_SECRET_KEY` and `BROWSERLESS_TOKEN`.
- Default behavior is unchanged when `CRW_HOST_PORT` is unset or empty; the
  container-side port stays `3000`.
- Namespaced (`CRW_HOST_PORT`, not a generic `HOST_PORT`) so it can't collide
  with a pre-existing value in the operator's shell/`.env`. It is interpolated
  by Compose host-side only and never delivered into the container, so the
  engine's config never reads it.
- `docs/docs/docker.md` port table documents the override.

## Verification
`docker compose config` via a real `.env`:
- unset / no `.env` -> `published: "3000"`
- `CRW_HOST_PORT=` (empty) -> `published: "3000"`
- `CRW_HOST_PORT=3055` -> `published: "3055"`

No script/CI/healthcheck parses the literal `3000:3000` from the compose file.

## Out of scope
Making the bind address configurable (default `0.0.0.0`) is tracked separately;
it is a hardening concern distinct from the port conflict in #336, and changing
the default to loopback would break the no-reverse-proxy quickstart.