### PR TITLE
fix(crawl): stop flagging cleared managed pages as CF challenges

### DIFF
--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -1013,10 +1013,16 @@ fn classify_block(
     // substring search avoids allocating a lowercased copy on every scrape.
     // Runs before the markdown-substantial guard: a challenge is a block even if
     // it yields boilerplate text.
-    // ponytail: strong-markers-only keeps false positives ~nil; a real page that
-    // cleared the challenge no longer carries _cf_chl_opt / challenge-platform.
-    const CF_STRONG_MARKERS: [&str; 5] = [
-        "/cdn-cgi/challenge-platform/",
+    //
+    // `/cdn-cgi/challenge-platform/` is deliberately NOT in this list: Cloudflare
+    // re-injects that telemetry loader into the CLEARED page too (measured at byte
+    // ~782k of a real post-solve 783k Glassdoor page that carries NO _cf_chl_opt),
+    // so a full-html scan for it false-positives every managed site the cloak arm
+    // successfully solves — emptying real content back to a challenge block. The
+    // remaining markers are interstitial-only: window._cf_chl_opt (the challenge
+    // config object) and the older cf-*/managed-token strings are absent once the
+    // page clears.
+    const CF_STRONG_MARKERS: [&str; 4] = [
         "_cf_chl_opt",
         "cf-challenge-running",
         "cf-browser-verification",
@@ -1129,6 +1135,36 @@ mod tests {
         let b = classify_block(200, Some("text/html"), &html, Some(&md), false, THRESH)
             .expect("Turnstile 200 interstitial must be flagged");
         assert_eq!(b.vendor, "cloudflare");
+    }
+
+    #[test]
+    fn classify_block_no_block_on_cleared_managed_page_with_trailing_platform_script() {
+        // Real prod regression (cloak arm): a managed-Turnstile site the cloak
+        // tier successfully SOLVED returns the real page (~783KB Glassdoor), but
+        // Cloudflare re-injects the `/cdn-cgi/challenge-platform/` telemetry loader
+        // near the END of the cleared body (measured at byte ~782k) with NO
+        // `_cf_chl_opt`. A full-html scan for challenge-platform false-positived it
+        // as an interstitial and emptied the recovered content. The cleared page
+        // must NOT be flagged: it carries content markers and no interstitial-only
+        // token.
+        let mut html = String::from(
+            r#"<!DOCTYPE html><html><head><title>Working at Google | Glassdoor</title></head><body>"#,
+        );
+        html.push_str(&"<p>Real reviews and salaries content.</p>".repeat(10_000)); // >512KB
+        html.push_str(
+            r#"<script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=abc"></script></body></html>"#,
+        );
+        assert!(
+            html.contains("/cdn-cgi/challenge-platform/") && !html.contains("_cf_chl_opt"),
+            "fixture must reproduce the cleared-page shape"
+        );
+        // Substantial recovered markdown too — the real content extracts fine.
+        let md = "Real reviews and salaries content. ".repeat(50);
+        assert!(
+            classify_block(200, Some("text/html"), &html, Some(&md), false, THRESH).is_none(),
+            "a cleared managed page with a trailing challenge-platform telemetry \
+             script (but no _cf_chl_opt) must not be misflagged as a challenge"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The cloak Turnstile-recovery arm successfully solves Cloudflare-managed sites
(Glassdoor-class) and warm-replays the real page, but the scrape still returned
`success:false` with an empty body and a `cloudflare challenge interstitial`
block.

Root cause: `classify_block` (the single scrape choke that every consumer
inherits) scanned the **full** HTML for `/cdn-cgi/challenge-platform/` as a
strong CF-interstitial marker. Cloudflare re-injects that telemetry loader into
the **cleared** page too — measured at byte ~782k of a real post-solve 783k
Glassdoor page that carries **no** `_cf_chl_opt`. So the full-html scan
false-positived every managed site the cloak arm actually solved, emptying the
recovered content back into a challenge block.

## Fix

Drop `/cdn-cgi/challenge-platform/` from `CF_STRONG_MARKERS`. The remaining
markers (`_cf_chl_opt`, `cf-challenge-running`, `cf-browser-verification`,
`__cf_chl_managed_tk__`) are interstitial-only and absent once the page clears —
verified empirically: a bare 241KB Glassdoor interstitial carries `_cf_chl_opt`;
the cleared 783KB page does not.

## Verification

- New regression test `classify_block_no_block_on_cleared_managed_page_with_trailing_platform_script`
  (cleared >512KB page, trailing challenge-platform script, no `_cf_chl_opt` → not blocked).
- Existing interstitial tests still pass (`classify_block_turnstile_200_large_body`
  already keys on `_cf_chl_opt`).
- Full workspace: 1398 passed, 22 ignored. `cargo fmt --check` + `clippy --workspace -D warnings` clean.

Engine-only change: goes live on the next crw-saas release (pin bump), not on merge.