### PR TITLE
feat(docker): make published bind address configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,15 @@ services:
   crw:
     build: .
     ports:
-      # Override the host port via `.env` (CRW_HOST_PORT) for boxes already
-      # using 3000. Namespaced to `crw` so it can't collide with a generic
-      # `HOST_PORT` in the operator's env. Despite the `CRW_` prefix this is
-      # Compose-only host-side interpolation — it is NOT passed into the
-      # container, so the engine's figment config never sees it. Container
-      # port stays 3000.
-      - "${CRW_HOST_PORT:-3000}:3000"
+      # Override the host bind address / port via `.env` (CRW_BIND_ADDRESS,
+      # CRW_HOST_PORT) for boxes already using 3000, or to stop publishing on
+      # public interfaces (set CRW_BIND_ADDRESS=127.0.0.1 when fronting crw
+      # with a reverse proxy). Namespaced to `crw` so they can't collide with a
+      # generic `HOST_PORT` in the operator's env. Despite the `CRW_` prefix
+      # this is Compose-only host-side interpolation: it is NOT passed into the
+      # container, so the engine's figment config never sees it. Container port
+      # stays 3000; default bind stays 0.0.0.0 (all interfaces).
+      - "${CRW_BIND_ADDRESS:-0.0.0.0}:${CRW_HOST_PORT:-3000}:3000"
     depends_on:
       lightpanda:
         condition: service_started

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -41,7 +41,7 @@ The bundled `docker-compose.yml` starts these services:
 
 ² `searxng:8080` is internal to the Compose network only — `localhost:8080` on the host will not connect. Search traffic flows exclusively through crw's `/v1/search` endpoint. For direct debug access, add `ports: ["127.0.0.1:8888:8080"]` in `docker-compose.override.yml`.
 
-³ The host port defaults to `3000` but is overridable without editing the Compose file: set `CRW_HOST_PORT` in `.env` (e.g. `CRW_HOST_PORT=3055`) if something else already holds 3000 on the box. The container port stays `3000`. Note: Compose interpolates `CRW_HOST_PORT` on the host into the port mapping only; unlike the `CRW_*` config keys elsewhere it is not delivered into the container, so the engine never reads it.
+³ The host bind address and port are overridable without editing the Compose file: set `CRW_HOST_PORT` in `.env` (e.g. `CRW_HOST_PORT=3055`) if something else already holds 3000 on the box, and `CRW_BIND_ADDRESS` (e.g. `CRW_BIND_ADDRESS=127.0.0.1`) to stop publishing on public interfaces. Both default to today's behavior (`0.0.0.0:3000`) and the container port stays `3000`. Note: Compose interpolates these on the host into the port mapping only; unlike the `CRW_*` config keys elsewhere they are not delivered into the container, so the engine never reads them.
 
 The `crw` service reads its configuration from the mounted `config.docker.toml` (via
 `CRW_CONFIG=config.docker`), which already points each renderer and the search backend at the matching
@@ -184,7 +184,9 @@ never used.
   by default. The `chrome-stealth` service binds only to `127.0.0.1:9224`. Audit
   `ports:` entries before exposing to a public interface.
 - **Reverse proxy TLS**: Run crw behind nginx/Caddy with TLS termination and
-  `CRW_AUTH__API_KEYS` set. Do not expose port 3000 directly to the internet.
+  `CRW_AUTH__API_KEYS` set. Do not expose port 3000 directly to the internet. When
+  a proxy fronts crw, set `CRW_BIND_ADDRESS=127.0.0.1` in `.env` so the API only
+  publishes on loopback instead of every host interface (see footnote ³).
 
 ## LightPanda Restart Policy
 


### PR DESCRIPTION
Ref #339. Follow-up to #337, which made the host **port** overridable.

The `crw` service published on `0.0.0.0` (all host interfaces) with no way to change it short of editing the Compose file. On a public-IP box that exposes the API unless a firewall or reverse proxy fronts it, while the docs already recommend running behind Caddy/nginx.

## Change
```yaml
- "${CRW_BIND_ADDRESS:-0.0.0.0}:${CRW_HOST_PORT:-3000}:3000"
```
- Additive and default-preserving: unset/empty keeps `0.0.0.0:3000`.
- Operators fronting crw with a reverse proxy set `CRW_BIND_ADDRESS=127.0.0.1` in `.env` to publish on loopback only.
- Same host-side-only interpolation as `CRW_HOST_PORT`: never delivered into the container, the engine's figment config never sees it. Container port stays `3000`.
- Docs: footnote in `docs/docs/docker.md` port table + a note next to the existing "do not expose 3000" hardening bullet.

## Verified
`docker compose config` across `.env` scenarios:

| scenario | host_ip | published | container |
|---|---|---|---|
| unset (default) | `0.0.0.0` | 3000 | 3000 |
| empty | `0.0.0.0` | 3000 | 3000 |
| `CRW_BIND_ADDRESS=127.0.0.1`, `CRW_HOST_PORT=3055` | `127.0.0.1` | 3055 | 3000 |

No Rust code touched; the #90 docker-config regression guard does not parse the `ports:` line.