### PR TITLE
fix(search): distinguish a degraded backend from a zero-result query

### DIFF
--- a/crates/crw-core/src/error.rs
+++ b/crates/crw-core/src/error.rs
@@ -39,6 +39,9 @@ pub enum CrwError {
     SearchDisabled(String),
 
     #[error("{0}")]
+    SearchDegraded(String),
+
+    #[error("{0}")]
     Internal(String),
 
     #[error("Renderer pool shutting down")]
@@ -61,6 +64,7 @@ impl CrwError {
             CrwError::NotFound(_) => "not_found",
             CrwError::RateLimited => "rate_limited",
             CrwError::SearchDisabled(_) => "search_disabled",
+            CrwError::SearchDegraded(_) => "search_degraded",
             CrwError::Internal(_) => "internal_error",
             CrwError::Shutdown => "shutdown",
         }

--- a/crates/crw-search/src/client.rs
+++ b/crates/crw-search/src/client.rs
@@ -130,6 +130,19 @@ pub struct SearxngResponse {
     pub suggestions: Vec<String>,
     #[serde(default)]
     pub unresponsive_engines: Vec<serde_json::Value>,
+    /// Explicit degraded flag an upstream orchestrator may set. A plain
+    /// SearXNG backend never sets this, hence the serde default.
+    #[serde(default)]
+    pub degraded: bool,
+}
+
+impl SearxngResponse {
+    /// True when the backend answered with nothing AND reported that engines
+    /// failed. Emptiness is a PREREQUISITE for both signals: a response that
+    /// some later leg rescued into a non-empty pool is never degraded.
+    pub fn is_degraded(&self) -> bool {
+        self.results.is_empty() && (self.degraded || !self.unresponsive_engines.is_empty())
+    }
 }
 
 /// Thin async client for SearXNG. One instance per server; reuse across
@@ -229,5 +242,39 @@ impl SearxngClient {
         let buf = read_capped(response, MAX_RESPONSE_BYTES).await?;
         serde_json::from_slice::<SearxngResponse>(&buf)
             .map_err(|e| SearchError::InvalidResponse(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_degraded_true_on_empty_results_with_unresponsive_engines() {
+        let resp = SearxngResponse {
+            unresponsive_engines: vec![serde_json::json!(["google", "timeout"])],
+            ..Default::default()
+        };
+        assert!(resp.is_degraded());
+    }
+
+    #[test]
+    fn is_degraded_false_on_genuine_zero_results() {
+        // Empty results, no unresponsive engines, no degraded flag: a real
+        // zero-result query, not a backend failure — must stay a normal 200.
+        let resp = SearxngResponse::default();
+        assert!(!resp.is_degraded());
+    }
+
+    #[test]
+    fn is_degraded_false_when_results_non_empty() {
+        // Emptiness is a prerequisite: a later leg that rescued the pool into
+        // non-empty results is never degraded, even if engines failed.
+        let resp: SearxngResponse = serde_json::from_value(serde_json::json!({
+            "results": [{"url": "https://example.com", "title": "Example", "engine": "google"}],
+            "unresponsive_engines": [["google", "timeout"]],
+        }))
+        .unwrap();
+        assert!(!resp.is_degraded());
     }
 }

--- a/crates/crw-server/src/error.rs
+++ b/crates/crw-server/src/error.rs
@@ -47,6 +47,7 @@ impl IntoResponse for AppError {
             CrwError::ExtractionError(_) => StatusCode::UNPROCESSABLE_ENTITY,
             CrwError::RateLimited => StatusCode::TOO_MANY_REQUESTS,
             CrwError::SearchDisabled(_) => StatusCode::SERVICE_UNAVAILABLE,
+            CrwError::SearchDegraded(_) => StatusCode::SERVICE_UNAVAILABLE,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -43,6 +43,12 @@ const SCOUT_FETCH_LIMIT: u32 = 6;
 /// `multi_round` adds.
 const MULTI_ROUND_MIN_BUDGET_MS: u64 = 20_000;
 
+/// Customer-facing text for "the backend could not answer", used both as the
+/// non-LLM error and as the LLM-path warning. A single constant because the
+/// multi-round leg has to be able to REMOVE it again by value when a later
+/// round rescues the request. Names no backend, engine, or provider.
+const DEGRADED_MESSAGE: &str = "The search backend could not answer this query. Retry shortly.";
+
 /// Heuristic: did the synthesized answer ABSTAIN (sources lacked the fact)?
 /// Aligned with `answer.rs`'s calibrated clause ("ONLY if the sources genuinely
 /// do not contain the information, say so plainly"). Triggers the adaptive
@@ -268,6 +274,17 @@ pub async fn search_inner(
             .map_err(|e| map_search_error(e, state.config.search.timeout_ms, client.base_url()))?
     };
 
+    // The backend can answer HTTP 200 with an empty result set for two very
+    // different reasons: the query genuinely has no results, or the backend
+    // itself couldn't answer (engines failed / upstream flagged degraded).
+    // `is_degraded()` distinguishes the two. Off the LLM path `response` is
+    // final (every rescue leg below is gated on `llm_path`), so a degraded
+    // empty response can be rejected outright. On the LLM path, page-2 and
+    // Wikidata rescues still run, so we only warn and let the request continue.
+    if !llm_path && response.is_degraded() {
+        return Err(CrwError::SearchDegraded(DEGRADED_MESSAGE.into()));
+    }
+
     let has_sources = req.sources.as_ref().is_some_and(|s| !s.is_empty());
     // The LLM answer / summarize path feeds the top-N flat sources straight to
     // the model, so it must receive a clean, query-relevant pool. Re-rank the
@@ -387,6 +404,20 @@ pub async fn search_inner(
 
     let mut warning: Option<String> = None;
     let mut warnings: Vec<String> = Vec::new();
+    // Re-evaluated here, NOT carried over from the check above: both LLM-path
+    // rescues run in between, and a rescued request must not ship a "backend
+    // could not answer" warning alongside genuine results.
+    //   - page-2 pushes rows into `response.results`, which `is_degraded()`
+    //     already self-corrects on (it requires emptiness).
+    //   - Wikidata / structured facts populate `structured_sources` WITHOUT
+    //     touching `response.results`, so that rescue needs its own term — and
+    //     only counts when `answer` is set, since answer synthesis is the sole
+    //     consumer of `structured_sources`. A `summarizeResults`-only request
+    //     is NOT rescued by them and must still get the warning.
+    let structured_rescue = req.answer.unwrap_or(false) && !structured_sources.is_empty();
+    if response.is_degraded() && !structured_rescue {
+        warnings.push(DEGRADED_MESSAGE.into());
+    }
     if let Some(opts) = req.scrape_options.as_ref() {
         match enrich_with_scrape(&mut data, opts, state).await {
             Ok(()) => {}
@@ -624,6 +655,12 @@ pub async fn search_inner(
                                         ans = ans2;
                                         cites = cites2;
                                         warnings.append(&mut warns2);
+                                        // Round 2 answered. Its scout rows land
+                                        // in `data`, never in `response.results`,
+                                        // so the degraded warning pushed earlier
+                                        // would otherwise ship next to a real
+                                        // answer telling the caller to retry.
+                                        warnings.retain(|w| w != DEGRADED_MESSAGE);
                                     }
                                 }
                             }

--- a/crates/crw-server/tests/search_route.rs
+++ b/crates/crw-server/tests/search_route.rs
@@ -51,6 +51,30 @@ model = "claude-sonnet-4-20250514"
     TestServer::new(app)
 }
 
+fn test_app_with_structured_sources(url: &str) -> TestServer {
+    // As above, plus `use_structured_sources` so `infoboxes[]`/`answers[]` are
+    // parsed into pinned answer sources. Needed to tell a real structured-answer
+    // rescue apart from a merely-collected structured fact.
+    let toml = format!(
+        r#"
+[search]
+enabled = true
+searxng_url = "{url}"
+timeout_ms = 5000
+use_structured_sources = true
+
+[extraction.llm]
+provider = "anthropic"
+api_key = "sk-test"
+model = "claude-sonnet-4-20250514"
+"#
+    );
+    let config: AppConfig = toml::from_str(&toml).unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    let app = create_app(state);
+    TestServer::new(app)
+}
+
 fn test_app_search_disabled() -> TestServer {
     // Default config has no searxng_url → state.searxng = None.
     let config: AppConfig = toml::from_str("").unwrap();
@@ -243,6 +267,141 @@ async fn search_disabled_returns_503_with_search_disabled_code() {
     assert!(
         err.contains("Search is disabled"),
         "expected disabled error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn search_genuine_zero_result_stays_200_with_empty_array() {
+    // The counterpart to the degraded test below, and the guard against
+    // over-firing it: an empty pool with NO failed engines is a query that
+    // genuinely has no results. It must keep returning a normal 200 with an
+    // empty array, not a 503.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [],
+            "number_of_results": 0,
+            "unresponsive_engines": []
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = test_app_with_searxng(&mock.uri());
+    let resp = server
+        .post("/v1/search")
+        .json(&json!({"query": "zzzqqq no such thing"}))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["results"].as_array().map(|a| a.len()), Some(0));
+}
+
+#[tokio::test]
+async fn search_degraded_non_llm_returns_503_with_search_degraded_code() {
+    // Backend answers 200 with an empty pool AND reports failed engines: on
+    // the plain (non-LLM) path `response` is final, so this must surface as
+    // 503 `search_degraded` rather than a silent 200-with-empty-results.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [],
+            "number_of_results": 0,
+            "unresponsive_engines": [["google", "timeout"]]
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = test_app_with_searxng(&mock.uri());
+    let resp = server
+        .post("/v1/search")
+        .json(&json!({"query": "rust async"}))
+        .await;
+    resp.assert_status(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    let body: Value = resp.json();
+    assert_eq!(body["success"], false);
+    assert_eq!(body["errorCode"], "search_degraded");
+}
+
+#[tokio::test]
+async fn search_degraded_llm_path_does_not_503() {
+    // Same degraded backend shape, but `answer: true` puts the request on the
+    // LLM path, where page-2/Wikidata rescues still run after this point —
+    // erroring out here would kill those rescues. Must stay 200.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [],
+            "number_of_results": 0,
+            "unresponsive_engines": [["google", "timeout"]]
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = test_app_with_searxng_and_llm(&mock.uri());
+    let resp = server
+        .post("/v1/search")
+        .json(&json!({"query": "rust async", "answer": true}))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["success"], true);
+    // Nothing rescued it here, so the caller must still be told the backend
+    // could not answer — a silent empty answer is the bug this change removes.
+    let warnings = body["data"]["warnings"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or("").contains("could not answer")),
+        "degraded LLM-path request must carry the warning, got {warnings:?}"
+    );
+}
+
+#[tokio::test]
+async fn search_degraded_summarize_only_still_warns() {
+    // `summarizeResults` without `answer` never consumes `structured_sources`,
+    // so a structured fact can NOT rescue it — the warning must still fire even
+    // though structured sources WERE collected. The mock deliberately carries a
+    // parseable `answers[]` entry and the app enables `use_structured_sources`:
+    // without both, this test would also pass against the earlier, buggy plain
+    // `structured_sources.is_empty()` condition, i.e. it would pin nothing.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [],
+            "number_of_results": 0,
+            "unresponsive_engines": [["google", "timeout"]],
+            "answers": [{"answer": "Rust's async runtime is Tokio.", "url": "https://tokio.rs/"}],
+            "infoboxes": [],
+            "suggestions": [],
+            "corrections": []
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = test_app_with_structured_sources(&mock.uri());
+    let resp = server
+        .post("/v1/search")
+        .json(&json!({"query": "rust async", "summarizeResults": true}))
+        .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    let warnings = body["data"]["warnings"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or("").contains("could not answer")),
+        "summarize-only degraded request must still warn, got {warnings:?}"
     );
 }
 


### PR DESCRIPTION
`/v1/search` answered `200` with an empty array whenever no engine could answer
at all. That is indistinguishable from a query which genuinely has no results,
so a caller silently lost results with no way to detect it. The backend already
reported the failure in `unresponsive_engines` — the field was deserialized and
never read.

Measured on a live deployment: 8 concurrent `site:` queries, 4 of 8 came back
empty, and every empty one had zero engines answering and a non-empty
failed-engine list.

## What changed

- `SearxngResponse::is_degraded()` — empty pool AND engines reported as failed.
  Emptiness is a prerequisite for both signals, so a pool that a later leg
  rescued into non-empty is never treated as degraded.
- Non-LLM path returns `503` / `errorCode: "search_degraded"`. That path runs a
  single plain fetch, so `response` is final there and the check cannot discard
  a rescue. A genuine zero-result query still returns `200` with an empty array.
- LLM path warns instead of failing, so page-2, structured/Wikidata and
  multi-round rescues still run. The warning is withdrawn if one of them
  actually recovers the request.
- Explicit `503` arm in the server status match. That match ends in a
  `_ => INTERNAL_SERVER_ERROR` wildcard, so a missing arm would have compiled
  cleanly and returned `500`.

Customer-facing text names no backend, engine or provider.

## Tests

6 added: 3 unit (predicate incl. the non-empty and genuine-zero-result cases),
3 route (non-LLM `503`, genuine zero-result stays `200`, LLM path does not
`503` and keeps its warning; plus a summarize-only case that is
mutation-verified — reverting the production condition makes it fail).

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
and `cargo test --workspace` (1405 passed) are clean.

## Deploy note

Engine images build on release only, so merging this does not change production
until a release lands and the deployment pin advances. The pin bump must NOT go
out ahead of the matching search-orchestrator change, or a `503`-emitting engine
would run against an orchestrator that does not yet retry a degraded answer.

`/v2` response shape untouched.
