### PR TITLE
fix(packaging): verify downloaded binaries against published checksums

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -51,6 +51,65 @@ is already being actively exploited, we may move faster.
 
 ---
 
+## Verifying a release
+
+Every release publishes a `SHA256SUMS` file covering all binary assets, plus a
+keyless [Sigstore](https://www.sigstore.dev/) signature over that file
+(`SHA256SUMS.sigstore.json`).
+
+The Python SDK, and the npm launcher on Windows, download a prebuilt binary on
+first use. Before extracting it they fetch `SHA256SUMS` for their own release
+tag and compare it against the archive they received, and they abort if it does
+not match or if the release publishes no checksums at all. They ask only for the
+tag they were published alongside, never a mutable `latest`.
+
+On macOS and Linux, `npm install crw-mcp` normally pulls a prebuilt platform
+package instead, so the download path is usually unused there. Those binaries are
+checked against the same `SHA256SUMS` in CI before the packages are published,
+and npm's own integrity hash covers the install. An install that skips optional
+dependencies still falls back to the verified download path.
+
+Two limits worth stating plainly:
+
+- Once a binary is in the local cache, later runs execute it without re-hashing.
+  Anything that can write to your cache directory can therefore substitute it.
+  Closing that properly needs a digest baked into the wrapper at build time,
+  which we do not do yet.
+- `SHA256SUMS` is fetched from the same release as the archive, so this protects
+  against transfer corruption, truncation, and a mismatched or re-uploaded
+  asset. It is not a defence against someone who can write to the release
+  itself; that is what the signature is for, and verifying it is a manual step
+  today.
+
+To check a download yourself (requires cosign v3 or newer for step 2):
+
+```sh
+# 1. Integrity: the archive matches what the release records.
+curl -fsSLO https://github.com/us/crw/releases/download/vX.Y.Z/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+# macOS has no sha256sum; check just the file you downloaded:
+#   shasum -a 256 crw-darwin-arm64.tar.gz
+#   grep crw-darwin-arm64.tar.gz SHA256SUMS
+
+# 2. Authenticity: the checksums were produced by our release workflow.
+curl -fsSLO https://github.com/us/crw/releases/download/vX.Y.Z/SHA256SUMS.sigstore.json
+cosign verify-blob \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity-regexp '^https://github\.com/us/crw/\.github/workflows/release\.yml@refs/(tags/v.*|heads/main)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+```
+
+The identity is a regexp because keyless signing binds the certificate to the
+workflow ref: normally the release tag, or `main` when a release is re-run
+manually for recovery.
+
+Note on older releases: `v0.21.2` and `v0.21.3` carry per-asset `.sig`/`.pem`
+files instead, and releases from `v0.22.0` through `v0.27.0` are unsigned. The
+cosign version is now pinned explicitly.
+
+---
+
 ## Scope
 
 In scope for this policy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,13 @@ jobs:
       - name: Test
         run: npm test
 
+      # The launcher's SHA256SUMS parser is hand-rolled because Windows ships no
+      # sha256sum, and Windows is the one platform with no prebuilt package, so
+      # every Windows user depends on it. No deps, node:test is stdlib.
+      - name: Test crw-mcp launcher
+        working-directory: mcp/crw-mcp
+        run: npm test
+
   # Firecrawl v2 conformance gate (conformance/, issue #62). Drives the
   # deterministic corpus against a live `crw serve` and diffs each response's
   # SHAPE against the committed golden Firecrawl fixtures. `compare.py` only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,6 @@ jobs:
     needs: [release-context, check]
     permissions:
       contents: write
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -250,37 +249,30 @@ jobs:
               "${bin}-${{ matrix.platform }}-${{ matrix.arch_label }}.${ext}" --clobber
           done
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign artifacts (keyless)
-        continue-on-error: true
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ needs.release-context.outputs.release_tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ "${{ runner.os }}" = "Windows" ]; then ext="zip"; else ext="tar.gz"; fi
-          for bin in crw crw-server crw-mcp; do
-            f="${bin}-${{ matrix.platform }}-${{ matrix.arch_label }}.${ext}"
-            cosign sign-blob --yes \
-              --output-signature "${f}.sig" \
-              --output-certificate "${f}.pem" "$f"
-            gh release upload "$RELEASE_TAG" "${f}.sig" "${f}.pem" --clobber
-          done
+  # Signing lives in asset-gate, not here: one signature over SHA256SUMS covers
+  # all 18 assets transitively, keeps cosign off the Windows and macOS runners,
+  # and moves the failure out of a 6-leg matrix into one re-dispatchable job.
 
   asset-gate:
     needs: [release-context, publish-binaries]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.release-context.outputs.source_ref }}
 
-      - name: Verify all 18 binary assets attached
+      # Pin the cosign version explicitly. The installer's own default moved from
+      # cosign v2 to v3 in a grouped Dependabot bump, which changed sign-blob's
+      # output contract and silently broke signing from v0.22.0 onward.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
+      - name: Verify assets, publish SHA256SUMS and signature
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -337,7 +329,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Download platform release assets
+      - name: Download and verify platform release assets
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -345,7 +337,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/assets
-          gh release download "$RELEASE_TAG" -D /tmp/assets -p "crw-mcp-*"
+          gh release download "$RELEASE_TAG" -D /tmp/assets -p "crw-mcp-*.tar.gz"
+          gh release download "$RELEASE_TAG" -D /tmp/assets -p "SHA256SUMS"
+          # These bytes get repackaged into the platform packages that every
+          # macOS and Linux npm user installs, and that path never reaches the
+          # launcher's own verification. `gh release download` checks nothing,
+          # so check here.
+          ( cd /tmp/assets && sha256sum -c SHA256SUMS --ignore-missing )
 
       - name: Idempotent publish (platform packages)
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "base64",
  "clap",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.25.0"
+version = "0.27.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ version = "0.27.0"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/us/crw"
-homepage = "https://us.github.io/crw"
-keywords = ["web-scraper", "web-crawler", "firecrawl", "mcp", "llm"]
+homepage = "https://fastcrw.com"
+keywords = ["web-scraper", "web-crawler", "mcp", "llm"]
 categories = ["web-programming", "command-line-utilities"]
 
 [workspace.dependencies]

--- a/mcp/crw-mcp-darwin-arm64/package.json
+++ b/mcp/crw-mcp-darwin-arm64/package.json
@@ -3,10 +3,14 @@
   "version": "0.27.0",
   "description": "CRW MCP server binary for darwin arm64",
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/us/crw",
+  "author": "fastCRW <hello@fastcrw.com>",
+  "homepage": "https://fastcrw.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/us/crw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/us/crw/issues"
   },
   "os": [
     "darwin"

--- a/mcp/crw-mcp-darwin-x64/package.json
+++ b/mcp/crw-mcp-darwin-x64/package.json
@@ -3,10 +3,14 @@
   "version": "0.27.0",
   "description": "CRW MCP server binary for darwin x64",
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/us/crw",
+  "author": "fastCRW <hello@fastcrw.com>",
+  "homepage": "https://fastcrw.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/us/crw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/us/crw/issues"
   },
   "os": [
     "darwin"

--- a/mcp/crw-mcp-linux-arm64/package.json
+++ b/mcp/crw-mcp-linux-arm64/package.json
@@ -3,10 +3,14 @@
   "version": "0.27.0",
   "description": "CRW MCP server binary for linux arm64",
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/us/crw",
+  "author": "fastCRW <hello@fastcrw.com>",
+  "homepage": "https://fastcrw.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/us/crw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/us/crw/issues"
   },
   "os": [
     "linux"

--- a/mcp/crw-mcp-linux-x64/package.json
+++ b/mcp/crw-mcp-linux-x64/package.json
@@ -3,10 +3,14 @@
   "version": "0.27.0",
   "description": "CRW MCP server binary for linux x64",
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/us/crw",
+  "author": "fastCRW <hello@fastcrw.com>",
+  "homepage": "https://fastcrw.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/us/crw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/us/crw/issues"
   },
   "os": [
     "linux"

--- a/mcp/crw-mcp/bin/crw-mcp.js
+++ b/mcp/crw-mcp/bin/crw-mcp.js
@@ -1,17 +1,7 @@
 #!/usr/bin/env node
 
-// Handle install/init subcommands before delegating to the Rust binary.
-// `init` = skill only; `install` = skill + MCP server.
-if (process.argv[2] === "init") {
-  require("./init.js");
-  process.exit(0);
-}
-if (process.argv[2] === "install") {
-  require("./install.js");
-  process.exit(0);
-}
-
 const { spawnSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -36,13 +26,6 @@ const PLATFORMS = {
 
 const key = `${process.platform}-${process.arch}`;
 const plat = PLATFORMS[key];
-
-if (!plat) {
-  console.error(
-    `crw-mcp: unsupported platform ${key}. Supported: ${Object.keys(PLATFORMS).join(", ")}`
-  );
-  process.exit(1);
-}
 
 const binName = `crw-mcp${process.platform === "win32" ? ".exe" : ""}`;
 
@@ -73,26 +56,39 @@ function cacheDir() {
   return path.join(base, "crw-mcp", `v${VERSION}`);
 }
 
-function httpsGet(url, dest, redirects = 0) {
+// Always resolves a Buffer: the archive is verified in memory, so an unverified
+// byte never reaches disk at all.
+function httpsGet(url, redirects = 0) {
   return new Promise((resolve, reject) => {
     https
       .get(url, { headers: { "User-Agent": `crw-mcp/${VERSION}` } }, (res) => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
           if (redirects > 5) return reject(new Error("too many redirects"));
-          return resolve(httpsGet(res.headers.location, dest, redirects + 1));
+          return resolve(httpsGet(res.headers.location, redirects + 1));
         }
         if (res.statusCode !== 200) {
           res.resume();
           return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
         }
-        const file = fs.createWriteStream(dest);
-        res.pipe(file);
-        file.on("finish", () => file.close(() => resolve()));
-        file.on("error", reject);
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+        res.on("error", reject);
       })
       .on("error", reject);
   });
+}
+
+// Parse one entry out of a coreutils-style SHA256SUMS. Written on Linux, read
+// here on every platform, so tolerate CRLF and the "*" binary-mode marker.
+function digestFor(sumsText, asset) {
+  for (const line of sumsText.split(/\r?\n/)) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length === 2 && parts[1].replace(/^\*/, "") === asset)
+      return parts[0].toLowerCase();
+  }
+  return null;
 }
 
 // 3. Download the matching release asset and extract it (cached per version).
@@ -102,26 +98,69 @@ async function fromDownload() {
   if (fs.existsSync(bin)) return bin;
 
   fs.mkdirSync(dir, { recursive: true });
-  const archive = path.join(dir, plat.asset);
-  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${plat.asset}`;
+  const base = `https://github.com/${REPO}/releases/download/v${VERSION}`;
+  const url = `${base}/${plat.asset}`;
+
+  // Fail closed: fetch the expected digest first, so a release without one is
+  // refused before anything is downloaded rather than after.
+  let sums;
+  try {
+    sums = (await httpsGet(`${base}/SHA256SUMS`)).toString("utf8");
+  } catch (e) {
+    // Only a 404 means the release genuinely lacks checksums. Reporting a
+    // proxy or DNS failure as "our release is broken" sends users to file
+    // issues against a release that is fine.
+    throw new Error(
+      /^HTTP 404 /.test(e.message)
+        ? `release v${VERSION} publishes no SHA256SUMS, so ${plat.asset} cannot be verified`
+        : `could not fetch SHA256SUMS for v${VERSION}: ${e.message}`
+    );
+  }
+  const expected = digestFor(sums, plat.asset);
+  if (!expected) {
+    throw new Error(`${plat.asset} is not listed in SHA256SUMS for v${VERSION}`);
+  }
 
   // stderr only: stdout is the MCP (JSON-RPC) channel.
   console.error(`crw-mcp: downloading ${plat.asset} (v${VERSION})...`);
-  await httpsGet(url, archive);
+  const data = await httpsGet(url);
 
-  const tarArgs = plat.asset.endsWith(".zip")
-    ? ["-xf", archive, "-C", dir]
-    : ["-xzf", archive, "-C", dir];
-  const x = spawnSync("tar", tarArgs, { stdio: "inherit" });
-  if (x.status !== 0) {
-    throw new Error(`failed to extract ${plat.asset} (tar exit ${x.status})`);
+  const actual = crypto.createHash("sha256").update(data).digest("hex");
+  if (actual !== expected) {
+    throw new Error(
+      `checksum mismatch for ${plat.asset}: expected ${expected}, got ${actual}. ` +
+        `Refusing to run it.`
+    );
   }
-  fs.rmSync(archive, { force: true });
-
-  if (!fs.existsSync(bin)) {
-    throw new Error(`binary ${binName} not found in ${plat.asset}`);
+  // Stage per process, so two cold starts (MCP clients do spawn several at
+  // once on first configure) cannot truncate each other's archive or delete
+  // each other's extraction. The binary is moved in only once it is whole:
+  // `tar` applies the archive's mode from the first byte and the cache hit
+  // above gates on bare existsSync, so an interrupted extraction (Ctrl-C, disk
+  // full, OOM) would otherwise leave a truncated executable that every later
+  // run spawns. Python needs no staging: it writes the member itself, so the
+  // exec bit only arrives after the copy and its os.access(X_OK) gate rejects
+  // a partial file and re-downloads.
+  const stage = fs.mkdtempSync(path.join(dir, ".stage-"));
+  const archive = path.join(stage, plat.asset);
+  try {
+    fs.writeFileSync(archive, data);
+    const tarArgs = plat.asset.endsWith(".zip")
+      ? ["-xf", archive, "-C", stage]
+      : ["-xzf", archive, "-C", stage];
+    const x = spawnSync("tar", tarArgs, { stdio: "inherit" });
+    if (x.status !== 0) {
+      throw new Error(`failed to extract ${plat.asset} (tar exit ${x.status})`);
+    }
+    const staged = path.join(stage, binName);
+    if (!fs.existsSync(staged)) {
+      throw new Error(`binary ${binName} not found in ${plat.asset}`);
+    }
+    if (process.platform !== "win32") fs.chmodSync(staged, 0o755);
+    fs.renameSync(staged, bin);
+  } finally {
+    fs.rmSync(stage, { recursive: true, force: true });
   }
-  if (process.platform !== "win32") fs.chmodSync(bin, 0o755);
   return bin;
 }
 
@@ -129,7 +168,29 @@ async function resolveBinary() {
   return fromEnv() || fromPackage() || (await fromDownload());
 }
 
-resolveBinary()
+module.exports = { digestFor, fromDownload, cacheDir, plat, binName };
+
+// Only run when invoked as the CLI, so tests can require this file.
+if (require.main === module) {
+  // Handle install/init subcommands before delegating to the Rust binary.
+  // `init` = skill only; `install` = skill + MCP server. Both are file copies
+  // that need no binary, so they must run before the platform check: a 32-bit
+  // Pi or FreeBSD user can still install the skill.
+  if (process.argv[2] === "init") {
+    require("./init.js");
+    process.exit(0);
+  }
+  if (process.argv[2] === "install") {
+    require("./install.js");
+    process.exit(0);
+  }
+  if (!plat) {
+    console.error(
+      `crw-mcp: unsupported platform ${key}. Supported: ${Object.keys(PLATFORMS).join(", ")}`
+    );
+    process.exit(1);
+  }
+  resolveBinary()
   .then((bin) => {
     const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
     process.exit(result.status ?? 1);
@@ -142,3 +203,4 @@ resolveBinary()
     );
     process.exit(1);
   });
+}

--- a/mcp/crw-mcp/package.json
+++ b/mcp/crw-mcp/package.json
@@ -3,10 +3,14 @@
   "version": "0.27.0",
   "description": "MCP server for CRW web scraper — scrape, crawl, map, extract, search, and PDF-parse tools for AI agents",
   "license": "AGPL-3.0",
-  "homepage": "https://github.com/us/crw",
+  "author": "fastCRW <hello@fastcrw.com>",
+  "homepage": "https://fastcrw.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/us/crw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/us/crw/issues"
   },
   "keywords": [
     "mcp",
@@ -14,7 +18,6 @@
     "ai-agent",
     "claude",
     "cursor",
-    "firecrawl",
     "crawl",
     "scrape"
   ],
@@ -23,6 +26,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
   },
   "files": [
     "bin/crw-mcp.js",

--- a/mcp/crw-mcp/test/digest.test.js
+++ b/mcp/crw-mcp/test/digest.test.js
@@ -1,0 +1,47 @@
+// Coverage for the hand-rolled SHA256SUMS parser. It exists because Windows
+// ships no sha256sum, and Windows is the only platform with no prebuilt
+// package, so every Windows user depends on this code path.
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { digestFor } = require("../bin/crw-mcp.js");
+
+const H = "a".repeat(64);
+const ASSET = "crw-mcp-win32-x64.zip";
+
+test("two-space coreutils form", () => {
+  assert.equal(digestFor(`${H}  ${ASSET}\n`, ASSET), H);
+});
+
+test("binary-mode marker and CRLF", () => {
+  assert.equal(digestFor(`${H} *${ASSET}\r\n`, ASSET), H);
+});
+
+test("finds the entry among many", () => {
+  const body = `${H}  other.tar.gz\r\n${H}  ${ASSET}\r\n${H}  third.zip\n`;
+  assert.equal(digestFor(body, ASSET), H);
+});
+
+test("unlisted asset returns null", () => {
+  assert.equal(digestFor(`${H}  other.tar.gz\n`, ASSET), null);
+});
+
+test("a name that merely contains the asset is not a match", () => {
+  assert.equal(digestFor(`${H}  prefix-${ASSET}\n`, ASSET), null);
+});
+
+test("an HTML error page served with 200 yields nothing", () => {
+  const html = "<html><head><title>404</title></head><body>Not Found</body></html>";
+  assert.equal(digestFor(html, ASSET), null);
+});
+
+test("empty body yields nothing", () => {
+  assert.equal(digestFor("", ASSET), null);
+});
+
+test("an uppercase digest is normalised", () => {
+  // Keeps the two parsers in step: Python lowercases too, so a SHA256SUMS
+  // written by a tool emitting uppercase hex cannot pass on one and fail on
+  // the other.
+  assert.equal(digestFor(`${H.toUpperCase()}  ${ASSET}\n`, ASSET), H);
+});

--- a/mcp/crw-mcp/test/download.test.js
+++ b/mcp/crw-mcp/test/download.test.js
@@ -1,0 +1,154 @@
+// Entrypoint-level coverage for fromDownload(). Testing only digestFor would
+// pin the parser rather than the thesis: the point is that a mismatched or
+// unverifiable archive is never extracted, and that property lives in
+// fromDownload, not in the parser.
+//
+// Windows is the only platform without a prebuilt package, so this is the code
+// path the entire npm Windows install base takes on first run.
+const { test } = require("node:test");
+const assert = require("node:assert");
+const crypto = require("crypto");
+const fs = require("fs");
+const https = require("https");
+const os = require("os");
+const path = require("path");
+const { Readable } = require("stream");
+
+const { fromDownload, cacheDir, plat, binName } = require("../bin/crw-mcp.js");
+
+// Replace https.get with a queue of canned responses. The launcher holds the
+// same module object we mutate here, so this reaches the real code path.
+function stubHttps(queue) {
+  const original = https.get;
+  https.get = (_url, _opts, cb) => {
+    const item = queue.shift();
+    const body = item.body === undefined ? [] : [Buffer.from(item.body)];
+    const res = Readable.from(body);
+    res.statusCode = item.status ?? 200;
+    res.headers = {};
+    process.nextTick(() => cb(res));
+    return { on: () => ({ on: () => {} }) };
+  };
+  return () => {
+    https.get = original;
+  };
+}
+
+function withTempCache(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crw-mcp-test-"));
+  const prev = process.env.XDG_CACHE_HOME;
+  const prevLocal = process.env.LOCALAPPDATA;
+  process.env.XDG_CACHE_HOME = dir;
+  process.env.LOCALAPPDATA = dir;
+  return fn(dir).finally(() => {
+    if (prev === undefined) delete process.env.XDG_CACHE_HOME;
+    else process.env.XDG_CACHE_HOME = prev;
+    if (prevLocal === undefined) delete process.env.LOCALAPPDATA;
+    else process.env.LOCALAPPDATA = prevLocal;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+test("a mismatched archive is refused and nothing is cached", async () => {
+  await withTempCache(async () => {
+    const restore = stubHttps([
+      { body: `${"0".repeat(64)}  ${plat.asset}\n` },
+      { body: Buffer.from("not the archive you were promised") },
+    ]);
+    try {
+      await assert.rejects(fromDownload(), /checksum mismatch/);
+      assert.equal(fs.existsSync(path.join(cacheDir(), binName)), false);
+    } finally {
+      restore();
+    }
+  });
+});
+
+test("a release with no SHA256SUMS is refused", async () => {
+  await withTempCache(async () => {
+    const restore = stubHttps([{ status: 404 }]);
+    try {
+      await assert.rejects(fromDownload(), /publishes no SHA256SUMS/);
+    } finally {
+      restore();
+    }
+  });
+});
+
+test("a network failure is not reported as a broken release", async () => {
+  await withTempCache(async () => {
+    const restore = stubHttps([{ status: 500 }]);
+    try {
+      await assert.rejects(fromDownload(), /could not fetch SHA256SUMS/);
+    } finally {
+      restore();
+    }
+  });
+});
+
+test("an asset missing from SHA256SUMS is refused", async () => {
+  await withTempCache(async () => {
+    const restore = stubHttps([
+      { body: `${"0".repeat(64)}  some-other-file.tar.gz\n` },
+    ]);
+    try {
+      await assert.rejects(fromDownload(), /not listed in SHA256SUMS/);
+    } finally {
+      restore();
+    }
+  });
+});
+
+
+
+test("a verified archive is extracted and returned as an executable path", async () => {
+  // Pins the success path, which the refusal tests above cannot see: without
+  // it, collapsing the staging dir, dropping the chmod, or swapping rename for
+  // copy all stay green.
+  await withTempCache(async () => {
+    // 0644 in the archive, so the chmod below is what makes it runnable.
+    const archive = buildTarGz(binName, "#!/bin/sh\nexit 0\n", "0000644");
+    const digest = crypto.createHash("sha256").update(archive).digest("hex");
+    const restore = stubHttps([
+      { body: `${digest}  ${plat.asset}\n` },
+      { body: archive },
+    ]);
+    try {
+      const resolved = await fromDownload();
+      assert.equal(resolved, path.join(cacheDir(), binName));
+      assert.ok(fs.existsSync(resolved), "binary should be in the cache");
+      if (process.platform !== "win32") {
+        assert.ok(fs.statSync(resolved).mode & 0o111, "binary should be executable");
+      }
+      // Nothing left behind: no staging dir, no archive.
+      const leftovers = fs
+        .readdirSync(cacheDir())
+        .filter((n) => n !== binName);
+      assert.deepEqual(leftovers, [], "cache should hold only the binary");
+    } finally {
+      restore();
+    }
+  });
+});
+
+// Build a real .tar.gz in-process so the extraction path runs for real.
+function buildTarGz(name, content, mode = "0000755") {
+  const body = Buffer.from(content);
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100);
+  header.write(mode + "\0", 100, 8);
+  header.write("0000000\0", 108, 8);
+  header.write("0000000\0", 116, 8);
+  header.write(body.length.toString(8).padStart(11, "0") + "\0", 124, 12);
+  header.write("00000000000\0", 136, 12);
+  header.write("        ", 148, 8);
+  header.write("0", 156, 1);
+  header.write("ustar\0" + "00", 257, 8);
+  let sum = 0;
+  for (const b of header) sum += b;
+  header.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, 8);
+
+  const pad = Buffer.alloc((512 - (body.length % 512)) % 512);
+  const tar = Buffer.concat([header, body, pad, Buffer.alloc(1024)]);
+  return require("zlib").gzipSync(tar);
+}

--- a/scripts/release/asset_gate.sh
+++ b/scripts/release/asset_gate.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Verify the GitHub Release for $tag has all 18 expected binary assets
-# (3 binaries × 6 platforms). Runs after publish-binaries job, gates the
-# downstream registry publishes.
+# (3 binaries × 6 platforms), then publish SHA256SUMS and its signature.
+# Runs after publish-binaries, gates the downstream registry publishes.
+#
+# Uploads SHA256SUMS + SHA256SUMS.sigstore.json to the release; idempotent.
 #
 # Usage: asset_gate.sh <tag>
 set -euo pipefail
@@ -34,4 +36,61 @@ for e in "${expected[@]}"; do
     fail=1
   fi
 done
-exit "$fail"
+[ "$fail" -eq 0 ] || exit "$fail"
+
+# SHA256SUMS goes up before signing: the wrappers need the checksums, not the
+# signature, so a Sigstore outage must not leave an uninstallable release. A
+# failed signature still fails the job, so it cannot go unnoticed.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+for name in "${expected[@]}"; do
+  gh release download "$tag" -D "$work" -p "$name"
+done
+
+# `gh release download` verifies nothing, so a truncated fetch would otherwise be
+# hashed, signed and published as authoritative. Check what we downloaded against
+# the digests GitHub reports. A missing digest is fatal: silently skipping the
+# check is how signing stayed broken for eleven releases.
+gh release view "$tag" --json assets \
+  -q '.assets[] | select(.digest != null and .digest != "")
+      | "\(.digest|ltrimstr("sha256:"))  \(.name)"' > "$work/API_SUMS"
+[ -s "$work/API_SUMS" ] \
+  || { echo "::error::gh reported no asset digests at all; this runner's gh may predate the field"; exit 1; }
+for name in "${expected[@]}"; do
+  awk -v n="$name" '$2 == n { found = 1 } END { exit !found }' "$work/API_SUMS" \
+    || { echo "::error::release reports no digest for ${name}"; exit 1; }
+done
+( cd "$work" && sha256sum -c --ignore-missing --quiet API_SUMS )
+
+# Hash the bytes we downloaded, never the API's digest: signing GitHub's claim
+# about bytes we never observed would be a strictly weaker attestation.
+# Generated from inside $work so entries are bare basenames for `sha256sum -c`.
+( cd "$work" && sha256sum "${expected[@]}" > SHA256SUMS )
+gh release upload "$tag" "$work/SHA256SUMS" --clobber
+printf '✓ SHA256SUMS (%d assets)\n' "${#expected[@]}"
+
+for attempt in 1 2 3 4; do
+  cosign sign-blob --yes \
+    --bundle "$work/SHA256SUMS.sigstore.json" "$work/SHA256SUMS" && break
+  if [ "$attempt" -eq 4 ]; then
+    echo "::error::cosign sign-blob failed after 4 attempts"
+    exit 1
+  fi
+  echo "::warning::cosign attempt ${attempt}/4 failed; retrying in $((attempt * 20))s"
+  sleep "$((attempt * 20))"
+done
+
+# Verify what we just signed, in the job that already holds the OIDC token.
+# The identity pattern below is also published in .github/SECURITY.md; keep the
+# two in step, or the docs hand users a pattern CI no longer enforces.
+# This is the check that would have caught the v0.22.0 output-contract break on
+# the first release instead of eleven later, and it exercises the identity
+# regexp published in SECURITY.md.
+cosign verify-blob --bundle "$work/SHA256SUMS.sigstore.json" \
+  --certificate-identity-regexp '^https://github\.com/us/crw/\.github/workflows/release\.yml@refs/(tags/v.*|heads/main)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "$work/SHA256SUMS"
+
+gh release upload "$tag" "$work/SHA256SUMS.sigstore.json" --clobber
+printf '✓ signature uploaded and verified\n'

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -64,7 +64,7 @@ result = client.scrape("https://example.com")
 print(result["markdown"])
 
 # ...or pass the key explicitly:
-client = CrwClient(api_key="fc-...")
+client = CrwClient(api_key="crw_live_...")
 
 # Self-hosted server:
 client = CrwClient(api_url="http://localhost:3000")

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -9,7 +9,9 @@ description = "Python SDK for CRW web scraper — scrape, crawl, and map any web
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
-keywords = ["web-scraping", "mcp", "ai-agent", "crawler", "firecrawl", "scraper"]
+authors = [{ name = "fastCRW", email = "hello@fastcrw.com" }]
+maintainers = [{ name = "fastCRW", email = "hello@fastcrw.com" }]
+keywords = ["web-scraping", "mcp", "ai-agent", "crawler", "scraper"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -30,9 +32,10 @@ langchain = ["langchain-core>=0.3.0,<2.0.0"]
 crewai = ["crewai>=0.100.0"]
 
 [project.urls]
-Homepage = "https://github.com/us/crw"
-Documentation = "https://us.github.io/crw"
+Homepage = "https://fastcrw.com"
+Documentation = "https://docs.fastcrw.com"
 Repository = "https://github.com/us/crw"
+Issues = "https://github.com/us/crw/issues"
 
 [project.scripts]
 crw-mcp = "crw.__main__:main"

--- a/sdks/python/src/crw/_binary.py
+++ b/sdks/python/src/crw/_binary.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import json
+import hashlib
+import importlib.metadata
 import os
 import stat
 import tarfile
@@ -17,51 +18,74 @@ from crw._platform import BINARY_NAME, get_asset_name
 from crw.exceptions import CrwBinaryNotFoundError
 
 GITHUB_REPO = "us/crw"
-GITHUB_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+_RELEASES = f"https://github.com/{GITHUB_REPO}/releases/download"
+
+_HINT = (
+    "Set CRW_BINARY=/path/to/crw-mcp to use a binary you already have, "
+    "or install one with: cargo install crw-mcp"
+)
 
 
-def _get_latest_version() -> str:
-    """Fetch the latest release tag from GitHub API."""
-    req = Request(GITHUB_API, headers={
-        "User-Agent": "crw-python",
-        "Accept": "application/vnd.github+json",
-    })
-    with urlopen(req, timeout=10) as resp:
-        data = json.loads(resp.read())
-    tag = data.get("tag_name", "")
-    return tag.lstrip("v")
+def _release_tag() -> str:
+    """Git tag of the release this SDK was published alongside.
+
+    Resolved from our own installed version rather than the mutable
+    `releases/latest`, so a wrapper only ever asks for the tag it shipped with.
+    """
+    try:
+        version = importlib.metadata.version("crw")
+    except importlib.metadata.PackageNotFoundError as e:
+        raise CrwBinaryNotFoundError(
+            f"crw is importable but not installed as a distribution, so its "
+            f"release tag cannot be determined. {_HINT}"
+        ) from e
+
+    # Every tag this project has published is a plain vX.Y.Z. If a prerelease
+    # ever ships, PEP 440 normalisation (v0.28.0-alpha1 -> 0.28.0a1) will make
+    # this 404 loudly on first use, which beats reconstructing a tag by guess.
+    return "v" + version
 
 
-def _cache_dir(version: str) -> Path:
-    return Path(user_cache_dir("crw")) / f"v{version}"
+def _cache_dir(tag: str) -> Path:
+    return Path(user_cache_dir("crw")) / tag
 
 
-def _find_cached_latest() -> tuple[Path, str] | None:
-    """Find the newest cached binary version."""
-    cache_root = Path(user_cache_dir("crw"))
-    if not cache_root.is_dir():
-        return None
+def _expected_digest(tag: str, asset: str) -> str:
+    """SHA-256 recorded for `asset` in the release's SHA256SUMS.
 
-    def _version_key(name: str) -> tuple[int, ...]:
-        try:
-            return tuple(int(part) for part in name.lstrip("v").split("."))
-        except ValueError:
-            return (0,)
+    Fails closed: a missing or unlisted checksum aborts rather than falling
+    through to an unverified download.
+    """
+    url = f"{_RELEASES}/{tag}/SHA256SUMS"
+    req = Request(url, headers={"User-Agent": f"crw-python/{tag}"})
+    try:
+        with urlopen(req, timeout=30) as resp:
+            text = resp.read().decode("utf-8", "replace")
+    except OSError as e:
+        # HTTPError is an OSError. Only 404 maps to a different user action:
+        # this release predates SHA256SUMS, so pin a newer one.
+        if getattr(e, "code", None) == 404:
+            raise CrwBinaryNotFoundError(
+                f"release {tag} publishes no SHA256SUMS, so {asset} cannot be "
+                f"verified. {_HINT}"
+            ) from e
+        raise CrwBinaryNotFoundError(
+            f"could not reach GitHub to fetch SHA256SUMS for {tag}: {e}. {_HINT}"
+        ) from e
 
-    versions = sorted(
-        (d.name for d in cache_root.iterdir() if d.is_dir() and d.name.startswith("v")),
-        key=_version_key,
-        reverse=True,
+    for line in text.splitlines():
+        parts = line.split()
+        # coreutils writes "<hash>  <name>" or "<hash> *<name>" in binary mode.
+        if len(parts) == 2 and parts[1].lstrip("*") == asset:
+            return parts[0].lower()
+
+    raise CrwBinaryNotFoundError(
+        f"{asset} is not listed in SHA256SUMS for {tag}. {_HINT}"
     )
-    for v in versions:
-        binary = cache_root / v / BINARY_NAME
-        if binary.is_file() and os.access(binary, os.X_OK):
-            return binary, v.lstrip("v")
-    return None
 
 
-def _download_binary(version: str) -> Path:
-    """Download the binary from GitHub Releases and cache it."""
+def _download_binary(tag: str) -> Path:
+    """Download the release asset, verify it, then unpack it into the cache."""
     asset = get_asset_name()
     if asset is None:
         raise CrwBinaryNotFoundError(
@@ -69,21 +93,39 @@ def _download_binary(version: str) -> Path:
             "Install from source: cargo install crw-mcp"
         )
 
-    url = f"https://github.com/{GITHUB_REPO}/releases/download/v{version}/{asset}"
-    cache = _cache_dir(version)
+    expected = _expected_digest(tag, asset)
+
+    url = f"{_RELEASES}/{tag}/{asset}"
+    req = Request(url, headers={"User-Agent": f"crw-python/{tag}"})
+    try:
+        with urlopen(req, timeout=120) as resp:
+            data = resp.read()
+    except OSError as e:
+        raise CrwBinaryNotFoundError(
+            f"could not download {asset} from {tag}: {e}. {_HINT}"
+        ) from e
+
+    # Verified before anything touches disk: the archive is already fully in
+    # memory, so an unverified byte is never written at all.
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise CrwBinaryNotFoundError(
+            f"checksum mismatch for {asset} from {tag}: expected {expected}, "
+            f"got {actual}. Refusing to run it."
+        )
+
+    cache = _cache_dir(tag)
     cache.mkdir(parents=True, exist_ok=True)
 
-    req = Request(url, headers={"User-Agent": f"crw-python/{version}"})
-    with urlopen(req, timeout=120) as resp:
-        data = resp.read()
-
-    # Extract binary from archive
     if asset.endswith(".tar.gz"):
         with tarfile.open(fileobj=BytesIO(data), mode="r:gz") as tar:
             for member in tar.getmembers():
-                if member.name.endswith("crw-mcp"):
-                    member.name = BINARY_NAME
-                    tar.extract(member, path=cache)
+                # isreg() refuses links and devices, and we choose the
+                # destination path, so traversal is impossible by construction.
+                # This needs no `filter=`, which only exists on 3.10.12+ while
+                # we support >=3.10.
+                if member.isreg() and member.name.endswith("crw-mcp"):
+                    (cache / BINARY_NAME).write_bytes(tar.extractfile(member).read())
                     break
             else:
                 raise CrwBinaryNotFoundError(f"crw-mcp not found in {asset}")
@@ -117,7 +159,7 @@ def _is_native_binary(path: Path) -> bool:
 
 
 def ensure_binary() -> Path:
-    """Return path to crw-mcp binary, downloading latest if necessary."""
+    """Return path to the crw-mcp binary, downloading it if necessary."""
     # 1. Check CRW_BINARY env override
     env_path = os.environ.get("CRW_BINARY")
     if env_path:
@@ -128,27 +170,24 @@ def ensure_binary() -> Path:
 
     # 2. Check if crw-mcp native binary is on PATH (e.g. cargo install)
     for directory in os.environ.get("PATH", "").split(os.pathsep):
+        # An empty PATH entry means "current directory"; a trailing colon is
+        # common enough that this would otherwise exec ./crw-mcp from any cwd.
+        if not directory:
+            continue
         candidate = Path(directory) / BINARY_NAME
         if candidate.is_file() and _is_native_binary(candidate):
             return candidate
 
-    # 3. Try to get latest version and check cache
-    try:
-        version = _get_latest_version()
-    except Exception:
-        # Offline — use newest cached version if available
-        cached = _find_cached_latest()
-        if cached:
-            return cached[0]
-        raise CrwBinaryNotFoundError(
-            "Cannot reach GitHub API and no cached binary found. "
-            "Install manually: cargo install crw-mcp"
-        )
-
-    # 4. Check if latest is already cached
-    binary = _cache_dir(version) / BINARY_NAME
+    # 3. Already downloaded and verified for this exact version. No network
+    #    call happens on a cache hit, which is also the offline path.
+    #    ponytail: this trusts the cache. Re-hashing against a sidecar digest
+    #    would not help, since anything able to rewrite the binary can rewrite
+    #    the sidecar too; closing it properly needs a digest baked into the
+    #    wrapper at build time. Documented in SECURITY.md rather than faked.
+    tag = _release_tag()
+    binary = _cache_dir(tag) / BINARY_NAME
     if binary.is_file() and os.access(binary, os.X_OK):
         return binary
 
-    # 5. Download latest
-    return _download_binary(version)
+    # 4. Download and verify.
+    return _download_binary(tag)

--- a/sdks/python/tests/test_binary.py
+++ b/sdks/python/tests/test_binary.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+import hashlib
+import importlib.metadata
+import io
 import os
+import tarfile
 from pathlib import Path
 from unittest.mock import patch
+from urllib.error import HTTPError, URLError
 
 import pytest
 
-from crw._binary import ensure_binary
+from crw._binary import (
+    BINARY_NAME,
+    _download_binary,
+    _release_tag,
+    ensure_binary,
+)
 from crw._platform import PLATFORM_MAP, get_asset_name
 from crw.exceptions import CrwBinaryNotFoundError
 
@@ -58,3 +68,209 @@ class TestPlatformMap:
         for key in expected_keys:
             assert key in PLATFORM_MAP, f"Missing platform entry: {key}"
             assert isinstance(PLATFORM_MAP[key], str)
+
+
+def _targz(content: bytes = b"#!/bin/sh\nexit 0\n") -> bytes:
+    """A minimal release archive containing a crw-mcp entry."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo("crw-mcp")
+        info.size = len(content)
+        info.mode = 0o755
+        tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+@pytest.mark.unit
+class TestDownloadVerification:
+    """The digest check must fail closed. No fallback, no unverified binary.
+
+    This is the test that enforces the thesis of the hardening work: if it can
+    be made to pass while a mismatched archive still gets installed, the
+    verification is decorative.
+    """
+
+    ASSET = "crw-mcp-linux-x64.tar.gz"
+
+    def _run(self, tmp_path: Path, sums: bytes | Exception, archive: bytes):
+        responses: list[bytes | Exception] = [sums, archive]
+
+        def fake_urlopen(_req, **_kw):
+            item = responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return io.BytesIO(item)
+
+        with (
+            patch("crw._binary.get_asset_name", return_value=self.ASSET),
+            patch("crw._binary.urlopen", side_effect=fake_urlopen),
+            patch("crw._binary.user_cache_dir", return_value=str(tmp_path)),
+        ):
+            return _download_binary("v9.9.9")
+
+    def test_mismatch_raises_and_installs_nothing(self, tmp_path: Path) -> None:
+        archive = _targz()
+        wrong = "0" * 64
+        sums = f"{wrong}  {self.ASSET}\n".encode()
+
+        with pytest.raises(CrwBinaryNotFoundError, match="checksum mismatch"):
+            self._run(tmp_path, sums, archive)
+
+        # Fails closed: nothing cached, and in particular no fallback to some
+        # other binary that happens to be lying around.
+        assert not list(tmp_path.rglob("crw-mcp"))
+
+    def test_matching_digest_installs(self, tmp_path: Path) -> None:
+        archive = _targz()
+        good = hashlib.sha256(archive).hexdigest()
+        sums = f"{good}  {self.ASSET}\n".encode()
+
+        binary = self._run(tmp_path, sums, archive)
+        assert binary.is_file()
+        assert os.access(binary, os.X_OK)
+
+    def test_binary_mode_marker_is_tolerated(self, tmp_path: Path) -> None:
+        """coreutils writes "<hash> *<name>" for binary-mode entries."""
+        archive = _targz()
+        good = hashlib.sha256(archive).hexdigest()
+        sums = f"{good} *{self.ASSET}\n".encode()
+
+        assert self._run(tmp_path, sums, archive).is_file()
+
+    def test_absent_sha256sums_raises(self, tmp_path: Path) -> None:
+        """A release with no SHA256SUMS is unverifiable, so it is refused."""
+        err = HTTPError("u", 404, "Not Found", {}, None)  # type: ignore[arg-type]
+        with pytest.raises(CrwBinaryNotFoundError, match="no SHA256SUMS"):
+            self._run(tmp_path, err, _targz())
+
+    def test_unlisted_asset_raises(self, tmp_path: Path) -> None:
+        sums = b"%s  some-other-asset.tar.gz\n" % (b"0" * 64)
+        with pytest.raises(CrwBinaryNotFoundError, match="not listed"):
+            self._run(tmp_path, sums, _targz())
+
+    def test_network_error_is_distinguished_from_404(self, tmp_path: Path) -> None:
+        with pytest.raises(CrwBinaryNotFoundError, match="could not reach GitHub"):
+            self._run(tmp_path, URLError("no route to host"), _targz())
+
+
+@pytest.mark.unit
+class TestReleaseTag:
+    def test_tag_follows_the_installed_version(self) -> None:
+        with patch("crw._binary.importlib.metadata.version", return_value="0.27.0"):
+            assert _release_tag() == "v0.27.0"
+
+    def test_missing_distribution_names_the_escape_hatch(self) -> None:
+        """Importable but not installed: fail with a usable next step."""
+        with patch(
+            "crw._binary.importlib.metadata.version",
+            side_effect=importlib.metadata.PackageNotFoundError("crw"),
+        ):
+            with pytest.raises(CrwBinaryNotFoundError, match="CRW_BINARY"):
+                _release_tag()
+
+
+@pytest.mark.unit
+class TestEnsureBinaryEndToEnd:
+    """Drive the entrypoint, not the helper.
+
+    `ensure_binary()` is what client.py and __main__.py actually call. A test
+    that only exercises `_download_binary` leaves the resolution order itself
+    unpinned, so a refactor could inline an unverified download and stay green.
+    """
+
+    ASSET = "crw-mcp-linux-x64.tar.gz"
+
+    def _run(self, tmp_path: Path, sums: bytes, archive: bytes):
+        responses: list[bytes] = [sums, archive]
+        empty_path = tmp_path / "no-such-bin-dir"
+
+        with (
+            patch.dict(os.environ, {"PATH": str(empty_path)}, clear=True),
+            patch("crw._binary.get_asset_name", return_value=self.ASSET),
+            patch(
+                "crw._binary.urlopen",
+                side_effect=lambda *a, **k: io.BytesIO(responses.pop(0)),
+            ),
+            patch("crw._binary.user_cache_dir", return_value=str(tmp_path / "cache")),
+            patch("crw._binary.importlib.metadata.version", return_value="9.9.9"),
+        ):
+            return ensure_binary()
+
+    def test_mismatch_refused_through_the_entrypoint(self, tmp_path: Path) -> None:
+        archive = _targz()
+        sums = f"{'0' * 64}  {self.ASSET}\n".encode()
+
+        with pytest.raises(CrwBinaryNotFoundError, match="checksum mismatch"):
+            self._run(tmp_path, sums, archive)
+        assert not list(tmp_path.rglob("crw-mcp"))
+
+    def test_verified_archive_resolves_through_the_entrypoint(
+        self, tmp_path: Path
+    ) -> None:
+        archive = _targz()
+        sums = f"{hashlib.sha256(archive).hexdigest()}  {self.ASSET}\n".encode()
+
+        binary = self._run(tmp_path, sums, archive)
+        assert binary.is_file() and os.access(binary, os.X_OK)
+
+    def test_empty_path_entry_does_not_exec_the_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A trailing colon in PATH means cwd; that must not resolve a binary."""
+        planted = tmp_path / BINARY_NAME
+        planted.write_bytes(b"\x7fELF" + b"\x00" * 64)
+        planted.chmod(0o755)
+        monkeypatch.chdir(tmp_path)
+
+        archive = _targz()
+        sums = f"{hashlib.sha256(archive).hexdigest()}  {self.ASSET}\n".encode()
+        responses: list[bytes] = [sums, archive]
+
+        with (
+            patch.dict(os.environ, {"PATH": "/nonexistent:"}, clear=True),
+            patch("crw._binary.get_asset_name", return_value=self.ASSET),
+            patch(
+                "crw._binary.urlopen",
+                side_effect=lambda *a, **k: io.BytesIO(responses.pop(0)),
+            ),
+            patch("crw._binary.user_cache_dir", return_value=str(tmp_path / "cache")),
+            patch("crw._binary.importlib.metadata.version", return_value="9.9.9"),
+        ):
+            resolved = ensure_binary()
+
+        # Resolved from the verified download, never from the planted cwd file.
+        assert resolved != planted
+        assert "cache" in str(resolved)
+
+    def test_non_executable_cache_entry_is_not_trusted(self, tmp_path: Path) -> None:
+        """A partially-written cache entry must be re-downloaded, not returned.
+
+        The npm launcher's staging comment cites this gate as the reason Python
+        needs no staging of its own, so it is a cross-file invariant: assert it
+        rather than leave it living in a comment.
+        """
+        cache_root = tmp_path / "cache"
+        (cache_root / "v9.9.9").mkdir(parents=True)
+        partial = cache_root / "v9.9.9" / BINARY_NAME
+        partial.write_bytes(b"\x7fELF truncated")
+        partial.chmod(0o644)
+
+        archive = _targz()
+        sums = f"{hashlib.sha256(archive).hexdigest()}  {self.ASSET}\n".encode()
+        responses: list[bytes] = [sums, archive]
+
+        with (
+            patch.dict(os.environ, {"PATH": str(tmp_path / "nope")}, clear=True),
+            patch("crw._binary.get_asset_name", return_value=self.ASSET),
+            patch(
+                "crw._binary.urlopen",
+                side_effect=lambda *a, **k: io.BytesIO(responses.pop(0)),
+            ),
+            patch("crw._binary.user_cache_dir", return_value=str(cache_root)),
+            patch("crw._binary.importlib.metadata.version", return_value="9.9.9"),
+        ):
+            resolved = ensure_binary()
+
+        # Re-downloaded: the truncated placeholder was replaced, not returned.
+        assert resolved.read_bytes() != b"\x7fELF truncated"
+        assert os.access(resolved, os.X_OK)

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -27,7 +27,7 @@ console.log(res.markdown);
 
 ```ts
 // ...or pass the key explicitly
-const crw = new CrwClient({ apiKey: "fc-..." });
+const crw = new CrwClient({ apiKey: "crw_live_..." });
 ```
 
 ## Self-hosting

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -3,17 +3,20 @@
   "version": "0.27.0",
   "description": "TypeScript/JavaScript SDK for CRW — scrape, crawl, map, search, parse, and extract any website",
   "license": "MIT",
-  "homepage": "https://github.com/us/crw",
+  "author": "fastCRW <hello@fastcrw.com>",
+  "homepage": "https://fastcrw.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/us/crw.git"
+  },
+  "bugs": {
+    "url": "https://github.com/us/crw/issues"
   },
   "keywords": [
     "web-scraping",
     "crawler",
     "scraper",
     "ai-agent",
-    "firecrawl",
     "mcp"
   ],
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "CRW Web Scraper",
   "description": "Open-source web scraper for AI agents with scrape, crawl, and map tools",
   "version": "0.27.0",
-  "websiteUrl": "https://us.github.io/crw",
+  "websiteUrl": "https://fastcrw.com",
   "repository": {
     "url": "https://github.com/us/crw",
     "source": "github",


### PR DESCRIPTION
# Findings and evidence — package hardening PR

Goes in the PR description. Every line was opened and verified during review;
corrections from later rounds are folded in rather than annotated.

## Why

`crw` on PyPI is classified CRITICAL "malicious code / supply chain attack" by
Corgea (MAL-2026-4746, published 2026-05-19), which feeds Amazon Inspector. Its
remediation advice tells our users to remove the package and rotate keys. Four
signals are cited and four are factually true of our packaging. Nothing here is a
compromise; it is that our packages are, to an automated classifier,
indistinguishable from one.

## Published identities: 9 across 5 registries

| # | Finding | Location |
|---|---|---|
| P1 | `firecrawl` keyword | `sdks/python/pyproject.toml:12` |
| P2 | No `authors`, PyPI renders `author: null` | absent |
| P3 | `Homepage` on GitHub; `Documentation` stale at `us.github.io` | `sdks/python/pyproject.toml:34` |
| P4 | Competitor key prefix in the primary example | `sdks/python/README.md:67` |
| T1 | `crw-sdk` (npm), live at 0.27.0, same signals | `sdks/typescript/package.json:16` keywords, `:6` homepage, no `author`; `README.md:30` |
| N1 | `firecrawl` keyword | `mcp/crw-mcp/package.json` |
| N2 | No `author` on main + 4 platform packages | `mcp/crw-mcp/package.json`, `mcp/crw-mcp-*/package.json` |
| C1 | `firecrawl` in workspace keywords, inherited by 12 published crates via `keywords.workspace = true` (`crates/*/Cargo.toml:8`); stale `homepage` | `Cargo.toml:24`, `:23` |
| S1 | `server.json`, published to the MCP Registry every release (`release.yml:486`): stale `websiteUrl`, and a mutable `ghcr.io/us/crw:latest` (follow-up, no updater can rewrite it correctly) | `server.json:7`, `:16` |
| G1 | Bare `firecrawl` repo topic; `docker/metadata-action` (`release.yml:462-470`) stamps the repo description onto the GHCR image every release | repo metadata |

Registries: PyPI, npm, crates.io, MCP Registry, GHCR.

## Download paths: 4, verified complete

`grep -rn 'releases/download\|https://github.com' crates/ --include='*.rs'` returns
5 hits: the three LightPanda constants, `camoufox.rs:3` (doc comment) and
`crw-cli/src/main.rs:54` (help text). `mcp/crw-mcp/bin/{init,install,agents}.js`
contain no HTTP client. There is no fifth.

| # | Path | Location | This PR? |
|---|---|---|---|
| D1 | Python wrapper: mutable `latest`, no verification, chmod before validation, `os.execvp` | `_binary.py:23-32`, `:63-102`, `:101`; `__main__.py:11` | yes |
| D2 | npm wrapper: version pinned (`crw-mcp.js:20` → `:106`), no verification | `crw-mcp.js:99-126`, chmod `:124` | yes |
| D3 | `install.sh`, the advertised path: mutable `latest`, zero verification | `install.sh:107-118`, `:137-160` | follow-up (coupled to R7) |
| D4 | LightPanda: third-party binary, mutable `nightly`, chmod 755, spawned | `browser.rs:219-265`, URL `:275`; duplicates at `crw-cli/src/commands/setup/browser.rs:46`, `crw-server/src/setup.rs:8` | follow-up |

Three scoping facts that must be stated accurately, because all three were wrong
in earlier drafts and all three are checkable in seconds:

- **D4 does not run on prod.** `spawn_all_headless()` (`browser.rs:182`) is the
  sole entry to the download, and its five callers are `crw-mcp/src/main.rs:465`
  and `crw-cli/src/commands/{crawl.rs:76, scrape.rs:355, map.rs:85, mcp.rs:387}`.
  None is `serve`; `serve.rs:62` only reads config. Prod runs `crw serve`. This is
  a call-graph fact, not a config value.
- **`ensure_binary()` has a small blast radius.** Reached only via the `crw-mcp`
  console script (`pyproject.toml:38`) or `CRW_LOCAL=1` (`client.py:704`). The
  documented default, `CrwClient()` against cloud, never imports it.
- **Windows npm is 100% on the download path.** No win32 platform packages exist
  (`crw-mcp-win32-x64` on npm is `0.0.1-security`, name-held, `release.yml:377-379`),
  so `fromPackage()` always returns null there. This makes the npm fix the
  highest-value phase, not the lowest.

## Release workflow

| # | Finding | Location |
|---|---|---|
| R1 | The cosign call is correct for cosign v2 and wrong for v3. Under v3.0.6, `--new-bundle-format` and `--use-signing-config` default true, so `sign_blob.go:118` writes an empty `--bundle` path and returns at `:122` before `--output-signature` is read | `release.yml:256-271` |
| R2 | Signing **worked on v0.21.2 and v0.21.3** (18 signatures each), broke at v0.22.0, zero since. Cause: Dependabot bumped `cosign-installer` v3 → v4.1.2 in `a4baa0a`, grouped under one weekly `actions` pattern (`.github/dependabot.yml:26-33`). Installer v3 ships cosign v2.x; v4.1.2 defaults to v3.0.6 | masked by `release.yml:257` |
| R3 | No cosign version pin: the installer step passes no `with:` block, so v3.0.6 is `cosign-installer` v4.1.2's own default. This is the entire root cause of R2 | `release.yml:253-254` |
| R4 | No checksum file of any kind | absent |
| R5 | `asset-gate` runs once after all 6 legs and every registry publisher `needs:` it, so a file produced there is guaranteed present before any wrapper publishes. But it declares `contents: read` | `release.yml:273-277`; publishers `:120 :292 :321 :537 :554 :571` |
| R6 | `publish-docker` (`:437`) and `publish-mcp-registry` (`:486`) bypass `asset-gate`, so a gate failure ships GHCR `latest` (`:469`) for a version on no registry | follow-up |
| R7 | release-please publishes a **non-draft** Release at tag time, so `releases/latest` points at an assetless tag for ~12-21 min (measured on v0.26.1: release 11:59:46Z, first asset ~12:12, last ~12:20) | `_binary.py:20`, `install.sh:107-118` |

Certificate identity, verified against v0.21.2's real `.pem` (base64-wrapped,
needs a decode before openssl parses it):

```
X509v3 Subject Alternative Name: critical
    URI:https://github.com/us/crw/.github/workflows/release.yml@refs/tags/v0.21.2
```

The tag is in the identity, so a literal `--certificate-identity` goes stale every
release and the first command a third party runs would fail. The regexp form is
required.

## What changed

**CI produces integrity data.** `asset_gate.sh` verifies the 18 assets are
attached, downloads each one, cross-checks it against the digest GitHub reports
(`gh release download` validates nothing, so a truncated fetch would otherwise be
hashed, signed and published as authoritative), emits `SHA256SUMS`, uploads it,
signs it, and then verifies its own signature under the identity published in
SECURITY.md. Signing moved out of the 6-leg matrix into this single job, so the
per-asset loop and its 36 files per release are gone, and `cosign-release` is
pinned explicitly. `continue-on-error` is gone. `SHA256SUMS` uploads *before*
signing, so a Sigstore outage leaves an unsigned but installable release rather
than an uninstallable one.

**Both wrappers fail closed.** They resolve their own version instead of the
mutable `releases/latest`, fetch `SHA256SUMS` for that tag, and abort on a
mismatch or when the release publishes no checksums. Python verifies in memory,
so an unverified byte never reaches disk. `publish-npm` also verifies the
platform tarballs it repackages, which is the path most macOS and Linux users
take and which the launcher's own check never sees.

**Identity metadata cleaned** across all 9 published identities, plus the repo
topic.

## Verification

- Python: 54 tests, on 3.13 **and** 3.10.11 (the `filter=` kwarg from PEP 706
  does not exist there, and `requires-python` is `>=3.10`)
- npm: 13 tests, including 5 that drive `fromDownload()` with `https` stubbed

Both suites are sabotage-checked rather than merely green. Measured, on
`test_binary.py` (16 tests) and the npm suite (13):

| Mutation | Result |
|---|---|
| digest comparison disabled | 2 Python fail |
| `ensure_binary` inlines an unverified fetch, bypassing `_download_binary` | 1 Python fail |
| `expected` set to the archive's own hash | 2 Python fail |
| empty-`PATH`-entry guard removed | 1 Python fail |
| cache exec-bit gate weakened to bare `is_file()` | 1 Python fail |
| npm checksum comparison deleted | 1 npm fail |
| npm fails open on a missing `SHA256SUMS` | 2 npm fail |
| npm staging dir collapsed into the cache dir | 1 npm fail |
| npm `chmod` on the staged binary dropped | 1 npm fail |
| npm `finally` cleanup dropped | 1 npm fail |
| `digestFor` lowercasing removed | 1 npm fail |

Baselines: 16 in `test_binary.py`, 13 npm. The second row is the load-bearing
one: that mutation used to fail **nothing**, which is why the entrypoint tests
exist. An earlier Python suite passed 14/14 with the entrypoint gutted, and an
earlier npm suite passed 7/7 with the checksum check deleted.

Two mutations stay green and are known rather than overlooked: replacing
`renameSync` with `copyFileSync` (the observable end state is identical, only
atomicity differs, and pinning it needs a simulated interrupt), and dropping the
Python `isreg()` guard (it only matters for an archive that already passed the
digest check).

## What this PR does not buy

A digest check does not remove the `download → chmod → exec` shape a static
analyser fires on. Per-platform wheels do, and that is deferred. This PR buys a
defensible position with no verification bypass, not an automatic declassification.

Two limits are stated in SECURITY.md rather than papered over: a cached binary is
not re-hashed on later runs, and `SHA256SUMS` shares an origin with the assets it
covers, so it defends against corruption and substitution in transit rather than
against write access to the release itself.
