### PR TITLE
fix(v2): honor renderJs on the Firecrawl-compat surface

### DIFF
--- a/crates/crw-server/src/routes/v2/crawl.rs
+++ b/crates/crw-server/src/routes/v2/crawl.rs
@@ -78,6 +78,7 @@ pub(crate) struct ScrapeOpts {
     pub json_schema: Option<Value>,
     pub only_main_content: bool,
     pub wait_for: Option<u64>,
+    pub render_js: Option<bool>,
 }
 
 /// Pull the internal scrape projection out of a v2 `scrapeOptions` object.
@@ -87,6 +88,7 @@ pub(crate) fn scrape_opts_to_internal(opts: &Option<Value>) -> Result<ScrapeOpts
         json_schema: None,
         only_main_content: true,
         wait_for: None,
+        render_js: None,
     };
     if let Some(Value::Object(m)) = opts {
         if let Some(f) = m.get("formats") {
@@ -102,6 +104,22 @@ pub(crate) fn scrape_opts_to_internal(opts: &Option<Value>) -> Result<ScrapeOpts
         }
         if let Some(w) = m.get("waitFor").and_then(Value::as_u64) {
             out.wait_for = Some(w);
+        }
+        // crw extension, same semantics as `/v1/crawl`'s `renderJs`. Absent (or
+        // null) leaves `None` so the server default still applies; an explicit
+        // `false` must survive all the way to `CrawlRequest` or a v2 caller has
+        // no way to keep a crawl off the browser tiers. A non-boolean is an
+        // error rather than a silent fallback to auto — quietly ignoring this
+        // key is the exact failure #346 reported. The snake_case alias mirrors
+        // the one on the v2 scrape wire; the sibling keys here are camelCase
+        // only, but dropping it would mean `render_js` gets silently ignored —
+        // again the same failure mode.
+        if let Some(v) = m.get("renderJs").or_else(|| m.get("render_js"))
+            && !v.is_null()
+        {
+            out.render_js = Some(v.as_bool().ok_or_else(|| {
+                CrwError::InvalidRequest("scrapeOptions.renderJs must be a boolean".into())
+            })?);
         }
     }
     Ok(out)
@@ -127,7 +145,7 @@ pub async fn start_crawl(
         formats: opts.formats,
         only_main_content: opts.only_main_content,
         json_schema: opts.json_schema,
-        render_js: None,
+        render_js: opts.render_js,
         wait_for: opts.wait_for,
         renderer: v2.renderer,
         country: v2.country,
@@ -233,4 +251,60 @@ pub async fn get_errors(
     Ok(Json(
         serde_json::json!({ "success": true, "errors": errors, "robotsBlocked": [] }),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #346. `scrapeOptions` is parsed key-by-key out of a raw
+    /// `Value`, so a key nobody reads is silently dropped; `renderJs` was such a
+    /// key and `CrawlRequest.render_js` was hardcoded `None`. A v2 caller then
+    /// had no way to keep a crawl off the browser tiers.
+    #[test]
+    fn scrape_opts_reads_render_js() {
+        for (key, wire, expected) in [
+            ("renderJs", serde_json::json!(false), Some(false)),
+            ("renderJs", serde_json::json!(true), Some(true)),
+            ("render_js", serde_json::json!(false), Some(false)),
+        ] {
+            let opts = Some(serde_json::json!({ key: wire }));
+            let parsed = scrape_opts_to_internal(&opts).unwrap();
+            assert_eq!(parsed.render_js, expected, "{key} = {wire}");
+        }
+    }
+
+    #[test]
+    fn scrape_opts_render_js_defaults_to_none() {
+        // "No scrapeOptions at all", "scrapeOptions without renderJs" and an
+        // explicit null must all stay None so the server's render_js_default
+        // still applies.
+        assert_eq!(scrape_opts_to_internal(&None).unwrap().render_js, None);
+        for opts in [
+            serde_json::json!({ "onlyMainContent": false }),
+            serde_json::json!({ "renderJs": null }),
+        ] {
+            let parsed = scrape_opts_to_internal(&Some(opts.clone())).unwrap();
+            assert_eq!(parsed.render_js, None, "{opts}");
+        }
+    }
+
+    /// A non-boolean must not degrade to auto. `scrapeOptions` is hand-parsed
+    /// out of a `Value`, so `"false"` would otherwise read as "key absent" and
+    /// leave JS on — the same silent-drop shape as #346 itself.
+    #[test]
+    fn scrape_opts_render_js_rejects_non_boolean() {
+        for bad in [
+            serde_json::json!("false"),
+            serde_json::json!(0),
+            serde_json::json!([false]),
+        ] {
+            let opts = Some(serde_json::json!({ "renderJs": bad }));
+            match scrape_opts_to_internal(&opts) {
+                Err(CrwError::InvalidRequest(m)) => assert!(m.contains("renderJs"), "{m}"),
+                Err(e) => panic!("{bad} rejected with the wrong error: {e}"),
+                Ok(_) => panic!("{bad} must be rejected, not silently ignored"),
+            }
+        }
+    }
 }

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -70,6 +70,12 @@ pub struct V2ScrapeRequest {
     /// Optional explicit renderer pin (crw extension, tolerated alongside v2).
     #[serde(default)]
     pub renderer: Option<RequestedRenderer>,
+    /// JS-rendering preference (crw extension, tolerated alongside v2 — upstream
+    /// Firecrawl has no equivalent). Same semantics as `/v1/scrape`: null =
+    /// auto/server default, true = force JS, false = never reach a browser tier.
+    /// Accepts the snake_case alias for parity with the v1 wire.
+    #[serde(default, alias = "render_js")]
+    pub render_js: Option<bool>,
     /// Firecrawl `parsers` — document parsing directives. Accepts `["pdf"]` or
     /// `[{"type":"pdf","maxPages":N}]`. Omitted = auto-parse PDFs; `[]` = leave
     /// raw. See [`crw_core::types::ParserSpec`].
@@ -156,6 +162,7 @@ pub(crate) fn to_internal(
         base_url: v2.base_url,
         summary_prompt: v2.summary_prompt,
         renderer,
+        render_js: v2.render_js,
         parsers: v2.parsers,
         proxy_list: v2.proxy_list,
         proxy_rotation: v2.proxy_rotation,
@@ -301,6 +308,43 @@ mod tests {
             req.proxy_rotation,
             Some(crw_core::proxy::ProxyRotation::RoundRobin)
         );
+    }
+
+    /// Regression for #346: `renderJs` used to have no field on the v2 wire, so
+    /// the lenient-unknown-fields policy swallowed it and `to_internal` left
+    /// `render_js: None` (auto). With a browser tier configured, auto escalates,
+    /// which made `renderJs:false` indistinguishable from `renderJs:true`.
+    /// Asserted through `to_internal` — deserialization alone would still pass
+    /// if the forwarding line were dropped.
+    #[test]
+    fn v2_scrape_threads_render_js_to_internal() {
+        for (wire, expected) in [
+            (serde_json::json!(false), Some(false)),
+            (serde_json::json!(true), Some(true)),
+        ] {
+            let body = serde_json::json!({ "url": "http://example.com", "renderJs": wire });
+            let v2: V2ScrapeRequest = serde_json::from_value(body).unwrap();
+            let (req, _, _) = to_internal(v2).unwrap();
+            assert_eq!(req.render_js, expected, "renderJs {wire} must survive");
+        }
+    }
+
+    #[test]
+    fn v2_scrape_render_js_snake_case_alias() {
+        let body = serde_json::json!({ "url": "http://example.com", "render_js": false });
+        let v2: V2ScrapeRequest = serde_json::from_value(body).unwrap();
+        let (req, _, _) = to_internal(v2).unwrap();
+        assert_eq!(req.render_js, Some(false));
+    }
+
+    #[test]
+    fn v2_scrape_omitted_render_js_stays_none() {
+        // Absent must remain None so the server's render_js_default still
+        // applies — omitting the field is not the same as sending false.
+        let body = serde_json::json!({ "url": "http://example.com" });
+        let v2: V2ScrapeRequest = serde_json::from_value(body).unwrap();
+        let (req, _, _) = to_internal(v2).unwrap();
+        assert_eq!(req.render_js, None);
     }
 
     fn minimal_doc() -> V2Document {

--- a/crates/crw-server/tests/v2_render_js.rs
+++ b/crates/crw-server/tests/v2_render_js.rs
@@ -1,0 +1,170 @@
+//! Integration coverage for `renderJs` on the v2 (Firecrawl-compat) surface.
+//!
+//! Regression for #346: the field had no home on `V2ScrapeRequest`, so the
+//! lenient-unknown-fields policy swallowed it and every v2 request reached the
+//! engine with `render_js: None`. Honoring it makes one previously-accepted
+//! combination fail loudly, which is what this file pins down.
+//!
+//! Loopback is opted in via `CRW_ALLOW_LOOPBACK_FOR_TESTS` (same pattern as
+//! `kimi_route.rs` / `map_filter.rs`) so SSRF validation lets a 127.0.0.1 target
+//! through and the request reaches the handler. Nothing here performs a fetch:
+//! the assertions all land on rejections raised before the renderer runs.
+
+use axum_test::TestServer;
+use crw_core::config::AppConfig;
+use crw_server::app::create_app;
+use crw_server::state::AppState;
+use serde_json::{Value, json};
+use std::sync::Once;
+
+static INIT_TEST_ENV: Once = Once::new();
+fn allow_loopback_for_tests() {
+    INIT_TEST_ENV.call_once(|| {
+        // SAFETY: set once before any tokio worker spawns its own thread.
+        unsafe {
+            std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        }
+    });
+}
+
+/// `mode = "none"` pins the renderer set to empty. Without it the default
+/// `auto` mode would discover whatever browser happens to exist on the machine
+/// running the tests, and `validate_renderer_pin` (which the crawl assertions
+/// below hinge on) would then behave differently on a dev laptop with Chrome
+/// installed than on CI.
+fn test_app() -> TestServer {
+    allow_loopback_for_tests();
+    let config: AppConfig = toml::from_str("[renderer]\nmode = \"none\"\n").unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    TestServer::new(create_app(state))
+}
+
+/// `screenshot` needs a CDP capture, so the engine refuses to pair it with an
+/// explicit `renderJs:false` rather than returning a document with a null
+/// screenshot (`crw-crawl/src/single.rs`). That guard is shared with `/v1` but
+/// was unreachable from v2 while the field was being dropped: the same body
+/// used to return 200. Honoring `renderJs` turns it into a 400, which is a
+/// deliberate, user-visible behavior change and belongs in the record.
+#[tokio::test]
+async fn v2_scrape_screenshot_with_render_js_false_is_rejected() {
+    let server = test_app();
+    let res = server
+        .post("/v2/scrape")
+        .json(&json!({
+            "url": "http://127.0.0.1:9/never-fetched",
+            "formats": ["screenshot"],
+            "renderJs": false,
+        }))
+        .await;
+
+    assert_eq!(res.status_code(), 400, "body: {}", res.text());
+    let body: Value = res.json();
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("screenshot") && err.contains("renderJs"),
+        "the error must name both sides of the contradiction, got: {err}"
+    );
+}
+
+/// The same pair on the canonical `/firecrawl/v2` alias. Both prefixes are
+/// built from one `routes::v2::router()` call, so this guards against a future
+/// fork of the handler rather than testing a second code path today.
+#[tokio::test]
+async fn firecrawl_v2_scrape_screenshot_with_render_js_false_is_rejected() {
+    let server = test_app();
+    let res = server
+        .post("/firecrawl/v2/scrape")
+        .json(&json!({
+            "url": "http://127.0.0.1:9/never-fetched",
+            "formats": ["screenshot"],
+            "renderJs": false,
+        }))
+        .await;
+
+    assert_eq!(res.status_code(), 400, "body: {}", res.text());
+}
+
+/// Omitting `renderJs` must not inherit the rejection above — a screenshot on
+/// its own is a perfectly ordinary v2 request. Proves the new field only bites
+/// when the caller actually sets it.
+#[tokio::test]
+async fn v2_scrape_screenshot_without_render_js_is_not_rejected_upfront() {
+    let server = test_app();
+    let res = server
+        .post("/v2/scrape")
+        .json(&json!({
+            "url": "http://127.0.0.1:9/refused",
+            "formats": ["screenshot"],
+        }))
+        .await;
+
+    // Nothing rejects this up front, so it runs on to the fetch and dies on the
+    // refused port. Asserting that exact outcome (rather than merely "not 400")
+    // pins down WHERE it failed: a validation error here would mean the
+    // contradiction guard fired without an explicit `false`.
+    assert_eq!(res.status_code(), 422, "body: {}", res.text());
+    let body: Value = res.json();
+    assert_eq!(body["errorCode"], "target_unreachable", "body: {body}");
+}
+
+/// The crawl half of the fix. `scrapeOptions.renderJs` has to reach
+/// `CrawlRequest.render_js`, not just the intermediate `ScrapeOpts` projection.
+/// `validate_crawl_renderer` reads that exact field: an explicit `false` means
+/// the request never touches a browser, so the availability check for a pinned
+/// renderer is skipped. With a default config (no JS tier configured) that
+/// difference is observable as 200 vs 400, which is what makes this a real
+/// end-to-end assertion on the field rather than on the parser.
+#[tokio::test]
+async fn v2_crawl_render_js_false_reaches_the_crawl_request() {
+    let server = test_app();
+    let res = server
+        .post("/v2/crawl")
+        .json(&json!({
+            "url": "http://127.0.0.1:9/never-fetched",
+            "limit": 1,
+            "renderer": "chrome",
+            "scrapeOptions": { "renderJs": false },
+        }))
+        .await;
+
+    assert_eq!(
+        res.status_code(),
+        200,
+        "renderJs:false must reach CrawlRequest and waive the pin check: {}",
+        res.text()
+    );
+}
+
+/// Control for the test above: the same pin WITHOUT `renderJs:false` still has
+/// to be rejected, or the assertion above would pass for the trivial reason
+/// that the pin check never runs.
+#[tokio::test]
+async fn v2_crawl_renderer_pin_without_render_js_still_400s() {
+    let server = test_app();
+    let res = server
+        .post("/v2/crawl")
+        .json(&json!({
+            "url": "http://127.0.0.1:9/never-fetched",
+            "limit": 1,
+            "renderer": "chrome",
+        }))
+        .await;
+
+    assert_eq!(res.status_code(), 400, "body: {}", res.text());
+}
+
+/// A non-boolean `scrapeOptions.renderJs` is rejected at the route, not
+/// silently treated as absent.
+#[tokio::test]
+async fn v2_crawl_non_boolean_render_js_400s() {
+    let server = test_app();
+    let res = server
+        .post("/v2/crawl")
+        .json(&json!({
+            "url": "http://127.0.0.1:9/never-fetched",
+            "scrapeOptions": { "renderJs": "false" },
+        }))
+        .await;
+
+    assert_eq!(res.status_code(), 400, "body: {}", res.text());
+}

--- a/docs/docs/v2-api.md
+++ b/docs/docs/v2-api.md
@@ -83,6 +83,7 @@ Scrape one URL synchronously. Returns immediately with a `V2Document`.
 | `proxyRotation` | `"round_robin" \| "random"` | — | Rotation strategy for `proxyList` |
 | `timeout` | `number` | server default | Request deadline in milliseconds |
 | `renderer` | `"auto" \| "lightpanda" \| "chrome" \| "chrome_proxy" \| "playwright"` | — | Pin a renderer tier |
+| `renderJs` | `boolean` | — | `true` forces JS rendering, `false` keeps the request HTTP-only, omitted uses auto-detection. Same semantics as on `/v1/scrape`, see [JS Rendering](js-rendering.md) |
 | `parsers` | `ParserSpec[]` | — | Document parser directives (e.g. `["pdf"]`) |
 | `llmApiKey` | `string` | — | Per-request LLM API key (required for `summary` / `json` if no server key) |
 | `llmProvider` | `"anthropic" \| "openai" \| "deepseek" \| "azure" \| "openai-compatible"` | — | Per-request LLM provider |
@@ -170,7 +171,7 @@ Start an asynchronous recursive crawl. Returns a job ID immediately; poll `GET /
 | `url` | `string` | **required** | Seed URL |
 | `limit` | `number` | — | Maximum pages to crawl |
 | `maxDiscoveryDepth` | `number` | — | Maximum link-follow depth from the seed |
-| `scrapeOptions` | `object` | — | Per-page scrape settings (`formats`, `onlyMainContent`, `waitFor`) |
+| `scrapeOptions` | `object` | — | Per-page scrape settings (`formats`, `onlyMainContent`, `waitFor`, `renderJs`) |
 | `renderer` | `RequestedRenderer` | — | Pin a renderer tier for all pages |
 | `country` | `string` | — | 2-letter ISO country for proxy egress |
 | `proxyList` | `string[]` | `[]` | BYOP proxy pool |


### PR DESCRIPTION
`V2ScrapeRequest` had no `render_js` field. The struct deliberately ignores unknown keys so a newer Firecrawl SDK build cannot 400, which meant a caller's `renderJs` was accepted and dropped: the request reached the engine as `None`, auto-detection kicked in, and with a browser tier configured it escalated anyway. `renderJs:false` was indistinguishable from `renderJs:true`, exactly as reported.

On a server with `render_js_default = true` it was worse: a v2 caller had no way to turn JS off at all.

`/v1/scrape`, `/v1/crawl`, `/v1/batch/scrape` and the MCP `crw_scrape` tool were never affected, they deserialize the native request type directly.

## What changed

- `render_js` added to `V2ScrapeRequest` and forwarded in `to_internal`. This also covers `/v2/batch/scrape`, which builds its per-URL template from the same struct and function, and `/firecrawl/v2/*`, which is the same router.
- `scrapeOptions.renderJs` is read into `CrawlRequest.render_js`, replacing a hardcoded `None`. A non-boolean value is rejected rather than silently treated as absent, since quietly ignoring the key is the failure being fixed.
- Documented on both v2 request tables.

`/v2/map`, `/v2/extract` and `/v2/search` are untouched: none of them models a render preference on either API version.

## Verification

Against a real LightPanda container in the reporter's compose shape, counting inbound requests on a local origin. Two hits means a browser tier ran.

| request | before | after |
|---|---|---|
| `/v1/scrape` `renderJs:false` | 1 | 1 |
| `/v1/scrape` `renderJs:true` | 2 | 2 |
| `/v2/scrape` `renderJs:false` | **2** | **1** |
| `/v2/scrape` `renderJs:true` | 2 | 2 |
| `/v2/crawl` `scrapeOptions.renderJs:false` | 2 | **1** |
| `/v2/crawl` without `renderJs` | 2 | 2 |

Every production line touched was mutation-tested: reverting it makes a specific new test fail. `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings` and `cargo test --workspace` are green.

## Behavior change to be aware of

`screenshot` together with `renderJs:false` now returns 400 on v2, as it already did on v1. A capture needs CDP, so the combination is contradictory. Previously the flag was ignored and the request succeeded. Covered by a test.

Separately, the hosted playground's "Render JS: off" control posts to `/v2` and has therefore been a no-op; it starts taking effect once this ships.

## Follow-ups found while investigating, not fixed here

- `actions` is silently swallowed on v2 the same way, while `/v1` rejects it loudly.
- `/v2/batch/scrape` never calls `validate_renderer_pin`, unlike v1 batch and the other v2 routes. Pre-existing and unrelated to this change.

ref #346