### PR TITLE
fix(openapi): the published spec described an API we do not have

### DIFF
--- a/.github/workflows/docs-format-snapshot.yml
+++ b/.github/workflows/docs-format-snapshot.yml
@@ -1,7 +1,8 @@
 name: Docs Format Snapshot
 
-# Asserts that the docs tables for OutputFormat and RequestedRenderer list
-# exactly the variants defined in crates/crw-core/src/types.rs.
+# Asserts that the docs tables for OutputFormat and RequestedRenderer, and the
+# OpenAPI ScrapeRequest.formats enum, list exactly the variants defined in
+# crates/crw-core/src/types.rs.
 #
 # Triggers on: any push to main, any PR that touches the Rust types or either
 # doc. Does NOT modify docs-guards.sh or docs-guards.yml.
@@ -15,6 +16,8 @@ on:
       - "crates/crw-core/src/types.rs"
       - "docs/docs/output-formats.md"
       - "docs/docs/js-rendering.md"
+      - "docs/openapi.json"
+      - "crates/crw-server/openapi/**"
       - "scripts/check-format-tables.sh"
 
 permissions:

--- a/crates/crw-server/openapi/openapi-3.0.json
+++ b/crates/crw-server/openapi/openapi-3.0.json
@@ -783,9 +783,11 @@
                 "rawHtml",
                 "plainText",
                 "links",
+                "images",
                 "json",
                 "summary",
-                "changeTracking"
+                "changeTracking",
+                "screenshot"
               ]
             },
             "default": [
@@ -816,6 +818,11 @@
           "judgeEnabled": {
             "type": "boolean",
             "description": "Run the LLM meaningful-change judge on a changed page (requires goal)"
+          },
+          "screenshotFullPage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Capture the whole page rather than the viewport, for `formats: [\"screenshot\"]`."
           }
         }
       },

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -346,7 +346,7 @@
           "change-tracking"
         ],
         "summary": "Diff current scrape content against a previous snapshot",
-        "description": "Stateless: opencore stores nothing — the caller supplies the `previous` snapshot. Accepts a single body or a `batch` array (presence of `batch` selects batch mode). The crawl-path workhorse for monitors.",
+        "description": "Stateless: opencore stores nothing \u2014 the caller supplies the `previous` snapshot. Accepts a single body or a `batch` array (presence of `batch` selects batch mode). The crawl-path workhorse for monitors.",
         "operationId": "changeTrackingDiff",
         "requestBody": {
           "required": true,
@@ -447,7 +447,7 @@
           "capabilities"
         ],
         "summary": "Server capability discovery",
-        "description": "Returns what this opencore instance actually supports: LLM providers, output formats, search features, screenshot/renderer availability, document parsers and enforced limits. Every boolean is derived from the real build features and effective config — a capability is true only when the instance can perform it for a request that supplies no extra credentials. SaaS frontends call this on boot to validate a minimum capability set before sending traffic.",
+        "description": "Returns what this opencore instance actually supports: LLM providers, output formats, search features, screenshot/renderer availability, document parsers and enforced limits. Every boolean is derived from the real build features and effective config \u2014 a capability is true only when the instance can perform it for a request that supplies no extra credentials. SaaS frontends call this on boot to validate a minimum capability set before sending traffic.",
         "operationId": "capabilities",
         "security": [
           {
@@ -502,7 +502,7 @@
                         },
                         "supportsBaseUrl": {
                           "type": "boolean",
-                          "description": "The LLM dispatcher accepts a custom baseUrl, but only as part of a BYOK request: the per-request LLM config that carries it is only built when the request also supplies llmApiKey. Sending baseUrl without a key leaves the server's own endpoint in force (the server never points its own key at a caller-chosen host). POST /v1/extract rejects baseUrl outright — configure [extraction.llm.base_url] server-side for that route. Build-invariant: no config turns this off."
+                          "description": "The LLM dispatcher accepts a custom baseUrl, but only as part of a BYOK request: the per-request LLM config that carries it is only built when the request also supplies llmApiKey. Sending baseUrl without a key leaves the server's own endpoint in force (the server never points its own key at a caller-chosen host). POST /v1/extract rejects baseUrl outright \u2014 configure [extraction.llm.base_url] server-side for that route. Build-invariant: no config turns this off."
                         },
                         "serverKeyConfigured": {
                           "type": "boolean",
@@ -629,7 +629,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "description": "JS renderer tiers this instance constructed, in fallback order — reflects both the build features and the config. These are the values the per-request `renderer` pin accepts.",
+                          "description": "JS renderer tiers this instance constructed, in fallback order \u2014 reflects both the build features and the config. These are the values the per-request `renderer` pin accepts.",
                           "example": [
                             "lightpanda",
                             "chrome"
@@ -664,7 +664,7 @@
                       "properties": {
                         "supported": {
                           "type": "boolean",
-                          "description": "POST /v1/extract works for a request that carries no credentials of its own. The route is ALWAYS mounted, but it needs an LLM: false means a server LLM key is absent, or llm.requireByokHeader is set (which makes the server key insufficient). false does NOT mean 'not implemented' — a request carrying llmApiKey still extracts on a self-hosted instance."
+                          "description": "POST /v1/extract works for a request that carries no credentials of its own. The route is ALWAYS mounted, but it needs an LLM: false means a server LLM key is absent, or llm.requireByokHeader is set (which makes the server key insufficient). false does NOT mean 'not implemented' \u2014 a request carrying llmApiKey still extracts on a self-hosted instance."
                         },
                         "maxUrls": {
                           "type": "integer",
@@ -712,7 +712,7 @@
                             },
                             "maxBytes": {
                               "type": "integer",
-                              "description": "The ENFORCED body cap ([document].max_upload_bytes, clamped by the hard ceiling) — the same value the body-limit layer applies."
+                              "description": "The ENFORCED body cap ([document].max_upload_bytes, clamped by the hard ceiling) \u2014 the same value the body-limit layer applies."
                             },
                             "types": {
                               "type": "array",
@@ -1037,7 +1037,8 @@
             "type": "boolean",
             "default": true
           }
-        }
+        },
+        "description": "Per-result enrichment for `/v1/search`. The search result envelope only carries these formats; `plainText` and `json` are rejected outright."
       },
       "FieldStatus": {
         "type": "string",
@@ -1147,17 +1148,7 @@
           "formats": {
             "type": "array",
             "items": {
-              "type": "string",
-              "enum": [
-                "markdown",
-                "html",
-                "rawHtml",
-                "plainText",
-                "links",
-                "json",
-                "summary",
-                "changeTracking"
-              ]
+              "$ref": "#/components/schemas/OutputFormat"
             },
             "default": [
               "markdown"
@@ -1169,8 +1160,10 @@
             "description": "Strip navigation, ads, and boilerplate; keep main article content only"
           },
           "renderJs": {
-            "type": "boolean",
-            "nullable": true,
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "null = auto-detect, true = force JS rendering, false = skip JS rendering"
           },
           "waitFor": {
@@ -1272,7 +1265,7 @@
           "actions": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Unsupported Firecrawl parameter — returns a clear error if supplied"
+            "description": "Unsupported Firecrawl parameter \u2014 returns a clear error if supplied"
           },
           "extract": {
             "$ref": "#/components/schemas/ExtractOptions",
@@ -1318,7 +1311,8 @@
               "lightpanda",
               "chrome",
               "chrome_proxy",
-              "playwright"
+              "playwright",
+              "camoufox"
             ],
             "description": "Pin this request to a specific renderer. Non-auto implies renderJs:true unless renderJs:false is set."
           },
@@ -1351,6 +1345,11 @@
               "$ref": "#/components/schemas/ParserSpec"
             },
             "description": "Document parser directives. Omit = auto-parse PDFs. Empty array = disable parsing."
+          },
+          "screenshotFullPage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Capture the whole page rather than the viewport, for `formats: [\"screenshot\"]`."
           }
         }
       },
@@ -1404,8 +1403,13 @@
                 }
               },
               "renderDecision": {
-                "type": "string",
-                "description": "Which renderer ran (e.g. 'http', 'browser')"
+                "type": "object",
+                "description": "How the renderer was chosen. A tagged object: `kind` is one of `userPinned`, `autoDefault`, `autoPromoted`, `breakerSkipped`, `failover`, and the remaining fields depend on it.",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  }
+                }
               },
               "creditCost": {
                 "type": "number"
@@ -1426,6 +1430,52 @@
               "llmInputHash": {
                 "type": "string",
                 "description": "'sha256:'-prefixed hash of the canonical text sent to the extraction LLM. The independent record a consumer checks a citation's sourceHash against, so the check is not circular."
+              },
+              "sourceHash": {
+                "type": "string",
+                "description": "Fingerprint of the canonical markdown, for dedup and caching."
+              },
+              "plainText": {
+                "type": "string",
+                "description": "Plain-text view; present when `formats` includes `plainText`."
+              },
+              "images": {
+                "$ref": "#/components/schemas/ScrapedImages"
+              },
+              "summary": {
+                "type": "string",
+                "description": "LLM summary; present when `formats` includes `summary`."
+              },
+              "llmUsage": {
+                "type": "object",
+                "description": "Token usage for the LLM call, when one ran."
+              },
+              "chunks": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Chunked content, when a `chunkStrategy` was requested."
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the fetched resource."
+              },
+              "changeTracking": {
+                "type": "object",
+                "description": "Diff result; present when `formats` includes `changeTracking`."
+              },
+              "screenshot": {
+                "type": "string",
+                "description": "PNG capture as a `data:image/png;base64,...` URL; present when `formats` includes `screenshot`."
+              },
+              "block": {
+                "type": "object",
+                "description": "Anti-bot verdict. Present only when the page was a block or challenge shell, in which case `success` is false."
+              },
+              "debugExtraction": {
+                "type": "object",
+                "description": "Extraction trace; present only when `debug: true`."
               }
             }
           }
@@ -1532,7 +1582,62 @@
             "default": 2
           },
           "scrapeOptions": {
-            "$ref": "#/components/schemas/ScrapeOptions"
+            "$ref": "#/components/schemas/CrawlScrapeOptions"
+          },
+          "formats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CrawlOutputFormat"
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "jsonSchema": {
+            "type": "object"
+          },
+          "renderJs": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "waitFor": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "renderer": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "lightpanda",
+              "chrome",
+              "chrome_proxy",
+              "playwright",
+              "camoufox"
+            ]
+          },
+          "country": {
+            "type": "string",
+            "description": "2-letter ISO 3166-1 alpha-2 proxy egress country."
+          },
+          "proxyList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "proxyRotation": {
+            "type": "string",
+            "enum": [
+              "round_robin",
+              "random",
+              "sticky_per_host"
+            ]
           }
         }
       },
@@ -1807,7 +1912,7 @@
           },
           "firstObservation": {
             "type": "boolean",
-            "description": "True when no previous was supplied — caller maps to 'new'"
+            "description": "True when no previous was supplied \u2014 caller maps to 'new'"
           },
           "contentHash": {
             "type": "string"
@@ -2154,38 +2259,45 @@
         }
       },
       "BatchScrapeRequest": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ScrapeOptions"
+        "type": "object",
+        "description": "Every `/v1/scrape` body field except `url` is accepted here and applied to each URL. See `ScrapeRequest` for the full set.",
+        "required": [
+          "urls"
+        ],
+        "properties": {
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "minItems": 1,
+            "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
           },
-          {
-            "type": "object",
-            "required": [
-              "urls"
-            ],
-            "properties": {
-              "urls": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "minItems": 1,
-                "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
-              },
-              "ignoreInvalidUrls": {
-                "type": "boolean",
-                "default": true,
-                "description": "When false, a single invalid URL rejects the whole submit with 400."
-              },
-              "maxConcurrency": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
-              }
-            }
+          "ignoreInvalidUrls": {
+            "type": "boolean",
+            "default": true,
+            "description": "When false, a single invalid URL rejects the whole submit with 400."
+          },
+          "maxConcurrency": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
+          },
+          "formats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutputFormat"
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
           }
-        ]
+        }
       },
       "BatchScrapeAccepted": {
         "type": "object",
@@ -2208,6 +2320,89 @@
               "type": "string"
             },
             "description": "Submitted URLs rejected by parsing or the SSRF guard, verbatim."
+          }
+        }
+      },
+      "OutputFormat": {
+        "type": "string",
+        "enum": [
+          "markdown",
+          "html",
+          "rawHtml",
+          "plainText",
+          "links",
+          "images",
+          "json",
+          "summary",
+          "changeTracking",
+          "screenshot"
+        ],
+        "description": "Aliases accepted in addition to these: `extract` and `llm-extract` for `json`, `change-tracking` for `changeTracking`, `screenshot@fullPage` for `screenshot`."
+      },
+      "CrawlOutputFormat": {
+        "type": "string",
+        "enum": [
+          "markdown",
+          "html",
+          "rawHtml",
+          "plainText",
+          "links",
+          "images",
+          "json"
+        ],
+        "description": "The crawl path runs extraction and the optional LLM `json` pass. It does not produce `summary`, `screenshot` or inline `changeTracking`; use `/v1/scrape` for those."
+      },
+      "ScrapedImages": {
+        "type": "array",
+        "description": "Present when `formats` includes `images`.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "alt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ]
+        }
+      },
+      "CrawlScrapeOptions": {
+        "type": "object",
+        "description": "Per-page scrape settings. Every key here may also be sent at the top level; an explicit top-level value wins.",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CrawlOutputFormat"
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "jsonSchema": {
+            "type": "object",
+            "description": "JSON Schema for structured extraction, with `formats: [\"json\"]`."
+          },
+          "renderJs": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "null = auto-detect, true = force JS, false = never use a browser tier."
+          },
+          "waitFor": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Milliseconds to wait after JS rendering on each page."
           }
         }
       }

--- a/crates/crw-server/src/routes/crawl.rs
+++ b/crates/crw-server/src/routes/crawl.rs
@@ -8,13 +8,40 @@ use uuid::Uuid;
 use crate::error::AppError;
 use crate::state::{AppState, validate_crawl_renderer};
 
+/// Lift a nested `scrapeOptions` object onto the top level.
+///
+/// `CrawlRequest` is flat, but Firecrawl — and our own published OpenAPI spec,
+/// and the API-reference page generated from it — nest the per-page settings
+/// under `scrapeOptions`. A body written against that shape had every key
+/// silently dropped: `scrapeOptions.formats` never reached the engine and the
+/// crawl quietly returned markdown.
+///
+/// An explicit top-level key always wins, so every request that works today
+/// keeps working; this only fills in what the caller expressed the other way.
+pub(crate) fn lift_scrape_options(mut body: serde_json::Value) -> serde_json::Value {
+    let Some(obj) = body.as_object_mut() else {
+        return body;
+    };
+    let nested = obj
+        .remove("scrapeOptions")
+        .or_else(|| obj.remove("scrape_options"));
+    if let Some(serde_json::Value::Object(nested)) = nested {
+        for (k, v) in nested {
+            obj.entry(k).or_insert(v);
+        }
+    }
+    body
+}
+
 /// POST /v1/crawl — start a crawl job.
 /// Response format matches Firecrawl: { success: true, id: "..." }
 pub async fn start_crawl(
     State(state): State<AppState>,
-    body: Result<Json<CrawlRequest>, JsonRejection>,
+    body: Result<Json<serde_json::Value>, JsonRejection>,
 ) -> Result<Json<CrawlStartResponse>, AppError> {
-    let Json(req) = body.map_err(AppError::from)?;
+    let Json(raw) = body.map_err(AppError::from)?;
+    let req: CrawlRequest = serde_json::from_value(lift_scrape_options(raw))
+        .map_err(|e| CrwError::InvalidRequest(format!("Invalid crawl request: {e}")))?;
     let parsed_url = url::Url::parse(&req.url)
         .map_err(|e| CrwError::InvalidRequest(format!("Invalid URL: {e}")))?;
     crw_core::url_safety::validate_safe_url_resolved(&parsed_url)
@@ -78,4 +105,79 @@ pub async fn get_crawl(
 
     let current = job.rx.borrow().clone();
     Ok(Json(current))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crw_core::types::OutputFormat;
+    use serde_json::json;
+
+    fn parse(body: serde_json::Value) -> CrawlRequest {
+        serde_json::from_value(lift_scrape_options(body)).unwrap()
+    }
+
+    /// The shape our own OpenAPI spec publishes. Before this, `formats` here
+    /// was an unknown key on a flat struct and the crawl silently produced
+    /// markdown — verified against production.
+    #[test]
+    fn nested_scrape_options_reach_the_request() {
+        let req = parse(json!({
+            "url": "https://example.com",
+            "scrapeOptions": {
+                "formats": ["html"],
+                "onlyMainContent": false,
+                "renderJs": false,
+                "waitFor": 1500,
+            },
+        }));
+        assert_eq!(req.formats, vec![OutputFormat::Html]);
+        assert!(!req.only_main_content);
+        assert_eq!(req.render_js, Some(false));
+        assert_eq!(req.wait_for, Some(1500));
+    }
+
+    #[test]
+    fn a_flat_body_is_unchanged() {
+        let req = parse(json!({
+            "url": "https://example.com",
+            "formats": ["links"],
+            "renderJs": true,
+        }));
+        assert_eq!(req.formats, vec![OutputFormat::Links]);
+        assert_eq!(req.render_js, Some(true));
+    }
+
+    /// Both shapes at once is a contradiction only the caller can resolve, so
+    /// the explicit top-level value wins and nothing that works today changes.
+    #[test]
+    fn top_level_wins_over_nested() {
+        let req = parse(json!({
+            "url": "https://example.com",
+            "formats": ["links"],
+            "scrapeOptions": { "formats": ["html"] },
+        }));
+        assert_eq!(req.formats, vec![OutputFormat::Links]);
+    }
+
+    #[test]
+    fn snake_case_alias_and_absent_options_are_handled() {
+        let req = parse(json!({
+            "url": "https://example.com",
+            "scrape_options": { "formats": ["rawHtml"] },
+        }));
+        assert_eq!(req.formats, vec![OutputFormat::RawHtml]);
+
+        // No scrapeOptions at all keeps the documented defaults.
+        let req = parse(json!({ "url": "https://example.com" }));
+        assert_eq!(req.formats, vec![OutputFormat::Markdown]);
+        assert!(req.only_main_content);
+    }
+
+    #[test]
+    fn a_non_object_scrape_options_is_ignored_not_fatal() {
+        // A caller sending `scrapeOptions: null` (some SDKs do) must not 400.
+        let req = parse(json!({ "url": "https://example.com", "scrapeOptions": null }));
+        assert_eq!(req.formats, vec![OutputFormat::Markdown]);
+    }
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -346,7 +346,7 @@
           "change-tracking"
         ],
         "summary": "Diff current scrape content against a previous snapshot",
-        "description": "Stateless: opencore stores nothing — the caller supplies the `previous` snapshot. Accepts a single body or a `batch` array (presence of `batch` selects batch mode). The crawl-path workhorse for monitors.",
+        "description": "Stateless: opencore stores nothing \u2014 the caller supplies the `previous` snapshot. Accepts a single body or a `batch` array (presence of `batch` selects batch mode). The crawl-path workhorse for monitors.",
         "operationId": "changeTrackingDiff",
         "requestBody": {
           "required": true,
@@ -447,7 +447,7 @@
           "capabilities"
         ],
         "summary": "Server capability discovery",
-        "description": "Returns what this opencore instance actually supports: LLM providers, output formats, search features, screenshot/renderer availability, document parsers and enforced limits. Every boolean is derived from the real build features and effective config — a capability is true only when the instance can perform it for a request that supplies no extra credentials. SaaS frontends call this on boot to validate a minimum capability set before sending traffic.",
+        "description": "Returns what this opencore instance actually supports: LLM providers, output formats, search features, screenshot/renderer availability, document parsers and enforced limits. Every boolean is derived from the real build features and effective config \u2014 a capability is true only when the instance can perform it for a request that supplies no extra credentials. SaaS frontends call this on boot to validate a minimum capability set before sending traffic.",
         "operationId": "capabilities",
         "security": [
           {
@@ -502,7 +502,7 @@
                         },
                         "supportsBaseUrl": {
                           "type": "boolean",
-                          "description": "The LLM dispatcher accepts a custom baseUrl, but only as part of a BYOK request: the per-request LLM config that carries it is only built when the request also supplies llmApiKey. Sending baseUrl without a key leaves the server's own endpoint in force (the server never points its own key at a caller-chosen host). POST /v1/extract rejects baseUrl outright — configure [extraction.llm.base_url] server-side for that route. Build-invariant: no config turns this off."
+                          "description": "The LLM dispatcher accepts a custom baseUrl, but only as part of a BYOK request: the per-request LLM config that carries it is only built when the request also supplies llmApiKey. Sending baseUrl without a key leaves the server's own endpoint in force (the server never points its own key at a caller-chosen host). POST /v1/extract rejects baseUrl outright \u2014 configure [extraction.llm.base_url] server-side for that route. Build-invariant: no config turns this off."
                         },
                         "serverKeyConfigured": {
                           "type": "boolean",
@@ -629,7 +629,7 @@
                           "items": {
                             "type": "string"
                           },
-                          "description": "JS renderer tiers this instance constructed, in fallback order — reflects both the build features and the config. These are the values the per-request `renderer` pin accepts.",
+                          "description": "JS renderer tiers this instance constructed, in fallback order \u2014 reflects both the build features and the config. These are the values the per-request `renderer` pin accepts.",
                           "example": [
                             "lightpanda",
                             "chrome"
@@ -664,7 +664,7 @@
                       "properties": {
                         "supported": {
                           "type": "boolean",
-                          "description": "POST /v1/extract works for a request that carries no credentials of its own. The route is ALWAYS mounted, but it needs an LLM: false means a server LLM key is absent, or llm.requireByokHeader is set (which makes the server key insufficient). false does NOT mean 'not implemented' — a request carrying llmApiKey still extracts on a self-hosted instance."
+                          "description": "POST /v1/extract works for a request that carries no credentials of its own. The route is ALWAYS mounted, but it needs an LLM: false means a server LLM key is absent, or llm.requireByokHeader is set (which makes the server key insufficient). false does NOT mean 'not implemented' \u2014 a request carrying llmApiKey still extracts on a self-hosted instance."
                         },
                         "maxUrls": {
                           "type": "integer",
@@ -712,7 +712,7 @@
                             },
                             "maxBytes": {
                               "type": "integer",
-                              "description": "The ENFORCED body cap ([document].max_upload_bytes, clamped by the hard ceiling) — the same value the body-limit layer applies."
+                              "description": "The ENFORCED body cap ([document].max_upload_bytes, clamped by the hard ceiling) \u2014 the same value the body-limit layer applies."
                             },
                             "types": {
                               "type": "array",
@@ -1037,7 +1037,8 @@
             "type": "boolean",
             "default": true
           }
-        }
+        },
+        "description": "Per-result enrichment for `/v1/search`. The search result envelope only carries these formats; `plainText` and `json` are rejected outright."
       },
       "FieldStatus": {
         "type": "string",
@@ -1147,17 +1148,7 @@
           "formats": {
             "type": "array",
             "items": {
-              "type": "string",
-              "enum": [
-                "markdown",
-                "html",
-                "rawHtml",
-                "plainText",
-                "links",
-                "json",
-                "summary",
-                "changeTracking"
-              ]
+              "$ref": "#/components/schemas/OutputFormat"
             },
             "default": [
               "markdown"
@@ -1169,8 +1160,10 @@
             "description": "Strip navigation, ads, and boilerplate; keep main article content only"
           },
           "renderJs": {
-            "type": "boolean",
-            "nullable": true,
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "null = auto-detect, true = force JS rendering, false = skip JS rendering"
           },
           "waitFor": {
@@ -1272,7 +1265,7 @@
           "actions": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Unsupported Firecrawl parameter — returns a clear error if supplied"
+            "description": "Unsupported Firecrawl parameter \u2014 returns a clear error if supplied"
           },
           "extract": {
             "$ref": "#/components/schemas/ExtractOptions",
@@ -1318,7 +1311,8 @@
               "lightpanda",
               "chrome",
               "chrome_proxy",
-              "playwright"
+              "playwright",
+              "camoufox"
             ],
             "description": "Pin this request to a specific renderer. Non-auto implies renderJs:true unless renderJs:false is set."
           },
@@ -1351,6 +1345,11 @@
               "$ref": "#/components/schemas/ParserSpec"
             },
             "description": "Document parser directives. Omit = auto-parse PDFs. Empty array = disable parsing."
+          },
+          "screenshotFullPage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Capture the whole page rather than the viewport, for `formats: [\"screenshot\"]`."
           }
         }
       },
@@ -1404,8 +1403,13 @@
                 }
               },
               "renderDecision": {
-                "type": "string",
-                "description": "Which renderer ran (e.g. 'http', 'browser')"
+                "type": "object",
+                "description": "How the renderer was chosen. A tagged object: `kind` is one of `userPinned`, `autoDefault`, `autoPromoted`, `breakerSkipped`, `failover`, and the remaining fields depend on it.",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  }
+                }
               },
               "creditCost": {
                 "type": "number"
@@ -1426,6 +1430,52 @@
               "llmInputHash": {
                 "type": "string",
                 "description": "'sha256:'-prefixed hash of the canonical text sent to the extraction LLM. The independent record a consumer checks a citation's sourceHash against, so the check is not circular."
+              },
+              "sourceHash": {
+                "type": "string",
+                "description": "Fingerprint of the canonical markdown, for dedup and caching."
+              },
+              "plainText": {
+                "type": "string",
+                "description": "Plain-text view; present when `formats` includes `plainText`."
+              },
+              "images": {
+                "$ref": "#/components/schemas/ScrapedImages"
+              },
+              "summary": {
+                "type": "string",
+                "description": "LLM summary; present when `formats` includes `summary`."
+              },
+              "llmUsage": {
+                "type": "object",
+                "description": "Token usage for the LLM call, when one ran."
+              },
+              "chunks": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Chunked content, when a `chunkStrategy` was requested."
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type of the fetched resource."
+              },
+              "changeTracking": {
+                "type": "object",
+                "description": "Diff result; present when `formats` includes `changeTracking`."
+              },
+              "screenshot": {
+                "type": "string",
+                "description": "PNG capture as a `data:image/png;base64,...` URL; present when `formats` includes `screenshot`."
+              },
+              "block": {
+                "type": "object",
+                "description": "Anti-bot verdict. Present only when the page was a block or challenge shell, in which case `success` is false."
+              },
+              "debugExtraction": {
+                "type": "object",
+                "description": "Extraction trace; present only when `debug: true`."
               }
             }
           }
@@ -1532,7 +1582,62 @@
             "default": 2
           },
           "scrapeOptions": {
-            "$ref": "#/components/schemas/ScrapeOptions"
+            "$ref": "#/components/schemas/CrawlScrapeOptions"
+          },
+          "formats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CrawlOutputFormat"
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "jsonSchema": {
+            "type": "object"
+          },
+          "renderJs": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "waitFor": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "renderer": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "lightpanda",
+              "chrome",
+              "chrome_proxy",
+              "playwright",
+              "camoufox"
+            ]
+          },
+          "country": {
+            "type": "string",
+            "description": "2-letter ISO 3166-1 alpha-2 proxy egress country."
+          },
+          "proxyList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "proxyRotation": {
+            "type": "string",
+            "enum": [
+              "round_robin",
+              "random",
+              "sticky_per_host"
+            ]
           }
         }
       },
@@ -1807,7 +1912,7 @@
           },
           "firstObservation": {
             "type": "boolean",
-            "description": "True when no previous was supplied — caller maps to 'new'"
+            "description": "True when no previous was supplied \u2014 caller maps to 'new'"
           },
           "contentHash": {
             "type": "string"
@@ -2154,38 +2259,45 @@
         }
       },
       "BatchScrapeRequest": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ScrapeOptions"
+        "type": "object",
+        "description": "Every `/v1/scrape` body field except `url` is accepted here and applied to each URL. See `ScrapeRequest` for the full set.",
+        "required": [
+          "urls"
+        ],
+        "properties": {
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "minItems": 1,
+            "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
           },
-          {
-            "type": "object",
-            "required": [
-              "urls"
-            ],
-            "properties": {
-              "urls": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "minItems": 1,
-                "description": "URLs to scrape. Each is SSRF-validated; invalid entries are reported in invalidUrls."
-              },
-              "ignoreInvalidUrls": {
-                "type": "boolean",
-                "default": true,
-                "description": "When false, a single invalid URL rejects the whole submit with 400."
-              },
-              "maxConcurrency": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
-              }
-            }
+          "ignoreInvalidUrls": {
+            "type": "boolean",
+            "default": true,
+            "description": "When false, a single invalid URL rejects the whole submit with 400."
+          },
+          "maxConcurrency": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "How many URLs the job scrapes concurrently. Clamped server-side to crawler.max_batch_concurrency."
+          },
+          "formats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutputFormat"
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
           }
-        ]
+        }
       },
       "BatchScrapeAccepted": {
         "type": "object",
@@ -2208,6 +2320,89 @@
               "type": "string"
             },
             "description": "Submitted URLs rejected by parsing or the SSRF guard, verbatim."
+          }
+        }
+      },
+      "OutputFormat": {
+        "type": "string",
+        "enum": [
+          "markdown",
+          "html",
+          "rawHtml",
+          "plainText",
+          "links",
+          "images",
+          "json",
+          "summary",
+          "changeTracking",
+          "screenshot"
+        ],
+        "description": "Aliases accepted in addition to these: `extract` and `llm-extract` for `json`, `change-tracking` for `changeTracking`, `screenshot@fullPage` for `screenshot`."
+      },
+      "CrawlOutputFormat": {
+        "type": "string",
+        "enum": [
+          "markdown",
+          "html",
+          "rawHtml",
+          "plainText",
+          "links",
+          "images",
+          "json"
+        ],
+        "description": "The crawl path runs extraction and the optional LLM `json` pass. It does not produce `summary`, `screenshot` or inline `changeTracking`; use `/v1/scrape` for those."
+      },
+      "ScrapedImages": {
+        "type": "array",
+        "description": "Present when `formats` includes `images`.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "alt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ]
+        }
+      },
+      "CrawlScrapeOptions": {
+        "type": "object",
+        "description": "Per-page scrape settings. Every key here may also be sent at the top level; an explicit top-level value wins.",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CrawlOutputFormat"
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "jsonSchema": {
+            "type": "object",
+            "description": "JSON Schema for structured extraction, with `formats: [\"json\"]`."
+          },
+          "renderJs": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "null = auto-detect, true = force JS, false = never use a browser tier."
+          },
+          "waitFor": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Milliseconds to wait after JS rendering on each page."
           }
         }
       }

--- a/scripts/check-format-tables.sh
+++ b/scripts/check-format-tables.sh
@@ -21,6 +21,7 @@ cd "${CHECK_REPO_ROOT:-$(dirname "$0")/..}"
 TYPES_RS="crates/crw-core/src/types.rs"
 OUTPUT_FORMATS_DOC="docs/docs/output-formats.md"
 JS_RENDERING_DOC="docs/docs/js-rendering.md"
+OPENAPI_SPEC="docs/openapi.json"
 
 FAIL=0
 
@@ -350,6 +351,95 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+
+if [ "$FAIL" -ne 0 ]; then
+  echo >&2
+  echo "FAIL: format/renderer table drift detected." >&2
+  echo "      Update the docs tables to match crates/crw-core/src/types.rs." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Check the OpenAPI spec's ScrapeRequest.formats enum lists exactly the
+#    OutputFormat wire keys.
+#
+#    This is the gap that let `screenshot` and `images` sit in the enum in
+#    types.rs while the published spec said they did not exist, for long enough
+#    that our own marketing copied the omission as a missing feature.
+#    `check-openapi.sh` cannot catch it: it only compares the committed spec
+#    against the copy the binary embeds, which is the same file.
+#
+#    Aliases are stripped for the same reason as the markdown tables: they are
+#    documented in the property description, not as enum members.
+# ---------------------------------------------------------------------------
+
+echo "==> Checking ${OPENAPI_SPEC} OutputFormat enum"
+
+if [ ! -f "$OPENAPI_SPEC" ]; then
+  echo "FAIL: ${OPENAPI_SPEC} not found" >&2
+  FAIL=1
+else
+  # Reads the single `OutputFormat` component and asserts every ScrapeRequest-
+  # style formats array points at it by $ref rather than inlining a copy. An
+  # inlined enum is how `screenshot` and `images` could sit in types.rs while
+  # the published spec said they did not exist — long enough that our own
+  # marketing copied the omission as a missing feature.
+  #
+  # `check-openapi.sh` cannot catch this: it only compares the committed spec
+  # against the copy the binary embeds, which is the same bytes.
+  spec_format_keys_raw=$(python3 - "$OPENAPI_SPEC" 2>&1 <<'PYEOF'
+import json, sys
+
+spec = json.load(open(sys.argv[1]))
+schemas = spec["components"]["schemas"]
+enum = schemas.get("OutputFormat", {}).get("enum")
+if not enum:
+    sys.exit("components.schemas.OutputFormat has no enum")
+
+# Every formats array that is meant to carry the full set must $ref it.
+REF = "#/components/schemas/OutputFormat"
+for name in ("ScrapeRequest", "BatchScrapeRequest"):
+    items = schemas[name]["properties"]["formats"].get("items", {})
+    if items.get("$ref") != REF:
+        sys.exit(
+            f"{name}.formats.items must be a $ref to OutputFormat, not an inline "
+            f"copy (found: {items})"
+        )
+
+print("\n".join(enum))
+PYEOF
+  ) || {
+    echo "FAIL: ${OPENAPI_SPEC} formats check failed: ${spec_format_keys_raw}" >&2
+    FAIL=1
+    spec_format_keys_raw=""
+  }
+
+  spec_format_keys=()
+  while IFS= read -r k; do
+    [ -n "$k" ] && spec_format_keys+=("$k")
+  done <<< "$spec_format_keys_raw"
+
+  if [ "${#spec_format_keys[@]}" -eq 0 ]; then
+    FAIL=1
+  else
+    echo "  Spec enum: ${spec_format_keys[*]}"
+    if ! diff_sets "OutputFormat (openapi.json)" \
+         "${output_format_keys[*]}" \
+         "${spec_format_keys[*]}"; then
+      echo "      The spec is what SDKs and agents read. A format missing here" >&2
+      echo "      reads as unsupported even when the engine implements it." >&2
+      FAIL=1
+    fi
+  fi
+fi
+
+# The crate copy is what the binary serves; it must stay byte-identical.
+echo "==> Checking the embedded spec copy matches ${OPENAPI_SPEC}"
+if ! diff -q "$OPENAPI_SPEC" crates/crw-server/openapi/openapi.json >/dev/null; then
+  echo "FAIL: docs/openapi.json and crates/crw-server/openapi/openapi.json differ." >&2
+  echo "      The binary embeds the crate copy; they must be identical." >&2
+  FAIL=1
+fi
 
 if [ "$FAIL" -ne 0 ]; then
   echo >&2


### PR DESCRIPTION
Found while investigating why a customer thought screenshot capture was unsupported. It is not: `formats: ["screenshot"]` has always worked on `/v1/scrape`. Our own OpenAPI spec said otherwise, and a marketing page copied that into a customer-facing claim.

Digging further, the spec was wrong in a way that silently broke real requests.

## The crawl shape does not exist

The spec describes `/v1/crawl` as taking per-page settings under `scrapeOptions`, and the API-reference page generated from it shows exactly that body. `CrawlRequest` is flat and has no such field, so serde discarded the object whole.

Measured on production:

```
POST /api/v1/crawl {"url":"https://example.com","maxPages":1,"maxDepth":0,
                    "scrapeOptions":{"formats":["html"],"onlyMainContent":false}}
→ completed, 1 page, content keys present: ["markdown"]
```

No `html`, and no error saying the option had been ignored. Anyone who integrated against our own documentation could not select a crawl output format.

`lift_scrape_options` now hoists the nested keys onto the top level before deserializing, with an explicit top-level key winning. Every body that works today is untouched; this only repairs the ones written against the shape we published. `/v2/crawl` stays nested-only on purpose, since that is Firecrawl's only documented shape.

## The spec omitted real features and misdescribed real ones

- `screenshot` and `images` were missing from the formats enum, though both are `OutputFormat` variants
- `screenshotFullPage` was absent entirely
- `ScrapeResponse.data` omitted eleven fields the engine returns, including `screenshot`, `images`, `plainText`, `summary` and `changeTracking`
- `images` is now typed as `{url, alt?}[]`, which is what the engine emits, not bare strings
- `ScrapeOptions` was shared between search, crawl and batch while only describing search's four formats, so batch looked far narrower than it is and crawl looked wrong in the other direction
- two pre-existing errors in the same class corrected: the renderer enum omitted `camoufox`, and `renderDecision` was typed as a string although it serializes as a tagged object
- `nullable` replaced with 3.1 type arrays; the file declares 3.1.0, where `nullable` means nothing

The crawl formats enum is deliberately narrower than the scrape one: `run_crawl` runs extraction and the optional LLM `json` pass, but has no summary, screenshot or inline change-tracking orchestration, so advertising those would repeat the mistake in the other direction.

## Why CI never caught it

`check-openapi.sh` starts the binary and diffs `GET /openapi.json` against `docs/openapi.json`. The binary embeds that same file via `include_str!` and the two copies are byte-identical, so the check compares the file to itself. It can detect a stale copy, never code-vs-spec drift.

The real guard belongs beside the table checks that already derive wire keys from the Rust enums, which is why `docs/output-formats.md` was correct all along while the spec was not. `check-format-tables.sh` now also asserts:

1. the spec's `OutputFormat` enum matches the Rust enum
2. the formats arrays `$ref` that component instead of inlining a copy, so the values cannot drift apart again
3. the two spec files stay byte-identical

Verified it fails on each of those three drifts individually and passes after. The workflow's `paths:` filter was widened so a spec-only edit still runs it.

## Verification

- 5 unit tests on the lift (nested, flat, both-at-once, snake_case alias, null), mutation-tested: reverting the merge fails two of them
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `bash scripts/docs-guards.sh`, `bash scripts/check-format-tables.sh` all clean
- `cargo test --workspace` passes apart from `chrome_proxy_arm_fires_below_old_floor`, which is flaky under load and fails identically on a clean `main` checkout (2 of 3 runs pass in isolation). Unrelated to this change; worth its own look.

## Not in scope

- The 3.0 spec variant is a deliberately narrower hand-maintained subset. Only the same factual enum error is corrected there.
- `/v1/search` accepts formats its result envelope cannot carry (it only rejects `plainText` and `json`), so a request for e.g. `screenshot` is accepted and then dropped. Same silent-drop class, separate fix.

ref #346