### PR TITLE
fix(search): bound the per-result scrape budget for scrapeOptions

### DIFF
--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -747,6 +747,13 @@ pub struct ScrapeData {
     /// `success:false`. `None` (skipped when serializing) = not blocked.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block: Option<BlockOutcome>,
+    /// The renderer snapshotted a partial DOM because the navigation budget
+    /// elapsed (`FetchResult.truncated`). The content is usable but incomplete,
+    /// and a caller cannot otherwise tell it apart from a page that genuinely
+    /// has little content — which is what makes a shrinking scrape budget a
+    /// silent recall regression.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
 }
 
 impl ScrapeData {
@@ -992,6 +999,7 @@ mod tests {
                 vendor: "cloudflare".into(),
                 reason: "cloudflare challenge interstitial".into(),
             }),
+            truncated: false,
         };
         data.clear_body();
         // content-shell + LLM outputs cleared
@@ -1473,6 +1481,12 @@ pub struct SearchScrapeOptions {
     /// Populated by the SaaS layer from the caller's IP (geo-aware proxy). `None` = engine default.
     #[serde(default)]
     pub country: Option<String>,
+    /// Per-result scrape budget (ms). `None` = the search-enrichment default,
+    /// NOT the implicit full-ladder deadline a single `/v1/scrape` gets: search
+    /// waits for every result, so one straggler walking the whole renderer
+    /// ladder would stall the entire response. Must be in `(0, 60000]`.
+    #[serde(default)]
+    pub timeout: Option<u64>,
 }
 
 /// POST /v1/search request body. Mirrors the zod schema in
@@ -1614,6 +1628,13 @@ pub struct SearchResult {
     /// had no markdown". Absent on success — backward-compatible.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Set when the enrichment scrape returned a partial-DOM snapshot because
+    /// its budget elapsed (`ScrapeData.truncated`). Sibling of `error`: `error`
+    /// marks a total failure, this marks an incomplete success — without it a
+    /// budget-shortened render is indistinguishable from a thin page. Absent
+    /// (not `false`) when the scrape completed — backward-compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<bool>,
 }
 
 /// A single image result. Mirrors `ImageResult` in

--- a/crates/crw-core/tests/api_casing.rs
+++ b/crates/crw-core/tests/api_casing.rs
@@ -95,6 +95,7 @@ fn sample_scrape_data() -> ScrapeData {
         change_tracking: None,
         screenshot: Some("data:image/png;base64,AAAA".into()),
         block: None,
+        truncated: false,
     }
 }
 

--- a/crates/crw-core/tests/types_tests.rs
+++ b/crates/crw-core/tests/types_tests.rs
@@ -222,6 +222,7 @@ fn scrape_data_skip_serializing_none() {
         change_tracking: None,
         screenshot: None,
         block: None,
+        truncated: false,
     };
 
     let json = serde_json::to_value(&data).unwrap();
@@ -341,6 +342,7 @@ fn scrape_data_serializes_debug_extraction_as_camel_case() {
         change_tracking: None,
         screenshot: None,
         block: None,
+        truncated: false,
     };
     let v = serde_json::to_value(&data).unwrap();
     assert!(v.get("debugExtraction").is_none(), "absent when None");

--- a/crates/crw-crawl/src/pdf.rs
+++ b/crates/crw-crawl/src/pdf.rs
@@ -575,6 +575,8 @@ fn build_scrape_data(
         screenshot: None,
         // PDFs are the content, never an anti-bot shell.
         block: None,
+        // The PDF parser reads whole documents; there is no partial-DOM snapshot.
+        truncated: false,
     }
 }
 

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -694,6 +694,12 @@ async fn scrape_url_inner(
     // crawl path) can hash binary/non-text content rather than diff it.
     data.content_type = fetch_result.content_type.clone();
 
+    // A partial-DOM snapshot (navigation budget elapsed) extracts to usable but
+    // incomplete content. Carry the flag out so callers that bound the scrape
+    // budget — `/v1/search` enrichment above all — can observe truncation
+    // instead of mistaking it for a thin page.
+    data.truncated = fetch_result.truncated;
+
     // Wrap the raw base64 screenshot in a `data:image/png;base64,` URL exactly
     // once, here, so both v1 and v2 responses are identical (D8). FetchResult
     // keeps the raw b64.

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -949,6 +949,8 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         screenshot: None,
         // Anti-bot verdict is stamped post-extract at the scrape choke.
         block: None,
+        // Copied post-extract from FetchResult.truncated, same as content_type.
+        truncated: false,
     })
 }
 

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -453,6 +453,10 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
                         "onlyMainContent": {
                             "type": "boolean",
                             "description": "Strip nav/footer/ads (default true)"
+                        },
+                        "timeout": {
+                            "type": "integer",
+                            "description": "Per-result scrape budget, ms (default 15000, max 60000)"
                         }
                     }
                 }

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -4201,10 +4201,13 @@ mod tests {
     #[tokio::test]
     async fn chrome_proxy_arm_fires_below_old_floor() {
         // Regression lock for the budget-STARVATION bug: a non-CF hard block with
-        // only ~2s of request deadline left (real prod: the ladder burns a 15s
-        // scrape deadline to ~2s before the arm) must STILL fire chrome_proxy. The
-        // arm now runs on a fresh `Deadline::now_plus(ARM_BUDGET)`, so any floor
-        // against `deadline.remaining()` is gone. Old 8s-floor code fails here.
+        // only a sliver of request deadline left (real prod: the ladder burns a
+        // 15s scrape deadline down to ~2s before the arm) must STILL fire
+        // chrome_proxy. The arm now runs on a fresh `Deadline::now_plus(ARM_BUDGET)`,
+        // so any floor against `deadline.remaining()` is gone. Old 8s-floor code
+        // fails here — the budget below only has to stay under that floor, so it
+        // carries enough headroom to survive a loaded machine (a 2s budget made
+        // this flake ~1 run in 3 when the whole suite runs in parallel).
         let lp = Arc::new(MockFetcher {
             name: "lightpanda",
             behavior: MockBehavior::Ok(network_security_block_html()),
@@ -4231,13 +4234,13 @@ mod tests {
                 Some(true),
                 None,
                 Some("auto"),
-                crw_core::Deadline::from_request_ms(2_000),
+                crw_core::Deadline::from_request_ms(6_000),
             )
             .await
             .unwrap();
         assert!(
             result.html.contains("PROXY-"),
-            "chrome_proxy must fire even with ~2s deadline left (fresh arm budget), got: {}",
+            "chrome_proxy must fire well below the old 8s floor (fresh arm budget), got: {}",
             result.html
         );
     }

--- a/crates/crw-search/src/transform.rs
+++ b/crates/crw-search/src/transform.rs
@@ -80,6 +80,7 @@ fn to_search_result(r: &SearxngResult, position: u32) -> SearchResult {
         metadata: None,
         summary: None,
         error: None,
+        truncated: None,
     }
 }
 

--- a/crates/crw-server/openapi/openapi-3.0.json
+++ b/crates/crw-server/openapi/openapi-3.0.json
@@ -584,7 +584,7 @@
             }
           },
           "scrapeOptions": {
-            "$ref": "#/components/schemas/ScrapeOptions"
+            "$ref": "#/components/schemas/SearchScrapeOptions"
           }
         }
       },
@@ -641,6 +641,37 @@
             "items": {
               "$ref": "#/components/schemas/SearchResult"
             }
+          }
+        }
+      },
+      "SearchScrapeOptions": {
+        "type": "object",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "markdown",
+                "html",
+                "rawHtml",
+                "links"
+              ]
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Per-result scrape budget in ms. Default 15000. Search awaits every result, so this bounds the whole response; raise it for heavy JS pages.",
+            "minimum": 1,
+            "maximum": 60000,
+            "default": 15000
           }
         }
       },

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -955,7 +955,7 @@
             }
           },
           "scrapeOptions": {
-            "$ref": "#/components/schemas/ScrapeOptions"
+            "$ref": "#/components/schemas/SearchScrapeOptions"
           }
         }
       },
@@ -1012,6 +1012,37 @@
             "items": {
               "$ref": "#/components/schemas/SearchResult"
             }
+          }
+        }
+      },
+      "SearchScrapeOptions": {
+        "type": "object",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "markdown",
+                "html",
+                "rawHtml",
+                "links"
+              ]
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Per-result scrape budget in ms. Default 15000. Search awaits every result, so this bounds the whole response; raise it for heavy JS pages.",
+            "minimum": 1,
+            "maximum": 60000,
+            "default": 15000
           }
         }
       },

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -43,6 +43,58 @@ const SCOUT_FETCH_LIMIT: u32 = 6;
 /// `multi_round` adds.
 const MULTI_ROUND_MIN_BUDGET_MS: u64 = 20_000;
 
+/// Per-result scrape budget for search enrichment when the caller passes no
+/// `scrapeOptions.timeout`.
+///
+/// NOT `effective_deadline_ms(None, None)`: an implicit deadline auto-extends to
+/// the full renderer ladder (`http + lightpanda + chrome + 28s per CDP tier` —
+/// 92.5s on the docker config), which is the right budget for ONE `/v1/scrape`
+/// but not here: search waits for every result, so a single straggler walking
+/// the whole ladder stalls the entire response. 15s is the deadline this
+/// codebase already validated against the zero-byte-miss class
+/// (`config.docker.toml` `[request]`), and it leaves chrome its full
+/// `chrome_nav_budget_ms` whenever the HTTP prefetch is quick.
+const SEARCH_ENRICH_DEADLINE_MS: u64 = 15_000;
+
+/// Upper bound for a caller-supplied `scrapeOptions.timeout`. Matches the range
+/// documented on `ScrapeRequest.deadline_ms`; enforced here because search
+/// multiplies the budget across every result.
+const SEARCH_ENRICH_DEADLINE_MAX_MS: u64 = 60_000;
+
+/// Fold the C1-overlap prefetch outcomes into the final (reranked-over-union)
+/// pool. A successful prefetch hands over its content; a FAILED one hands over
+/// its error, which is what stops `enrich_with_scrape` from scraping that URL a
+/// second time and spending the per-result budget twice in one request.
+fn fold_prescraped(pool: &mut [SearchResult], prescraped: &[SearchResult]) {
+    let by_url: std::collections::HashMap<&str, &SearchResult> =
+        prescraped.iter().map(|r| (r.url.as_str(), r)).collect();
+    for r in pool.iter_mut() {
+        if r.metadata.is_some() {
+            continue;
+        }
+        let Some(src) = by_url.get(r.url.as_str()) else {
+            continue;
+        };
+        if src.metadata.is_some() {
+            r.markdown = src.markdown.clone();
+            r.html = src.html.clone();
+            r.raw_html = src.raw_html.clone();
+            r.links = src.links.clone();
+            r.metadata = src.metadata.clone();
+            r.truncated = src.truncated;
+        } else if src.error.is_some() {
+            r.error = src.error.clone();
+        }
+    }
+}
+
+/// Per-result scrape budget for one enrichment fan-out. Validated in
+/// [`validate_request`], so the caller value is already within
+/// `(0, SEARCH_ENRICH_DEADLINE_MAX_MS]` by the time it reaches here.
+fn enrich_deadline_ms(opts: &SearchScrapeOptions) -> u64 {
+    opts.timeout.unwrap_or(SEARCH_ENRICH_DEADLINE_MS)
+}
+
 /// Customer-facing text for "the backend could not answer", used both as the
 /// non-LLM error and as the LLM-path warning. A single constant because the
 /// multi-round leg has to be able to REMOVE it again by value when a later
@@ -381,23 +433,17 @@ pub async fn search_inner(
 
     // Phase C1: fold the original-results scrapes done during the overlap back
     // into the final (reranked-over-union) source set. Entries that match by URL
-    // get their scraped fields reused; enrich_with_scrape then skips them
-    // (metadata.is_some()) and only scrapes the URLs the expansion newly added.
-    if !prescraped.is_empty()
-        && let SearchData::Flat(v) = &mut data
-    {
-        let by_url: std::collections::HashMap<&str, &SearchResult> =
-            prescraped.iter().map(|r| (r.url.as_str(), r)).collect();
-        for r in v.iter_mut() {
-            if r.metadata.is_none()
-                && let Some(src) = by_url.get(r.url.as_str())
-                && src.metadata.is_some()
-            {
-                r.markdown = src.markdown.clone();
-                r.html = src.html.clone();
-                r.raw_html = src.raw_html.clone();
-                r.links = src.links.clone();
-                r.metadata = src.metadata.clone();
+    // get their scraped outcome reused; enrich_with_scrape then skips them and
+    // only scrapes the URLs the expansion newly added. Grouped responses fold
+    // too — the prefetch pool is flat either way, and skipping the fold there
+    // would scrape those URLs a second time on the same request.
+    if !prescraped.is_empty() {
+        match &mut data {
+            SearchData::Flat(v) => fold_prescraped(v, &prescraped),
+            SearchData::Grouped(g) => {
+                if let Some(web) = g.web.as_mut() {
+                    fold_prescraped(web, &prescraped);
+                }
             }
         }
     }
@@ -1077,6 +1123,14 @@ fn validate_request(req: &SearchRequest, max_limit: u32) -> Result<(), CrwError>
                 )));
             }
         }
+        if let Some(t) = opts.timeout
+            && (t == 0 || t > SEARCH_ENRICH_DEADLINE_MAX_MS)
+        {
+            return Err(CrwError::InvalidRequest(format!(
+                "scrapeOptions.timeout must be between 1 and \
+                 {SEARCH_ENRICH_DEADLINE_MAX_MS} ms (got {t})"
+            )));
+        }
     }
     Ok(())
 }
@@ -1201,9 +1255,11 @@ async fn enrich_with_scrape(
     // Validate each URL and remember which slot it came from.
     let mut jobs: Vec<(usize, String)> = Vec::new();
     for (idx, r) in targets.iter().enumerate() {
-        // C1 overlap: a slot already enriched by the original-results prefetch
-        // (metadata set by apply_scrape_to_result) is reused, not re-scraped.
-        if r.metadata.is_some() {
+        // C1 overlap: a slot already handled by the original-results prefetch is
+        // reused, not re-scraped — whether it succeeded (metadata set by
+        // apply_scrape_to_result) or failed (error set). Re-scraping a failure
+        // here would spend the per-result budget twice in one request.
+        if r.metadata.is_some() || r.error.is_some() {
             continue;
         }
         let parsed = match url::Url::parse(&r.url) {
@@ -1240,7 +1296,7 @@ async fn enrich_with_scrape(
         let default_stealth =
             state.config.crawler.stealth.enabled && state.config.crawler.stealth.inject_headers;
         let render_js_default = state.config.renderer.render_js_default;
-        let deadline_ms = state.config.effective_deadline_ms(None, None);
+        let deadline_ms = enrich_deadline_ms(opts);
         let permit_src = semaphore.clone();
 
         // Deliberately NOT scoped to `ScrapeClass::Batch`: `/v1/search` is a
@@ -1347,6 +1403,9 @@ fn apply_scrape_to_result(slot: &mut SearchResult, data: ScrapeData, formats: &[
     if formats.contains(&OutputFormat::Links) {
         slot.links = data.links;
     }
+    if data.truncated {
+        slot.truncated = Some(true);
+    }
     slot.metadata = Some(data.metadata);
 }
 
@@ -1354,6 +1413,106 @@ fn apply_scrape_to_result(slot: &mut SearchResult, data: ScrapeData, formats: &[
 mod tests {
     use super::*;
     use crw_core::types::SearchSource;
+
+    fn scrape_opts(timeout: Option<u64>) -> SearchScrapeOptions {
+        SearchScrapeOptions {
+            formats: vec![OutputFormat::Markdown],
+            only_main_content: true,
+            country: None,
+            timeout,
+        }
+    }
+
+    #[test]
+    fn enrichment_deadline_is_bounded_not_the_renderer_ladder() {
+        // Regression pin: enrichment must NOT inherit the implicit full-ladder
+        // deadline (`effective_deadline_ms(None, None)` — 92.5s on the docker
+        // renderer config). Search waits for every result, so one straggler
+        // walking the ladder stalls the whole response.
+        // Prod raises the implicit budget to 60s and the ladder extension takes
+        // it to ~92.5s; the enrichment budget must be independent of both.
+        let cfg: crw_core::config::AppConfig =
+            toml::from_str("[request]\ndeadline_ms_default = 60000\n").expect("config parses");
+        assert_eq!(cfg.effective_deadline_ms(None, None), 60_000);
+        assert_eq!(enrich_deadline_ms(&scrape_opts(None)), 15_000);
+    }
+
+    #[test]
+    fn truncated_render_is_marked_on_the_result() {
+        // A budget-shortened render still returns content, so without this flag
+        // it is indistinguishable from a page that genuinely has little text —
+        // which is what would make a tightened budget a silent recall loss.
+        let mut slot = bare_result("https://example.com/a");
+        let mut data: ScrapeData = serde_json::from_value(serde_json::json!({
+            "markdown": "# partial",
+            "metadata": {"sourceURL": "https://example.com/a", "statusCode": 200, "elapsedMs": 1}
+        }))
+        .expect("valid scrape data");
+        data.truncated = true;
+        apply_scrape_to_result(&mut slot, data, &[OutputFormat::Markdown]);
+        assert_eq!(slot.truncated, Some(true));
+
+        let mut slot = bare_result("https://example.com/b");
+        let data: ScrapeData = serde_json::from_value(serde_json::json!({
+            "markdown": "# whole",
+            "metadata": {"sourceURL": "https://example.com/b", "statusCode": 200, "elapsedMs": 1}
+        }))
+        .expect("valid scrape data");
+        apply_scrape_to_result(&mut slot, data, &[OutputFormat::Markdown]);
+        assert_eq!(slot.truncated, None);
+    }
+
+    fn bare_result(url: &str) -> SearchResult {
+        serde_json::from_value(serde_json::json!({
+            "url": url, "title": "t", "description": "d", "position": 1
+        }))
+        .expect("valid result")
+    }
+
+    #[test]
+    fn prefetch_outcomes_fold_back_into_the_final_pool() {
+        let mut ok = bare_result("https://example.com/ok");
+        ok.markdown = Some("# ok".into());
+        ok.truncated = Some(true);
+        ok.metadata = Some(
+            serde_json::from_value(serde_json::json!({
+                "sourceURL": "https://example.com/ok", "statusCode": 200, "elapsedMs": 1
+            }))
+            .expect("valid metadata"),
+        );
+        let mut failed = bare_result("https://example.com/failed");
+        failed.error = Some("Timeout after 15000ms".into());
+
+        let mut pool = vec![
+            bare_result("https://example.com/ok"),
+            bare_result("https://example.com/failed"),
+            bare_result("https://example.com/fresh"),
+        ];
+        fold_prescraped(&mut pool, &[ok, failed]);
+
+        assert_eq!(pool[0].markdown.as_deref(), Some("# ok"));
+        // A truncated prefetch must not lose its marker on the way through.
+        assert_eq!(pool[0].truncated, Some(true));
+        // A failed prefetch carries its error, which is what makes
+        // `enrich_with_scrape` skip it instead of paying the budget twice.
+        assert!(pool[1].error.is_some() && pool[1].metadata.is_none());
+        // A URL the expansion newly added is untouched and still gets scraped.
+        assert!(pool[2].error.is_none() && pool[2].metadata.is_none());
+    }
+
+    #[test]
+    fn scrape_options_timeout_range_is_validated() {
+        let req = |timeout: Option<u64>| {
+            let json = serde_json::json!({"query": "q", "scrapeOptions": {}});
+            let mut r: SearchRequest = serde_json::from_value(json).expect("valid request");
+            r.scrape_options = Some(scrape_opts(timeout));
+            r
+        };
+        assert!(validate_request(&req(Some(15_000)), 20).is_ok());
+        assert!(validate_request(&req(None), 20).is_ok());
+        assert!(validate_request(&req(Some(0)), 20).is_err());
+        assert!(validate_request(&req(Some(60_001)), 20).is_err());
+    }
 
     #[test]
     fn block_shell_detected_but_not_real_articles() {

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -338,6 +338,7 @@ mod tests {
             change_tracking: None,
             screenshot: None,
             block: None,
+            truncated: false,
         }
     }
 

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -345,6 +345,7 @@ mod tests {
             change_tracking: None,
             screenshot: None,
             block: None,
+            truncated: false,
         };
         to_v2_document(data, "basic", "id".into())
     }

--- a/crates/crw-server/tests/mcp.rs
+++ b/crates/crw-server/tests/mcp.rs
@@ -721,6 +721,7 @@ fn real_search_result(idx: u32) -> SearchResult {
         metadata: None,
         summary: None,
         error: None,
+        truncated: None,
     }
 }
 

--- a/crates/crw-server/tests/search_enrichment_deadline.rs
+++ b/crates/crw-server/tests/search_enrichment_deadline.rs
@@ -1,0 +1,165 @@
+//! `/v1/search` + `scrapeOptions` per-result scrape budget.
+//!
+//! The enrichment fan-out used to hand every result the IMPLICIT request
+//! deadline, which auto-extends to the whole renderer ladder (92.5s on the
+//! docker renderer config). Search waits for every result, so one straggler
+//! walking that ladder stalled the entire response. The budget is now bounded
+//! and caller-overridable via `scrapeOptions.timeout`.
+//!
+//! These tests pin the HTTP-only tier deliberately: it is the only tier where
+//! an elapsed budget surfaces as an `Err` (its reqwest client is built with
+//! `.timeout(deadline.remaining())`), so "no markdown + `error` set" is the
+//! guaranteed outcome. A CDP tier would instead return `Ok` with a partial DOM.
+
+use axum_test::TestServer;
+use crw_core::config::AppConfig;
+use crw_server::app::create_app;
+use crw_server::state::AppState;
+use serde_json::{Value, json};
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The enrichment scrape resolves the result URL, so loopback has to be allowed.
+fn allow_loopback() {
+    // SAFETY: test-only env opt-in, set before the server handles any request.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    }
+}
+
+fn test_app(searxng_url: &str) -> TestServer {
+    let toml = format!(
+        r#"
+[search]
+enabled = true
+searxng_url = "{searxng_url}"
+timeout_ms = 5000
+
+[request]
+# Prod-shaped: an implicit deadline would be 60s, far past any of the budgets
+# asserted below — so a regression to the old behaviour fails these tests.
+deadline_ms_default = 60000
+"#
+    );
+    let config: AppConfig = toml::from_str(&toml).unwrap();
+    let state = AppState::new(config).expect("AppState::new failed");
+    TestServer::new(create_app(state))
+}
+
+/// SearXNG stub returning a single result that points back at `page_url`.
+async fn mock_searxng_and_page(page_delay: Duration) -> MockServer {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(page_delay)
+                .set_body_string("<html><body><article>hello from the page</article></body></html>")
+                .insert_header("content-type", "text/html"),
+        )
+        .mount(&mock)
+        .await;
+    let page_url = format!("{}/slow", mock.uri());
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "query": "q",
+            "number_of_results": 1,
+            "results": [{
+                "url": page_url,
+                "title": "slow page",
+                "engine": "google",
+                "content": "snippet",
+                "score": 1.0,
+                "category": "general",
+                "template": "default.html"
+            }],
+            "answers": [], "corrections": [], "infoboxes": [],
+            "suggestions": [], "unresponsive_engines": []
+        })))
+        .mount(&mock)
+        .await;
+    mock
+}
+
+#[tokio::test]
+async fn enrichment_scrape_is_cut_at_the_caller_budget() {
+    allow_loopback();
+    let mock = mock_searxng_and_page(Duration::from_millis(2_000)).await;
+    let server = test_app(&mock.uri());
+
+    let started = std::time::Instant::now();
+    let resp = server
+        .post("/v1/search")
+        .json(&json!({
+            "query": "q",
+            "limit": 1,
+            "scrapeOptions": {"formats": ["markdown"], "timeout": 300}
+        }))
+        .await;
+    let elapsed = started.elapsed();
+    resp.assert_status_ok();
+
+    let body: Value = resp.json();
+    let results = body["data"]["results"].as_array().expect("flat results");
+    assert_eq!(results.len(), 1);
+    // Budget elapsed → no content, and the failure is visible on the result
+    // rather than looking like a page that simply had no markdown.
+    assert!(results[0]["markdown"].is_null(), "{:?}", results[0]);
+    assert!(!results[0]["error"].is_null(), "{:?}", results[0]);
+    // The snippet survives, so the result itself is not lost.
+    assert_eq!(results[0]["description"], "snippet");
+    assert!(
+        elapsed < Duration::from_millis(2_000),
+        "search waited for the whole page instead of its budget: {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn caller_timeout_raises_the_budget() {
+    allow_loopback();
+    let mock = mock_searxng_and_page(Duration::from_millis(300)).await;
+    let server = test_app(&mock.uri());
+
+    let resp = server
+        .post("/v1/search")
+        .json(&json!({
+            "query": "q",
+            "limit": 1,
+            "scrapeOptions": {"formats": ["markdown"], "timeout": 10_000}
+        }))
+        .await;
+    resp.assert_status_ok();
+
+    let body: Value = resp.json();
+    let results = body["data"]["results"].as_array().expect("flat results");
+    let markdown = results[0]["markdown"].as_str().unwrap_or_default();
+    assert!(
+        markdown.contains("hello from the page"),
+        "expected scraped content, got {:?}",
+        results[0]
+    );
+    assert!(results[0]["truncated"].is_null(), "{:?}", results[0]);
+}
+
+#[tokio::test]
+async fn out_of_range_timeout_is_rejected() {
+    let mock = MockServer::start().await;
+    let server = test_app(&mock.uri());
+    for bad in [0u64, 60_001] {
+        let resp = server
+            .post("/v1/search")
+            .json(&json!({
+                "query": "q",
+                "scrapeOptions": {"formats": ["markdown"], "timeout": bad}
+            }))
+            .await;
+        assert_eq!(
+            resp.status_code(),
+            400,
+            "timeout {bad} should be rejected, got {}",
+            resp.text()
+        );
+    }
+}

--- a/docs/openapi-3.0.json
+++ b/docs/openapi-3.0.json
@@ -584,7 +584,7 @@
             }
           },
           "scrapeOptions": {
-            "$ref": "#/components/schemas/ScrapeOptions"
+            "$ref": "#/components/schemas/SearchScrapeOptions"
           }
         }
       },
@@ -641,6 +641,37 @@
             "items": {
               "$ref": "#/components/schemas/SearchResult"
             }
+          }
+        }
+      },
+      "SearchScrapeOptions": {
+        "type": "object",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "markdown",
+                "html",
+                "rawHtml",
+                "links"
+              ]
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Per-result scrape budget in ms. Default 15000. Search awaits every result, so this bounds the whole response; raise it for heavy JS pages.",
+            "minimum": 1,
+            "maximum": 60000,
+            "default": 15000
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -955,7 +955,7 @@
             }
           },
           "scrapeOptions": {
-            "$ref": "#/components/schemas/ScrapeOptions"
+            "$ref": "#/components/schemas/SearchScrapeOptions"
           }
         }
       },
@@ -1012,6 +1012,37 @@
             "items": {
               "$ref": "#/components/schemas/SearchResult"
             }
+          }
+        }
+      },
+      "SearchScrapeOptions": {
+        "type": "object",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "markdown",
+                "html",
+                "rawHtml",
+                "links"
+              ]
+            },
+            "default": [
+              "markdown"
+            ]
+          },
+          "onlyMainContent": {
+            "type": "boolean",
+            "default": true
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Per-result scrape budget in ms. Default 15000. Search awaits every result, so this bounds the whole response; raise it for heavy JS pages.",
+            "minimum": 1,
+            "maximum": 60000,
+            "default": 15000
           }
         }
       },


### PR DESCRIPTION
## Problem

`POST /v1/search` with `scrapeOptions` has a 30-90s tail. Measured on prod
2026-07-22: the same query at limit=5 ran 32-36s twice in a row, while the same
result URLs scraped as separate parallel `/v1/scrape` calls finished in 6.5s
wall clock.

The fan-out was never the problem: it is a `Semaphore(crawler.max_concurrency)`
+ `JoinSet` and it does run concurrently. The per-result **budget** was.
`enrich_with_scrape` built each scrape with an implicit deadline, and an
implicit deadline auto-extends to the full renderer ladder:

```
http 4000 + lightpanda 2500 + chrome 30000 + 2 CDP tiers x 28000 = 92_500 ms
```

That is the right budget for a single `/v1/scrape`. It is the wrong one here:
`/v1/search` awaits every result, so one straggler walking the ladder stalls the
entire response. For comparison, a standalone scrape through the SaaS is capped
at 5s, which is why the two paths looked "7x apart" on the same URLs.

## Change

- Per-result budget is now **15s**, independent of `request.deadline_ms_default`
  and of the ladder. 15s is the deadline `config.docker.toml` already documents
  as the one that recovered the zero-byte-miss class on the 150-URL diagnose
  bench, so it is not a new number.
- New **`scrapeOptions.timeout`** (1..=60000) raises it per request, for callers
  with genuinely slow pages. Exposed on the `crw_search` MCP tool and on a
  search-specific OpenAPI schema, so the crawl schema keeps its own shape.
- `ScrapeData` / `SearchResult` now carry **`truncated`**. A budget-shortened
  render still returns content, and without this flag it is indistinguishable
  from a page that genuinely has little text — which is what would make a
  tightened budget a silent recall regression.
- The C1-overlap prefetch now folds its outcome back for **failures too**, and
  for grouped (`sources`) responses. A failed prefetch was previously re-scraped
  by the main enrichment pass, spending the per-result budget twice in one
  request.
- Separate commit: the `chrome_proxy` arm regression test ran on a 2s wall-clock
  deadline and failed roughly one run in three under full-parallel `cargo test`.
  Raised to 6s, still well below the 8s floor it exists to lock.

## Trade-off, stated plainly

Pages that legitimately need more than 15s of ladder — heavy SPAs, gov/legal
portals (`config.rs` documents 30-40s for `networkidle`) — will now come back
empty or truncated inside a search response where they previously might have
arrived after ~90s. Callers who need them pass `scrapeOptions.timeout`. Anti-bot
pages are unaffected: the `chrome_proxy` recovery arm deliberately runs on its
own fresh 12s budget and is not gated on the shared deadline.

Measured content parity on prod before the change: 5 result URLs scraped at the
default budget and at 60s returned byte-identical markdown lengths (6143 /
11883 / 5270 / 32117 / 872809 chars), and a 5/8/10/15/20s sweep on the largest
page never shortened the output.

## Tests

- `crates/crw-server/tests/search_enrichment_deadline.rs`: a page slower than
  the budget comes back with no markdown and `error` set, in ~the budget, not
  the page's own time; the caller override is honoured; out-of-range timeouts
  are rejected. Pinned to the HTTP-only tier, the only tier where an elapsed
  budget surfaces as an `Err`.
- Unit tests: the default budget is independent of the configured request
  deadline; prefetch outcomes (success, failure, truncation) fold back
  correctly; `apply_scrape_to_result` marks a truncated render.
- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`,
  `cargo test --workspace` (1412 tests) green.

## Notes

- `/v2/search` shares `search_inner`, so its per-scrape behaviour changes too;
  its request/response shape does not.
- Docker images build only on releases, so merging this is not live on prod
  until the next release-please release.