### PR TITLE
fix(openapi): re-sync the docs copy of the 3.0 spec

### DIFF
--- a/docs/openapi-3.0.json
+++ b/docs/openapi-3.0.json
@@ -814,9 +814,11 @@
                 "rawHtml",
                 "plainText",
                 "links",
+                "images",
                 "json",
                 "summary",
-                "changeTracking"
+                "changeTracking",
+                "screenshot"
               ]
             },
             "default": [
@@ -847,6 +849,11 @@
           "judgeEnabled": {
             "type": "boolean",
             "description": "Run the LLM meaningful-change judge on a changed page (requires goal)"
+          },
+          "screenshotFullPage": {
+            "type": "boolean",
+            "default": false,
+            "description": "Capture the whole page rather than the viewport, for `formats: [\"screenshot\"]`."
           }
         }
       },


### PR DESCRIPTION
Follow-up to #350, which turned main red.

There are two spec pairs, not one: `openapi.json` and `openapi-3.0.json`, each with a docs-site copy and a crate copy that must stay byte-identical. #350 kept the 3.1 pair in sync but corrected only the crate copy of the 3.0 spec, so `docs/openapi-3.0.json` drifted and `preflight.py` failed on main.

Straight re-sync, no other change. `python scripts/release/preflight.py` passes locally.

Worth noting the guard added in #350 checks the 3.1 pair for exactly this; preflight already covers the 3.0 pair, which is why it caught this one.