### PR TITLE
fix(search): thin-HTML, DNS, and scout follow-ups from the enrichment latency work

### DIFF
--- a/crates/crw-core/src/url_safety.rs
+++ b/crates/crw-core/src/url_safety.rs
@@ -100,11 +100,31 @@ pub async fn validate_safe_url_resolved(url: &url::Url) -> Result<(), String> {
     let port = url
         .port_or_known_default()
         .ok_or_else(|| "URL has no resolvable port".to_string())?;
-    let addrs = tokio::net::lookup_host((stripped, port))
-        .await
-        .map_err(|_| "DNS resolution failed".to_string())?;
+    // Bound the lookup. `lookup_host` inherits the OS resolver's own retry
+    // behaviour, which against a stalled or blackholed nameserver can hang for
+    // tens of seconds — long past any route backstop. This is the single choke
+    // point every SSRF caller routes through, so bounding it here covers the ~14
+    // callers that have no request-scoped timeout of their own; the two that do
+    // (crw-crawl seed + BFS) keep winning since the tighter timeout applies.
+    // Fails CLOSED: an elapsed lookup maps to the same rejection a resolver error
+    // already produces.
+    let addrs = tokio::time::timeout(
+        DNS_RESOLVE_TIMEOUT,
+        tokio::net::lookup_host((stripped, port)),
+    )
+    .await
+    .map_err(|_| "DNS resolution timed out".to_string())?
+    .map_err(|_| "DNS resolution failed".to_string())?;
     validate_resolved_ips(addrs.map(|addr| addr.ip()))
 }
+
+/// Upper bound on a single SSRF DNS resolution. Purpose is to bound a stalled /
+/// blackholed resolver, not to race a slow-but-working one: recall is the hard
+/// invariant, so this sits high enough (8s) to still resolve a legitimate host
+/// behind a CNAME chain or a slow authoritative server that needs a UDP retry,
+/// while staying under the search enrichment per-result budget. Two orders of
+/// magnitude above a healthy lookup (tens of ms).
+const DNS_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
 
 /// Synchronous resolved validation for places that cannot await, notably
 /// reqwest's redirect-policy callback. Keep use narrow; it performs DNS on the
@@ -309,5 +329,17 @@ mod tests {
         assert!(validate_safe_url_blocking_resolved(&url("http://169.254.169.254")).is_err());
         assert!(validate_safe_url_blocking_resolved(&url("http://127.0.0.1")).is_err());
         assert!(validate_safe_url_blocking_resolved(&url("http://[::1]")).is_err());
+    }
+
+    #[tokio::test]
+    async fn resolution_fails_closed_and_bounded() {
+        // `.invalid` is reserved (RFC 6761) and never resolves. The result must be
+        // a fail-closed `Err`, and it must return in well under the DNS timeout
+        // (proving the wrapper doesn't hang the caller). NXDOMAIN returns fast; the
+        // bound here only asserts we never sit past the timeout.
+        let start = std::time::Instant::now();
+        let res = validate_safe_url_resolved(&url("https://nonexistent.invalid")).await;
+        assert!(res.is_err());
+        assert!(start.elapsed() < DNS_RESOLVE_TIMEOUT + std::time::Duration::from_secs(1));
     }
 }

--- a/crates/crw-renderer/src/detector.rs
+++ b/crates/crw-renderer/src/detector.rs
@@ -13,8 +13,9 @@ pub fn needs_js_rendering(html: &str) -> bool {
     // and the <body> may start well beyond 50KB. Every fixed-cap prefix slice of the
     // page HTML here goes through `floor_char_boundary`: a page longer than the cap
     // can straddle it with a multibyte char, and slicing mid-char panics.
+    let was_truncated = html.len() > 500_000;
     let lower = html[..html.floor_char_boundary(500_000)].to_lowercase();
-    let body_len = extract_body_text_len(&lower);
+    let body_len = extract_body_text_len(&lower, was_truncated);
 
     // Very short body text + presence of JS framework indicators.
     // After stripping script/style, most SPA shells have very little actual text.
@@ -109,7 +110,9 @@ pub fn looks_like_generic_bot_wall(html: &str) -> bool {
     // small `{"error":"access_denied"}` payload would trip an existing phrase.
     // The 600-char cap below still guards against real articles.
     let body_stripped = if lower.contains("<body") {
-        body_html_without_scripts_lower(&lower)
+        // This fn already bailed above for `html.len() > 80_000`, so the input is
+        // never truncated at the 500 KB cap: `was_truncated = false`.
+        body_html_without_scripts_lower(&lower, false)
     } else if lower.contains("<html") || lower.contains("<!doctype html") {
         strip_tag_blocks(&strip_tag_blocks(&lower, "script"), "style")
     } else {
@@ -224,8 +227,9 @@ pub fn looks_like_vendor_block(html: &str) -> Option<&'static str> {
 /// on raw markup, looking for framework shells. This one is purely about
 /// outcome — does the page have *any* content for an extractor to chew on.
 pub fn looks_like_thin_html(html: &str) -> bool {
+    let was_truncated = html.len() > 500_000;
     let lower = html[..html.floor_char_boundary(500_000)].to_lowercase();
-    extract_body_text_len(&lower) < 200
+    extract_body_text_len(&lower, was_truncated) < 200
 }
 
 /// Would a headless browser plausibly reveal MORE content than the raw HTTP
@@ -382,7 +386,8 @@ pub fn looks_like_loading_placeholder(html: &str) -> bool {
         return false;
     }
     let lower = html.to_lowercase();
-    let body_stripped = body_html_without_scripts_lower(&lower);
+    // Bailed above for `html.len() > 80_000`, so never truncated at the 500 KB cap.
+    let body_stripped = body_html_without_scripts_lower(&lower, false);
     let body_text = visible_text_from_stripped_html(&body_stripped);
     let body_text_len = body_text.chars().filter(|c| !c.is_whitespace()).count();
 
@@ -430,11 +435,22 @@ pub fn looks_like_loading_placeholder(html: &str) -> bool {
 /// Return the `<body>` of a lowercased HTML document with `<script>` and
 /// `<style>` blocks removed. Remaining tags (and their attributes) are
 /// preserved. Returns an empty string if no `<body>` is found.
-fn body_html_without_scripts_lower(lower: &str) -> String {
+fn body_html_without_scripts_lower(lower: &str, was_truncated: bool) -> String {
     let body_start = lower
         .find("<body")
         .and_then(|i| lower[i..].find('>').map(|j| i + j + 1));
-    let body_end = lower.rfind("</body>");
+    // A missing `</body>` means two different things. On a page that was cut at
+    // the 500 KB scan cap, the tag simply sits past the cut and the real body
+    // text is right here in the slice — measuring to the end of the slice is
+    // correct (a 1.8 MB article was being called "thin" and needlessly escalated
+    // to Chrome). On a NON-truncated page, a missing `</body>` is a genuinely
+    // malformed / mid-stream-truncated response, and treating it as thin so it
+    // escalates to a fresh render is the right recovery — keep that.
+    let body_end = match lower.rfind("</body>") {
+        Some(end) => Some(end),
+        None if was_truncated => Some(lower.len()),
+        None => None,
+    };
 
     let body = match (body_start, body_end) {
         (Some(start), Some(end)) if start < end => &lower[start..end],
@@ -474,11 +490,11 @@ fn visible_text_from_stripped_html(stripped: &str) -> String {
 /// Rough estimate of non-whitespace text length inside `<body>` of a
 /// lowercased HTML document. Returns `1000` as a "probably has content"
 /// fallback if no `<body>` is found.
-fn extract_body_text_len(lower: &str) -> usize {
+fn extract_body_text_len(lower: &str, was_truncated: bool) -> usize {
     if !lower.contains("<body") {
         return 1000;
     }
-    let stripped = body_html_without_scripts_lower(lower);
+    let stripped = body_html_without_scripts_lower(lower, was_truncated);
     visible_text_from_stripped_html(&stripped)
         .chars()
         .filter(|c| !c.is_whitespace())

--- a/crates/crw-renderer/tests/detector_tests.rs
+++ b/crates/crw-renderer/tests/detector_tests.rs
@@ -170,6 +170,30 @@ fn thin_html_substantive_page_not_thin() {
 }
 
 #[test]
+fn thin_html_large_page_past_500kb_is_not_thin() {
+    // Regression: a >500 KB content-rich page (e.g. a long Wikipedia article) was
+    // truncated at the 500 KB scan cap, its `</body>` fell past the cut, and the
+    // whole body text was discarded → falsely "thin" → needless Chrome escalation.
+    // The real body text sits inside the slice; it must be measured, not dropped.
+    let article = "<p>Real article prose about a real topic. </p>".repeat(30_000);
+    let html = format!("<html><body><article>{article}</article></body></html>");
+    assert!(html.len() > 500_000, "fixture must exceed the scan cap");
+    assert!(!looks_like_thin_html(&html));
+    // The same shared helper backs needs_js_rendering; it must not misfire either.
+    assert!(!needs_js_rendering(&html));
+}
+
+#[test]
+fn thin_html_short_truncated_page_still_thin() {
+    // A genuinely short page with no `</body>` (mid-stream cut / malformed) is NOT
+    // large, so it stays "thin" and escalates to a fresh render for recovery —
+    // the was_truncated guard must not flip this case.
+    let html = "<html><body><article>Some opening text that never closes";
+    assert!(html.len() < 500_000);
+    assert!(looks_like_thin_html(html));
+}
+
+#[test]
 fn bot_wall_scanpy_style() {
     let html = r#"<html><body><h1>Performing security verification</h1><p>This page checks your browser.</p></body></html>"#;
     assert!(looks_like_generic_bot_wall(html));

--- a/crates/crw-server/src/routes/extract.rs
+++ b/crates/crw-server/src/routes/extract.rs
@@ -165,31 +165,36 @@ pub(crate) async fn prepare_extract(
         ));
     }
 
-    // Per-URL preflight in original order. Bad parse / SSRF failures become
-    // `failed` results (surfaced, not dropped); valid URLs are enqueued.
-    let mut entries = Vec::with_capacity(req.urls.len());
-    let mut valid_count = 0usize;
-    for u in &req.urls {
-        match url::Url::parse(u) {
-            Ok(parsed) => match crw_core::url_safety::validate_safe_url_resolved(&parsed).await {
-                Ok(()) => {
-                    valid_count += 1;
-                    entries.push(PreparedUrl {
+    // Per-URL preflight. Each SSRF check does a DNS lookup, so a serial loop over
+    // up to `max_extract_urls` (50) URLs added tens of seconds of cold DNS before
+    // any extraction started. Validate concurrently; `join_all` preserves order,
+    // which the response relies on (`entries` align 1:1 with `req.urls`). Bad
+    // parse / SSRF failures become `failed` results (surfaced, not dropped).
+    let entries: Vec<PreparedUrl> =
+        futures::future::join_all(req.urls.iter().map(|u| async move {
+            match url::Url::parse(u) {
+                Ok(parsed) => match crw_core::url_safety::validate_safe_url_resolved(&parsed).await
+                {
+                    Ok(()) => PreparedUrl {
                         url: u.clone(),
                         preflight_error: None,
-                    });
-                }
-                Err(e) => entries.push(PreparedUrl {
+                    },
+                    Err(e) => PreparedUrl {
+                        url: u.clone(),
+                        preflight_error: Some(e),
+                    },
+                },
+                Err(e) => PreparedUrl {
                     url: u.clone(),
-                    preflight_error: Some(e),
-                }),
-            },
-            Err(e) => entries.push(PreparedUrl {
-                url: u.clone(),
-                preflight_error: Some(format!("invalid URL: {e}")),
-            }),
-        }
-    }
+                    preflight_error: Some(format!("invalid URL: {e}")),
+                },
+            }
+        }))
+        .await;
+    let valid_count = entries
+        .iter()
+        .filter(|e| e.preflight_error.is_none())
+        .count();
     if valid_count == 0 {
         return Err(CrwError::InvalidRequest(
             "no valid URLs to extract (all failed URL parsing or the SSRF safety check)".into(),

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -175,6 +175,20 @@ fn is_block_shell(md: &str) -> bool {
     .any(|p| l.contains(p))
 }
 
+/// Drop rows whose URL is already in the flat pool. Used to skip re-scraping a
+/// scout result the answer pool already holds. Recall-safe: `merge_scraped` would
+/// discard these same rows anyway (it dedups by URL), and nothing on this path
+/// re-scrapes for fresher content — this just avoids paying for the scrape first.
+fn drop_known_urls(data: &SearchData, rows: Vec<SearchResult>) -> Vec<SearchResult> {
+    let SearchData::Flat(pool) = data else {
+        return rows;
+    };
+    let seen: std::collections::HashSet<&str> = pool.iter().map(|r| r.url.as_str()).collect();
+    rows.into_iter()
+        .filter(|r| !seen.contains(r.url.as_str()))
+        .collect()
+}
+
 /// Merge freshly-scraped scout rows into the flat answer pool (dedup by URL,
 /// only rows that actually carry markdown). Returns true if any were added.
 /// Grouped data (the explicit-`sources` path) is left untouched — multi-round
@@ -653,7 +667,18 @@ pub async fn search_inner(
                                             SCOUT_FETCH_LIMIT,
                                             state.config.search.rerank_relevance,
                                         );
-                                        let mut sd = SearchData::Flat(extra);
+                                        // Drop scout results already in the pool
+                                        // BEFORE scraping. merge_scraped only dedups
+                                        // AFTER the scrape, so a URL from round 1 (or
+                                        // returned by both scout queries — the pool
+                                        // has grown by iteration 2) would otherwise be
+                                        // scraped again and its result discarded,
+                                        // paying the per-result budget for nothing.
+                                        let fresh = drop_known_urls(&data, extra);
+                                        if fresh.is_empty() {
+                                            continue;
+                                        }
+                                        let mut sd = SearchData::Flat(fresh);
                                         let _ = enrich_with_scrape(&mut sd, opts, state).await;
                                         if let SearchData::Flat(rows) = sd {
                                             grew |= merge_scraped(&mut data, rows);
@@ -1253,27 +1278,40 @@ async fn enrich_with_scrape(
     }
 
     // Validate each URL and remember which slot it came from.
-    let mut jobs: Vec<(usize, String)> = Vec::new();
-    for (idx, r) in targets.iter().enumerate() {
+    // Each `validate_safe_url_resolved` does a DNS lookup; running them serially
+    // added up to ~max_limit cold lookups (~9s at limit 20) on the critical path
+    // before any scrape could start. SERP results are diverse domains, so this is
+    // the common case, not the worst case. Validate concurrently instead — N is
+    // bounded by `max_limit` (≤20), so `join_all` needs no width cap, and it
+    // preserves order (irrelevant here since each job carries its own `idx`).
+    let candidates: Vec<(usize, url::Url, String)> = targets
+        .iter()
+        .enumerate()
         // C1 overlap: a slot already handled by the original-results prefetch is
         // reused, not re-scraped — whether it succeeded (metadata set by
         // apply_scrape_to_result) or failed (error set). Re-scraping a failure
         // here would spend the per-result budget twice in one request.
-        if r.metadata.is_some() || r.error.is_some() {
-            continue;
-        }
-        let parsed = match url::Url::parse(&r.url) {
-            Ok(u) => u,
-            Err(_) => continue,
-        };
-        if crw_core::url_safety::validate_safe_url_resolved(&parsed)
-            .await
-            .is_err()
-        {
-            continue;
-        }
-        jobs.push((idx, r.url.clone()));
-    }
+        .filter(|(_, r)| r.metadata.is_none() && r.error.is_none())
+        .filter_map(|(idx, r)| {
+            url::Url::parse(&r.url)
+                .ok()
+                .map(|parsed| (idx, parsed, r.url.clone()))
+        })
+        .collect();
+    let jobs: Vec<(usize, String)> = futures::future::join_all(candidates.into_iter().map(
+        |(idx, parsed, original)| async move {
+            crw_core::url_safety::validate_safe_url_resolved(&parsed)
+                .await
+                .ok()
+                // Scrape the caller's original URL string, not the reparsed
+                // (possibly re-normalized) one — same as the serial version.
+                .map(|()| (idx, original))
+        },
+    ))
+    .await
+    .into_iter()
+    .flatten()
+    .collect();
     if jobs.is_empty() {
         return Ok(());
     }
@@ -1467,6 +1505,23 @@ mod tests {
             "url": url, "title": "t", "description": "d", "position": 1
         }))
         .expect("valid result")
+    }
+
+    #[test]
+    fn scout_dedup_drops_urls_already_in_the_pool() {
+        // The scout must not re-scrape a URL the answer pool already holds:
+        // enrich_with_scrape spends the per-result budget, then merge_scraped
+        // discards the duplicate. drop_known_urls removes them before the scrape.
+        let mut known = bare_result("https://example.com/known");
+        known.markdown = Some("# known".into());
+        let data = SearchData::Flat(vec![known]);
+        let scout_rows = vec![
+            bare_result("https://example.com/known"), // already in the pool
+            bare_result("https://example.com/fresh"), // new -> keep
+        ];
+        let fresh = drop_known_urls(&data, scout_rows);
+        assert_eq!(fresh.len(), 1);
+        assert_eq!(fresh[0].url, "https://example.com/fresh");
     }
 
     #[test]


### PR DESCRIPTION
Three engine-side follow-ups deferred out of the shipped `/v1/search` enrichment
latency fix (us/crw#354). Each is its own commit; all touch disjoint files/regions.

## 1. `fix(renderer)` — stop misclassifying >500 KB pages as thin

`looks_like_thin_html` / `needs_js_rendering` measure body text in the first
500 KB of HTML, but the shared helper required a `</body>` tag. On any page over
~500 KB the closing tag sits past the scan cap, the whole body text is discarded,
and the page is declared thin. Observed on prod: `en.m.wikipedia.org/wiki/Tokyo`
(1.85 MB of real HTML) logged `"HTTP 2xx but body is thin, escalating to JS
renderer"` and paid for a full Chrome render it did not need — a pool slot plus a
proxied egress.

A `was_truncated` flag is threaded from the two callers: when the input was cut at
the cap, a missing `</body>` means the body runs past the slice, so measure to the
end of the slice. A genuinely short / mid-stream-truncated page (not cut at the
cap) still has no `</body>`, stays thin, and keeps escalating for recovery —
**recall is unchanged, only false escalations drop.** Verified on the real 1.85 MB
page bytes.

Residual, documented as a follow-up (not fixed here): if the first 500 KB ends
inside an unclosed `<script>`/`<style>`, `strip_tag_blocks` still discards the
remainder — a narrow extra-escalation case, not a regression.

## 2. `fix(core)` — bound SSRF DNS resolution with an 8 s timeout

`validate_safe_url_resolved` is the single choke point every SSRF check routes
through, and its `lookup_host` had no timeout — against a stalled or blackholed
resolver it hangs the request for however long the OS resolver takes, past any
route backstop. This exact class already reproduced a "504 with zero URLs" once
(hence the request-scoped wrap in crw-crawl's seed check).

Wrapped in an 8 s timeout, fail-closed. 8 s bounds a genuine hang while still
resolving a legitimate host behind a CNAME chain or a slow authoritative server;
the two callers that already impose a tighter request-scoped bound keep winning.

## 3. `perf(search)` — parallelize enrichment DNS validation, dedup scout scrapes

- The per-URL SSRF/DNS validation before the scrape fan-out (and the same loop in
  `/v1/extract`) ran serially — up to ~max_limit (20) / ~max_extract_urls (50)
  cold lookups on the critical path before any work started. Now `join_all`;
  validation is pure per URL, N is server-bounded, order preserved (search carries
  its own `idx`, extract's preflight slots still align 1:1 with input).
- The multi-round scout scraped every result then deduped by URL afterwards, so a
  URL already in the answer pool (or returned by both scout queries) was scraped
  again and discarded. Now filtered against the pool BEFORE scraping. Recall-neutral
  (`merge_scraped` would drop those rows anyway); this just avoids paying for the
  scrape first. Reachable via the documented `multiRound` request override.

## Cut during review (not in this PR)

A call-site hard timeout to make the per-result budget a real ceiling was
considered and **dropped**: `PoolGuard::release()` takes its slot before its own
`.await` points, so cancelling the scrape mid-release leaves the browser context
orphaned (a chrome-process leak). The parent plan already deliberately left the
anti-bot recovery arm uncapped for recall; the ~24 s tail on a bot-walled URL is
that arm doing its job.

## Tests

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`,
`cargo test --workspace` (1433 tests) green. New: detector large-page + short-
truncated cases, url_safety fail-closed-and-bounded, scout dedup. Item-2's
parallelization ships without a wall-clock test — the loopback test escape
short-circuits before `lookup_host`, so slow-DNS timing can't be mocked; it's a
straight serial→`join_all` refactor of a pure function, verified equivalent in
review.

## Deploy note

Engine images build only on releases, so merging this is not live on prod until
the next release-please release.