### PR TITLE
fix(renderer): custom headers are dropped on every browser render

### DIFF
--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -736,6 +736,28 @@ fn lightpanda_safe_ua(ua: &str) -> &str {
     ua.strip_prefix("Mozilla/5.0 ").unwrap_or(ua)
 }
 
+/// Split a caller-supplied header map into the UA override value and the rest.
+///
+/// On CDP a User-Agent is set via `Network.setUserAgentOverride`, not through
+/// `Network.setExtraHTTPHeaders`, so a `User-Agent` header (matched
+/// case-insensitively) is pulled out and returned separately; every other
+/// header becomes the extra-headers payload. The last `User-Agent` entry wins,
+/// matching how the HTTP tier's `RequestBuilder::header` overrides duplicates.
+fn split_caller_headers(
+    headers: &HashMap<String, String>,
+) -> (Option<String>, serde_json::Map<String, serde_json::Value>) {
+    let mut ua = None;
+    let mut extra = serde_json::Map::new();
+    for (k, v) in headers {
+        if k.eq_ignore_ascii_case("user-agent") {
+            ua = Some(v.clone());
+        } else {
+            extra.insert(k.clone(), serde_json::Value::String(v.clone()));
+        }
+    }
+    (ua, extra)
+}
+
 async fn connect_chrome_with_retry_inner(
     name: &str,
     configured_ws_url: &str,
@@ -1350,7 +1372,7 @@ impl PageFetcher for CdpRenderer {
     async fn fetch(
         &self,
         url: &str,
-        _headers: &HashMap<String, String>,
+        headers: &HashMap<String, String>,
         wait_for_ms: Option<u64>,
         deadline: crw_core::Deadline,
     ) -> CrwResult<FetchResult> {
@@ -1400,7 +1422,7 @@ impl PageFetcher for CdpRenderer {
         }
 
         let first = self
-            .fetch_once(url, wait_for_ms, deadline, overall_timeout)
+            .fetch_once(url, headers, wait_for_ms, deadline, overall_timeout)
             .await;
 
         // On-failure country fallback (residential chrome_proxy tier only).
@@ -1439,7 +1461,7 @@ impl PageFetcher for CdpRenderer {
                 return crate::REQUEST_COUNTRY
                     .scope(
                         self.default_country.clone(),
-                        self.fetch_once(url, wait_for_ms, deadline, retry_timeout),
+                        self.fetch_once(url, headers, wait_for_ms, deadline, retry_timeout),
                     )
                     .await;
             }
@@ -1533,6 +1555,7 @@ impl CdpRenderer {
     async fn fetch_once(
         &self,
         url: &str,
+        headers: &HashMap<String, String>,
         wait_for_ms: Option<u64>,
         deadline: crw_core::Deadline,
         overall_timeout: Duration,
@@ -1546,9 +1569,11 @@ impl CdpRenderer {
             .unwrap_or(false);
         let fut = async {
             if let Some(pool) = self.pool.as_ref().filter(|_| !proxy_active) {
-                self.fetch_with_pool(pool, url, wait_for_ms, deadline).await
+                self.fetch_with_pool(pool, url, headers, wait_for_ms, deadline)
+                    .await
             } else {
-                self.fetch_with_ws(url, wait_for_ms, deadline).await
+                self.fetch_with_ws(url, headers, wait_for_ms, deadline)
+                    .await
             }
         };
         tokio::time::timeout(overall_timeout, fut)
@@ -1605,6 +1630,7 @@ impl CdpRenderer {
         &self,
         pool: &Arc<crate::browser_pool::BrowserContextPool<CdpConnection>>,
         url: &str,
+        headers: &HashMap<String, String>,
         wait_for_ms: Option<u64>,
         deadline: crw_core::Deadline,
     ) -> CrwResult<FetchResult> {
@@ -1644,6 +1670,7 @@ impl CdpRenderer {
                 Some(&ctx_id),
                 &recorder,
                 url,
+                headers,
                 wait_for_ms,
                 deadline,
             )
@@ -1708,6 +1735,7 @@ impl CdpRenderer {
     async fn fetch_with_ws(
         &self,
         url: &str,
+        headers: &HashMap<String, String>,
         wait_for_ms: Option<u64>,
         deadline: crw_core::Deadline,
     ) -> CrwResult<FetchResult> {
@@ -1788,6 +1816,7 @@ impl CdpRenderer {
                 proxy_ctx.as_deref(),
                 &recorder,
                 url,
+                headers,
                 wait_for_ms,
                 deadline,
             )
@@ -2208,12 +2237,14 @@ impl CdpRenderer {
         Ok(last_html)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn fetch_inner(
         &self,
         conn: &CdpConnection,
         browser_context_id: Option<&str>,
         target_recorder: &(dyn Fn(&str) + Send + Sync),
         url: &str,
+        headers: &HashMap<String, String>,
         wait_for_ms: Option<u64>,
         deadline: crw_core::Deadline,
     ) -> CrwResult<(
@@ -2299,6 +2330,13 @@ impl CdpRenderer {
         )
         .await?;
 
+        // Split the caller headers into the UA override (CDP sets a UA via
+        // `setUserAgentOverride`, not via extra headers) and everything else.
+        // A caller-supplied `User-Agent` wins over the tier default, the same
+        // precedence the HTTP fetcher gives it (http_only.rs applies caller
+        // headers last).
+        let (caller_ua, extra_headers) = split_caller_headers(headers);
+
         // Present a modern UA on the CDP path too (the HTTP fetcher already does,
         // but renderers otherwise send the browser's own — often stale — UA, which
         // trips "your browser is outdated" gates). Session-scoped (so pooled
@@ -2306,15 +2344,32 @@ impl CdpRenderer {
         // must NOT abort an otherwise-fine render — hence `.ok()`, not `?`.
         // lightpanda rejects "Mozilla" UAs (→ `lightpanda_safe_ua`); it routes
         // Network.* → Emulation.* internally, so the method name is fine. Skip if empty.
-        if !self.user_agent.is_empty() {
-            let ua = if self.name == "lightpanda" {
-                lightpanda_safe_ua(&self.user_agent)
+        let effective_ua = caller_ua.as_deref().unwrap_or(&self.user_agent);
+        if !effective_ua.is_empty() {
+            let ua: &str = if self.name == "lightpanda" {
+                lightpanda_safe_ua(effective_ua)
             } else {
-                &self.user_agent
+                effective_ua
             };
             conn.send_recv(
                 "Network.setUserAgentOverride",
                 serde_json::json!({ "userAgent": ua }),
+                Some(&session_id),
+                self.page_timeout,
+            )
+            .await
+            .ok();
+        }
+
+        // Forward the caller's custom request headers. These were dropped on the
+        // CDP path entirely (only the HTTP tier honored them), so a documented
+        // `headers` field silently did nothing on any browser render. Additive:
+        // skipped when the caller passed none, so the default render sends
+        // byte-identical CDP traffic. Best-effort like the UA override above.
+        if !extra_headers.is_empty() {
+            conn.send_recv(
+                "Network.setExtraHTTPHeaders",
+                serde_json::json!({ "headers": extra_headers }),
                 Some(&session_id),
                 self.page_timeout,
             )
@@ -2914,8 +2969,9 @@ fn is_spa_text_ready(text_len: i64) -> bool {
 mod tests {
     use super::{
         CdpRenderer, CrwError, build_auth_response, is_content_stable, is_proxy_tunnel_error,
-        lightpanda_safe_ua, screenshot_clip,
+        lightpanda_safe_ua, screenshot_clip, split_caller_headers,
     };
+    use std::collections::HashMap;
 
     #[test]
     fn proxy_tunnel_error_matches_connect_failures() {
@@ -3130,6 +3186,40 @@ mod tests {
         assert!(safe.contains("Chrome/150"));
         // A UA without the prefix is returned unchanged (no double-strip).
         assert_eq!(lightpanda_safe_ua("Chrome/150.0.0.0"), "Chrome/150.0.0.0");
+    }
+
+    #[test]
+    fn split_caller_headers_pulls_out_user_agent() {
+        // A caller User-Agent must go to setUserAgentOverride, not into the
+        // extra-headers payload, and the match is case-insensitive.
+        let mut h = HashMap::new();
+        h.insert("user-agent".to_string(), "MyAgent/1.0".to_string());
+        h.insert("X-Probe".to_string(), "v".to_string());
+        let (ua, extra) = split_caller_headers(&h);
+        assert_eq!(ua.as_deref(), Some("MyAgent/1.0"));
+        assert_eq!(extra.get("X-Probe").and_then(|v| v.as_str()), Some("v"));
+        assert!(!extra.contains_key("user-agent"));
+        assert_eq!(extra.len(), 1);
+    }
+
+    #[test]
+    fn split_caller_headers_empty_and_no_ua() {
+        // No headers → no UA, empty payload (the render skips both CDP calls).
+        let (ua, extra) = split_caller_headers(&HashMap::new());
+        assert!(ua.is_none());
+        assert!(extra.is_empty());
+
+        // Headers but no User-Agent → all of them are extra headers.
+        let mut h = HashMap::new();
+        h.insert("Accept-Language".to_string(), "de".to_string());
+        h.insert("Cookie".to_string(), "a=b".to_string());
+        let (ua, extra) = split_caller_headers(&h);
+        assert!(ua.is_none());
+        assert_eq!(extra.len(), 2);
+        assert_eq!(
+            extra.get("Accept-Language").and_then(|v| v.as_str()),
+            Some("de")
+        );
     }
 
     #[test]

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -741,8 +741,11 @@ fn lightpanda_safe_ua(ua: &str) -> &str {
 /// On CDP a User-Agent is set via `Network.setUserAgentOverride`, not through
 /// `Network.setExtraHTTPHeaders`, so a `User-Agent` header (matched
 /// case-insensitively) is pulled out and returned separately; every other
-/// header becomes the extra-headers payload. The last `User-Agent` entry wins,
-/// matching how the HTTP tier's `RequestBuilder::header` overrides duplicates.
+/// header becomes the extra-headers payload.
+///
+/// A blank `User-Agent` is treated as absent: it neither overrides the tier
+/// default nor lands in the extra headers, so the render keeps sending the
+/// tier's modern UA rather than falling back to the browser's own (stale) one.
 fn split_caller_headers(
     headers: &HashMap<String, String>,
 ) -> (Option<String>, serde_json::Map<String, serde_json::Value>) {
@@ -750,7 +753,9 @@ fn split_caller_headers(
     let mut extra = serde_json::Map::new();
     for (k, v) in headers {
         if k.eq_ignore_ascii_case("user-agent") {
-            ua = Some(v.clone());
+            if !v.trim().is_empty() {
+                ua = Some(v.clone());
+            }
         } else {
             extra.insert(k.clone(), serde_json::Value::String(v.clone()));
         }
@@ -2366,6 +2371,17 @@ impl CdpRenderer {
         // `headers` field silently did nothing on any browser render. Additive:
         // skipped when the caller passed none, so the default render sends
         // byte-identical CDP traffic. Best-effort like the UA override above.
+        //
+        // Scope note: `setExtraHTTPHeaders` applies to EVERY request the page
+        // makes, including cross-origin subresources — the standard browser
+        // behaviour (Playwright/Puppeteer `setExtraHTTPHeaders` are identical),
+        // but broader than the HTTP tier, which decorates only the single main
+        // fetch. A caller must therefore not put cross-origin-sensitive
+        // credentials (e.g. `Authorization`) here for a browser render; the docs
+        // carry this warning. Scoping to the main document would require enabling
+        // `Fetch` request interception on every render (it is otherwise only on
+        // for proxy-auth / blocklist), a latency cost the engine deliberately
+        // avoids on the hot path.
         if !extra_headers.is_empty() {
             conn.send_recv(
                 "Network.setExtraHTTPHeaders",
@@ -3200,6 +3216,17 @@ mod tests {
         assert_eq!(extra.get("X-Probe").and_then(|v| v.as_str()), Some("v"));
         assert!(!extra.contains_key("user-agent"));
         assert_eq!(extra.len(), 1);
+    }
+
+    #[test]
+    fn split_caller_headers_blank_ua_is_absent() {
+        // A blank caller UA must not suppress the tier default: it becomes None
+        // and does not land in the extra headers either.
+        let mut h = HashMap::new();
+        h.insert("User-Agent".to_string(), "   ".to_string());
+        let (ua, extra) = split_caller_headers(&h);
+        assert!(ua.is_none());
+        assert!(extra.is_empty());
     }
 
     #[test]

--- a/docs/docs/scraping.md
+++ b/docs/docs/scraping.md
@@ -135,7 +135,7 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `renderer` | string | `auto` | Pin to a specific renderer: `auto`, `lightpanda`, `chrome`, `chrome_proxy`, `playwright`, or `camoufox`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set explicitly. See [JS rendering](#js-rendering) |
 | `includeTags` | string[] | `[]` | CSS selectors to keep |
 | `excludeTags` | string[] | `[]` | CSS selectors to remove |
-| `headers` | object | `{}` | Custom HTTP headers |
+| `headers` | object | `{}` | Custom HTTP headers, forwarded on both the HTTP and browser render paths. A `User-Agent` here overrides the default. |
 | `cssSelector` | string | -- | Narrow extraction to one CSS selector |
 | `xpath` | string | -- | Narrow extraction to one XPath expression |
 | `chunkStrategy` | object | -- | Topic, sentence, or regex chunking |

--- a/docs/docs/scraping.md
+++ b/docs/docs/scraping.md
@@ -135,7 +135,7 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `renderer` | string | `auto` | Pin to a specific renderer: `auto`, `lightpanda`, `chrome`, `chrome_proxy`, `playwright`, or `camoufox`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set explicitly. See [JS rendering](#js-rendering) |
 | `includeTags` | string[] | `[]` | CSS selectors to keep |
 | `excludeTags` | string[] | `[]` | CSS selectors to remove |
-| `headers` | object | `{}` | Custom HTTP headers, forwarded on both the HTTP and browser render paths. A `User-Agent` here overrides the default. |
+| `headers` | object | `{}` | Custom HTTP headers, forwarded on both the HTTP and browser render paths. A `User-Agent` here overrides the default. On a browser render they apply to every request the page makes (subresources included), so avoid putting cross-origin-sensitive credentials like `Authorization` here. |
 | `cssSelector` | string | -- | Narrow extraction to one CSS selector |
 | `xpath` | string | -- | Narrow extraction to one XPath expression |
 | `chunkStrategy` | object | -- | Topic, sentence, or regex chunking |


### PR DESCRIPTION
`CdpRenderer::fetch` took the caller's `headers` map as `_headers` and never used it. The whole chain down to `fetch_inner` had no headers argument, so a documented `headers` field worked on the HTTP tier and was silently dropped on every browser render (chrome, chrome_proxy, lightpanda). Whether a header reached the target depended on which tier the escalation ladder happened to pick.

## Change

The map is threaded through `fetch_once` → `fetch_with_pool`/`fetch_with_ws` → `fetch_inner` (both branches, plus the country-fallback retry), and `fetch_inner` sends `Network.setExtraHTTPHeaders` beside the existing `setUserAgentOverride`.

A `User-Agent` header is pulled out via a pure `split_caller_headers` helper and drives the UA override instead (CDP sets a UA that way, not via extra headers), giving a caller UA the same precedence the HTTP tier already gives it. A blank UA is treated as absent so the tier default still applies.

Both CDP calls are best-effort (`.ok()`) and skipped when the caller passed nothing, so the default no-headers render sends byte-identical CDP traffic and anti-bot recall is untouched.

## Verification

- unit tests for the header split (UA precedence, UA excluded from the extra-headers payload, blank-UA-as-absent, empty-map skip), mutation-tested
- `cargo test --workspace` 1432 pass; clippy clean on default AND `--features cdp`
- end-to-end against real headless Chrome: an origin logging request headers saw `X-Probe-Header`, a custom `Accept-Language`, and a custom `User-Agent` on the browser-rendered request; a no-headers request saw only the default UA

## Known scope limit (called out in review)

`setExtraHTTPHeaders` applies to every request the page makes, including cross-origin subresources — standard browser behaviour (Playwright/Puppeteer are identical), but broader than the HTTP tier's single main fetch. So a caller should not put cross-origin-sensitive credentials (e.g. `Authorization`) in `headers` for a browser render; the docs and code carry that warning. Scoping to the main document would require enabling `Fetch` request interception on every render (it is otherwise only on for proxy-auth / blocklist), a hot-path latency cost the engine deliberately avoids. Left as a deliberate limitation rather than a heavier follow-up.

## Follow-up

Camoufox and the cloak arm have the same `_headers` drop in their own `fetch` impls (HTTP sidecars, not CDP). Separate, smaller fixes.

ref #351