### PR TITLE
fix(v2): the extraction prompt was dropped on /v2/extract and /v2/scrape json

### DIFF
--- a/crates/crw-server/src/routes/v2/extract.rs
+++ b/crates/crw-server/src/routes/v2/extract.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crw_core::error::CrwError;
-use crw_core::types::{OutputFormat, ScrapeRequest};
+use crw_core::types::{ExtractOptions, OutputFormat, ScrapeRequest};
 
 use super::adapters::system_time_rfc3339;
 use crate::error::AppError;
@@ -41,6 +41,25 @@ pub struct V2ExtractStartResponse {
     pub replacement: String,
 }
 
+/// Build the per-URL scrape template for an extract job.
+///
+/// The prompt has to ride `extract.prompt` — that is the field the JSON
+/// extraction path reads (single.rs). It used to go into `summary_prompt`,
+/// which only drives the `summary` format, so a prompt-only extract hit the
+/// "requires a jsonSchema field or a prompt" error despite carrying one, and a
+/// schema+prompt extract silently ignored the prompt.
+pub(crate) fn extract_template(prompt: Option<String>, schema: Option<Value>) -> ScrapeRequest {
+    ScrapeRequest {
+        formats: vec![OutputFormat::Json],
+        json_schema: schema,
+        extract: Some(ExtractOptions {
+            schema: None,
+            prompt,
+        }),
+        ..Default::default()
+    }
+}
+
 pub async fn start_extract(
     State(state): State<AppState>,
     body: Result<Json<V2ExtractRequest>, JsonRejection>,
@@ -50,6 +69,21 @@ pub async fn start_extract(
         return Err(AppError::from(CrwError::InvalidRequest(
             "`urls` is required for extract on this engine (prompt-only extraction \
              without URLs is not supported)"
+                .into(),
+        )));
+    }
+    // `systemPrompt` is a distinct Firecrawl feature (its own LLM `system`
+    // role), not an alias for `prompt`, and the extractor has no slot for it
+    // yet. Reject it loudly rather than accept it and silently ignore it —
+    // the same contract the engine already gives `actions` (single.rs).
+    if req
+        .system_prompt
+        .as_deref()
+        .is_some_and(|s| !s.trim().is_empty())
+    {
+        return Err(AppError::from(CrwError::InvalidRequest(
+            "systemPrompt is not yet supported on this engine; fold your \
+             instruction into `prompt`."
                 .into(),
         )));
     }
@@ -64,14 +98,7 @@ pub async fn start_extract(
         valid.push(u.clone());
     }
 
-    let template = ScrapeRequest {
-        formats: vec![OutputFormat::Json],
-        json_schema: req.schema.clone(),
-        // A free-text extraction prompt (no schema) rides the summary_prompt slot,
-        // which the extractor folds into the structured-extraction instruction.
-        summary_prompt: req.prompt.clone(),
-        ..Default::default()
-    };
+    let template = extract_template(req.prompt.clone(), req.schema.clone());
 
     // v2 early-returns on the first bad URL (above), so every entry is valid.
     let entries = valid
@@ -124,4 +151,36 @@ pub async fn get_extract(
         credits_used: rec.credits_used,
         tokens_used: rec.tokens_used,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The regression: the prompt must land in `extract.prompt`, which the JSON
+    /// extraction path reads, NOT in `summary_prompt`, which only drives the
+    /// summary format. Putting it in the wrong slot made a prompt-only extract
+    /// fail with "requires a jsonSchema field or a prompt" despite the caller
+    /// having supplied one.
+    #[test]
+    fn prompt_lands_in_extract_not_summary() {
+        let t = extract_template(Some("Get the title".into()), None);
+        assert_eq!(
+            t.extract.as_ref().and_then(|e| e.prompt.as_deref()),
+            Some("Get the title")
+        );
+        assert!(t.summary_prompt.is_none());
+        assert!(t.formats.contains(&OutputFormat::Json));
+    }
+
+    #[test]
+    fn schema_and_prompt_both_survive() {
+        let schema = serde_json::json!({"type": "object"});
+        let t = extract_template(Some("steer".into()), Some(schema.clone()));
+        assert_eq!(t.json_schema.as_ref(), Some(&schema));
+        assert_eq!(
+            t.extract.as_ref().and_then(|e| e.prompt.as_deref()),
+            Some("steer")
+        );
+    }
 }

--- a/crates/crw-server/src/routes/v2/formats.rs
+++ b/crates/crw-server/src/routes/v2/formats.rs
@@ -57,6 +57,10 @@ pub struct DecomposedFormats {
     pub formats: Vec<OutputFormat>,
     /// `ScrapeRequest.json_schema` (from a `{"type":"json","schema":...}` entry).
     pub json_schema: Option<Value>,
+    /// `ScrapeRequest.extract.prompt` (from a `{"type":"json","prompt":...}`
+    /// entry). The documented `/v2/extract` replacement carries the extraction
+    /// instruction here; without threading it the prompt is silently dropped.
+    pub json_prompt: Option<String>,
     /// `ScrapeRequest.change_tracking` (from a `{"type":"changeTracking",...}` entry).
     pub change_tracking: Option<ChangeTrackingOptions>,
     /// A `screenshot` format was requested. The format is now produced via CDP
@@ -148,9 +152,18 @@ fn handle_token(
             }
             if fmt == OutputFormat::Json
                 && let Some(m) = obj
-                && let Some(schema) = m.get("schema")
             {
-                out.json_schema = Some(schema.clone());
+                if let Some(schema) = m.get("schema") {
+                    out.json_schema = Some(schema.clone());
+                }
+                // Firecrawl's json format object carries a free-text `prompt`
+                // alongside (or instead of) the schema. It reaches the LLM via
+                // `extract.prompt`; reading only `schema` here dropped it.
+                if let Some(p) = m.get("prompt").and_then(Value::as_str)
+                    && !p.trim().is_empty()
+                {
+                    out.json_prompt = Some(p.to_string());
+                }
             }
             if fmt == OutputFormat::ChangeTracking {
                 out.change_tracking = Some(match obj {
@@ -230,6 +243,37 @@ mod tests {
         assert!(d.formats.contains(&OutputFormat::Json));
         assert!(d.formats.contains(&OutputFormat::Summary));
         assert_eq!(d.json_schema.as_ref(), Some(&schema));
+    }
+
+    #[test]
+    fn object_json_lifts_prompt() {
+        // The documented `/v2/extract` replacement. The prompt reaches the LLM
+        // only via `extract.prompt`, so dropping it here (as the code did) made
+        // the format object silently ignore the caller's instruction.
+        let d = decompose(&specs(json!([
+            {"type": "json", "prompt": "Extract the author name"}
+        ])))
+        .unwrap();
+        assert!(d.formats.contains(&OutputFormat::Json));
+        assert_eq!(d.json_prompt.as_deref(), Some("Extract the author name"));
+        assert!(d.json_schema.is_none());
+    }
+
+    #[test]
+    fn object_json_lifts_schema_and_prompt_together() {
+        let schema = json!({"type": "object"});
+        let d = decompose(&specs(json!([
+            {"type": "json", "schema": schema.clone(), "prompt": "steer it"}
+        ])))
+        .unwrap();
+        assert_eq!(d.json_schema.as_ref(), Some(&schema));
+        assert_eq!(d.json_prompt.as_deref(), Some("steer it"));
+    }
+
+    #[test]
+    fn object_json_blank_prompt_is_ignored() {
+        let d = decompose(&specs(json!([{"type": "json", "prompt": "   "}]))).unwrap();
+        assert!(d.json_prompt.is_none());
     }
 
     #[test]

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -152,6 +152,15 @@ pub(crate) fn to_internal(
         wait_for: v2.wait_for,
         headers: v2.headers,
         json_schema: decomposed.json_schema.clone(),
+        // A `{"type":"json","prompt":...}` format object carries the extraction
+        // instruction; it reaches the LLM only via `extract.prompt`.
+        extract: decomposed
+            .json_prompt
+            .clone()
+            .map(|prompt| crw_core::types::ExtractOptions {
+                schema: None,
+                prompt: Some(prompt),
+            }),
         change_tracking: decomposed.change_tracking.clone(),
         screenshot_full_page: decomposed.screenshot_full_page,
         country,

--- a/crates/crw-server/tests/v2_api.rs
+++ b/crates/crw-server/tests/v2_api.rs
@@ -91,6 +91,46 @@ async fn v2_extract_requires_urls_400() {
 }
 
 #[tokio::test]
+async fn v2_extract_rejects_system_prompt() {
+    // systemPrompt is a distinct Firecrawl feature with no slot in the engine
+    // yet. It must be rejected loudly, not accepted and silently ignored.
+    let s = test_app();
+    let r = s
+        .post("/v2/extract")
+        .json(&json!({
+            "urls": ["http://example.com"],
+            "prompt": "get the title",
+            "systemPrompt": "you are a careful extractor",
+        }))
+        .await;
+    r.assert_status(StatusCode::BAD_REQUEST);
+    assert!(r.text().contains("systemPrompt"), "body: {}", r.text());
+}
+
+#[tokio::test]
+async fn v2_extract_blank_system_prompt_is_tolerated() {
+    // An empty systemPrompt is not a real instruction — do not 400 on it, or a
+    // client that always sends the key gets rejected for nothing.
+    let s = test_app();
+    let r = s
+        .post("/v2/extract")
+        .json(&json!({
+            "urls": ["http://example.com"],
+            "prompt": "get the title",
+            "systemPrompt": "   ",
+        }))
+        .await;
+    // Not a 400 for the systemPrompt reason (it will start a job or fail on SSRF,
+    // either way not our rejection).
+    assert_ne!(
+        r.status_code(),
+        StatusCode::BAD_REQUEST,
+        "blank systemPrompt must not be rejected: {}",
+        r.text()
+    );
+}
+
+#[tokio::test]
 async fn v2_batch_requires_urls_400() {
     let s = test_app();
     let r = s.post("/v2/batch/scrape").json(&json!({"urls": []})).await;

--- a/docs/docs/v2-api.md
+++ b/docs/docs/v2-api.md
@@ -556,7 +556,9 @@ Async multi-URL LLM extraction. Starts a job that scrapes each URL with `formats
 | `urls` | `string[]` | **required** | URLs to extract from |
 | `prompt` | `string` | — | Free-text extraction instruction (no schema required) |
 | `schema` | `object` | — | JSON Schema for structured output |
-| `systemPrompt` | `string` | — | System-level instruction prepended to the extraction prompt |
+
+`systemPrompt` is a Firecrawl field this engine does not implement yet; sending a
+non-empty value returns a 400. Fold your instruction into `prompt` instead.
 
 ### Start response
 


### PR DESCRIPTION
A `/v2/extract` prompt was written into `ScrapeRequest.summary_prompt`, which only drives the `summary` format. The JSON extraction path reads `extract.prompt`, so the prompt never reached the LLM.

Verified on production: a prompt-only `/v2/extract` returned `"Structured extraction (formats: json/extract) requires a 'jsonSchema' field or an extraction 'prompt'"` — despite carrying a prompt — and still burned a credit. A schema+prompt extract silently ran off the schema alone, ignoring the instruction.

The documented replacement, `/v2/scrape` with a `{"type":"json","prompt":...}` format object, had the same bug from the other side: the format decomposer only ever read `schema`, never `prompt`, so the migration path everyone is pointed at dropped the instruction too.

## Change

- both paths route the prompt into `ScrapeRequest.extract.prompt`, matching native `/v1/extract`
- `systemPrompt` is a distinct Firecrawl feature with no engine slot yet; it is rejected with a clear 400 (blank values tolerated) rather than accepted and silently ignored — the same contract `actions` gets
- docs corrected: `systemPrompt` documented as unsupported

## Verification

- unit tests: the prompt lands in `extract.prompt` not `summary_prompt`; schema+prompt both survive; the json format object lifts `prompt`; blank prompt ignored
- integration tests: `/v2/extract` rejects a real `systemPrompt`, tolerates a blank one
- all three production changes mutation-tested (each revert fails a specific test)
- `cargo fmt`/`clippy`/`cargo test --workspace` (1436) green

ref #352