### PR TITLE
docs: use crw_live_ key format in config template

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -181,7 +181,7 @@ max_html_bytes = 100000
 always_run = false
 
 [auth]
-# api_keys = ["fc-key-1234"]
+# api_keys = ["crw_live_key-1234"]
 
 # LLM configuration — powers both:
 #   1. structured JSON extraction (formats: ["json"] with jsonSchema)


### PR DESCRIPTION
Follow-up to #363: the last legacy `fc-` placeholder key, in the commented self-host `api_keys` example of the default config template.

Comment-only change; TOML still parses. Full pre-commit suite (fmt, clippy, `cargo test --workspace`) passed locally.