### PR TITLE
fix(antibot): catch Reddit/Cloudflare/Vercel block pages sent as 200

### DIFF
--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -1059,6 +1059,34 @@ fn classify_block(
             reason: "wikimedia datacenter-ip block".to_string(),
         });
     }
+    // Reddit's own block page ("You've been blocked by network security...") is
+    // itself ~115 bytes of prose — over the markdown-substantial guard below —
+    // so antibot::classify (which already recognizes this exact phrase via its
+    // NetworkSecurity pattern) never runs. Same trap as the Wikimedia/CF cases
+    // above. Require both halves of the sentence (not just the first clause) so
+    // an article merely quoting "blocked by network security" in isolation
+    // cannot trip this ahead of the guard.
+    if html.contains("blocked by network security")
+        && html.contains("log in to your Reddit account")
+    {
+        return Some(BlockOutcome {
+            vendor: "network_security".to_string(),
+            reason: "blocked by network security".to_string(),
+        });
+    }
+    // Cloudflare's hard block page (an outright deny, distinct from the
+    // Turnstile/managed-challenge interstitial matched by CF_STRONG_MARKERS
+    // above) also beats the guard. `<span class="cf-error-code">` is the exact
+    // structural marker antibot::classify already trusts for this vendor
+    // (`crw-extract/src/antibot.rs`); require it together with the page's own
+    // block heading so a page that merely mentions the token in prose, a code
+    // sample, or documentation cannot trip this ahead of the guard.
+    if html.contains(r#"<span class="cf-error-code">"#) && html.contains("you have been blocked") {
+        return Some(BlockOutcome {
+            vendor: "cloudflare".to_string(),
+            reason: "cloudflare block page (cf-error-code)".to_string(),
+        });
+    }
     if markdown.map(|m| m.trim().len()).unwrap_or(0) >= threshold {
         return None;
     }
@@ -1202,6 +1230,85 @@ mod tests {
         let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
             .expect("wikimedia datacenter block must be flagged even with substantial markdown");
         assert_eq!(b.vendor, "generic_block");
+    }
+
+    #[test]
+    fn classify_block_reddit_network_security_over_markdown_guard() {
+        // Regression: Reddit's own block page extracts to ~115 bytes of prose
+        // (> THRESH), so without the strong-marker check the guard would
+        // suppress the verdict before antibot::classify ever ran.
+        let html = "<html><body><p>You've been blocked by network security.</p>\
+            <p>To continue, log in to your Reddit account or use your developer token</p></body></html>";
+        let md = "You've been blocked by network security.\n\nTo continue, \
+            log in to your Reddit account or use your developer token";
+        assert!(
+            md.len() >= THRESH,
+            "fixture must exceed the guard to be meaningful"
+        );
+        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
+            .expect("reddit network security block must be flagged even with substantial markdown");
+        assert_eq!(b.vendor, "network_security");
+    }
+
+    #[test]
+    fn classify_block_reddit_phrase_alone_is_not_enough() {
+        // Negative: an article that quotes the first half of Reddit's block
+        // sentence in isolation (no "log in to your Reddit account" nearby)
+        // must NOT be flagged — only the full page's block page trips this.
+        let html = "<html><body><article><p>Many scrapers report seeing \
+            \"blocked by network security\" style errors when hitting Reddit at \
+            scale, which is a common anti-bot pattern across social platforms.</p>\
+            </article></body></html>";
+        let md = "Many scrapers report seeing \"blocked by network security\" style \
+            errors when hitting Reddit at scale, which is a common anti-bot pattern.";
+        assert!(md.len() >= THRESH);
+        assert!(
+            classify_block(200, Some("text/html"), html, Some(md), false, THRESH).is_none(),
+            "an article merely discussing the phrase must not be misflagged as a block"
+        );
+    }
+
+    #[test]
+    fn classify_block_cloudflare_hard_block_over_markdown_guard() {
+        // Regression: Cloudflare's hard-deny page (no interstitial, so
+        // CF_STRONG_MARKERS above doesn't match) extracts to well over THRESH
+        // bytes of prose, so it needs its own strong-marker check.
+        let html = r#"<html><body><h1>Attention Required! | Cloudflare</h1>
+            <p>Please enable cookies.</p>
+            <span class="cf-error-code">1020</span>
+            <h1>Sorry, you have been blocked</h1>
+            <h2>You are unable to access example.com</h2></body></html>"#;
+        let md = "# Attention Required! | Cloudflare\n\nPlease enable cookies.\n\n\
+            # Sorry, you have been blocked\n\n## You are unable to access example.com";
+        assert!(
+            md.len() >= THRESH,
+            "fixture must exceed the guard to be meaningful"
+        );
+        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
+            .expect("cloudflare hard block must be flagged even with substantial markdown");
+        assert_eq!(b.vendor, "cloudflare");
+    }
+
+    #[test]
+    fn classify_block_cf_error_code_marker_alone_is_not_enough() {
+        // Negative: a page that legitimately renders a `cf-error-code` span
+        // (e.g. a status/monitoring dashboard embedding one as a live example,
+        // not a real hard-block response) but has no "you have been blocked"
+        // heading must not be misflagged — the marker alone isn't sufficient,
+        // only its co-occurrence with the block heading is.
+        let html = r#"<html><body><article><h1>Error code reference</h1>
+            <p>Example live element: <span class="cf-error-code">1020</span></p>
+            <p>This is a normal reference page with plenty of unrelated
+            documentation content describing how status codes are displayed.</p>
+            </article></body></html>"#;
+        let md = "# Error code reference\n\nExample live element: 1020\n\n\
+            This is a normal reference page with plenty of unrelated documentation \
+            content describing how status codes are displayed.";
+        assert!(md.len() >= THRESH);
+        assert!(
+            classify_block(200, Some("text/html"), html, Some(md), false, THRESH).is_none(),
+            "a page merely rendering the cf-error-code marker without the block heading must not be misflagged"
+        );
     }
 
     #[test]

--- a/crates/crw-extract/src/antibot.rs
+++ b/crates/crw-extract/src/antibot.rs
@@ -22,6 +22,7 @@ pub enum AntibotSignal {
     Imperva,
     Sucuri,
     Kasada,
+    Vercel,
     NetworkSecurity,
     RateLimited,
     GenericBlock,
@@ -39,6 +40,7 @@ impl AntibotSignal {
             Self::Imperva => "imperva",
             Self::Sucuri => "sucuri",
             Self::Kasada => "kasada",
+            Self::Vercel => "vercel",
             Self::NetworkSecurity => "network_security",
             Self::RateLimited => "rate_limited",
             Self::GenericBlock => "generic_block",
@@ -148,6 +150,19 @@ static TIER1_PATTERNS: Lazy<Vec<SignalPattern>> = Lazy::new(|| {
             Regex::new(r"(?i)blocked\s+by\s+network\s+security").unwrap(),
             AntibotSignal::NetworkSecurity,
             "Network security block",
+        ),
+        // Vercel's bot-check interstitial ("Vercel Security Checkpoint —
+        // We're verifying your browser" / "Failed to verify your browser").
+        // Require both the heading AND the verifying/failed phrase within a
+        // bounded window so a page merely mentioning "Vercel" (a common
+        // hosting platform name) in prose cannot trip this alone.
+        (
+            Regex::new(
+                r"(?i)Vercel\s+Security\s+Checkpoint[\s\S]{0,300}(?:verifying|Failed\s+to\s+verify)\s+your\s+browser",
+            )
+            .unwrap(),
+            AntibotSignal::Vercel,
+            "Vercel security checkpoint",
         ),
         // Google's rate-limit page ("Error 429 (Too Many Requests)!!1"). Google
         // serves it with a real 429 over HTTP, but lightpanda/CDP renderers
@@ -513,6 +528,35 @@ mod tests {
         let html = "<html><body><script>KPSDK.scriptStart = KPSDK.now()</script></body></html>";
         let r = classify(Some(200), html);
         assert_eq!(r.signal, AntibotSignal::Kasada);
+    }
+
+    #[test]
+    fn vercel_security_checkpoint_detected() {
+        let html = "<html><body><h1>Vercel Security Checkpoint</h1>\
+            <p>We're verifying your browser</p></body></html>";
+        let r = classify(Some(200), html);
+        assert_eq!(r.signal, AntibotSignal::Vercel);
+        assert_eq!(r.signal.class_name(), "vercel");
+    }
+
+    #[test]
+    fn vercel_security_checkpoint_failed_variant_detected() {
+        let html = "<html><body><h1>Vercel Security Checkpoint</h1>\
+            <p>Failed to verify your browser</p><p>Code 21</p></body></html>";
+        let r = classify(Some(200), html);
+        assert_eq!(r.signal, AntibotSignal::Vercel);
+    }
+
+    #[test]
+    fn vercel_mention_alone_is_not_enough() {
+        // Negative: a page that merely mentions Vercel (a common hosting
+        // platform) in prose, with no checkpoint heading, must not be flagged.
+        let html = "<html><body><article><p>This site is deployed on Vercel, \
+            a popular platform for hosting frontend applications and static \
+            sites with automatic previews on every pull request.</p></article>\
+            </body></html>";
+        let r = classify(Some(200), html);
+        assert_eq!(r.signal, AntibotSignal::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Block pages from Reddit ("blocked by network security"), Cloudflare's hard-deny page, and Vercel's bot checkpoint were long enough to clear `classify_block()`'s markdown-substantial guard, so `antibot::classify()` never ran and the block text was returned to callers as `success:true`.
- Add compound-signature pre-guard checks in `classify_block()` (mirroring the existing Turnstile/Wikimedia strong-marker checks), requiring co-occurrence of two markers per vendor so legitimate pages that merely mention these vendors in prose are not misflagged.
- Add `Vercel` as a named antibot vendor for the shorter-body case that does reach `classify()`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (75/75 suites green)
- [x] New tests: positive detection + negative (legitimate-content) regression tests for all three vendors