### PR TITLE
feat(renderer): decouple chrome_proxy arm pool from renderer.pool_size

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -626,6 +626,14 @@ pub struct RendererConfig {
     pub chrome_timeout_ms: Option<u64>,
     #[serde(default = "default_pool_size")]
     pub pool_size: usize,
+    /// Concurrency cap for the `chrome_proxy` hard-block recovery arm
+    /// (`auto_egress_escalation`), decoupled from the general `pool_size`.
+    /// `None` falls back to `pool_size` — self-hosters see identical behavior.
+    /// Raise this independently when the arm is shedding recoveries
+    /// (`crw_render_route_decision_total{decision="armShed"}` rising) without
+    /// touching the main chrome/lightpanda tiers' concurrency.
+    #[serde(default)]
+    pub chrome_proxy_pool_size: Option<usize>,
     /// latency-qn: override the chrome post-navigate challenge-clear retry count
     /// (default 3 → 3×3s=9s). Measured at 28% of render time, mostly on shells
     /// that never clear (fail anyway); Firecrawl/Spider run no such loop. Lower
@@ -952,6 +960,7 @@ impl Default for RendererConfig {
             lightpanda_timeout_ms: None,
             chrome_timeout_ms: None,
             pool_size: default_pool_size(),
+            chrome_proxy_pool_size: None,
             chrome_challenge_max_retries: None,
             chrome_spa_selector_max_ms: None,
             chrome_fast_ready: false,
@@ -1011,6 +1020,9 @@ impl RendererConfig {
     pub fn chrome_proxy_timeout(&self) -> u64 {
         self.chrome_proxy_timeout_ms
             .unwrap_or_else(|| self.chrome_timeout().saturating_add(15_000))
+    }
+    pub fn chrome_proxy_pool_size(&self) -> usize {
+        self.chrome_proxy_pool_size.unwrap_or(self.pool_size).max(1)
     }
     pub fn camoufox_timeout(&self) -> u64 {
         self.camoufox_timeout_ms
@@ -1942,6 +1954,36 @@ mod tests {
         let cfg = RendererConfig::default();
         assert_eq!(cfg.mode, RendererMode::Auto);
         assert_eq!(cfg.render_js_default, None);
+    }
+
+    #[test]
+    fn chrome_proxy_pool_size_falls_back_to_pool_size() {
+        let cfg = RendererConfig {
+            pool_size: 8,
+            chrome_proxy_pool_size: None,
+            ..Default::default()
+        };
+        assert_eq!(cfg.chrome_proxy_pool_size(), 8);
+    }
+
+    #[test]
+    fn chrome_proxy_pool_size_explicit_override_wins() {
+        let cfg = RendererConfig {
+            pool_size: 8,
+            chrome_proxy_pool_size: Some(16),
+            ..Default::default()
+        };
+        assert_eq!(cfg.chrome_proxy_pool_size(), 16);
+    }
+
+    #[test]
+    fn chrome_proxy_pool_size_clamps_zero_to_one() {
+        let cfg = RendererConfig {
+            pool_size: 8,
+            chrome_proxy_pool_size: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(cfg.chrome_proxy_pool_size(), 1);
     }
 
     #[cfg(feature = "camoufox")]

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -405,8 +405,10 @@ pub(crate) const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
 pub(crate) const CHROME_PROXY_ARM_BUDGET_MS: u64 = 12_000;
 
 // Concurrency permits for the chrome_proxy auto-egress recovery arm are sized to
-// `config.pool_size` at construction (see `chrome_proxy_arm_sem`). The residential
-// chrome_proxy pool blocking-acquires a small (~pool_size) slot set; without a
+// `config.chrome_proxy_pool_size()` at construction (see `chrome_proxy_arm_sem`) —
+// falls back to `pool_size` when unset, but can be raised independently so a burst
+// of hard-blocks doesn't compete with the main chrome/lightpanda tiers' pool. The
+// residential chrome_proxy pool blocking-acquires a small (~pool_size) slot set; without a
 // non-blocking load-shed a burst of datacenter-blocked URLs (batch/crawl) would
 // queue every page on it for up to the SaaS 120s timeout, collapsing throughput
 // for co-tenant traffic. The arm `try_acquire_owned`s a permit and skips recovery
@@ -598,7 +600,7 @@ impl FallbackRenderer {
                 chrome_hedge: config.chrome_hedge,
                 hedge_sem: Arc::new(tokio::sync::Semaphore::new((config.pool_size / 2).max(1))),
                 chrome_proxy_arm_sem: Arc::new(tokio::sync::Semaphore::new(
-                    config.pool_size.max(1),
+                    config.chrome_proxy_pool_size(),
                 )),
                 preferences: Arc::new(HostPreferences::with_defaults()),
                 breakers: Arc::new(BreakerRegistry::with_defaults()),
@@ -775,7 +777,7 @@ impl FallbackRenderer {
                         "chrome_proxy",
                         &cp.ws_url,
                         config.chrome_proxy_timeout(),
-                        config.pool_size,
+                        config.chrome_proxy_pool_size(),
                     )
                     .with_user_agent(&effective_ua)
                     .with_nav_budget(config.chrome_nav_budget_ms)
@@ -910,7 +912,9 @@ impl FallbackRenderer {
             auto_egress_escalation: config.auto_egress_escalation,
             chrome_hedge: config.chrome_hedge,
             hedge_sem: Arc::new(tokio::sync::Semaphore::new((config.pool_size / 2).max(1))),
-            chrome_proxy_arm_sem: Arc::new(tokio::sync::Semaphore::new(config.pool_size.max(1))),
+            chrome_proxy_arm_sem: Arc::new(tokio::sync::Semaphore::new(
+                config.chrome_proxy_pool_size(),
+            )),
             preferences: Arc::new(HostPreferences::with_defaults()),
             breakers: Arc::new(BreakerRegistry::with_defaults()),
             tier_timeouts: tier_timeouts_from(config),
@@ -2736,7 +2740,9 @@ impl FallbackRenderer {
             // shared deadline near-exhausted (~2s of a 15s scrape deadline), which
             // starved the arm below any floor and is exactly why it never fired.
             //
-            // The `arm_sem == chrome_proxy conn_semaphore == pool_size` sizing makes
+            // The `arm_sem == chrome_proxy conn_semaphore == chrome_proxy_pool_size()`
+            // sizing (decoupled from the general `pool_size`, see
+            // `Config::chrome_proxy_pool_size`) makes
             // "a permit implies a free pool slot" hold on the managed prod path,
             // where `chrome_proxy` is arm-EXCLUSIVE (`!proxy_active` retained it out
             // of the ladder). In a mixed self-host config that ALSO runs


### PR DESCRIPTION
## Summary
- The chrome_proxy hard-block recovery arm shared its concurrency semaphore with the general `renderer.pool_size` knob (also sizing the main chrome/lightpanda tiers and `hedge_sem`). Prod trace analysis showed the arm sheds most recovery attempts during traffic bursts of concurrent hard-blocks, because the shared pool saturates well before the burst clears.
- Add an optional `chrome_proxy_pool_size` config field with a `chrome_proxy_timeout()`-style fallback accessor: unset defaults to `pool_size` (zero-config self-hosters see identical behavior), set independently raises only the arm's capacity.
- `hedge_sem` and `render_reserve` are untouched.
- Pairs with a `crw-saas` compose change (separate PR) that sets `CRW_RENDERER__CHROME_PROXY_POOL_SIZE=16` and resizes the `chrome-proxy` container accordingly.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (75/75 suites green)
- [x] New tests for the accessor's fallback/override/zero-clamp behavior