### PR TITLE
fix(renderer): stop discarding good content when the JS ladder fails

### DIFF
--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -402,8 +402,19 @@ async fn scrape_url_inner(
 
         let escalate_for_quality =
             !md_is_byte_thin && md_is_low_quality && fetch_result.html.len() > 5000;
+        // A request whose JS ladder already failed comes back as an HTTP body
+        // carrying the `js_escalation_failed:` warning. It looks exactly like a
+        // low-tier result, so without this check we would re-run the whole
+        // ladder that was just exhausted — a second HTTP fetch, a second full JS
+        // attempt and a second extraction, on the same (already spent) deadline,
+        // for a result that cannot differ.
+        let js_ladder_exhausted = fetch_result
+            .warning
+            .as_deref()
+            .is_some_and(|w| w.contains(crw_renderer::JS_ESCALATION_FAILED));
         let should_escalate = (md_is_byte_thin || escalate_for_quality)
             && used_low_tier
+            && !js_ladder_exhausted
             && should_escalate_status
             && escalation_eligible;
         if should_escalate {
@@ -700,6 +711,27 @@ async fn scrape_url_inner(
     // instead of mistaking it for a thin page.
     data.truncated = fetch_result.truncated;
 
+    // ...but a truncated render that extracted to NOTHING is not incomplete
+    // content, it is no content. The navigation budget expired mid-load and the
+    // partial DOM held nothing extractable, so a 200 here bills the caller for a
+    // blank document and reads as "this page is empty" when the truth is "we ran
+    // out of time" — two states the caller cannot tell apart, and only one of
+    // which they can fix (by raising `timeout`). Measured on prod 2026-07-24:
+    // 4 of 26 truncated scrapes shipped 0 bytes as a billed success.
+    //
+    // Scoped deliberately: only when markdown was ASKED FOR (a `rawHtml`/`links`
+    // caller can still use a partial DOM) and only when it is entirely empty.
+    // A thin-but-present body stays a success — that is a judgment call about
+    // quality, not a missing answer, and taking it would risk recall.
+    if is_empty_truncated_render(data.truncated, &req.formats, data.markdown.as_deref()) {
+        tracing::warn!(
+            url = %req.url,
+            elapsed_ms = fetch_result.elapsed_ms,
+            "render budget expired with no extractable content; failing instead of billing an empty page"
+        );
+        return Err(crw_core::error::CrwError::Timeout(fetch_result.elapsed_ms));
+    }
+
     // Wrap the raw base64 screenshot in a `data:image/png;base64,` URL exactly
     // once, here, so both v1 and v2 responses are identical (D8). FetchResult
     // keeps the raw b64.
@@ -900,13 +932,37 @@ fn redirect_is_material(requested: &str, final_url: &str) -> bool {
     !req_path.is_empty() && fin_path.is_empty()
 }
 
+/// A truncated render that extracted to nothing: the render budget expired
+/// mid-load and the partial DOM held no markdown. See the call site for why
+/// that is a failure rather than an empty page.
+fn is_empty_truncated_render(
+    truncated: bool,
+    formats: &[OutputFormat],
+    markdown: Option<&str>,
+) -> bool {
+    truncated
+        && formats.contains(&OutputFormat::Markdown)
+        && markdown.map(|m| m.trim().is_empty()).unwrap_or(true)
+}
+
 pub(crate) fn derive_target_warning(fetch_result: &FetchResult) -> Option<String> {
     // Anti-bot detection wins over any other warning. The renderer chain
     // annotates thin results with "X returned a loading placeholder", but the
     // underlying HTML may be a CAPTCHA shell — surfacing the placeholder
     // misattributes the failure to our renderer instead of the site block.
     if let Some(block) = detect_block_interstitial(&fetch_result.html) {
-        return Some(block);
+        // Exception: a `js_escalation_failed:` prefix explains WHY the caller is
+        // looking at an HTTP shell at all, and a block page is the single most
+        // likely body to be holding one. Dropping it here would leave a
+        // `renderJs:true` caller with "Blocked by …" and no way to tell the
+        // browser tier ran and lost — which is exactly what the docs tell them
+        // to look for. Keep both, block first.
+        return Some(match fetch_result.warning.as_deref() {
+            Some(w) if w.starts_with(crw_renderer::JS_ESCALATION_FAILED) => {
+                format!("{block}; {w}")
+            }
+            _ => block,
+        });
     }
 
     if fetch_result.warning.is_some() {
@@ -1436,6 +1492,46 @@ mod tests {
             "<html><title>Just a moment</title><body>cf-browser-verification</body></html>",
         ));
         assert_eq!(warning.as_deref(), Some("Blocked by anti-bot protection"));
+    }
+
+    #[test]
+    fn empty_truncated_render_is_a_failure_not_an_empty_page() {
+        let md = [OutputFormat::Markdown];
+        // The billed-blank-page case: budget expired, nothing extracted.
+        assert!(is_empty_truncated_render(true, &md, None));
+        assert!(is_empty_truncated_render(true, &md, Some("   \n ")));
+        // A thin-but-present body is a quality judgment, not a missing answer —
+        // failing it would cost recall.
+        assert!(!is_empty_truncated_render(true, &md, Some("# Title")));
+        // An empty page that rendered fully is genuinely empty; say so.
+        assert!(!is_empty_truncated_render(false, &md, None));
+        // A caller who wanted raw HTML can still use a partial DOM.
+        assert!(!is_empty_truncated_render(
+            true,
+            &[OutputFormat::RawHtml],
+            None
+        ));
+    }
+
+    #[test]
+    fn warning_keeps_js_escalation_failure_alongside_a_block() {
+        // A block page is the likeliest body to be holding a failed-ladder
+        // explanation, and the docs tell callers to look for that prefix. The
+        // block marker used to short-circuit and drop it.
+        let mut fetch = sample_fetch(
+            200,
+            "<html><title>Just a moment</title><body>cf-browser-verification</body></html>",
+        );
+        fetch.warning = Some(format!(
+            "{} Timeout after 5000ms",
+            crw_renderer::JS_ESCALATION_FAILED
+        ));
+        let warning = derive_target_warning(&fetch).expect("both signals expected");
+        assert!(
+            warning.contains("Blocked by anti-bot protection"),
+            "{warning}"
+        );
+        assert!(warning.contains("js_escalation_failed"), "{warning}");
     }
 
     #[test]

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1718,14 +1718,14 @@ impl CdpRenderer {
             rendered_with: Some(self.name.clone()),
             elapsed_ms: start.elapsed().as_millis() as u64,
             warning: if truncated {
-                Some("chrome_budget_truncated".to_string())
+                Some(self.budget_truncated_warning())
             } else {
                 None
             },
             render_decision: None,
             credit_cost: 0,
             warnings: if truncated {
-                vec!["chrome_budget_truncated".to_string()]
+                vec![self.budget_truncated_warning()]
             } else {
                 Vec::new()
             },
@@ -1734,6 +1734,16 @@ impl CdpRenderer {
             captured_responses,
             screenshot,
         })
+    }
+
+    /// Name the tier that actually ran out of budget. This struct drives every
+    /// CDP-speaking renderer, so the hardcoded `chrome_budget_truncated` blamed
+    /// Chrome for LightPanda's much smaller budget — prod, 2026-07-24: every
+    /// truncation sampled was LightPanda's, reported as Chrome's, sending anyone
+    /// debugging it to the wrong tier. Chrome's string is unchanged, so existing
+    /// consumers see no difference.
+    fn budget_truncated_warning(&self) -> String {
+        format!("{}_budget_truncated", self.name)
     }
 
     /// Inner fetch with WebSocket lifecycle management.
@@ -1887,14 +1897,14 @@ impl CdpRenderer {
             rendered_with: Some(self.name.clone()),
             elapsed_ms: start.elapsed().as_millis() as u64,
             warning: if truncated {
-                Some("chrome_budget_truncated".to_string())
+                Some(self.budget_truncated_warning())
             } else {
                 None
             },
             render_decision: None,
             credit_cost: 0,
             warnings: if truncated {
-                vec!["chrome_budget_truncated".to_string()]
+                vec![self.budget_truncated_warning()]
             } else {
                 Vec::new()
             },
@@ -2988,6 +2998,17 @@ mod tests {
         lightpanda_safe_ua, screenshot_clip, split_caller_headers,
     };
     use std::collections::HashMap;
+
+    #[test]
+    fn budget_truncated_warning_names_the_tier_that_ran_out() {
+        // One struct drives every CDP tier, so a hardcoded string reported
+        // LightPanda's truncation as Chrome's and sent debuggers to the wrong
+        // renderer. Chrome's wording is unchanged for existing consumers.
+        let chrome = CdpRenderer::new("chrome", "ws://x/", 1000, 1);
+        let lp = CdpRenderer::new("lightpanda", "ws://x/", 1000, 1);
+        assert_eq!(chrome.budget_truncated_warning(), "chrome_budget_truncated");
+        assert_eq!(lp.budget_truncated_warning(), "lightpanda_budget_truncated");
+    }
 
     #[test]
     fn proxy_tunnel_error_matches_connect_failures() {

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -381,6 +381,36 @@ fn is_origin_navigation_failure(e: &CrwError) -> bool {
     }
 }
 
+/// Prefix of the `warning` set when a JS escalation failed and the HTTP body was
+/// returned in its place. Public because it is BOTH the caller-facing
+/// explanation and the signal `crw_crawl::single` reads to skip a second
+/// escalation round that would re-run a ladder this request already exhausted.
+/// A shared constant so the producer and that consumer cannot drift.
+pub const JS_ESCALATION_FAILED: &str = "js_escalation_failed:";
+
+/// Soft-block / soft-error status codes where the body often contains real
+/// content despite the status header. Sources:
+///   - UA/header-based bot filters: 401, 403, 405, 406, 412
+///   - Rate limits: 429
+///   - Geo gates: 451
+///   - Origin overload: 503
+///   - "Not found" SPAs that 404 the route but render content via JS
+///     hydration: 404, 410
+///   - Origin error that still serves a usable page: 500
+///
+/// Firecrawl-comparison (April 2026 bench): the JS render path recovered
+/// content in ~25/99 such cases that HTTP alone could not. Shared by the auto
+/// and forced-JS arms of `fetch_inner`, which must agree on what counts as a
+/// body worth warning about. Two further copies of this list still live inline
+/// in `fetch_with_js` — worth folding in, but not while this change is in
+/// flight.
+fn is_soft_block_status(status_code: u16) -> bool {
+    matches!(
+        status_code,
+        401 | 403 | 404 | 405 | 406 | 410 | 412 | 429 | 451 | 500 | 503
+    )
+}
+
 /// Minimum remaining request budget for a network attempt to be worth making.
 /// Below this a CDP tier cannot complete its handshake and returns a fabricated
 /// `Timeout after Nms` (single-digit N) while still consuming a pool slot.
@@ -1396,10 +1426,53 @@ impl FallbackRenderer {
             }
             Some(true) => {
                 // Fetch via HTTP first to check content type — PDFs can't be JS-rendered.
-                let mut http_result = self
+                // An HTTP-layer failure is not terminal here either: the auto arm
+                // escalates on it (bench: 10/147 false "unreachable" + 5/147
+                // "http_502" recover via a real Chromium navigation), and a
+                // caller who explicitly asked for JS must not get LESS recall
+                // than one who asked for nothing. Without this, `renderJs:true`
+                // — and every screenshot request, which :1242 forces down this
+                // arm — never reached the browser on an origin that rejects
+                // reqwest's TLS fingerprint.
+                let mut http_result = match self
                     .http_fetcher_for_request()?
                     .fetch(url, headers, None, deadline)
-                    .await?;
+                    .await
+                {
+                    Ok(r) => r,
+                    Err(e) if !self.js_renderers.is_empty() => {
+                        tracing::info!(
+                            url,
+                            error = %e,
+                            "HTTP fetch failed, escalating to JS renderer"
+                        );
+                        return self
+                            .fetch_with_js(
+                                url,
+                                headers,
+                                wait_for_ms,
+                                requested_renderer,
+                                cloak_attempted,
+                                deadline,
+                            )
+                            .await
+                            .map_err(|js_err| {
+                                tracing::warn!("Both HTTP and JS failed: http={e}, js={js_err}");
+                                // Same attribution rule as the auto arm: a dead
+                                // origin is the caller's target (422), not our
+                                // renderer breaking (500).
+                                match (&e, &js_err) {
+                                    (CrwError::TargetUnreachable(_), js)
+                                        if is_origin_navigation_failure(js) =>
+                                    {
+                                        e
+                                    }
+                                    _ => js_err,
+                                }
+                            });
+                    }
+                    Err(e) => return Err(e),
+                };
                 if http_result.content_type.as_deref() == Some("application/pdf") {
                     // A PDF has no rendered DOM to capture. A screenshot request
                     // on a PDF returns the parsed document with no `screenshot`
@@ -1434,15 +1507,76 @@ impl FallbackRenderer {
                     stamp_http_decision(&mut result, requested_renderer);
                     Ok(result)
                 } else {
-                    self.fetch_with_js(
-                        url,
-                        headers,
-                        wait_for_ms,
-                        requested_renderer,
-                        cloak_attempted,
-                        deadline,
-                    )
-                    .await
+                    // The HTTP body was already fetched above for the
+                    // content-type check, so when the JS ladder fails there is a
+                    // valid document sitting in hand — returning `Err` and a 504
+                    // instead of that body is a straight recall loss, and the
+                    // auto arm below has never done it.
+                    //
+                    // Unlike auto, the fallback here is ALWAYS announced. Auto
+                    // can swap silently because the caller expressed no
+                    // preference; a `renderJs:true` caller asked for a browser
+                    // and must be able to tell they did not get one, both to
+                    // debug and because the request is billed either way.
+                    let is_auth_blocked = is_soft_block_status(http_result.status_code);
+                    let started_at = std::time::Instant::now();
+                    match self
+                        .fetch_with_js(
+                            url,
+                            headers,
+                            wait_for_ms,
+                            requested_renderer,
+                            cloak_attempted,
+                            deadline,
+                        )
+                        .await
+                    {
+                        Ok(js_result) => Ok(js_result),
+                        // A capture has no HTTP substitute (the caller asked for
+                        // pixels), and an explicit renderer pin is a caller
+                        // contract that forbids silent substitution. Both fail
+                        // closed, matching the no-renderer arm directly above.
+                        Err(e) if screenshot_requested() || is_hard_pinned => Err(e),
+                        Err(e) => {
+                            if is_auth_blocked {
+                                tracing::error!(
+                                    url,
+                                    status_code = http_result.status_code,
+                                    "JS escalation failed for soft-block status; surfacing HTTP shell with warning: {e}"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    "JS rendering failed, falling back to HTTP result: {e}"
+                                );
+                            }
+                            let warning = format!("{JS_ESCALATION_FAILED} {e}");
+                            http_result.warning = Some(match http_result.warning.take() {
+                                Some(prev) => format!("{warning}; {prev}"),
+                                None => warning,
+                            });
+                            // `elapsed_ms` came from the HTTP fetch alone, so it
+                            // would report a few hundred ms for a request that
+                            // spent the whole deadline in the ladder.
+                            http_result.elapsed_ms = http_result
+                                .elapsed_ms
+                                .saturating_add(started_at.elapsed().as_millis() as u64);
+                            // `stamp_http_decision` below records this as a plain
+                            // `http`/`success` route, which is what an operator
+                            // would read as "no browser was needed". Emit the
+                            // real story first so forced-JS fallbacks are
+                            // separable from ordinary HTTP traffic; without it
+                            // the whole failure class is invisible in metrics.
+                            metrics()
+                                .render_route_decision_total
+                                .with_label_values(&[
+                                    RendererKind::Http.as_str(),
+                                    "jsLadderExhausted",
+                                ])
+                                .inc();
+                            stamp_http_decision(&mut http_result, requested_renderer);
+                            Ok(http_result)
+                        }
+                    }
                 }
             }
             None => {
@@ -1510,22 +1644,7 @@ impl FallbackRenderer {
                 let is_blocked = cf_header_signal
                     || detector::looks_like_cloudflare_challenge(&result.html)
                     || is_generic_bot_wall;
-                // Soft-block / soft-error status codes where the body often
-                // contains real content despite the status header. Sources:
-                //   - UA/header-based bot filters: 401, 403, 405, 406, 412
-                //   - Rate limits: 429
-                //   - Geo gates: 451
-                //   - Origin overload: 503
-                //   - "Not found" SPAs that 404 the route but render content
-                //     via JS hydration: 404, 410
-                //   - Origin error that still serves a usable page: 500
-                // Firecrawl-comparison (April 2026 bench): the JS render
-                // path recovered content in ~25/99 such cases that HTTP
-                // alone could not.
-                let is_auth_blocked = matches!(
-                    result.status_code,
-                    401 | 403 | 404 | 405 | 406 | 410 | 412 | 429 | 451 | 500 | 503
-                );
+                let is_auth_blocked = is_soft_block_status(result.status_code);
                 // Post-fetch thin-content trigger: HTTP returned 2xx but the
                 // body has effectively no extractable text. Catches sites whose
                 // SPA marker we don't recognize (no `id="root"`, no
@@ -1604,7 +1723,7 @@ impl FallbackRenderer {
                                     status_code = result.status_code,
                                     "JS escalation failed for soft-block status; surfacing HTTP shell with warning: {e}"
                                 );
-                                let warning = format!("js_escalation_failed: {e}");
+                                let warning = format!("{JS_ESCALATION_FAILED} {e}");
                                 result.warning = Some(match result.warning.take() {
                                     Some(prev) => format!("{warning}; {prev}"),
                                     None => warning,
@@ -3557,7 +3676,9 @@ mod tests {
     }
 
     fn make_renderer_with_mocks(mocks: Vec<Arc<dyn PageFetcher>>) -> FallbackRenderer {
-        // Build a real HTTP fetcher (won't be hit when render_js=Some(true)).
+        // Builds a REAL HTTP fetcher. The forced-JS arm fetches HTTP before the
+        // ladder (content-type check), so any test that exercises it should
+        // override `r.http` rather than reach the network.
         let cfg = base_cfg(RendererMode::None);
         let mut r =
             FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap();
@@ -3820,7 +3941,15 @@ mod tests {
             name: "chrome",
             behavior: MockBehavior::Err("boom".into()),
         }) as Arc<dyn PageFetcher>;
-        let r = make_renderer_with_mocks(vec![chrome]);
+        let mut r = make_renderer_with_mocks(vec![chrome]);
+        // Stub the HTTP tier: the forced-JS arm fetches it before the ladder, so
+        // without this the assertion depends on reaching example.com over the
+        // network — and now that a JS failure can fall back to the HTTP body,
+        // this test is the only thing pinning the hard-pin exclusion.
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::Ok(rich_html("HTTP-")),
+        });
 
         let err = r
             .fetch(
@@ -3834,6 +3963,219 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("boom"));
+    }
+
+    /// `renderJs:true` used to be the only arm that threw away a perfectly good
+    /// HTTP body when the JS ladder failed, so a forced-JS scrape returned a 504
+    /// while holding the document.
+    #[tokio::test]
+    async fn forced_js_failure_falls_back_to_http_body() {
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Err("Timeout after 1ms".into()),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![chrome]);
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::Ok(rich_html("HTTP-")),
+        });
+
+        let res = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true), // forced JS
+                None,
+                None, // unpinned
+                tdl(),
+            )
+            .await
+            .expect("a failed JS ladder must not discard a valid HTTP body");
+        assert!(res.html.contains("HTTP-"));
+        // A 2xx fallback is the motivating case and the one most at risk of
+        // going out silently: the caller asked for a browser, is billed either
+        // way, and has nothing else in the response to tell them they got HTTP.
+        assert!(
+            res.warning
+                .as_deref()
+                .is_some_and(|w| w.contains("js_escalation_failed")),
+            "every forced-JS fallback must be announced; got {:?}",
+            res.warning
+        );
+        assert!(
+            res.warning
+                .as_deref()
+                .is_some_and(|w| w.contains(JS_ESCALATION_FAILED)),
+            "single.rs reads this exact prefix to skip re-escalation: {:?}",
+            res.warning
+        );
+    }
+
+    /// A 4xx/5xx body is usually an error shell, so the swap is surfaced rather
+    /// than made silently — same rule the auto arm applies.
+    #[tokio::test]
+    async fn forced_js_failure_on_soft_block_warns() {
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Err("Timeout after 1ms".into()),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![chrome]);
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::OkStatus(403, rich_html("SHELL-")),
+        });
+
+        let res = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                None,
+                tdl(),
+            )
+            .await
+            .expect("soft-block bodies still ship, with a warning");
+        assert!(
+            res.warning
+                .as_deref()
+                .is_some_and(|w| w.contains("js_escalation_failed")),
+            "the caller must be able to tell the JS tier failed; got {:?}",
+            res.warning
+        );
+    }
+
+    /// A capture has no HTTP substitute: returning a body with no `screenshot`
+    /// field would silently drop the thing the caller actually asked for.
+    #[tokio::test]
+    async fn forced_js_failure_with_screenshot_fails_closed() {
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Err("Timeout after 1ms".into()),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![chrome]);
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::Ok(rich_html("HTTP-")),
+        });
+
+        // `render_js: None`, not `Some(true)`: a real caller just sends
+        // `formats: ["screenshot"]`, and :1242 is what forces them onto this
+        // arm. Passing None exercises that promotion together with the guard.
+        let err = REQUEST_SCREENSHOT
+            .scope(
+                Some(ScreenshotReq { full_page: false }),
+                r.fetch(
+                    "https://example.com",
+                    &HashMap::new(),
+                    None,
+                    None,
+                    None,
+                    tdl(),
+                ),
+            )
+            .await
+            .expect_err("a screenshot request cannot be satisfied by an HTTP body");
+        assert!(err.to_string().contains("Timeout"), "got {err:?}");
+    }
+
+    /// The real production failure is a deadline, and `MockBehavior::Err` can
+    /// only build a `RendererError` — so the timeout shape gets its own fetcher.
+    #[tokio::test]
+    async fn forced_js_timeout_falls_back_to_http_body() {
+        struct TimesOut;
+        #[async_trait::async_trait]
+        impl PageFetcher for TimesOut {
+            async fn fetch(
+                &self,
+                _u: &str,
+                _h: &HashMap<String, String>,
+                _w: Option<u64>,
+                _d: crw_core::Deadline,
+            ) -> CrwResult<FetchResult> {
+                Err(CrwError::Timeout(1))
+            }
+            fn name(&self) -> &str {
+                "chrome"
+            }
+            fn supports_js(&self) -> bool {
+                true
+            }
+            async fn is_available(&self) -> bool {
+                true
+            }
+        }
+
+        let mut r = make_renderer_with_mocks(vec![Arc::new(TimesOut)]);
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::Ok(rich_html("HTTP-")),
+        });
+
+        let res = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                None,
+                tdl(),
+            )
+            .await
+            .expect("a ladder timeout must not discard a valid HTTP body");
+        assert!(res.html.contains("HTTP-"));
+        assert_eq!(res.rendered_with.as_deref(), Some("http"));
+    }
+
+    /// An HTTP-layer failure under `renderJs:true` must still reach the browser.
+    /// It did not before: the arm used `?`, so a caller who explicitly asked for
+    /// JS got LESS recall than one who asked for nothing.
+    #[tokio::test]
+    async fn forced_js_escalates_when_http_tier_fails() {
+        struct Unreachable;
+        #[async_trait::async_trait]
+        impl PageFetcher for Unreachable {
+            async fn fetch(
+                &self,
+                url: &str,
+                _h: &HashMap<String, String>,
+                _w: Option<u64>,
+                _d: crw_core::Deadline,
+            ) -> CrwResult<FetchResult> {
+                Err(CrwError::TargetUnreachable(format!(
+                    "Could not reach {url}"
+                )))
+            }
+            fn name(&self) -> &str {
+                "http"
+            }
+            fn supports_js(&self) -> bool {
+                false
+            }
+            async fn is_available(&self) -> bool {
+                true
+            }
+        }
+
+        let chrome = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Ok(rich_html("CHROME-")),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![chrome]);
+        r.http = Arc::new(Unreachable);
+
+        let res = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                None,
+                tdl(),
+            )
+            .await
+            .expect("a dead HTTP tier must escalate, not abort the request");
+        assert!(res.html.contains("CHROME-"));
     }
 
     #[tokio::test]

--- a/docs/docs/js-rendering.md
+++ b/docs/docs/js-rendering.md
@@ -295,6 +295,7 @@ When rendered output looks wrong, check:
 
 - **Empty content from JS-heavy sites**: Increase `waitFor` (e.g., `3000`-`5000`). Some SPAs need extra time to hydrate.
 - **`renderedWith: "http_only_fallback"` in metadata**: JS rendering was requested but no renderer is available. Check your deployment configuration.
+- **`renderedWith: "http"` plus a `js_escalation_failed:` warning**: a renderer was configured and attempted, but every tier failed. The HTTP body is returned instead of an error so the request still yields content. The usual cause is a `timeout` too short for a browser — a cold Chrome navigation can take 15s or more on a heavy page.
 - **Internal error on `renderJs: true`**: Verify the LightPanda sidecar is running and reachable. Check `/health` for renderer status.
 - **Still poor output after increasing `waitFor`**: The issue may be anti-bot protection or authentication flow, not rendering delay.
 

--- a/docs/docs/recipe-js-spa.md
+++ b/docs/docs/recipe-js-spa.md
@@ -282,7 +282,13 @@ else:
 ## Troubleshooting
 
 **`renderedWith` is `"http"` even with `renderJs: true`**
-No JS renderer is configured. Check your deployment or use the cloud endpoint (`https://api.fastcrw.com`).
+Check `warning`. If it starts with `js_escalation_failed:`, a renderer was
+configured and tried but every tier failed (usually the deadline was too short
+for a browser — raise `timeout`); the HTTP body is returned rather than an error
+so you still get content. A PDF also legitimately reports `"http"`, because
+there is no DOM to render. If `renderedWith` is `"http_only_fallback"` instead,
+no JS renderer is configured at all: check your deployment or use the cloud
+endpoint (`https://api.fastcrw.com`).
 
 **Markdown is still empty after rendering**
 The page may be behind an anti-bot wall. Look for a `warnings` array in the response — it will name the vendor (Cloudflare, Akamai, etc.). Switch to `renderer: "chrome_proxy"` with a `country` code to route through a residential IP.


### PR DESCRIPTION
Three failures found while reading prod scrape logs (2026-07-24).

## A failed JS ladder threw away the HTTP body it already had

`fetch_inner`'s `Some(true)` (forced `renderJs:true`) arm called `fetch_with_js` with no `match`, so when every JS tier failed it discarded the HTTP body fetched moments earlier for the content-type check and returned 504.

Reproduced against the prod engine, `https://stripe.com/pricing`:

| request | result |
|---|---|
| auto mode, deadline 5000 | 200 in 0.96s, 37503 B markdown |
| `renderJs:true`, deadline 5000 | 504 `Timeout after 1ms` |
| `renderJs:true`, deadline 15000 | 504 `Timeout after 1ms` |
| `renderJs:true`, deadline 25000 | 200 in 16.5s, **37503 B, byte-identical** |

The auto arm has handled this correctly since the escalation path was written; the asymmetry was the whole bug. Both arms now share the same failure handling, plus:

- **Every** forced-JS fallback is announced via a `js_escalation_failed:` warning. Auto can swap silently because the caller expressed no preference; a `renderJs:true` caller asked for a browser, is billed either way, and must be able to tell they did not get one. The warning survives the block-interstitial short-circuit in `derive_target_warning`, since a block page is the likeliest body to be holding one.
- `elapsed_ms` covers the ladder time actually spent, not just the HTTP fetch.
- Screenshots and hard renderer pins still fail closed.
- `crw-crawl` reads the warning to skip a second escalation round that would re-run the ladder just exhausted.

## Forced-JS gave *less* recall than auto on an HTTP-layer failure

The same arm used `?` on its HTTP fetch, so a `TargetUnreachable` / decode / transient failure never reached the browser — on exactly the origins that reject reqwest's TLS fingerprint, and for every screenshot request, which is routed down this arm. It escalates now, with the auto arm's `TargetUnreachable` attribution rule.

## A truncated render that extracted to nothing was a billed success

The navigation budget expired, the partial DOM held no markdown, and the caller got 200 + an empty document — indistinguishable from a genuinely empty page, and only one of those is fixable by raising `timeout`. Prod, 2026-07-24: 4 of 26 truncated scrapes shipped 0 bytes this way.

Fails as a timeout instead. Scoped deliberately: only when markdown was asked for and is entirely empty. A thin-but-present body stays a success — that is a quality judgment, and taking it would risk recall.

## Also: the truncation warning blamed the wrong tier

`chrome_budget_truncated` was hardcoded, but one struct drives every CDP tier. Every truncation sampled on prod was LightPanda's, reported as Chrome's, sending anyone debugging it to the wrong renderer. It names the tier that ran out now; Chrome's string is unchanged, so existing consumers see no difference.

## Verification

- `cargo test --workspace` 1465 pass / 0 fail
- `cargo fmt --check` and `cargo clippy --workspace -- -D warnings` clean
- End-to-end against a live engine with a dead CDP endpoint: before, `renderJs:true` + 5s returned 500 with no content; after, 200 with the full body, `renderedWith: http`, and the `js_escalation_failed:` warning.
- The truncation fixes are covered by unit tests and prod log evidence; I could not reproduce a live truncation locally to exercise them end to end.