### PR TITLE
fix(renderer): stop anti-bot blocks from stranding the recovery tier

### DIFF
--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -412,11 +412,35 @@ async fn scrape_url_inner(
             .warning
             .as_deref()
             .is_some_and(|w| w.contains(crw_renderer::JS_ESCALATION_FAILED));
+        // The renderer ladder enforces this same floor per tier; apply it one
+        // layer up so we never DISPATCH an escalation that cannot run. `deadline`
+        // is Copy and is the same one the first fetch already spent, so by this
+        // point it is routinely near-exhausted — prod measured 432 of 536
+        // escalations starting with <50ms of budget, which is where the
+        // "JS escalation after empty markdown failed: Timeout after 1ms" lines
+        // come from. Those attempts cannot succeed; they only burn a pool slot
+        // and hide the real outcome behind a fabricated timeout.
+        let escalation_budget = deadline.remaining();
+        let has_escalation_budget = escalation_budget >= crw_renderer::MIN_TIER_BUDGET;
         let should_escalate = (md_is_byte_thin || escalate_for_quality)
             && used_low_tier
             && !js_ladder_exhausted
             && should_escalate_status
-            && escalation_eligible;
+            && escalation_eligible
+            && has_escalation_budget;
+        if (md_is_byte_thin || escalate_for_quality)
+            && used_low_tier
+            && should_escalate_status
+            && escalation_eligible
+            && !has_escalation_budget
+        {
+            tracing::debug!(
+                url = %req.url,
+                remaining_ms = escalation_budget.as_millis() as u64,
+                min_ms = crw_renderer::MIN_TIER_BUDGET.as_millis() as u64,
+                "skipping JS escalation: not enough deadline left to attempt it"
+            );
+        }
         if should_escalate {
             // If the prior tier was lightpanda (returned 200 with thin/no content
             // that fooled the renderer-level thinness check), force chrome on the

--- a/crates/crw-renderer/src/breaker.rs
+++ b/crates/crw-renderer/src/breaker.rs
@@ -18,9 +18,9 @@
 //! [`BreakerOutcome`] which distinguishes deadline-clamped attempts (parent
 //! end-to-end deadline ate the budget) from genuine tier failures. Only
 //! `TierTimeout`/`ConnectionError`/`RenderError` advance the failure window;
-//! `DeadlineClamped` is observed via `crw_breaker_ignored_total` only.
-//! `Truncated` is configurable (default ignored — chrome partial-DOM is a
-//! feature, not a tier failure).
+//! `DeadlineClamped` and `SiteBlocked` are observed via
+//! `crw_breaker_ignored_total` only. `Truncated` is configurable (default
+//! ignored — chrome partial-DOM is a feature, not a tier failure).
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -80,6 +80,16 @@ pub enum BreakerOutcome {
     TierTimeout,
     ConnectionError,
     RenderError,
+    /// The origin refused *us*, not this tier: an anti-bot wall, a vendor
+    /// block, a Cloudflare interstitial, or a block status. Every tier would
+    /// see the same thing, so it says nothing about tier health. Observed via
+    /// `crw_breaker_ignored_total` only, exactly like `DeadlineClamped`.
+    ///
+    /// Recording it as `RenderError` is what let a blocked host trip the
+    /// per-host breaker for lightpanda *and* chrome, leaving `fetch_with_js`
+    /// with no renderer and stranding the one tier (residential egress) that
+    /// could have served the page.
+    SiteBlocked,
 }
 
 impl BreakerOutcome {
@@ -88,6 +98,7 @@ impl BreakerOutcome {
             BreakerOutcome::Success => false,
             BreakerOutcome::Truncated => count_truncated_as_failure,
             BreakerOutcome::DeadlineClamped => false,
+            BreakerOutcome::SiteBlocked => false,
             BreakerOutcome::TierTimeout
             | BreakerOutcome::ConnectionError
             | BreakerOutcome::RenderError => true,
@@ -95,11 +106,15 @@ impl BreakerOutcome {
     }
 
     /// True if this outcome should advance the failure window at all.
-    /// `DeadlineClamped` is fully ignored (only counted in observability).
-    /// `Truncated` is conditionally ignored.
+    /// `DeadlineClamped` and `SiteBlocked` are fully ignored (only counted in
+    /// observability). `Truncated` is conditionally ignored.
+    ///
+    /// NOTE: this match and `ignored_reason` below both end in a wildcard, so
+    /// adding a variant and updating only `is_failure` compiles and silently
+    /// keeps advancing the window. Any new variant must be considered here too.
     fn advances_window(&self, count_truncated_as_failure: bool) -> bool {
         match self {
-            BreakerOutcome::DeadlineClamped => false,
+            BreakerOutcome::DeadlineClamped | BreakerOutcome::SiteBlocked => false,
             BreakerOutcome::Truncated => count_truncated_as_failure,
             _ => true,
         }
@@ -108,6 +123,7 @@ impl BreakerOutcome {
     pub fn ignored_reason(&self) -> Option<&'static str> {
         match self {
             BreakerOutcome::DeadlineClamped => Some("deadline_clamped"),
+            BreakerOutcome::SiteBlocked => Some("site_blocked"),
             BreakerOutcome::Truncated => Some("truncated"),
             _ => None,
         }
@@ -136,12 +152,22 @@ impl AttemptContext {
 /// Classify a tier-attempt result into a BreakerOutcome. Callers must
 /// supply the AttemptContext captured *before* the call so deadline
 /// classification is deterministic regardless of post-await wall time.
+///
+/// `site_blocked` wins over every failure class, including a timeout: an origin
+/// that walls us can also be slow about it, and the wall is still not this
+/// tier's fault. Callers must compute it fresh per attempt — never from a
+/// cumulative "did anything in this request see a block" flag, or one tier's
+/// block would mask the next tier's genuine render failure.
 pub fn classify_outcome(
     success: bool,
     is_truncated: bool,
     error_was_timeout: bool,
+    site_blocked: bool,
     ctx: &AttemptContext,
 ) -> BreakerOutcome {
+    if !success && site_blocked {
+        return BreakerOutcome::SiteBlocked;
+    }
     if success {
         if is_truncated {
             BreakerOutcome::Truncated
@@ -649,13 +675,22 @@ impl BreakerRegistry {
         global_outcome: Option<BreakerOutcome>,
         host_outcome: Option<BreakerOutcome>,
     ) {
+        // Emit the ignored-reason metric for whichever outcome is present, not
+        // just the global one. The host-only callers (the leak-through arm) pass
+        // `global_outcome: None`, so keeping this inside the global branch made
+        // every outcome they record invisible on the dashboard — including the
+        // `site_blocked` pressure this counter exists to surface. Prefer the
+        // global label when both are present so a single call counts once.
+        if let Some(reason) = global_outcome
+            .or(host_outcome)
+            .and_then(|o| o.ignored_reason())
+        {
+            metrics()
+                .breaker_ignored_total
+                .with_label_values(&[renderer.as_str(), reason])
+                .inc();
+        }
         if let Some(outcome) = global_outcome {
-            if let Some(reason) = outcome.ignored_reason() {
-                metrics()
-                    .breaker_ignored_total
-                    .with_label_values(&[renderer.as_str(), reason])
-                    .inc();
-            }
             let g_tripped = self.global_for(renderer).record_outcome(outcome);
             if g_tripped {
                 self.emit_breaker_opened(renderer, "global", host);
@@ -1073,22 +1108,121 @@ mod tests {
     #[test]
     fn classify_outcome_deadline_clamped() {
         let ctx = AttemptContext::capture(Duration::from_millis(500), Duration::from_millis(2500));
-        let outcome = classify_outcome(false, false, true, &ctx);
+        let outcome = classify_outcome(false, false, true, false, &ctx);
         assert_eq!(outcome, BreakerOutcome::DeadlineClamped);
     }
 
     #[test]
     fn classify_outcome_tier_timeout_with_full_budget() {
         let ctx = AttemptContext::capture(Duration::from_millis(8000), Duration::from_millis(2500));
-        let outcome = classify_outcome(false, false, true, &ctx);
+        let outcome = classify_outcome(false, false, true, false, &ctx);
         assert_eq!(outcome, BreakerOutcome::TierTimeout);
     }
 
     #[test]
     fn classify_outcome_truncated_success() {
         let ctx = AttemptContext::capture(Duration::from_millis(8000), Duration::from_millis(2500));
-        let outcome = classify_outcome(true, true, false, &ctx);
+        let outcome = classify_outcome(true, true, false, false, &ctx);
         assert_eq!(outcome, BreakerOutcome::Truncated);
+    }
+
+    /// The bug this exists for: an anti-bot wall is a property of the ORIGIN, so
+    /// every tier egressing from this IP sees it. Counting it as a tier failure
+    /// tripped the per-host breaker for lightpanda AND chrome, which left
+    /// `fetch_with_js` with no renderer to run and stranded the residential tier
+    /// that could have served the page.
+    #[test]
+    fn site_blocks_never_open_the_breaker() {
+        let b = CircuitBreaker::new(small_cfg());
+        // Far more than `min_calls`, all blocks.
+        for _ in 0..200 {
+            b.record_outcome(BreakerOutcome::SiteBlocked);
+        }
+        assert!(
+            !b.is_open(),
+            "a walled origin must not be recorded as renderer ill-health"
+        );
+        assert_eq!(
+            b.snapshot().window_call_count,
+            0,
+            "SiteBlocked must not advance the window at all"
+        );
+    }
+
+    /// A blocked host must not mask a genuinely broken tier: `SiteBlocked` is
+    /// ignored, but real failures interleaved with it still count.
+    #[test]
+    fn site_blocks_do_not_mask_real_failures() {
+        let b = CircuitBreaker::new(small_cfg());
+        for _ in 0..50 {
+            b.record_outcome(BreakerOutcome::SiteBlocked);
+            b.record_outcome(fail());
+        }
+        assert!(
+            b.is_open(),
+            "interleaved genuine failures must still trip the breaker"
+        );
+    }
+
+    #[test]
+    fn site_blocked_is_observable_and_non_advancing() {
+        assert_eq!(
+            BreakerOutcome::SiteBlocked.ignored_reason(),
+            Some("site_blocked"),
+            "must be visible on the dashboard, not silently dropped"
+        );
+        assert!(!BreakerOutcome::SiteBlocked.is_failure(false));
+        assert!(!BreakerOutcome::SiteBlocked.advances_window(false));
+        // Guard against the wildcard trap: `advances_window` and
+        // `ignored_reason` both end in `_ =>`, so a new variant that updates only
+        // `is_failure` would compile and silently keep advancing the window.
+        assert!(!BreakerOutcome::DeadlineClamped.advances_window(false));
+    }
+
+    /// `site_blocked` outranks a timeout: an origin that walls us can also be
+    /// slow about it, and the wall is still not the tier's fault.
+    #[test]
+    fn classify_outcome_site_blocked_beats_timeout() {
+        let ctx = AttemptContext::capture(Duration::from_millis(8000), Duration::from_millis(2500));
+        assert_eq!(
+            classify_outcome(false, false, true, true, &ctx),
+            BreakerOutcome::SiteBlocked
+        );
+        // …but a SUCCESS is still a success, block flag or not.
+        assert_eq!(
+            classify_outcome(true, false, false, true, &ctx),
+            BreakerOutcome::Success
+        );
+    }
+
+    /// Documents a real side effect of non-advancing outcomes rather than
+    /// leaving it to be discovered later: because the HalfOpen arm returns the
+    /// admitted slot, a stream of `SiteBlocked` never reaches `max_probes`, so
+    /// HalfOpen cannot be decided by probe count and exits only via
+    /// `eval_timeout`. Until then it admits unbounded probes. Accepted because
+    /// per-host in-flight work is separately capped by `host_limiter`, and the
+    /// alternative (counting blocks) is the bug this whole change removes.
+    #[test]
+    fn site_blocked_probes_are_returned_not_counted() {
+        let cfg = BreakerConfig {
+            max_probes: 2,
+            ..small_cfg()
+        };
+        let b = CircuitBreaker::new(cfg);
+        for _ in 0..cfg.min_calls * 2 {
+            b.record_outcome(fail());
+        }
+        assert!(b.is_open());
+        std::thread::sleep(cfg.base_cooldown + Duration::from_millis(50));
+        // Now HalfOpen. Every probe reports a site block.
+        for _ in 0..10 {
+            assert_eq!(b.try_acquire(), Permit::Probe, "slot is always returned");
+            b.record_outcome(BreakerOutcome::SiteBlocked);
+        }
+        assert!(
+            !b.is_open(),
+            "ignored outcomes must not re-open the breaker by themselves"
+        );
     }
 
     #[test]

--- a/crates/crw-renderer/src/detector.rs
+++ b/crates/crw-renderer/src/detector.rs
@@ -591,6 +591,28 @@ pub fn is_cloudflare_mitigated_header(header_value: &str) -> bool {
     matches!(lower.as_str(), "challenge" | "block")
 }
 
+/// Returns true when the `x-amzn-waf-action` response header indicates AWS WAF
+/// Bot Control challenged the request.
+///
+/// AWS serves a Challenge/CAPTCHA action as **HTTP 202 with a zero-length
+/// body**, so no body-based detector can see it — `looks_like_generic_bot_wall`
+/// and `antibot::classify` both have nothing to scan. Measured on the prod host:
+/// ballotpedia.org, jwa.org and seattletimes.com all answer `202` +
+/// `content-length: 0` + this header, and all three return a full page through
+/// residential egress. Without this predicate the empty 202 is returned to the
+/// caller as a successful scrape with no content.
+///
+/// Deliberately a SEPARATE predicate from [`is_cloudflare_mitigated_header`]
+/// rather than a shared value list: AWS documents `challenge` and `captcha`
+/// (a WAF Block action uses its own configured status and body instead, so
+/// `block` is not a value of this header), while Cloudflare's `cf-mitigated`
+/// uses `challenge` and `block`. One merged match arm would silently either
+/// widen CF to `captcha` or drop `block` from it.
+pub fn is_aws_waf_action_header(header_value: &str) -> bool {
+    let lower = header_value.trim().to_ascii_lowercase();
+    matches!(lower.as_str(), "challenge" | "captcha")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -39,6 +39,26 @@ const HTTP_MAX_RETRIES: u32 = 1;
 /// Backoff before the retry attempt. Short — we are inside the request path
 /// and the upstream timeout is 30s, so we cannot afford long sleeps.
 const HTTP_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
+/// Budget held back from a proxy attempt that was armed mid-loop by a 429 or a
+/// header-announced challenge, so a hanging proxy can always fall back to direct.
+///
+/// Much smaller than [`crate::egress::DIRECT_FALLBACK_RESERVE`] (4s) on purpose:
+/// that one reserves for a FIRST-CONTACT direct attempt on a latched host, while
+/// this one only has to repeat a response we already received milliseconds ago.
+const CHALLENGE_DIRECT_RESERVE: std::time::Duration = std::time::Duration::from_millis(1500);
+/// Ceiling on a single challenge-armed proxy attempt, independent of how much
+/// deadline is left.
+///
+/// Without a ceiling the attempt gets `remaining - CHALLENGE_DIRECT_RESERVE`,
+/// which on the 15s search budget is 13.5s — so a hanging exit burns almost the
+/// whole request and THEN returns the same empty body the origin gave us in 70ms.
+/// That is a p90 regression on exactly the class this change exists to improve.
+///
+/// 6s comes from the measured distribution of the residential exit on the
+/// affected hosts: p50 2.3s, with one 38.2s outlier. It covers the realistic
+/// success cases with >2x headroom while capping the wasted wall-clock when the
+/// exit is in its bad tail. Everything above it stays with the direct rescue.
+const CHALLENGE_PROXY_MAX: std::time::Duration = std::time::Duration::from_secs(6);
 
 /// Returns true if a `reqwest::Error` is worth retrying on the SAME egress.
 /// Read-phase timeouts only (`is_timeout` without `is_connect`): the origin
@@ -109,12 +129,64 @@ fn is_ratelimit_status(status: u16) -> bool {
     matches!(status, 429)
 }
 
+/// A vendor challenge announced in a response header, independent of status and
+/// body. Both variants mean "this origin refused *this egress IP*", which is
+/// exactly the class a different egress can clear.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChallengeHeader {
+    CloudflareMitigated,
+    AwsWaf,
+}
+
+impl ChallengeHeader {
+    /// Stable marker written to `FetchResult::warning`; `crate::fetch_inner`
+    /// matches on it to decide whether to escalate.
+    pub(crate) fn marker(self) -> &'static str {
+        match self {
+            Self::CloudflareMitigated => "cloudflare_mitigated",
+            Self::AwsWaf => "waf_challenge",
+        }
+    }
+
+    /// Customer-visible text. Kept next to the marker so an AWS-WAF block can
+    /// never be reported to the caller as a Cloudflare one (the previous text
+    /// was hardcoded and reaches the API via `crw_crawl::single`).
+    pub(crate) fn warning_text(self) -> &'static str {
+        match self {
+            Self::CloudflareMitigated => {
+                "cf-mitigated header indicates Cloudflare challenge or block"
+            }
+            Self::AwsWaf => "x-amzn-waf-action header indicates an AWS WAF challenge",
+        }
+    }
+}
+
+/// Detect a header-announced challenge on a response.
+///
+/// Dispatches on header NAME to its own predicate — the two value lists differ
+/// (`cf-mitigated`: challenge|block, `x-amzn-waf-action`: challenge|captcha) and
+/// merging them would silently change the pre-existing Cloudflare behaviour.
+///
+/// Factored because the same read appeared verbatim at three points in the retry
+/// state machine (direct retry arm, latched-proxy rescue guard, and the final
+/// `FetchResult` stamp), each against a different response value.
+pub(crate) fn challenge_header(headers: &reqwest::header::HeaderMap) -> Option<ChallengeHeader> {
+    let value = |name: &str| headers.get(name).and_then(|v| v.to_str().ok());
+    if value("cf-mitigated").is_some_and(crate::detector::is_cloudflare_mitigated_header) {
+        return Some(ChallengeHeader::CloudflareMitigated);
+    }
+    if value("x-amzn-waf-action").is_some_and(crate::detector::is_aws_waf_action_header) {
+        return Some(ChallengeHeader::AwsWaf);
+    }
+    None
+}
+
 /// Should the fetch retry once through the fallback proxy? True on an explicit
-/// rate-limit status (429) OR when the `cf-mitigated` response header flags a
-/// Cloudflare challenge/block — the header is a positive signal, so a different
-/// egress IP may clear it even when served as 200/403/503. Pure for unit test.
-fn should_arm_proxy(status: u16, cf_mitigated: bool) -> bool {
-    is_ratelimit_status(status) || cf_mitigated
+/// rate-limit status (429) OR when a response header flags a vendor
+/// challenge — the header is a positive signal, so a different egress IP may
+/// clear it even when served as 200/202/403/503. Pure for unit test.
+fn should_arm_proxy(status: u16, challenge: Option<ChallengeHeader>) -> bool {
+    is_ratelimit_status(status) || challenge.is_some()
 }
 
 /// Is `CRW_HTTP_TLS_RELAXED_FALLBACK` enabled? When on, a fetch that fails TLS
@@ -138,6 +210,28 @@ fn tls_relaxed_fallback_enabled() -> bool {
 /// behind a single shared IP when a huge proxy pool is available. Unset (or
 /// empty) = behavior identical to before (no proxy retry). SSRF protection is
 /// unaffected (it runs on the resolved target URL, not the proxy hop).
+/// Does the environment configure a proxy that `reqwest` will pick up on its own?
+///
+/// `build_client` does not call `.no_proxy()`, so reqwest honours `HTTP_PROXY` /
+/// `HTTPS_PROXY` / `ALL_PROXY` automatically. A fetcher built with `proxy: None`
+/// therefore still egresses through a proxy when those are set — which would make
+/// the egress-latch hooks below attribute a proxy-observed block to DIRECT
+/// traffic, latch it, and demote every other caller's healthy direct egress.
+/// Unset on the managed deployment; load-bearing for self-hosters behind a
+/// corporate proxy.
+fn env_proxy_configured() -> bool {
+    [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ]
+    .iter()
+    .any(|k| std::env::var(k).is_ok_and(|v| !v.trim().is_empty()))
+}
+
 fn ratelimit_proxy_url() -> Option<String> {
     std::env::var("CRW_HTTP_RATELIMIT_PROXY_URL")
         .ok()
@@ -230,6 +324,13 @@ pub struct HttpFetcher {
     /// different egress IP (`is_ratelimit_status`); `None` keeps behavior
     /// identical to before.
     ratelimit_proxy_client: Option<reqwest::Client>,
+    /// True when the PRIMARY `client` already egresses through a proxy (config
+    /// rotation / BYOP via [`Self::with_proxy`]). Egress provenance is not
+    /// otherwise recoverable: `use_proxy` stays `false` for such a fetcher even
+    /// though every request leaves through a proxy, so without this flag the
+    /// egress-latch write hooks below would record a proxy-observed block as a
+    /// DIRECT one and demote every other caller's healthy direct traffic.
+    has_static_proxy: bool,
     inject_stealth_headers: bool,
 }
 
@@ -241,6 +342,14 @@ impl HttpFetcher {
             inject_stealth_headers,
             HTTP_REQUEST_TIMEOUT,
         )
+    }
+
+    /// Did a usable fallback-proxy client actually build? Distinct from "the env
+    /// var is set": a malformed `CRW_HTTP_RATELIMIT_PROXY_URL` leaves this `None`,
+    /// and callers reasoning about whether a recovery egress EXISTS must not be
+    /// fooled by a typo.
+    pub fn has_ratelimit_proxy(&self) -> bool {
+        self.ratelimit_proxy_client.is_some()
     }
 
     /// Same as [`Self::new`] but with a caller-supplied request timeout.
@@ -271,6 +380,7 @@ impl HttpFetcher {
             client,
             relaxed_client,
             ratelimit_proxy_client,
+            has_static_proxy: proxy.is_some() || env_proxy_configured(),
             inject_stealth_headers,
         }
     }
@@ -298,6 +408,7 @@ impl HttpFetcher {
             client,
             relaxed_client,
             ratelimit_proxy_client,
+            has_static_proxy: true,
             inject_stealth_headers,
         })
     }
@@ -377,6 +488,19 @@ impl PageFetcher for HttpFetcher {
         };
         let mut use_proxy = proxy_first;
         let mut direct_rescue_used = false;
+        // Set when the proxy is armed MID-LOOP (by a 429 or a header-announced
+        // challenge) rather than by the latch. Such an attempt needs the same
+        // direct-rescue guarantee the latched path gets, or a hung proxy turns a
+        // soft response into a hard Timeout.
+        let mut armed_mid_loop = false;
+        // Narrower: armed specifically by a challenge HEADER. Only this case takes
+        // the challenge budget shaping below. The 429 arm predates this change and
+        // its budget behaviour is deliberately left byte-identical — the 6s ceiling
+        // is derived from the residential exit's distribution on the AWS-WAF hosts
+        // in this ticket, which says nothing about the rate-limited population, and
+        // capping it would newly time out a slow-but-working exit on the 15s search
+        // and 92.5s crawl budgets.
+        let mut armed_from_challenge = false;
         if proxy_first {
             let m = crw_core::metrics::metrics();
             m.egress_latch_hit_total.inc();
@@ -406,8 +530,36 @@ impl PageFetcher for HttpFetcher {
             // origin no longer fits in it. `proxy_first` already guarantees the
             // budget is at least MIN_BUDGET_FOR_LATCH, so this subtraction always
             // leaves a real proxy attempt behind.
-            let attempt_budget = if use_proxy && proxy_first && !direct_rescue_used {
-                remaining.saturating_sub(crate::egress::DIRECT_FALLBACK_RESERVE)
+            //
+            // The challenge-armed case (`armed_from_challenge`) needs a reserve
+            // too — without one, a hung proxy consumes the whole deadline, the
+            // rescue arm switches to direct, and the next loop iteration finds
+            // zero budget and returns Timeout anyway. But it must NOT use
+            // DIRECT_FALLBACK_RESERVE: on a 5s scrape that leaves ~0.9s, which
+            // `attempt_budget.is_zero()` immediately hands back to direct, making
+            // the whole retry inert.
+            //
+            // `CHALLENGE_DIRECT_RESERVE`, capped at half of what is left: the
+            // direct response this arm rescues to is one we ALREADY received
+            // (that is what armed the proxy), so the rescue only has to repeat a
+            // request measured at ~70ms — it does not need the full 4s a latched
+            // first-contact rescue does. On a 5s scrape that leaves the proxy
+            // ~3.4s against a measured p50 of 2.3s; a flat `remaining / 2` left
+            // only 2.4s, i.e. 165ms of headroom over p50, which would have made
+            // F3a a coin flip on the tightest real budget. The `/ 2` cap keeps a
+            // rescue reachable when very little time is left.
+            let attempt_budget = if use_proxy && !direct_rescue_used {
+                if proxy_first {
+                    remaining.saturating_sub(crate::egress::DIRECT_FALLBACK_RESERVE)
+                } else if armed_from_challenge {
+                    let after_reserve = remaining
+                        .saturating_sub(std::cmp::min(remaining / 2, CHALLENGE_DIRECT_RESERVE));
+                    // Capped so a large budget does not turn a hanging exit into a
+                    // 13.5s wait for the same empty body direct returned in 70ms.
+                    std::cmp::min(after_reserve, CHALLENGE_PROXY_MAX)
+                } else {
+                    remaining
+                }
             } else {
                 remaining
             };
@@ -441,7 +593,7 @@ impl PageFetcher for HttpFetcher {
                 // This is the case the reserve exists for: fall back to direct with
                 // the budget we held back, instead of failing the whole fetch on a
                 // proxy that a latch — possibly a false one — put in front of it.
-                Err(_) if use_proxy && proxy_first && !direct_rescue_used => {
+                Err(_) if use_proxy && (proxy_first || armed_mid_loop) && !direct_rescue_used => {
                     tracing::warn!(
                         "proxy attempt for {url} exhausted its budget while latched; falling back to direct"
                     );
@@ -479,30 +631,33 @@ impl PageFetcher for HttpFetcher {
                         // burn the rescue budget on an attempt we know fails.
                         && !direct_rescue_used
                         && self.ratelimit_proxy_client.is_some()
-                        && should_arm_proxy(
-                            r.status().as_u16(),
-                            r.headers()
-                                .get("cf-mitigated")
-                                .and_then(|v| v.to_str().ok())
-                                .map(crate::detector::is_cloudflare_mitigated_header)
-                                .unwrap_or(false),
-                        ) =>
+                        && should_arm_proxy(r.status().as_u16(), challenge_header(r.headers())) =>
                 {
+                    let armed_by_header = challenge_header(r.headers()).is_some();
                     tracing::warn!(
-                        "HTTP {} from {url} (origin rate-limited or cf-mitigated); retrying once via proxy (ratelimit_bypassed)",
+                        "HTTP {} from {url} (origin rate-limited or header-announced challenge); retrying once via proxy (ratelimit_bypassed)",
                         r.status()
                     );
                     drop(r);
-                    // WRITE HOOK — direct-only by construction: this arm is gated on
-                    // `!use_proxy`, so the block we just saw was observed on a
-                    // genuine direct attempt. Remember it, so the next URL on this
-                    // host starts on the proxy instead of paying the climb again.
+                    // The proxy was armed mid-loop, so `proxy_first` is false and
+                    // the three rescue arms below would not fire for it. Arm them
+                    // explicitly, or a hung proxy eats the whole deadline and turns
+                    // a soft empty response into a hard Timeout.
+                    armed_mid_loop = true;
+                    armed_from_challenge = armed_by_header;
+                    // WRITE HOOK — direct-only: this arm is gated on `!use_proxy`,
+                    // AND on `!has_static_proxy` because a BYOP/config-rotation
+                    // fetcher egresses through a proxy while `use_proxy` stays
+                    // false. Remember it, so the next URL on this host starts on
+                    // the proxy instead of paying the climb again.
                     //
                     // A block seen *through* a proxy must never land here: it would
                     // say the proxy is blocked, not direct, and would let one
                     // caller's broken proxy demote every other caller's healthy
                     // direct traffic onto paid bandwidth.
-                    if let Some(h) = &host {
+                    if let Some(h) = &host
+                        && !self.has_static_proxy
+                    {
                         let eg = crate::egress::global();
                         eg.note_block(h).await;
                         crw_core::metrics::metrics()
@@ -535,14 +690,10 @@ impl PageFetcher for HttpFetcher {
                 // never wastes the rescue.
                 Ok(Ok(r))
                     if use_proxy
-                        && proxy_first
+                        && (proxy_first || armed_mid_loop)
                         && !direct_rescue_used
                         && (!r.status().is_success()
-                            || r.headers()
-                                .get("cf-mitigated")
-                                .and_then(|v| v.to_str().ok())
-                                .map(crate::detector::is_cloudflare_mitigated_header)
-                                .unwrap_or(false)) =>
+                            || challenge_header(r.headers()).is_some()) =>
                 {
                     tracing::warn!(
                         "HTTP {} from {url} via proxy while latched; falling back to direct",
@@ -566,7 +717,9 @@ impl PageFetcher for HttpFetcher {
                 // every scrape of a latched host into a hard failure for the whole
                 // cooldown — a scrape-success regression, and precisely the case the
                 // "reorder, never suppress" rule exists to prevent.
-                Ok(Err(_)) if use_proxy && proxy_first && !direct_rescue_used => {
+                Ok(Err(_))
+                    if use_proxy && (proxy_first || armed_mid_loop) && !direct_rescue_used =>
+                {
                     tracing::warn!(
                         "proxy egress failed for {url} while latched; falling back to direct"
                     );
@@ -675,21 +828,45 @@ impl PageFetcher for HttpFetcher {
             .as_deref()
             .and_then(charset_from_content_type);
 
-        let cf_mitigated = resp
-            .headers()
-            .get("cf-mitigated")
-            .and_then(|v| v.to_str().ok())
-            .map(crate::detector::is_cloudflare_mitigated_header)
-            .unwrap_or(false);
+        let challenge = challenge_header(resp.headers());
 
         let is_pdf = content_type.as_deref() == Some("application/pdf");
 
         let final_url_str = resp.url().as_str().to_string();
 
-        let bytes = resp
-            .bytes()
-            .await
-            .map_err(|e| CrwError::HttpError(e.to_string()))?;
+        // Bound the body read by the caller's remaining budget. Without this the
+        // read is governed only by the client-level `HTTP_REQUEST_TIMEOUT` (30s),
+        // so an origin (or proxy exit) that sends headers promptly and then stalls
+        // the body blows straight through a 5-15s request deadline.
+        //
+        // Floored at MIN_TIER_BUDGET, NOT at ~0: `send()` resolves on HEADERS, and
+        // the attempt above may legitimately have consumed almost the whole
+        // deadline reaching them. A bare `remaining` would hand a slow-TTFB origin
+        // a sliver of a millisecond to stream a body it would have delivered in
+        // 200ms — turning "late but complete" into a hard error, which is strictly
+        // worse than the 30s blow-through this bound exists to stop (`Ok` counts
+        // toward scrape success; `Err` does not).
+        //
+        // ponytail: known residual, deliberately not fixed here. The loop exits on
+        // a clean 2xx BEFORE the body is known, so a challenge-armed proxy that
+        // sends 200 headers and then stalls yields an error rather than falling
+        // back to direct — the same shape the pre-existing 429 arm has always had.
+        // Fixing it properly means restructuring `fetch` so the body read sits
+        // inside the retry loop; that is a bigger change than this ticket, and the
+        // failure needs a proxy that answers headers and then dies.
+        let bytes = match tokio::time::timeout(
+            deadline.remaining().max(crate::MIN_TIER_BUDGET),
+            resp.bytes(),
+        )
+        .await
+        {
+            Ok(r) => r.map_err(|e| CrwError::HttpError(e.to_string()))?,
+            Err(_) => {
+                return Err(CrwError::Timeout(
+                    (start.elapsed().as_millis().max(1)) as u64,
+                ));
+            }
+        };
 
         if bytes.len() > MAX_RESPONSE_BYTES {
             return Err(CrwError::HttpError(format!(
@@ -703,6 +880,51 @@ impl PageFetcher for HttpFetcher {
         } else {
             (decode_html_bytes(&bytes, header_charset.as_deref()), None)
         };
+
+        // SECOND WRITE HOOK — body-verdict blocks that carry no header and no
+        // block status, which is how Wikimedia serves its datacenter-IP ban
+        // (the canonical footer phrase in a `<body>`-less shell; see
+        // `detector::looks_like_generic_bot_wall`). The header hook above cannot
+        // see those, and the arm it sits in never fires for them, so without this
+        // every URL on such a host re-climbs the whole doomed ladder.
+        //
+        // Placed HERE rather than in `crate::fetch_inner` on purpose: this is the
+        // only point where the decoded body and the egress provenance
+        // (`use_proxy` / `has_static_proxy`) are both in scope. Latching from the
+        // renderer would be unable to tell a direct block from a proxied one, and
+        // a proxy-observed block would re-latch on every request — the TTL would
+        // never expire, so direct would never be re-probed and the host would be
+        // pinned to paid egress permanently.
+        //
+        // Fingerprint walls are excluded: a residential IP does not clear a
+        // Cloudflare managed challenge or a vendor SDK wall, so latching one only
+        // burns paid bandwidth.
+        //
+        // ponytail: `antibot::classify` deliberately does not run on this tier, so
+        // a vendor wall recognisable only from visible text (a PerimeterX/Imperva
+        // page with no SDK marker) is not excluded here and can latch for the
+        // 10-minute TTL. Bounded — the latch only reorders egress, never suppresses
+        // direct. Upgrade path if it ever matters: thread the classifier verdict
+        // down instead of adding a second classify() call to this hot path.
+        if !use_proxy
+            && !self.has_static_proxy
+            && !is_pdf
+            && let Some(h) = &host
+            && crate::detector::looks_like_generic_bot_wall(&html)
+            && !crate::detector::looks_like_cloudflare_challenge(&html)
+            && crate::detector::looks_like_vendor_block(&html).is_none()
+        {
+            let eg = crate::egress::global();
+            eg.note_block(h).await;
+            crw_core::metrics::metrics()
+                .egress_latched_hosts
+                .set(eg.latched_hosts() as i64);
+            tracing::info!(
+                url,
+                status,
+                "direct egress hit an IP-reputation block; latching host to proxy-first"
+            );
+        }
 
         let final_url = if final_url_str != url {
             Some(final_url_str)
@@ -723,18 +945,12 @@ impl PageFetcher for HttpFetcher {
                 Some("http".to_string())
             },
             elapsed_ms: start.elapsed().as_millis() as u64,
-            warning: if cf_mitigated {
-                Some("cloudflare_mitigated".to_string())
-            } else {
-                None
-            },
+            warning: challenge.map(|c| c.marker().to_string()),
             render_decision: None,
             credit_cost: 0,
-            warnings: if cf_mitigated {
-                vec!["cf-mitigated header indicates Cloudflare challenge or block".to_string()]
-            } else {
-                Vec::new()
-            },
+            warnings: challenge
+                .map(|c| vec![c.warning_text().to_string()])
+                .unwrap_or_default(),
             truncated: false,
             deadline_exceeded: false,
             captured_responses: Vec::new(),
@@ -811,14 +1027,71 @@ mod tests {
 
     #[test]
     fn should_arm_proxy_truth_table() {
-        assert!(should_arm_proxy(429, false), "429 arms on its own");
+        use ChallengeHeader::{AwsWaf, CloudflareMitigated};
+        assert!(should_arm_proxy(429, None), "429 arms on its own");
         assert!(
-            !should_arm_proxy(403, false),
+            !should_arm_proxy(403, None),
             "403 without header does not arm"
         );
-        assert!(should_arm_proxy(403, true), "403 + cf-mitigated arms");
-        assert!(should_arm_proxy(200, true), "challenge served as 200 arms");
-        assert!(!should_arm_proxy(200, false), "clean 200 does not arm");
+        assert!(
+            should_arm_proxy(403, Some(CloudflareMitigated)),
+            "403 + cf-mitigated arms"
+        );
+        assert!(
+            should_arm_proxy(200, Some(CloudflareMitigated)),
+            "challenge served as 200 arms"
+        );
+        assert!(!should_arm_proxy(200, None), "clean 200 does not arm");
+        // The AWS-WAF shape: 202 with an empty body. Nothing in the status or
+        // the body says "blocked", so without the header this response is
+        // indistinguishable from a legitimate empty 202.
+        assert!(
+            should_arm_proxy(202, Some(AwsWaf)),
+            "202 + x-amzn-waf-action arms"
+        );
+        assert!(!should_arm_proxy(202, None), "bare 202 does not arm");
+    }
+
+    fn header_map(pairs: &[(&str, &str)]) -> reqwest::header::HeaderMap {
+        let mut h = reqwest::header::HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    /// The two header predicates must NOT share a value list: `cf-mitigated`
+    /// uses challenge|block, `x-amzn-waf-action` uses challenge|captcha. Merging
+    /// them would silently drop `block` from the pre-existing Cloudflare path.
+    #[test]
+    fn challenge_header_keeps_the_two_value_lists_separate() {
+        use ChallengeHeader::{AwsWaf, CloudflareMitigated};
+        assert_eq!(
+            challenge_header(&header_map(&[("cf-mitigated", "block")])),
+            Some(CloudflareMitigated),
+            "cf-mitigated: block must still arm"
+        );
+        assert_eq!(
+            challenge_header(&header_map(&[("x-amzn-waf-action", "captcha")])),
+            Some(AwsWaf)
+        );
+        assert_eq!(
+            challenge_header(&header_map(&[("x-amzn-waf-action", "CHALLENGE")])),
+            Some(AwsWaf),
+            "header values are matched case-insensitively"
+        );
+        assert_eq!(
+            challenge_header(&header_map(&[("x-amzn-waf-action", "block")])),
+            None,
+            "`block` is not a documented value of this header"
+        );
+        assert_eq!(challenge_header(&header_map(&[])), None);
+        // The customer-visible text must name the right vendor.
+        assert!(AwsWaf.warning_text().contains("AWS WAF"));
+        assert!(CloudflareMitigated.warning_text().contains("Cloudflare"));
     }
 
     /// Complete the handshake, read the request, THEN abort with RST
@@ -982,6 +1255,7 @@ mod tests {
         let fetcher = HttpFetcher {
             client: reqwest::Client::new(),
             relaxed_client: None,
+            has_static_proxy: false,
             ratelimit_proxy_client: Some(
                 build_client(
                     "test-ua",
@@ -1020,6 +1294,7 @@ mod tests {
             client: reqwest::Client::new(),
             relaxed_client: None,
             ratelimit_proxy_client: None,
+            has_static_proxy: false,
             inject_stealth_headers: false,
         };
         let err = fetcher
@@ -1081,6 +1356,7 @@ mod tests {
             client: reqwest::Client::new(),
             relaxed_client: None,
             ratelimit_proxy_client: None,
+            has_static_proxy: false,
             inject_stealth_headers: false,
         };
         let _ = fetcher
@@ -1115,6 +1391,7 @@ mod tests {
         let fetcher = HttpFetcher {
             client: reqwest::Client::new(),
             relaxed_client: None,
+            has_static_proxy: false,
             ratelimit_proxy_client: Some(
                 build_client(
                     "ua",

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -313,6 +313,65 @@ struct JsAttemptClass {
 /// residential egress DOES recover — those still fire the arm. The `vendor_block`
 /// "cloudflare" arm is deliberately excluded (CF is matched via `cf_challenge`)
 /// so a CF error-1020 IP block is NOT wrongly suppressed.
+/// See [`FallbackRenderer::has_recovery_tier`]. True when SOME tier can plausibly
+/// clear an IP-reputation block: residential CDP egress, a stealth tier that the
+/// auto path can actually reach, or a usable fallback HTTP proxy.
+///
+/// Every input is the REAL constructed thing, never a config flag or an env var:
+///   * a `chrome_proxy` / `camoufox` entry present in `js_renderers` — camoufox
+///     with `include_in_auto = false` is filtered out of the auto chain per
+///     request, so it is excluded here too or a self-hoster who configured it
+///     for pinned use only would silently lose the breaker's brake;
+///   * `cloak_arm`, which is stored OUTSIDE `js_renderers` and would otherwise
+///     read as "no recovery" while a perfectly good recovery tier exists;
+///   * the concrete fetcher's `has_ratelimit_proxy()`, not the env var — a malformed
+///     `CRW_HTTP_RATELIMIT_PROXY_URL` leaves the client `None`, and a typo must
+///     not be mistaken for a recovery egress.
+fn has_recovery_tier(
+    config: &crw_core::config::RendererConfig,
+    js_renderers: &[Arc<dyn PageFetcher>],
+    cloak_arm_present: bool,
+    http_fallback_proxy_ready: bool,
+) -> bool {
+    let auto_reachable = |name: &str| {
+        js_renderers.iter().any(|r| r.name() == name)
+            && match name {
+                "camoufox" => config
+                    .camoufox
+                    .as_ref()
+                    .is_some_and(|cf| cf.include_in_auto),
+                _ => true,
+            }
+    };
+    auto_reachable("chrome_proxy")
+        || auto_reachable("camoufox")
+        || cloak_arm_present
+        || http_fallback_proxy_ready
+}
+
+/// May a browser render plausibly reveal more than this response body did?
+///
+/// The HTTP tier decodes every non-PDF response as HTML regardless of its
+/// declared type, so an empty `application/json` / `text/plain` / `image/*` /
+/// archive response is indistinguishable from an empty HTML shell by body shape
+/// alone. A browser cannot add content to any of those, so escalating them buys
+/// nothing but latency. Absent or unrecognised types stay eligible: a server
+/// that omits `Content-Type` on a bot-wall shell is exactly the case worth
+/// escalating.
+fn content_type_allows_js_escalation(content_type: Option<&str>) -> bool {
+    match content_type {
+        None => true,
+        Some(ct) => {
+            let ct = ct.trim().to_ascii_lowercase();
+            ct.is_empty()
+                || ct == "text/html"
+                || ct == "application/xhtml+xml"
+                || ct == "application/xml"
+                || ct == "text/xml"
+        }
+    }
+}
+
 fn is_fingerprint_vendor_wall(
     cf_challenge: bool,
     vendor_block: Option<&str>,
@@ -416,7 +475,7 @@ fn is_soft_block_status(status_code: u16) -> bool {
 /// `Timeout after Nms` (single-digit N) while still consuming a pool slot.
 /// Guards the main ladder loop, the hedge dispatch, the breaker leak-through arm,
 /// and the HTTP tier's proxy retry (`http_only`).
-pub(crate) const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
+pub const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
 
 /// Fresh render budget the `chrome_proxy` auto-egress recovery arm gets when it
 /// fires, instead of the shared request deadline. The HTTP/LightPanda/Chrome
@@ -475,6 +534,19 @@ pub struct FallbackRenderer {
     /// the residential pool (see [`CHROME_PROXY_ARM_BUDGET_MS`]). Sized to
     /// `pool_size` so at most a poolful of arms run and none blocks.
     chrome_proxy_arm_sem: Arc<tokio::sync::Semaphore>,
+    /// Is there any tier that could actually clear an IP-reputation block —
+    /// residential CDP egress, the stealth tier, or a fallback HTTP proxy?
+    ///
+    /// Gates the `SiteBlocked` breaker classification. Ignoring a site block in
+    /// the failure window only pays off when something downstream can recover
+    /// the page. Where nothing can (the common self-host build: no
+    /// `chrome_proxy`, no cloak, no `CRW_HTTP_RATELIMIT_PROXY_URL`), every tier
+    /// egresses from the same banned IP, so suppressing the breaker would make a
+    /// permanently blocked host re-walk the whole serial ladder on every request
+    /// — measured ~3-6s/page against ~0.5s once the breaker opens, i.e. a 6-12x
+    /// slowdown on a crawl, buying exactly zero recall. There, the breaker keeps
+    /// its brake and behaviour is unchanged.
+    has_recovery_tier: bool,
     /// Per-host renderer preference learning (auto-mode only).
     preferences: Arc<HostPreferences>,
     /// Per-host + global circuit breakers per renderer.
@@ -566,12 +638,17 @@ impl FallbackRenderer {
         if let Some(p) = proxy {
             crw_core::ProxyEntry::parse(p).map_err(CrwError::ConfigError)?;
         }
-        let http = Arc::new(http_only::HttpFetcher::with_timeout(
+        let http_concrete = http_only::HttpFetcher::with_timeout(
             &effective_ua,
             proxy,
             inject_headers,
             std::time::Duration::from_millis(http_timeout_ms),
-        )) as Arc<dyn PageFetcher>;
+        );
+        // Read off the CONCRETE fetcher: once coerced to `Arc<dyn PageFetcher>` the
+        // proxy-availability question is no longer askable, and asking the env var
+        // instead would call a malformed URL a working recovery egress.
+        let http_fallback_proxy_ready = http_concrete.has_ratelimit_proxy();
+        let http = Arc::new(http_concrete) as Arc<dyn PageFetcher>;
 
         // A pinned backend (Lightpanda/Chrome/Playwright) must have CDP compiled in
         // AND its matching endpoint configured. `Auto` and `None` remain functional
@@ -632,6 +709,9 @@ impl FallbackRenderer {
                 chrome_proxy_arm_sem: Arc::new(tokio::sync::Semaphore::new(
                     config.chrome_proxy_pool_size(),
                 )),
+                // `mode = none` builds no JS tier at all, so the only possible
+                // recovery is the HTTP fallback proxy.
+                has_recovery_tier: http_fallback_proxy_ready,
                 preferences: Arc::new(HostPreferences::with_defaults()),
                 breakers: Arc::new(BreakerRegistry::with_defaults()),
                 tier_timeouts: tier_timeouts_from(config),
@@ -934,6 +1014,19 @@ impl FallbackRenderer {
             );
         }
 
+        // The cloak arm is feature-gated and lives outside `js_renderers`, so its
+        // presence has to be reduced to a bool here — a lean build has no such
+        // binding at all.
+        #[cfg(feature = "cloak")]
+        let cloak_arm_present = cloak_arm.is_some();
+        #[cfg(not(feature = "cloak"))]
+        let cloak_arm_present = false;
+        let recovery_tier_available = has_recovery_tier(
+            config,
+            &js_renderers,
+            cloak_arm_present,
+            http_fallback_proxy_ready,
+        );
         Ok(Self {
             http,
             js_renderers,
@@ -945,6 +1038,7 @@ impl FallbackRenderer {
             chrome_proxy_arm_sem: Arc::new(tokio::sync::Semaphore::new(
                 config.chrome_proxy_pool_size(),
             )),
+            has_recovery_tier: recovery_tier_available,
             preferences: Arc::new(HostPreferences::with_defaults()),
             breakers: Arc::new(BreakerRegistry::with_defaults()),
             tier_timeouts: tier_timeouts_from(config),
@@ -1096,6 +1190,13 @@ impl FallbackRenderer {
 
     /// Names of the configured JS renderers in fallback order.
     /// Used for startup logs and tests — does not leak internal types.
+    /// Is some tier configured that could actually clear an IP-reputation block?
+    /// Exposed for the integration test that pins the self-host trade-off; see
+    /// the field docs.
+    pub fn has_recovery_tier(&self) -> bool {
+        self.has_recovery_tier
+    }
+
     pub fn js_renderer_names(&self) -> Vec<&str> {
         self.js_renderers.iter().map(|r| r.name()).collect()
     }
@@ -1349,7 +1450,11 @@ impl FallbackRenderer {
                                     >= Self::MIN_RENDERED_TEXT_LEN
                                     && detector::looks_like_failed_render(&r.html).is_none()
                                     && !detector::looks_like_loading_placeholder(&r.html)
-                                    && !detector::looks_like_cloudflare_challenge(&r.html);
+                                    && !detector::looks_like_cloudflare_challenge(&r.html)
+                                    // See the recovery arms: CF alone is not the
+                                    // only wall this tier can fail to clear.
+                                    && !detector::looks_like_generic_bot_wall(&r.html)
+                                    && detector::looks_like_vendor_block(&r.html).is_none();
                                 // Ship only a fully-rendered body: a curl_cffi shell
                                 // that passes `arm_ok` but is thin still falls
                                 // through to chrome (RED-2).
@@ -1639,9 +1744,26 @@ impl FallbackRenderer {
                 }
 
                 let needs_js = detector::needs_js_rendering(&result.html);
-                let cf_header_signal = result.warning.as_deref() == Some("cloudflare_mitigated");
+                // Either header-announced vendor challenge (`cf-mitigated` or
+                // `x-amzn-waf-action`). Independent of status and body, so it
+                // catches the AWS-WAF shape that carries NO body to inspect:
+                // HTTP 202 + content-length 0, which every body detector misses.
+                //
+                // The AWS half is additionally gated on `!is_hard_pinned`. The
+                // pinned path surfaces a JS failure as an error instead of falling
+                // back to the HTTP body (`Err(e) if is_hard_pinned`), so letting
+                // the new signal escalate a pinned request would convert today's
+                // `Ok`-with-an-empty-202 into a 5xx — the same debit the
+                // `!is_hard_pinned` term on `is_empty_2xx` exists to prevent, one
+                // line over. `cloudflare_mitigated` keeps its pre-existing
+                // behaviour untouched; this change adds no new pinned failure.
+                let challenge_header_signal = match result.warning.as_deref() {
+                    Some("cloudflare_mitigated") => true,
+                    Some("waf_challenge") => !is_hard_pinned,
+                    _ => false,
+                };
                 let is_generic_bot_wall = detector::looks_like_generic_bot_wall(&result.html);
-                let is_blocked = cf_header_signal
+                let is_blocked = challenge_header_signal
                     || detector::looks_like_cloudflare_challenge(&result.html)
                     || is_generic_bot_wall;
                 let is_auth_blocked = is_soft_block_status(result.status_code);
@@ -1661,9 +1783,35 @@ impl FallbackRenderer {
                 let is_thin_content = is_2xx
                     && detector::looks_like_thin_html(&result.html)
                     && detector::warrants_browser_retry(&result.html);
+                // A 2xx with a literally empty body carries no content by
+                // definition, and `warrants_browser_retry` structurally cannot
+                // fire on it (there is no markup to find a script tag in), so the
+                // thin-content path above misses it entirely and the empty
+                // response is returned to the caller as a success. Observed on
+                // AWS-WAF hosts that answer 202 + content-length 0.
+                //
+                // Narrow on purpose:
+                //   * 204/205/206 legitimately carry no (full) body;
+                //   * non-HTML content types (empty JSON, plain text, images,
+                //     archives) gain nothing from a browser — and this matters
+                //     because the HTTP tier decodes EVERY non-PDF response as
+                //     HTML, so without the check they would all escalate;
+                //   * a hard-pinned renderer surfaces JS failures as an error
+                //     rather than falling back to the HTTP body, so escalating
+                //     here would turn today's empty-but-Ok into a hard 5xx.
+                //   * PDFs already returned earlier.
+                let is_empty_2xx = is_2xx
+                    && !is_hard_pinned
+                    && !matches!(result.status_code, 204..=206)
+                    && content_type_allows_js_escalation(result.content_type.as_deref())
+                    && result.html.trim().is_empty();
 
                 if !self.js_renderers.is_empty()
-                    && (needs_js || is_blocked || is_auth_blocked || is_thin_content)
+                    && (needs_js
+                        || is_blocked
+                        || is_auth_blocked
+                        || is_thin_content
+                        || is_empty_2xx)
                 {
                     if is_auth_blocked {
                         tracing::info!(
@@ -1998,9 +2146,15 @@ impl FallbackRenderer {
         guard: &mut Option<ProbeGuard>,
     ) {
         if !host.is_empty() {
-            self.breakers
-                .record_outcome(host, k, BreakerOutcome::RenderError)
-                .await;
+            // Identical rule to the serial loop (`classify_outcome`'s
+            // `site_blocked`): the hedge must be provably equivalent to serial,
+            // and `cls.hard_block` is the same expression the serial arm derives.
+            let outcome = if cls.hard_block && self.has_recovery_tier {
+                BreakerOutcome::SiteBlocked
+            } else {
+                BreakerOutcome::RenderError
+            };
+            self.breakers.record_outcome(host, k, outcome).await;
             if k == RendererKind::Lightpanda {
                 let err_kind = if cls.is_status_blocked || cls.is_bot_wall || cls.antibot_blocked {
                     FailoverErrorKind::AntibotBlock
@@ -2503,7 +2657,37 @@ impl FallbackRenderer {
                         // Thin/placeholder/failed render → classify against
                         // attempt context so deadline-clamped attempts don't
                         // poison the breaker.
-                        let outcome = classify_outcome(false, false, false, &attempt_ctx);
+                        //
+                        // A site-side block is not a tier failure: every tier
+                        // egressing from this IP sees the same wall, so counting
+                        // it tripped the per-host breaker for lightpanda AND
+                        // chrome and left the ladder with nothing to run.
+                        //
+                        // Computed FRESH here, never from `saw_hard_block` — that
+                        // flag is cumulative across ladder iterations, so reading
+                        // it would let lightpanda's block mask a genuine chrome
+                        // render failure on the same host.
+                        //
+                        // Derived from the raw signals rather than `err_kind`:
+                        // that mapping is lossy (`is_bot_wall` lands on
+                        // `PlaceholderContent` and `cf_challenge` is absent), and
+                        // the bot-wall case is exactly how Wikimedia serves its
+                        // HTTP-200 datacenter ban. Mirrors `JsAttemptClass::
+                        // hard_block`, which deliberately omits 404/405/406/410/
+                        // 412/451/500 — those are not site-side blocks.
+                        let site_blocked = matches!(result.status_code, 401 | 403 | 429 | 503)
+                            || (520..=530).contains(&result.status_code)
+                            || is_bot_wall
+                            || vendor_block.is_some()
+                            || cf_challenge
+                            || antibot.signal.is_blocked();
+                        let outcome = classify_outcome(
+                            false,
+                            false,
+                            false,
+                            site_blocked && self.has_recovery_tier,
+                            &attempt_ctx,
+                        );
                         self.breakers.record_outcome(&host, k, outcome).await;
                         if k == RendererKind::Lightpanda
                             && let Some(target) =
@@ -2686,7 +2870,11 @@ impl FallbackRenderer {
                     last_failover_reason = Some(err_kind.clone());
                     if let Some(k) = trackable {
                         let was_timeout = matches!(e, CrwError::Timeout(_));
-                        let outcome = classify_outcome(false, false, was_timeout, &attempt_ctx);
+                        // No `site_blocked`: reaching this arm means the renderer
+                        // itself errored (no response to inspect), which is a
+                        // genuine tier signal the breaker should keep learning from.
+                        let outcome =
+                            classify_outcome(false, false, was_timeout, false, &attempt_ctx);
                         self.breakers.record_outcome(&host, k, outcome).await;
                         if k == RendererKind::Lightpanda {
                             let _ = self.preferences.record_failure(&host, &err_kind).await;
@@ -2756,18 +2944,59 @@ impl FallbackRenderer {
                 let res = renderer.fetch(url, headers, wait_for_ms, deadline).await;
                 match res {
                     Ok(mut result) => {
-                        let text_len = html_body_text_len(&result.html);
-                        let is_placeholder = detector::looks_like_loading_placeholder(&result.html);
-                        let failed_render = detector::looks_like_failed_render(&result.html);
+                        // One shared classification instead of four hand-rolled
+                        // detector calls: it feeds the accept gate, the breaker
+                        // outcome, and the recovery-arm flags below.
+                        let cls = self.classify_js_attempt(&result);
+                        let text_len = cls.text_len;
                         let truncated = result.truncated;
+                        // The ladder ran nothing, so the recovery arm's flags are
+                        // still false and it could not fire even though this
+                        // attempt just proved the page is walled. Seed BOTH — a
+                        // lone `hard_block` would fire the slow residential tier
+                        // on a fingerprint wall it cannot clear (the regression
+                        // ff09f30 was tuned against: success -2pp, p90 +69%).
+                        saw_hard_block |= cls.hard_block;
+                        saw_unrecoverable_wall |= cls.unrecoverable_wall;
                         // A large CF challenge shell has body text > 50 and no
                         // placeholder/failed marker, so guard it explicitly or it
-                        // would leak through this path as success.
+                        // would leak through this path as success. Same for a
+                        // generic bot wall (a Wikimedia ban shell clears the text
+                        // threshold) and a vendor block.
+                        //
+                        // Body detectors only — deliberately NOT `cls.acceptable`,
+                        // which also rejects `is_status_blocked` and would discard
+                        // a 403 that carries the real page. That behaviour is
+                        // intentional (see `crw_crawl::single`).
                         let content_ok = text_len >= Self::MIN_RENDERED_TEXT_LEN
-                            && !is_placeholder
-                            && failed_render.is_none()
-                            && !detector::looks_like_cloudflare_challenge(&result.html);
-                        let outcome = classify_outcome(content_ok, truncated, false, &attempt_ctx);
+                            && !cls.is_placeholder
+                            && cls.failed_render.is_none()
+                            && !cls.is_bot_wall
+                            && cls.vendor_block.is_none()
+                            // Covers the CF interstitial AND the vendor walls that
+                            // `classify` recognises from visible text alone (a
+                            // PerimeterX/Imperva page with no SDK marker), which
+                            // clear the 50-char threshold and evade the two lighter
+                            // detectors above.
+                            //
+                            // Deliberately NOT the broader `cls.antibot_blocked`:
+                            // `classify` returns GenericBlock for ANY 403 with a
+                            // non-data body regardless of how substantial it is
+                            // (`antibot.rs`), so gating on it would discard a 403
+                            // that carries the real page — which is accepted on
+                            // purpose (see `crw_crawl::single`).
+                            && !cls.unrecoverable_wall;
+                        // Same rule as the serial loop: a wall is not this tier's
+                        // fault. Without it the leak arm — which runs precisely
+                        // when breakers are already stressed — keeps advancing the
+                        // host window that F1 exists to protect.
+                        let outcome = classify_outcome(
+                            content_ok,
+                            truncated,
+                            false,
+                            cls.hard_block && self.has_recovery_tier,
+                            &attempt_ctx,
+                        );
                         // Record host only — global stays untouched so the
                         // existing trip can finish its cooldown naturally.
                         self.breakers
@@ -2779,17 +3008,32 @@ impl FallbackRenderer {
                                 Some(RenderDecision::AutoDefault { chosen: k });
                             return Ok(result);
                         }
-                        // Thin/placeholder on leak path → fall through to
-                        // the normal "no JS renderer" return below.
+                        // Thin/placeholder/blocked on the leak path → fall through
+                        // to the normal "no JS renderer" return below.
+                        //
+                        // Keep the body as the thin candidate rather than dropping
+                        // it. The tail returns `Err(last_error)` when `thin_result`
+                        // is None, and the `render_js = true` branch propagates that
+                        // straight to the caller — it has no "JS failed, fall back to
+                        // the HTTP body" net, unlike the auto branch. Dropping a
+                        // rejected body would therefore turn a response this path
+                        // used to return as `Ok` into a 5xx; `classify_block`
+                        // downstream still surfaces it as blocked and suppresses
+                        // billing, which is the pre-existing contract.
+                        // `best-result-wins` is unaffected: the leak arm only runs
+                        // when `thin_result` is None.
                         last_error = Some(CrwError::RendererError(format!(
                             "leak attempt on {} returned thin content (text_len={text_len})",
                             renderer.name()
                         )));
+                        thin_result = Some(result);
                         break;
                     }
                     Err(e) => {
                         let was_timeout = matches!(e, CrwError::Timeout(_));
-                        let outcome = classify_outcome(false, false, was_timeout, &attempt_ctx);
+                        // No response body to inspect → a genuine tier signal.
+                        let outcome =
+                            classify_outcome(false, false, was_timeout, false, &attempt_ctx);
                         self.breakers
                             .record_scoped_outcome(&host, k, None, Some(outcome))
                             .await;
@@ -2904,9 +3148,21 @@ impl FallbackRenderer {
                 match attempt {
                     Ok(r) => {
                         let r_text = html_body_text_len(&r.html);
+                        // Block detection is load-bearing here, not defensive: a
+                        // residential exit can land in the SAME ban range as the
+                        // box (or be challenged on its own), and this gate drives
+                        // both the ChromeProxy breaker outcome and `better` below.
+                        // Without it a ban shell is recorded Success — so the arm
+                        // keeps firing on a host it provably cannot serve — and,
+                        // being larger than the ladder's thin result, replaces it.
+                        // CF is checked too: a managed challenge is 100-300KB and
+                        // evades the size-capped vendor detector.
                         let r_ok = r_text >= Self::MIN_RENDERED_TEXT_LEN
                             && detector::looks_like_failed_render(&r.html).is_none()
-                            && !detector::looks_like_loading_placeholder(&r.html);
+                            && !detector::looks_like_loading_placeholder(&r.html)
+                            && !detector::looks_like_generic_bot_wall(&r.html)
+                            && detector::looks_like_vendor_block(&r.html).is_none()
+                            && !detector::looks_like_cloudflare_challenge(&r.html);
                         if !host.is_empty() {
                             let outcome = if r_ok {
                                 BreakerOutcome::Success
@@ -2984,7 +3240,12 @@ impl FallbackRenderer {
                         let r_ok = html_body_text_len(&r.html) >= Self::MIN_RENDERED_TEXT_LEN
                             && detector::looks_like_failed_render(&r.html).is_none()
                             && !detector::looks_like_loading_placeholder(&r.html)
-                            && !detector::looks_like_cloudflare_challenge(&r.html);
+                            && !detector::looks_like_cloudflare_challenge(&r.html)
+                            // Same gap as the chrome_proxy arm: the stealth tier
+                            // clears CF, but a DataDome / generic ban shell it
+                            // cannot clear would otherwise ship as content.
+                            && !detector::looks_like_generic_bot_wall(&r.html)
+                            && detector::looks_like_vendor_block(&r.html).is_none();
                         if !host.is_empty() {
                             let outcome = if r_ok {
                                 BreakerOutcome::Success
@@ -3231,6 +3492,36 @@ mod tests {
             r.js_renderer_names(),
             vec!["lightpanda", "chrome", "chrome_proxy"]
         );
+    }
+
+    /// The HTTP tier decodes every non-PDF body as HTML regardless of its
+    /// declared type, so without this gate an empty `application/json` or
+    /// `image/*` 2xx would buy a full browser render for nothing.
+    #[test]
+    fn empty_2xx_escalation_is_limited_to_htmlish_bodies() {
+        for ct in [
+            None,
+            Some(""),
+            Some("text/html"),
+            Some("application/xhtml+xml"),
+        ] {
+            assert!(
+                content_type_allows_js_escalation(ct),
+                "{ct:?} should stay eligible"
+            );
+        }
+        for ct in [
+            "application/json",
+            "text/plain",
+            "image/png",
+            "application/zip",
+            "text/csv",
+        ] {
+            assert!(
+                !content_type_allows_js_escalation(Some(ct)),
+                "{ct} cannot be improved by a browser"
+            );
+        }
     }
 
     #[cfg(feature = "cdp")]

--- a/crates/crw-renderer/tests/egress_latch_body_verdict.rs
+++ b/crates/crw-renderer/tests/egress_latch_body_verdict.rs
@@ -1,0 +1,84 @@
+//! A body-verdict IP-reputation block seen on DIRECT egress must latch the host.
+//!
+//! Wikimedia bans datacenter IPs with a `<body>`-less shell carrying a canonical
+//! footer phrase and no distinguishing header, so neither the 429 arm nor the
+//! challenge-header arm can see it. Without this latch every URL on such a host
+//! re-climbs the whole doomed renderer ladder: measured 7-12s per page against
+//! ~3s once the host is routed to residential egress first.
+//!
+//! The write is DIRECT-ONLY and that is load-bearing: a block observed through a
+//! proxy says the *proxy* is blocked, and latching on it would re-arm the TTL on
+//! every request, so the latch would never expire, direct would never be
+//! re-probed (TTL expiry *is* the half-open probe) and the host would be pinned
+//! to paid egress permanently.
+//!
+//! ONE test per binary, deliberately: the latch is keyed by
+//! `preference::normalize_host`, which returns the bare IP for a literal, so
+//! every wiremock origin in a process shares the single `127.0.0.1` key. Two
+//! tests in one binary would race on it and pass or fail by scheduling order.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+/// Fetch `body` from a throwaway origin over DIRECT egress and return its host.
+async fn fetch_direct(body: &'static str, status: u16) -> String {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env. No proxy,
+    // so the fetch is unambiguously direct and the latch verdict is meaningful.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        std::env::remove_var("CRW_HTTP_RATELIMIT_PROXY_URL");
+    }
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(status).set_body_string(body))
+        .mount(&origin)
+        .await;
+    let url = origin.uri();
+    let _ = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            Deadline::from_request_ms(15_000),
+        )
+        .await;
+    url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned()
+}
+
+/// The real shape, reduced: no `<body>` tag, and the canonical Wikimedia footer
+/// sentence that `looks_like_generic_bot_wall` matches on.
+const WIKIMEDIA_BAN_SHELL: &str = concat!(
+    "<!DOCTYPE html><html><head><title>Wikimedia Error</title></head>",
+    "<div><h1>Our servers are currently under maintenance or experiencing a technical problem.</h1>",
+    "<p>If you report this error to the Wikimedia System Administrators, please include ",
+    "the details below.</p></div></html>"
+);
+
+#[tokio::test]
+async fn ip_reputation_block_seen_on_direct_latches_the_host() {
+    let host = fetch_direct(WIKIMEDIA_BAN_SHELL, 403).await;
+    assert!(
+        crw_renderer::egress::global().should_proxy(&host).await,
+        "a datacenter-IP ban seen on direct egress must latch the host proxy-first"
+    );
+}

--- a/crates/crw-renderer/tests/egress_latch_no_latch_on_cf.rs
+++ b/crates/crw-renderer/tests/egress_latch_no_latch_on_cf.rs
@@ -1,0 +1,71 @@
+//! A fingerprint wall must NOT latch: a residential exit gets the same
+//! Cloudflare managed challenge, so latching one would only burn paid bandwidth
+//! for the whole cooldown while recovering nothing.
+//!
+//! ONE test per binary, deliberately: the latch is keyed by
+//! `preference::normalize_host`, which returns the bare IP for a literal, so
+//! every wiremock origin in a process shares the single `127.0.0.1` key. Two
+//! tests in one binary would race on it and pass or fail by scheduling order.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+/// Fetch `body` from a throwaway origin over DIRECT egress and return its host.
+async fn fetch_direct(body: &'static str, status: u16) -> String {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env. No proxy,
+    // so the fetch is unambiguously direct and the latch verdict is meaningful.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        std::env::remove_var("CRW_HTTP_RATELIMIT_PROXY_URL");
+    }
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(status).set_body_string(body))
+        .mount(&origin)
+        .await;
+    let url = origin.uri();
+    let _ = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            Deadline::from_request_ms(15_000),
+        )
+        .await;
+    url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned()
+}
+
+const CF_CHALLENGE: &str = concat!(
+    "<html><body><h1>Just a moment...</h1>",
+    "<script src=\"/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1\"></script>",
+    "<div id=\"cf-please-wait\">Enable JavaScript and cookies to continue</div></body></html>"
+);
+
+#[tokio::test]
+async fn cloudflare_challenge_does_not_latch() {
+    let host = fetch_direct(CF_CHALLENGE, 403).await;
+    assert!(
+        !crw_renderer::egress::global().should_proxy(&host).await,
+        "a Cloudflare managed challenge must not latch: residential egress cannot clear it"
+    );
+}

--- a/crates/crw-renderer/tests/egress_latch_no_latch_on_healthy.rs
+++ b/crates/crw-renderer/tests/egress_latch_no_latch_on_healthy.rs
@@ -1,0 +1,68 @@
+//! An ordinary page must never latch, or normal traffic would drift onto paid
+//! egress one host at a time.
+//!
+//! ONE test per binary, deliberately: the latch is keyed by
+//! `preference::normalize_host`, which returns the bare IP for a literal, so
+//! every wiremock origin in a process shares the single `127.0.0.1` key. Two
+//! tests in one binary would race on it and pass or fail by scheduling order.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+/// Fetch `body` from a throwaway origin over DIRECT egress and return its host.
+async fn fetch_direct(body: &'static str, status: u16) -> String {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env. No proxy,
+    // so the fetch is unambiguously direct and the latch verdict is meaningful.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        std::env::remove_var("CRW_HTTP_RATELIMIT_PROXY_URL");
+    }
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(status).set_body_string(body))
+        .mount(&origin)
+        .await;
+    let url = origin.uri();
+    let _ = renderer()
+        .fetch(
+            &url,
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            Deadline::from_request_ms(15_000),
+        )
+        .await;
+    url::Url::parse(&url)
+        .unwrap()
+        .host_str()
+        .unwrap()
+        .to_owned()
+}
+
+#[tokio::test]
+async fn healthy_page_does_not_latch() {
+    let host = fetch_direct(
+        "<html><body><article>a perfectly ordinary page with plenty of text</article></body></html>",
+        200,
+    )
+    .await;
+    assert!(
+        !crw_renderer::egress::global().should_proxy(&host).await,
+        "a healthy response must not latch"
+    );
+}

--- a/crates/crw-renderer/tests/site_block_recovery_gate.rs
+++ b/crates/crw-renderer/tests/site_block_recovery_gate.rs
@@ -1,0 +1,99 @@
+//! Ignoring a site block in the breaker's failure window only pays off when some
+//! tier downstream can actually clear it.
+//!
+//! In the common self-host build — no `chrome_proxy`, no stealth tier, no
+//! `CRW_HTTP_RATELIMIT_PROXY_URL` — every tier egresses from the same banned IP,
+//! so suppressing the breaker there would make a permanently blocked host re-walk
+//! the whole serial ladder on every request (~3-6s/page against ~0.5s once the
+//! breaker opens: a 6-12x slowdown on a crawl) while recovering exactly nothing.
+//! So the suppression is gated on a recovery tier actually existing.
+//!
+//! Own test binary because it mutates process-global environment. `HttpFetcher`
+//! reads `CRW_HTTP_RATELIMIT_PROXY_URL` and the `*_PROXY` variables when it is
+//! CONSTRUCTED, and under the Rust 2024 contract `remove_var` racing a concurrent
+//! `getenv` is undefined behaviour — which is exactly what would happen against
+//! the ~19 sibling constructors in the crate's unit-test binary.
+
+use crw_core::config::{CdpEndpoint, RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+
+/// Clear every egress-proxy signal so "no recovery tier" is really true, however
+/// the developer's shell happens to be configured.
+fn clear_proxy_env() {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env, and this
+    // runs before any fetcher in it is constructed.
+    unsafe {
+        for k in [
+            "CRW_HTTP_RATELIMIT_PROXY_URL",
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ] {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+fn chrome_only() -> RendererConfig {
+    RendererConfig {
+        mode: RendererMode::Auto,
+        chrome: Some(CdpEndpoint {
+            ws_url: "ws://127.0.0.1:9223/".into(),
+        }),
+        chrome_proxy: None,
+        ..Default::default()
+    }
+}
+
+/// All three cases in ONE test, run sequentially: they mutate the same process
+/// environment, and `cargo test` would otherwise run them on parallel threads
+/// where one's `clear_proxy_env` races another's construction.
+#[test]
+fn site_block_suppression_tracks_whether_a_recovery_tier_exists() {
+    clear_proxy_env();
+    let lean = FallbackRenderer::new(&chrome_only(), "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds");
+    assert!(
+        !lean.has_recovery_tier(),
+        "no residential tier, no stealth tier and no fallback proxy: a site block \
+         must keep counting, or a blocked host costs 6-12x for zero recall"
+    );
+
+    // Only meaningful with `cdp`: a lean build cannot CONSTRUCT chrome_proxy, so
+    // `has_recovery_tier` is correctly false there however the config reads. That
+    // is the point of deriving it from built state rather than from config.
+    #[cfg(feature = "cdp")]
+    {
+        let with_residential = RendererConfig {
+            chrome_proxy: Some(CdpEndpoint {
+                ws_url: "ws://127.0.0.1:9224/".into(),
+            }),
+            ..chrome_only()
+        };
+        let r = FallbackRenderer::new(
+            &with_residential,
+            "crw-test",
+            None,
+            &StealthConfig::default(),
+        )
+        .expect("renderer builds");
+        assert!(
+            r.has_recovery_tier(),
+            "chrome_proxy can clear an IP-reputation block, so blocks stop poisoning the breaker"
+        );
+    }
+
+    // The fallback HTTP proxy is a recovery egress in its own right — it is what
+    // turns the AWS-WAF 202 into a real page with no browser involved at all.
+    // SAFETY: see `clear_proxy_env`.
+    unsafe { std::env::set_var("CRW_HTTP_RATELIMIT_PROXY_URL", "http://127.0.0.1:18080") }
+    let r = FallbackRenderer::new(&chrome_only(), "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds");
+    assert!(
+        r.has_recovery_tier(),
+        "a usable fallback proxy is a recovery egress even with no residential CDP tier"
+    );
+}

--- a/crates/crw-renderer/tests/waf_challenge_no_false_arm.rs
+++ b/crates/crw-renderer/tests/waf_challenge_no_false_arm.rs
@@ -1,0 +1,72 @@
+//! Guard against the widened proxy arm over-firing: a healthy 202 that carries
+//! real content must be returned as-is, never dragged through a proxy retry.
+//!
+//! Own binary: sets `CRW_HTTP_RATELIMIT_PROXY_URL`.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+/// A bare 202 with real content is a perfectly good response and must not be
+/// dragged through a proxy retry. Guards the widened arm against over-firing.
+#[tokio::test]
+async fn plain_202_with_content_is_left_alone() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+
+    // If the proxy is ever consulted it answers with a marker we can detect.
+    let proxy = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html><body>PROXY</body></html>"))
+        .mount(&proxy)
+        .await;
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", &proxy.uri());
+
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(202).set_body_string(
+                "<html><body><article>accepted and rendered</article></body></html>",
+            ),
+        )
+        .mount(&origin)
+        .await;
+
+    let result = renderer()
+        .fetch(
+            &origin.uri(),
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            Deadline::from_request_ms(15_000),
+        )
+        .await
+        .expect("fetch succeeds");
+
+    assert!(
+        result.html.contains("accepted and rendered"),
+        "a healthy 202 must be returned as-is"
+    );
+    assert!(
+        !result.html.contains("PROXY"),
+        "no proxy retry should have been armed"
+    );
+}

--- a/crates/crw-renderer/tests/waf_challenge_proxy_hang.rs
+++ b/crates/crw-renderer/tests/waf_challenge_proxy_hang.rs
@@ -1,0 +1,96 @@
+//! The safety clause for the widened proxy arm: a challenge-armed proxy that
+//! HANGS must not turn a soft empty response into a hard error.
+//!
+//! Before this, all three proxy-rescue arms were gated on `proxy_first`, which is
+//! only true for a *latched* host. A proxy armed mid-loop by a 429 or a challenge
+//! header therefore matched none of them: control fell through to the bare
+//! `Err(_)` arm, which returns `CrwError::Timeout` after consuming the whole
+//! deadline. Measured motivation: one ballotpedia fetch through the residential
+//! exit took 38.2s. On a 15s search budget that arm would have converted today's
+//! soft `202`-with-no-body into a 5xx — a scrape-success regression, on the very
+//! requests this change exists to improve.
+//!
+//! Own test binary: sets `CRW_HTTP_RATELIMIT_PROXY_URL`, which is read when the
+//! fetcher is CONSTRUCTED, so two tests setting different values in one process
+//! would race.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+#[tokio::test]
+async fn hanging_challenge_proxy_falls_back_to_direct_instead_of_erroring() {
+    // A proxy that never answers within any budget we would give it.
+    let proxy = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(std::time::Duration::from_secs(60))
+                .set_body_string("<html><body>too late to matter</body></html>"),
+        )
+        .mount(&proxy)
+        .await;
+
+    // SAFETY: one binary per tests/*.rs, so this process owns its env.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+        std::env::set_var("CRW_HTTP_RATELIMIT_PROXY_URL", proxy.uri());
+    }
+
+    // The origin answers instantly with the AWS-WAF challenge shape, which is
+    // what arms the proxy in the first place.
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("x-amzn-waf-action", "challenge")
+                .set_body_string(""),
+        )
+        .mount(&origin)
+        .await;
+
+    let started = std::time::Instant::now();
+    let result = renderer()
+        .fetch(
+            &origin.uri(),
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            // The real search-enrichment budget.
+            Deadline::from_request_ms(15_000),
+        )
+        .await;
+
+    let elapsed = started.elapsed();
+    let fetched = result.expect(
+        "a hanging challenge-armed proxy must fall back to direct, \
+         not surface CrwError::Timeout",
+    );
+    assert_eq!(
+        fetched.status_code, 202,
+        "the direct rescue must return the origin's own response"
+    );
+    // A single challenge-armed proxy attempt is capped at CHALLENGE_PROXY_MAX
+    // (6s), so a hanging exit costs that plus a fast direct rescue — NOT
+    // `remaining - reserve` (13.5s of the 15s budget), which would have made a
+    // bad exit almost as expensive as the whole request while still returning the
+    // same empty body.
+    assert!(
+        elapsed < std::time::Duration::from_secs(9),
+        "the hanging proxy attempt must be capped, not given the whole budget; took {elapsed:?}"
+    );
+}

--- a/crates/crw-renderer/tests/waf_challenge_recovery.rs
+++ b/crates/crw-renderer/tests/waf_challenge_recovery.rs
@@ -1,0 +1,79 @@
+//! AWS WAF Bot Control announces a challenge in a response header and serves it
+//! as **HTTP 202 with a zero-length body**.
+//!
+//! That shape defeats every body-based detector — there is no markup to scan —
+//! and 202 is not in the soft-block status list, so the empty response used to
+//! be returned to the caller as a successful scrape with no content. Measured on
+//! the production host: ballotpedia.org and jwa.org both answer this way and
+//! both return a full page through residential egress.
+//!
+//! Its own test binary: `CRW_HTTP_RATELIMIT_PROXY_URL` is read when the fetcher
+//! is CONSTRUCTED, so two tests setting different values in one process race.
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+const RECOVERED: &str =
+    "<html><body><article>the real page, served through residential egress</article></body></html>";
+
+/// The headline case: a 202 + `x-amzn-waf-action: challenge` + empty body must
+/// arm the proxy retry in-request, and the caller gets the recovered page.
+#[tokio::test]
+async fn aws_waf_202_recovers_through_the_proxy() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+
+    let proxy = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(RECOVERED))
+        .mount(&proxy)
+        .await;
+    set_env("CRW_HTTP_RATELIMIT_PROXY_URL", &proxy.uri());
+
+    // The origin challenges: 202, no body, header names the action.
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("x-amzn-waf-action", "challenge")
+                .set_body_string(""),
+        )
+        .mount(&origin)
+        .await;
+
+    let result = renderer()
+        .fetch(
+            &origin.uri(),
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            Deadline::from_request_ms(15_000),
+        )
+        .await
+        .expect("fetch succeeds");
+
+    assert!(
+        result.html.contains("the real page"),
+        "the WAF challenge must be retried through the proxy, got: {:?}",
+        result.html
+    );
+}

--- a/crates/crw-renderer/tests/waf_challenge_warning_text.rs
+++ b/crates/crw-renderer/tests/waf_challenge_warning_text.rs
@@ -1,0 +1,70 @@
+//! The customer-visible warning must name the vendor that actually blocked us.
+//!
+//! Own binary: this test requires NO proxy in the environment (see the sibling
+//! `waf_challenge_*` tests, which set one).
+
+use std::collections::HashMap;
+
+use crw_core::Deadline;
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_renderer::FallbackRenderer;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn set_env(k: &str, v: &str) {
+    // SAFETY: one binary per tests/*.rs, so this process owns its env.
+    unsafe { std::env::set_var(k, v) }
+}
+
+fn renderer() -> FallbackRenderer {
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+        .expect("renderer builds in http-only mode")
+}
+
+/// The customer-visible warning must name the vendor that actually blocked us.
+/// Before this change the string was hardcoded to Cloudflare and reached the API
+/// caller through `crw_crawl::single`, so an AWS-WAF block on a CloudFront host
+/// was reported as a Cloudflare one.
+#[tokio::test]
+async fn aws_waf_warning_does_not_claim_cloudflare() {
+    set_env("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    // No proxy configured: the challenge survives to the returned result, which
+    // is exactly the self-host shape we want to inspect.
+    unsafe { std::env::remove_var("CRW_HTTP_RATELIMIT_PROXY_URL") }
+
+    let origin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(202)
+                .insert_header("x-amzn-waf-action", "challenge")
+                .set_body_string(""),
+        )
+        .mount(&origin)
+        .await;
+
+    let result = renderer()
+        .fetch(
+            &origin.uri(),
+            &HashMap::new(),
+            Some(false),
+            None,
+            Some("auto"),
+            Deadline::from_request_ms(15_000),
+        )
+        .await
+        .expect("fetch succeeds");
+
+    let warnings = result.warnings.join(" ");
+    assert!(
+        warnings.contains("AWS WAF"),
+        "warning must name AWS WAF, got: {warnings:?}"
+    );
+    assert!(
+        !warnings.to_lowercase().contains("cloudflare"),
+        "an AWS WAF block must never be reported as Cloudflare, got: {warnings:?}"
+    );
+}


### PR DESCRIPTION
An anti-bot block from an origin was recorded as a **renderer** failure. On a host
that blocks the server's IP, that tripped the per-host circuit breaker for
lightpanda **and** chrome, leaving the failover ladder with no renderer to run and
stranding `chrome_proxy` — the one tier whose residential egress can actually fetch
the page. The block was reported to the caller instead of recovered.

## What changed

- **A site-side block no longer advances the breaker window.** New
  `BreakerOutcome::SiteBlocked`: observed via `crw_breaker_ignored_total` but
  non-window-advancing, mirroring `DeadlineClamped`. An origin's wall is a property
  of the origin, not of the tier, so every tier egressing from the same IP would see
  it. Gated on a recovery tier actually being configured, so a build with no
  residential/stealth egress keeps the breaker's brake unchanged.
- **Recognise `x-amzn-waf-action: challenge|captcha`** alongside `cf-mitigated`. AWS
  WAF serves a challenge as an empty HTTP 202 that no body detector can see; the
  header is the only signal. Reuses the existing in-request proxy retry, so a page
  that returned 0 bytes now comes back complete over the fallback egress with no
  browser involved. The three header reads are factored into one `challenge_header()`
  and the caller-visible warning names the correct vendor.
- **Arm the egress latch from a body verdict**, direct-egress-only, so a host whose
  block carries no distinguishing header still routes proxy-first on subsequent URLs
  instead of re-climbing the whole ladder.
- **Budget hygiene:** reserve and cap a proxy-armed retry so a hanging exit falls back
  to direct instead of turning a soft empty result into a hard timeout; bound the
  response-body read by the remaining deadline; and skip JS escalation in `crw-crawl`
  when too little deadline remains to attempt it (the source of the
  `Timeout after 1ms` escalations).
- **Close block-shell gaps** in the `chrome_proxy` and cloak recovery arms and the
  leak-through path, so a residential/stealth result that is itself a wall is neither
  recorded as success nor shipped as content.

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, full `cargo test`
  workspace suite green. 12 new tests covering the breaker classification, the AWS-WAF
  recovery + proxy-hang fallback, the body-verdict latch (and its
  direct-only/no-fingerprint-wall exclusions), the empty-2xx escalation gate, and the
  recovery-tier gate.
- Exercised end to end against a genuinely IP-blocked origin: recovered content is
  byte-identical to a slow-path fetch (no recall change), with the repeat-request
  latency dropping to the fallback-egress path once the host is latched. A
  fingerprint-walled host is correctly left unrecovered and **not** latched.

## Notes

- Behavior for a build with no fallback proxy and no `chrome_proxy` is unchanged
  (the site-block suppression is gated on a recovery tier existing).
- Not a merge-time proof of the aggregate scrape-success / p90 line — that needs the
  frozen-dataset A/B, tracked separately.

ref us/crw-saas#517
