### PR TITLE
test: offline recall@budget harness for search answer quality

### DIFF
--- a/bench/recall-harness/README.md
+++ b/bench/recall-harness/README.md
@@ -1,0 +1,43 @@
+# recall@budget harness
+
+Offline measurement of where `/v1/search` answer quality is lost: **retrieval**
+(is the answer in the scraped markdown at all), **selection** (does it survive
+into the per-source window), or downstream. Removes prod latency variance, which
+has repeatedly swamped sampled A/B runs — the same code measured 80% and 52% on
+different runs. Runs in under a second, fully reproducible.
+
+## 1. Freeze a slice (one slow step, hits prod once)
+
+```bash
+CRW_KEY=<key> CRW_BASE=https://fastcrw.com/api \
+  bun run capture.ts 50 5 cap50.jsonl
+```
+
+Captures N SimpleQA questions: for each, the search result set with full scraped
+markdown per source (`answer:false`, so it is pure retrieval). One line per
+question: `{i, q, gold, sources:[{url,title,description,markdown}], ms}`.
+
+## 2. Replay through the real selection code (fast, offline, repeatable)
+
+The harness is an `#[ignore]`d test in `crates/crw-extract/src/answer.rs`
+(`recall_at_budget`) so it can reach the private `select_relevant_passages`
+without widening the API:
+
+```bash
+RB_CAP=/abs/path/cap50.jsonl RB_BUDGET=8192 \
+  cargo test -p crw-extract --release recall_at_budget -- --nocapture --ignored
+```
+
+Reports, for the frozen set:
+
+- **retrieval ceiling** — gold present anywhere in any source's markdown
+  (all-tokens match; strict-phrase also printed)
+- **survives head-truncation** vs **survives BM25 selection** — the two window
+  strategies, so selection loss is isolated from retrieval loss
+- **dropped by SELECTION** — retrieval had it, the window strategy lost it
+  (fixable in-window: scoring, budget, chunking)
+- **never RETRIEVED** — search/scrape never produced it (fixable upstream:
+  see the domain empty-markdown breakdown; this is where anti-bot blocks show up)
+
+`RB_BUDGET` sweeps the per-source cap (`DEFAULT_MAX_CHARS_PER_SOURCE` is 8192)
+without touching prod.

--- a/bench/recall-harness/capture.ts
+++ b/bench/recall-harness/capture.ts
@@ -1,0 +1,62 @@
+// Capture: freeze prod search+scrape output for a SimpleQA slice so the SELECTION layer
+// can be replayed offline, deterministically, without prod latency variance.
+// Usage: CRW_KEY=.. bun run capture.ts <N> <conc> <out.jsonl>
+const env = (k: string) => { const v = process.env[k]; if (!v) throw new Error(`missing ${k}`); return v; };
+const CRW_KEY = env("CRW_KEY"), CRW_BASE = process.env.CRW_BASE ?? "https://fastcrw.com/api";
+const N = Number(process.argv[2] ?? 50);
+const CONC = Number(process.argv[3] ?? 4);
+const OUT = process.argv[4] ?? "cap.jsonl";
+
+async function search(q: string): Promise<any> {
+  for (let a = 0; a < 3; a++) {
+    try {
+      const r = await fetch(`${CRW_BASE}/v1/search`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${CRW_KEY}` },
+        // answer:false -> pure retrieval. maxCharsPerSource high so we capture the FULL scraped
+        // markdown and can apply any budget offline.
+        body: JSON.stringify({
+          query: q, limit: 5,
+          scrapeOptions: { formats: ["markdown"], onlyMainContent: true },
+        }),
+        signal: AbortSignal.timeout(180_000),
+      });
+      if (r.status >= 500 || r.status === 429) { await Bun.sleep(2000 * (a + 1)); continue; }
+      if (!r.ok) throw new Error(`${r.status} ${await r.text()}`);
+      return r.json();
+    } catch (e) { if (a === 2) throw e; await Bun.sleep(2000 * (a + 1)); }
+  }
+}
+
+async function fetchRows(n: number) {
+  const r = await fetch(
+    `https://datasets-server.huggingface.co/rows?dataset=basicv8vc/SimpleQA&config=default&split=test&offset=0&length=${n}`,
+    { signal: AbortSignal.timeout(30_000) });
+  const j = await r.json();
+  return (j.rows as any[]).map((x) => ({ q: x.row.problem as string, gold: x.row.answer as string }));
+}
+
+const rows = await fetchRows(N);
+const out: string[] = [];
+let idx = 0, done = 0;
+async function worker() {
+  while (idx < rows.length) {
+    const i = idx++; const row = rows[i]; const t = Date.now();
+    let sources: any[] = [], err = "";
+    try {
+      const r = await search(row.q);
+      const arr = r?.data?.web ?? r?.web ?? r?.data ?? [];
+      sources = (Array.isArray(arr) ? arr : []).map((s: any) => ({
+        url: s.url ?? "", title: s.title ?? "",
+        description: s.description ?? "",
+        markdown: s.markdown ?? "",
+      }));
+    } catch (e) { err = String(e); }
+    out.push(JSON.stringify({ i, q: row.q, gold: row.gold, sources, err, ms: Date.now() - t }));
+    done++;
+    console.log(`[${done}/${rows.length}] ${((Date.now() - t) / 1000).toFixed(1)}s  src=${sources.length}  md=${sources.reduce((a, s) => a + s.markdown.length, 0)}  ${err ? "ERR " + err.slice(0, 60) : ""}  ${row.q.slice(0, 50)}`);
+  }
+}
+await Promise.all(Array.from({ length: CONC }, () => worker()));
+await Bun.write(OUT, out.sort((a, b) => JSON.parse(a).i - JSON.parse(b).i).join("\n") + "\n");
+console.log(`\nwrote ${out.length} rows -> ${OUT}`);

--- a/crates/crw-extract/src/answer.rs
+++ b/crates/crw-extract/src/answer.rs
@@ -847,4 +847,212 @@ mod tests {
         let out = select_relevant_passages(&long, "   ", 100);
         assert_eq!(out.len(), 100);
     }
+
+    // ---------------------------------------------------------------------
+    // Offline recall@budget harness.
+    //
+    // Replays a frozen capture of prod search+scrape output through the real
+    // selection code and reports whether the gold answer survives into the
+    // assembled per-source window. No LLM, no network: prod latency variance
+    // (which swamped every sampled A/B so far) is removed entirely, so a lever
+    // can be measured in seconds instead of a 30-minute noisy prod run.
+    //
+    //   RB_CAP=/path/cap50.jsonl RB_BUDGET=8192 \
+    //     cargo test -p crw-extract --release recall_at_budget -- --nocapture --ignored
+    //
+    // Capture line shape: {"q":..,"gold":..,"sources":[{"url":..,"markdown":..}]}
+    // ---------------------------------------------------------------------
+
+    /// Lowercase, strip everything that isn't alphanumeric or a space, collapse
+    /// runs of space. Makes gold matching robust to markdown punctuation
+    /// (`**June 24**`, `June&nbsp;24`, `June 24,`) without loosening it to a
+    /// per-token match, which would fire on unrelated text.
+    fn norm(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut sp = false;
+        for c in s.chars() {
+            if c.is_alphanumeric() {
+                if sp && !out.is_empty() {
+                    out.push(' ');
+                }
+                sp = false;
+                out.extend(c.to_lowercase());
+            } else {
+                sp = true;
+            }
+        }
+        out
+    }
+
+    /// Strict: the gold phrase appears verbatim (post-normalization).
+    fn has_gold(hay_norm: &str, gold_norm: &str) -> bool {
+        !gold_norm.is_empty() && hay_norm.contains(gold_norm)
+    }
+
+    /// Fair: every content token of the gold appears somewhere in the window.
+    /// An LLM can answer "The Coast Guard" from a page saying "U.S. Coast
+    /// Guard", which the strict phrase match rejects. Stopword-ish 1-2 char
+    /// tokens are dropped so they can't carry a match on their own.
+    fn has_gold_tokens(hay_norm: &str, gold_norm: &str) -> bool {
+        let toks: Vec<&str> = gold_norm.split(' ').filter(|t| t.len() > 2).collect();
+        if toks.is_empty() {
+            return has_gold(hay_norm, gold_norm);
+        }
+        toks.iter().all(|t| hay_norm.contains(t))
+    }
+
+    #[test]
+    #[ignore = "needs RB_CAP capture file; run explicitly"]
+    fn recall_at_budget() {
+        let path = std::env::var("RB_CAP").expect("set RB_CAP=<capture.jsonl>");
+        let budget: usize = std::env::var("RB_BUDGET")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8192);
+        let raw = std::fs::read_to_string(&path).expect("read RB_CAP");
+
+        // Per-question outcomes, each "did ANY source carry the gold".
+        // `_s` = strict phrase match, `_t` = all-tokens match.
+        let (mut n, mut ret_s, mut ret_t) = (0usize, 0usize, 0usize);
+        let (mut head_t, mut bm25_t) = (0usize, 0usize);
+        let (mut snip_t, mut no_md) = (0usize, 0usize);
+        let mut lost: Vec<String> = Vec::new();
+        let mut missed: Vec<String> = Vec::new();
+
+        for line in raw.lines().filter(|l| !l.trim().is_empty()) {
+            let row: serde_json::Value = serde_json::from_str(line).expect("bad capture line");
+            let q = row["q"].as_str().unwrap_or_default();
+            let gold = norm(row["gold"].as_str().unwrap_or_default());
+            let sources = row["sources"].as_array().cloned().unwrap_or_default();
+            n += 1;
+
+            let (mut rs, mut rt, mut h, mut b, mut sn) = (false, false, false, false, false);
+            let mut best_frac: Option<f64> = None;
+            let mut empty_md = 0usize;
+            for s in &sources {
+                // Title + snippet reach the model too (and are the whole source
+                // when `snippet_fallback` fires), so they count as retrieval.
+                let meta = norm(&format!(
+                    "{} {}",
+                    s["title"].as_str().unwrap_or_default(),
+                    s["description"].as_str().unwrap_or_default()
+                ));
+                if has_gold_tokens(&meta, &gold) {
+                    sn = true;
+                    rt = true;
+                }
+                let md = s["markdown"].as_str().unwrap_or_default();
+                if md.is_empty() {
+                    empty_md += 1;
+                    continue;
+                }
+                let nm = norm(md);
+                if has_gold(&nm, &gold) {
+                    rs = true;
+                    if let Some(o) = nm.find(&gold) {
+                        let f = o as f64 / nm.len().max(1) as f64;
+                        best_frac = Some(best_frac.map_or(f, |p: f64| p.min(f)));
+                    }
+                }
+                if has_gold_tokens(&nm, &gold) {
+                    rt = true;
+                }
+                if has_gold_tokens(&norm(truncate_on_char_boundary(md, budget)), &gold) {
+                    h = true;
+                }
+                if has_gold_tokens(&norm(&select_relevant_passages(md, q, budget)), &gold) {
+                    b = true;
+                }
+            }
+            if rs {
+                ret_s += 1;
+            }
+            if rt {
+                ret_t += 1;
+            }
+            if h {
+                head_t += 1;
+            }
+            if b || sn {
+                bm25_t += 1;
+            }
+            if sn {
+                snip_t += 1;
+            }
+            if empty_md == sources.len() && !sources.is_empty() {
+                no_md += 1;
+            }
+
+            if rt && !(b || sn) {
+                lost.push(format!(
+                    "  [{}] depth~{}% gold={:?}\n      q: {}",
+                    row["i"].as_i64().unwrap_or(-1),
+                    best_frac.map_or("?".into(), |f| format!("{:.0}", f * 100.0)),
+                    row["gold"].as_str().unwrap_or_default(),
+                    q
+                ));
+            }
+            if !rt {
+                let urls: Vec<String> = sources
+                    .iter()
+                    .map(|s| {
+                        format!(
+                            "{} ({}b)",
+                            s["url"].as_str().unwrap_or_default(),
+                            s["markdown"].as_str().unwrap_or_default().len()
+                        )
+                    })
+                    .collect();
+                missed.push(format!(
+                    "  [{}] gold={:?}\n      q: {}\n      {}",
+                    row["i"].as_i64().unwrap_or(-1),
+                    row["gold"].as_str().unwrap_or_default(),
+                    q,
+                    urls.join("\n      ")
+                ));
+            }
+        }
+
+        let pct = |x: usize| 100.0 * x as f64 / n.max(1) as f64;
+        println!("\n=== recall@budget  (budget {budget} chars/source, n={n}) ===");
+        println!(
+            "RETRIEVAL ceiling, strict phrase   : {ret_s:3} ({:5.1}%)",
+            pct(ret_s)
+        );
+        println!(
+            "RETRIEVAL ceiling, all-tokens      : {ret_t:3} ({:5.1}%)  <- the real ceiling",
+            pct(ret_t)
+        );
+        println!("  of which answerable from snippet : {snip_t:3}");
+        println!(
+            "survives head-truncation           : {head_t:3} ({:5.1}%)",
+            pct(head_t)
+        );
+        println!(
+            "survives BM25 selection (+snippet) : {bm25_t:3} ({:5.1}%)  <- what the LLM sees",
+            pct(bm25_t)
+        );
+        println!(
+            "SELECTION loss (had it, dropped)   : {:3}",
+            ret_t.saturating_sub(bm25_t)
+        );
+        println!(
+            "RETRIEVAL loss (never had it)      : {:3} ({:5.1}%)",
+            n - ret_t,
+            pct(n - ret_t)
+        );
+        println!("questions with zero scraped md     : {no_md:3}");
+        if !lost.is_empty() {
+            println!("\n--- dropped by SELECTION (fixable in the window) ---");
+            for l in &lost {
+                println!("{l}");
+            }
+        }
+        if !missed.is_empty() {
+            println!("\n--- never RETRIEVED (search/scrape problem) ---");
+            for l in &missed {
+                println!("{l}");
+            }
+        }
+    }
 }


### PR DESCRIPTION
Offline harness to locate where `/v1/search` answer quality is lost, so a lever
can be measured without a prod A/B (sampled A/B has repeatedly been swamped by
backend latency variance — the same code measured 80% and 52% on different runs).

Two-step flow:

1. `bench/recall-harness/capture.ts` freezes a SimpleQA slice: one prod
   `search` call per question with `answer:false`, storing the full scraped
   markdown per source. One line per question.
2. `recall_at_budget` — an `#[ignore]`d test in `crw-extract` — replays that
   capture through the real `select_relevant_passages` and reports where the
   gold answer is lost: retrieval (present in scraped markdown), selection
   (survives the per-source window), or downstream. `RB_BUDGET` sweeps the
   per-source cap offline.

Test-only. No public API change, no product-code change, no behavior change; the
harness reaches the private selection fn from inside the crate. Runs in under a
second and is fully reproducible.
