### PR TITLE
fix(extract): keep Elementor page content and collapse repeated nav

### DIFF
--- a/crates/crw-extract/src/clean.rs
+++ b/crates/crw-extract/src/clean.rs
@@ -183,8 +183,6 @@ fn clean_html_impl(
                 "skiplinks",
                 "promo",
                 "promotional",
-                "widget",
-                "widgets",
                 "site-footer",
                 "site-header",
                 "page-footer",
@@ -221,7 +219,36 @@ fn clean_html_impl(
                 "ads-",
             ];
 
-            let is_noise = NOISE_PATTERNS.iter().any(|p| combined.contains(p)) || {
+            // "widget" needs its own rule. Sidebar/footer widget areas are
+            // boilerplate (WordPress `widget_text`, Divi `et_pb_widget`,
+            // GeneratePress `footer-widgets`, Astra `ast-header-widget-area`),
+            // so any class token containing "widget" is noise by default.
+            //
+            // Elementor is the exception: it wraps EVERY piece of page content
+            // in a widget (the product title on a WooCommerce page is
+            // `elementor-widget-woocommerce-product-title`), so the default rule
+            // empties the whole page. Elementor tags each widget with BOTH
+            // `elementor-widget` and `elementor-widget-{slug}`, so both forms
+            // are treated as content — exempting only the literal wrapper class
+            // names leaves the bare token matching and the page still comes back
+            // empty. The one exception to the exception is `wp-widget-*`, the
+            // classic WordPress sidebar widgets dropped into the layout.
+            //
+            // The trade is precision: an Elementor boilerplate widget whose slug
+            // isn't independently caught (semantic `<nav>`/`<footer>`, or a
+            // NOISE_PATTERNS name like `sidebar`/`popup`/`social-icons`) now
+            // survives `onlyMainContent`. Recall wins over precision here.
+            let widget_noise =
+                combined
+                    .split_whitespace()
+                    .any(|t| match t.strip_prefix("elementor-widget") {
+                        Some(rest) => rest
+                            .strip_prefix('-')
+                            .is_some_and(|slug| slug.starts_with("wp-widget-")),
+                        None => t.contains("widget"),
+                    });
+
+            let is_noise = widget_noise || NOISE_PATTERNS.iter().any(|p| combined.contains(p)) || {
                 let tokens_iter = class.split_whitespace().chain(std::iter::once(id.as_str()));
                 tokens_iter.into_iter().any(|tok| {
                     NOISE_EXACT_TOKENS.contains(&tok)
@@ -422,6 +449,56 @@ mod tests {
         assert!(!result.contains("Menu"));
         assert!(!result.contains("Foot"));
         assert!(result.contains("Content"));
+    }
+
+    #[test]
+    fn keeps_elementor_content_widgets_but_drops_wp_widget_areas() {
+        // Elementor tags every widget with BOTH `elementor-widget` and
+        // `elementor-widget-{slug}`; the product title on a WooCommerce page
+        // lives inside `elementor-widget-woocommerce-product-title`. Missing
+        // either token empties the page (issue #365).
+        let html = r#"<body>
+            <div class="elementor-element elementor-widget elementor-widget-woocommerce-product-title">
+              <h1>30 RK PANORA M 102 STP</h1>
+            </div>
+            <div class="elementor-element elementor-widget elementor-widget-text-editor">
+              <p>Matt tiles offer a sophisticated finish.</p>
+            </div>
+            <div class="elementor-element elementor-widget elementor-widget-wp-widget-nav_menu">
+              <p>Classic sidebar menu</p>
+            </div>
+        </body>"#;
+        let result = clean_html(html, true, &[], &[]).unwrap();
+        assert!(result.contains("30 RK PANORA M 102 STP"), "got: {result}");
+        assert!(
+            result.contains("Matt tiles offer a sophisticated finish."),
+            "got: {result}"
+        );
+        assert!(!result.contains("Classic sidebar menu"), "got: {result}");
+    }
+
+    #[test]
+    fn keeps_elementor_widget_wrappers_but_drops_widget_areas() {
+        // Elementor wraps every piece of page content in `elementor-widget-*`;
+        // a blanket "widget" substring match emptied those pages (issue #365).
+        let html = r#"<body>
+            <div class="elementor-widget-wrap elementor-element-populated">
+              <div class="elementor-widget-container"><h1>Product title</h1>
+              <p>Product description text.</p></div>
+            </div>
+            <div class="widget_text">Sidebar promo</div>
+            <div class="footer-widgets">GeneratePress footer</div>
+            <div class="ast-header-widget-area">Astra header</div>
+        </body>"#;
+        let result = clean_html(html, true, &[], &[]).unwrap();
+        assert!(result.contains("Product title"), "got: {result}");
+        assert!(
+            result.contains("Product description text."),
+            "got: {result}"
+        );
+        assert!(!result.contains("Sidebar promo"), "got: {result}");
+        assert!(!result.contains("GeneratePress footer"), "got: {result}");
+        assert!(!result.contains("Astra header"), "got: {result}");
     }
 
     #[test]

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -669,6 +669,19 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         None
     };
 
+    // Collapse the repeated navigation a responsive template ships — a mobile
+    // copy, a desktop copy, one per dropdown. Applied after the candidate is
+    // chosen, so scoring (and therefore which candidate wins) is unaffected.
+    // Skipped without `onlyMainContent`: there the caller asked for the
+    // document as it is.
+    let md = md.map(|m| {
+        if only_main_content {
+            markdown::drop_repeated_nav_lines(&m)
+        } else {
+            m
+        }
+    });
+
     // News/blog templates frequently render the article H1 inside a `<header>`
     // sibling of the scored container, so readability drops it. Prepend the
     // metadata title (preferring the cleaner og:title) when it isn't already

--- a/crates/crw-extract/src/markdown.rs
+++ b/crates/crw-extract/src/markdown.rs
@@ -1,4 +1,6 @@
 use regex::Regex;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::LazyLock;
 
 /// Convert HTML to Markdown using htmd (turndown.js-inspired converter).
@@ -9,20 +11,153 @@ pub fn html_to_markdown(html: &str) -> String {
     convert_indented_code_to_fenced(&md)
 }
 
+/// One markdown link or image.
+static LINK_OR_IMAGE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"!?\[[^\]]*\]\([^)]*\)").unwrap());
+
+/// What must remain once the links are removed from a menu entry: exactly one
+/// bullet or ordered-list marker, and whitespace. A `#`, a `|` or any prose
+/// means the line carries content of its own, and an empty residue means a
+/// standalone link, which can just as easily be a paragraph.
+static NAV_RESIDUE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*([*+\-]|\d+[.)])\s*$").unwrap());
+
+/// Shortest line that may be dropped as a repeat.
+const MIN_DEDUP_LINE_LEN: usize = 30;
+
+/// How many repeated entries must sit together before the run counts as a
+/// repeated menu rather than a coincidence.
+const MIN_REPEATED_RUN: usize = 2;
+
+/// Drop verbatim repeats of navigation lines.
+///
+/// Responsive templates ship a mobile and a desktop copy of the same nav, and
+/// mega-menus repeat their whole link list in every dropdown, so one menu entry
+/// can appear six or more times. Only lines that are **nothing but** links plus
+/// a list marker qualify, which is the shape a menu entry takes; a heading, a
+/// table row, a paragraph or a line of code is never touched, however often it
+/// repeats. The first occurrence always survives.
+///
+/// Applied only when the caller asked for main content — with
+/// `onlyMainContent: false` they asked for the document as it is.
+pub fn drop_repeated_nav_lines(md: &str) -> String {
+    let lines: Vec<&str> = md.lines().collect();
+
+    // Pass 1: find the menu-shaped lines, note where each text first appeared,
+    // and mark the later occurrences.
+    let mut first_at: HashMap<&str, usize> = HashMap::new();
+    let mut shaped = vec![false; lines.len()];
+    let mut repeat = vec![false; lines.len()];
+    let mut in_fenced = false;
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with("```") {
+            in_fenced = !in_fenced;
+            continue;
+        }
+        if in_fenced || line.trim().len() < MIN_DEDUP_LINE_LEN {
+            continue;
+        }
+        let residue = LINK_OR_IMAGE_RE.replace_all(line, "");
+        // `replace_all` returning Borrowed means nothing matched: the line holds
+        // no link at all, so it is not a menu entry however much it looks like
+        // one (a `-----` rule leaves the same residue).
+        let has_link = matches!(residue, std::borrow::Cow::Owned(_));
+        if !has_link || !NAV_RESIDUE_RE.is_match(&residue) {
+            continue;
+        }
+        shaped[i] = true;
+        // Keyed on the untrimmed line, so a nested entry and a top-level one
+        // stay distinct.
+        match first_at.entry(line) {
+            Entry::Occupied(_) => repeat[i] = true,
+            Entry::Vacant(slot) => {
+                slot.insert(i);
+            }
+        }
+    }
+
+    // The next menu-shaped line, looking past blanks only. A line of prose ends
+    // the block.
+    let next_shaped = |from: usize| {
+        lines
+            .iter()
+            .enumerate()
+            .skip(from + 1)
+            .find(|(j, l)| shaped[*j] || !l.trim().is_empty())
+            .filter(|(j, _)| shaped[*j])
+            .map(|(j, _)| j)
+    };
+
+    // Pass 2: drop a repeat only where the whole block genuinely repeated —
+    // at least two entries in a row, in the same order they first appeared.
+    // A lone repeat, or two entries that merely happen to sit together now, is
+    // a real cross-listing (the same item catalogued under two categories) and
+    // is kept.
+    let mut kept: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+    while i < lines.len() {
+        if !repeat[i] {
+            kept.push(lines[i]);
+            i += 1;
+            continue;
+        }
+        let mut end = i;
+        let mut run: Vec<usize> = Vec::new();
+        while end < lines.len() && (repeat[end] || lines[end].trim().is_empty()) {
+            if repeat[end] {
+                run.push(end);
+            }
+            end += 1;
+        }
+        // Trailing blanks belong to whatever follows, not to the run.
+        while end > i && lines[end - 1].trim().is_empty() {
+            end -= 1;
+        }
+        let ordered_as_first_seen = run.windows(2).all(|w| {
+            first_at
+                .get(lines[w[0]])
+                .and_then(|&at| next_shaped(at))
+                .is_some_and(|j| lines[j] == lines[w[1]])
+        });
+        if run.len() < MIN_REPEATED_RUN || !ordered_as_first_seen {
+            kept.extend_from_slice(&lines[i..end]);
+        }
+        i = end;
+    }
+
+    let mut out = kept.join("\n");
+    if md.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// A markdown list item at any indent depth: `* x`, `    - x`, `\t1. x`.
+/// htmd indents nested `<ul>`/`<ol>` items by exactly 4 spaces, which is also
+/// the indented-code-block marker, so nested menus, sitemaps and multi-level
+/// footers must not be mistaken for code.
+static LIST_ITEM_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[ \t]*([*+\-]|\d+[.)])\s").unwrap());
+
 /// Convert 4-space indented code blocks to fenced (```) code blocks.
 /// Fenced blocks are unambiguous and easier for RAG pipelines to parse.
 fn convert_indented_code_to_fenced(md: &str) -> String {
     let mut result = String::with_capacity(md.len());
     let mut code_lines: Vec<&str> = Vec::new();
     let mut in_fenced = false;
+    // Whether the last non-blank line before the current indented run was a
+    // list item. Only then can the run be list continuation rather than code.
+    let mut after_list_item = false;
+    let mut run_continues_list = false;
 
     for line in md.lines() {
         // Track existing fenced code blocks to avoid double-fencing.
         if line.trim_start().starts_with("```") {
             in_fenced = !in_fenced;
             if !code_lines.is_empty() {
-                flush_code_block(&mut result, &mut code_lines);
+                flush_code_block(&mut result, &mut code_lines, run_continues_list);
             }
+            after_list_item = false;
             result.push_str(line);
             result.push('\n');
             continue;
@@ -38,19 +173,18 @@ fn convert_indented_code_to_fenced(md: &str) -> String {
         let is_blank = line.trim().is_empty();
 
         if is_code_indent {
-            let stripped = if let Some(s) = line.strip_prefix("    ") {
-                s
-            } else if let Some(s) = line.strip_prefix('\t') {
-                s
-            } else {
-                line
-            };
-            code_lines.push(stripped);
+            if code_lines.is_empty() {
+                run_continues_list = after_list_item;
+            }
+            code_lines.push(line);
         } else if is_blank && !code_lines.is_empty() {
             code_lines.push("");
         } else {
             if !code_lines.is_empty() {
-                flush_code_block(&mut result, &mut code_lines);
+                flush_code_block(&mut result, &mut code_lines, run_continues_list);
+            }
+            if !is_blank {
+                after_list_item = LIST_ITEM_RE.is_match(line);
             }
             result.push_str(line);
             result.push('\n');
@@ -58,7 +192,7 @@ fn convert_indented_code_to_fenced(md: &str) -> String {
     }
 
     if !code_lines.is_empty() {
-        flush_code_block(&mut result, &mut code_lines);
+        flush_code_block(&mut result, &mut code_lines, run_continues_list);
     }
 
     // Match original trailing newline behavior.
@@ -69,18 +203,37 @@ fn convert_indented_code_to_fenced(md: &str) -> String {
     result
 }
 
-fn flush_code_block(result: &mut String, code_lines: &mut Vec<&str>) {
+fn flush_code_block(result: &mut String, code_lines: &mut Vec<&str>, continues_list: bool) {
     while code_lines.last() == Some(&"") {
         code_lines.pop();
     }
-    if !code_lines.is_empty() {
-        result.push_str("```\n");
+    if code_lines.is_empty() {
+        return;
+    }
+
+    // An indented run that continues a list and holds list items is a nested
+    // list, not code. Emit it untouched — fencing it would strip the markers and
+    // destroy the list. Both conditions are needed: a genuine code block can
+    // contain a line that looks like a list item, but it will not follow one.
+    if continues_list && code_lines.iter().any(|l| LIST_ITEM_RE.is_match(l)) {
         for line in code_lines.iter() {
             result.push_str(line);
             result.push('\n');
         }
-        result.push_str("```\n");
+        code_lines.clear();
+        return;
     }
+
+    result.push_str("```\n");
+    for line in code_lines.iter() {
+        let stripped = line
+            .strip_prefix("    ")
+            .or_else(|| line.strip_prefix('\t'))
+            .unwrap_or(line);
+        result.push_str(stripped);
+        result.push('\n');
+    }
+    result.push_str("```\n");
     code_lines.clear();
 }
 
@@ -134,6 +287,103 @@ mod tests {
         assert!(!result.contains("[¶](#"));
         assert!(result.contains("## Heading  rest"));
         assert!(result.contains("Some  text"));
+    }
+
+    #[test]
+    fn nested_lists_are_not_fenced_as_code() {
+        // htmd indents nested list items by 4 spaces, which used to be read as
+        // an indented code block — every dropdown menu came back as ``` (#365).
+        let html = "<ul><li>Company<ul><li><a href=\"/about\">About</a></li>\
+                    <li><a href=\"/awards\">Awards</a></li></ul></li></ul>";
+        let md = html_to_markdown(html);
+        assert!(!md.contains("```"), "nested list got fenced: {md}");
+        assert!(md.contains("About"), "list content lost: {md}");
+        assert!(md.contains("*   [Awards]"), "list markers lost: {md}");
+    }
+
+    #[test]
+    fn genuine_indented_code_still_gets_fenced() {
+        let input = "Intro paragraph\n\n    let x = 1;\n    let y = 2;\n\nOutro";
+        let result = convert_indented_code_to_fenced(input);
+        assert!(result.contains("```"), "code lost its fence: {result}");
+        assert!(result.contains("let x = 1;"), "code body lost: {result}");
+        assert!(
+            !result.contains("    let x = 1;"),
+            "indent should be stripped inside the fence: {result}"
+        );
+    }
+
+    #[test]
+    fn drops_repeated_nav_blocks_only() {
+        let nav1 = "*   [Where to buy our tiles](https://example.com/where-to-buy/)";
+        let nav2 = "*   [Exclusive showrooms near you](https://example.com/showrooms/)";
+        let heading = "## Technical specification of the product";
+        let row = "| Porcelain Matt | 30x120CM | Stair Tiles | Residential |";
+        let prose = "Matt tiles offer a sophisticated, non-shiny surface finish.";
+        let input = format!(
+            "{nav1}\n{nav2}\n\n{heading}\n\n{row}\n\n{prose}\n\n{nav1}\n{nav2}\n\n{heading}\n\n{row}\n\n{prose}\n"
+        );
+        let result = drop_repeated_nav_lines(&input);
+
+        assert_eq!(result.matches(nav1).count(), 1, "nav repeat kept: {result}");
+        assert_eq!(result.matches(nav2).count(), 1, "nav repeat kept: {result}");
+        // Everything that carries content of its own keeps every occurrence:
+        // a repeated table row is a second record, not a duplicate menu.
+        assert_eq!(result.matches(heading).count(), 2, "heading lost: {result}");
+        assert_eq!(result.matches(row).count(), 2, "table row lost: {result}");
+        assert_eq!(result.matches(prose).count(), 2, "prose lost: {result}");
+    }
+
+    #[test]
+    fn keeps_a_lone_repeated_entry() {
+        // One link repeated on its own is more likely a genuine cross-listing
+        // (the same item catalogued under two categories) than a menu.
+        let item = "*   [The Pragmatic Programmer](https://example.com/books/pragmatic)";
+        let input = format!("## Best sellers\n\n{item}\n\n## New arrivals\n\n{item}\n");
+        let result = drop_repeated_nav_lines(&input);
+        assert_eq!(
+            result.matches(item).count(),
+            2,
+            "cross-listing lost: {result}"
+        );
+    }
+
+    #[test]
+    fn keeps_two_items_cross_listed_together() {
+        // A and B were each listed under their own category; a third category
+        // lists both together. That pair never appeared as a block before, so
+        // it is a real cross-listing, not a repeated menu.
+        let a = "*   [The Pragmatic Programmer](https://example.com/books/pragmatic)";
+        let b = "*   [Structure and Interpretation](https://example.com/books/sicp)";
+        let other = "*   [Working Effectively with Legacy Code](https://example.com/books/legacy)";
+        let input = format!(
+            "## Classics\n\n{a}\n{other}\n\n## Foundations\n\n{b}\n\n## Staff picks\n\n{a}\n{b}\n"
+        );
+        let result = drop_repeated_nav_lines(&input);
+        assert_eq!(result.matches(a).count(), 2, "cross-listing lost: {result}");
+        assert_eq!(result.matches(b).count(), 2, "cross-listing lost: {result}");
+    }
+
+    #[test]
+    fn dedup_keeps_nesting_levels_distinct() {
+        let top = "*   [Long privacy policy link text](https://example.com/privacy/)";
+        let nested = format!("    {top}");
+        let input = format!("{top}\n{nested}\n");
+        let result = drop_repeated_nav_lines(&input);
+        assert!(result.contains(&nested), "nested entry lost: {result}");
+        assert_eq!(result.lines().count(), 2, "structure changed: {result}");
+    }
+
+    #[test]
+    fn dedup_leaves_code_blocks_alone() {
+        // The lines are eligible in shape — a markdown sample inside a fence —
+        // so the fence tracking is the only thing keeping them.
+        let a = "*   [Where to buy our tiles](https://example.com/where-to-buy/)";
+        let b = "*   [Exclusive showrooms near you](https://example.com/showrooms/)";
+        let input = format!("```markdown\n{a}\n{b}\n{a}\n{b}\n```\n");
+        let result = drop_repeated_nav_lines(&input);
+        assert_eq!(result.matches(a).count(), 2, "code repeat lost: {result}");
+        assert_eq!(result.matches(b).count(), 2, "code repeat lost: {result}");
     }
 
     #[test]

--- a/crates/crw-extract/tests/extract_tests.rs
+++ b/crates/crw-extract/tests/extract_tests.rs
@@ -643,3 +643,108 @@ fn css_no_match_extract_returns_empty_single_warning() {
         data.warnings
     );
 }
+
+// Issue #365: an Elementor product page rendered with duplicated responsive
+// navigation used to come back as the whole unfiltered page — six copies of the
+// menu, the footer, a popup form and stray ``` fences where nested lists were.
+// Drives the full extract() path, not the individual helpers.
+//
+// The menus live INSIDE #main, so they reach markdown conversion whichever
+// candidate the ladder picks — that is what makes this guard the real
+// behaviour rather than readability's narrowing.
+#[test]
+fn elementor_page_with_duplicated_nav_extracts_cleanly() {
+    let menu = r#"<div class="elementor-widget-wrap"><ul>
+        <li><a href="/about/">Company overview and history</a>
+          <ul><li><a href="/about/awards/">Awards and certifications page</a></li></ul>
+        </li>
+      </ul></div>"#;
+    // The template ships the same menu three times (desktop, mobile, dropdown).
+    let html = format!(
+        r#"<html><head><title>30 RK PANORA</title></head><body>
+        <div id="main" role="main">
+          {menu}{menu}{menu}
+          <div class="elementor-widget-wrap elementor-element-populated">
+            <div class="elementor-element elementor-widget elementor-widget-woocommerce-product-title">
+              <div class="elementor-widget-container">
+                <h1>30 RK PANORA M 102 STP</h1>
+              </div>
+            </div>
+            <div class="elementor-element elementor-widget elementor-widget-text-editor">
+              <div class="elementor-widget-container">
+                <p>Matt tiles offer a sophisticated, non-shiny surface finish
+                   that suits a timeless and serene interior.</p>
+                <p>Size</p><p>30x120CM</p><p>Surface</p><p>Porcelain Matt</p>
+              </div>
+            </div>
+          </div>
+          <div class="widget_text">Subscribe to our newsletter today please</div>
+        </div>
+        </body></html>"#
+    );
+
+    let data = crw_extract::extract(ExtractOptions {
+        raw_html: &html,
+        source_url: "https://example.com/product/30-rk-panora/",
+        status_code: 200,
+        rendered_with: None,
+        elapsed_ms: 0,
+        render_decision: None,
+        credit_cost: 0,
+        warnings: Vec::new(),
+        formats: &[OutputFormat::Markdown],
+        only_main_content: true,
+        include_tags: &[],
+        exclude_tags: &[],
+        css_selector: None,
+        xpath: None,
+        chunk_strategy: None,
+        query: None,
+        filter_mode: None,
+        top_k: None,
+        domain_selectors: None,
+        captured_responses: &[],
+        llm_fallback: None,
+        debug: false,
+        debug_sink: None,
+    })
+    .unwrap();
+
+    let md = data.markdown.unwrap_or_default();
+
+    // The product content survives onlyMainContent — this is what the
+    // over-broad "widget" class filter used to delete.
+    assert!(md.contains("30 RK PANORA M 102 STP"), "title lost: {md}");
+    assert!(md.contains("Porcelain Matt"), "spec lost: {md}");
+    assert!(
+        md.contains("Matt tiles offer a sophisticated"),
+        "description lost: {md}"
+    );
+
+    // The nav is present exactly once, not three times. Exactly-one, so the
+    // test fails both if dedup is removed and if the nav is dropped wholesale
+    // for the wrong reason.
+    assert_eq!(
+        md.matches("Company overview and history").count(),
+        1,
+        "nav should appear exactly once: {md}"
+    );
+    assert_eq!(
+        md.matches("Awards and certifications page").count(),
+        1,
+        "nested nav entry should appear exactly once: {md}"
+    );
+
+    // A real widget area is still boilerplate and must go.
+    assert!(
+        !md.contains("Subscribe to our newsletter today"),
+        "widget area survived: {md}"
+    );
+
+    // A nested menu list must stay a list, not become a code block.
+    assert!(!md.contains("```"), "spurious code fence: {md}");
+    assert!(
+        md.contains("[Awards and certifications page]"),
+        "nested list link lost: {md}"
+    );
+}


### PR DESCRIPTION
Elementor pages came back as the whole unfiltered document: the nav repeated six
times, the footer and a popup form were included, and nested menus were wrapped
in stray ``` fences. Three separate defects chained together.

ref #365

## What was wrong

1. **`clean.rs` deleted the page body.** The `widget` noise pattern is matched as
   a substring of the class string. Elementor tags every widget with both
   `elementor-widget` and `elementor-widget-{slug}` and wraps ALL page content
   that way (the WooCommerce product title is
   `elementor-widget-woocommerce-product-title`), so under `onlyMainContent` the
   product title, description and spec table were all removed.
2. **The alternates ladder then fell back to `basic_clean`.** With the primary
   candidate empty, the ladder picked the candidate built with
   `only_main_content = false`, i.e. no boilerplate removal at all. That is where
   the repeated menus and the footer came from.
3. **Nested lists were fenced as code.** htmd indents nested `<ul>`/`<ol>` items
   by four spaces, which is also the indented-code-block marker, so every
   dropdown menu, sitemap and multi-level footer became a ``` block with its list
   markers destroyed. This affected every page with a nested list, not just this
   one.

## What changed

- Widget areas are still removed (`widget_text`, `widget_nav_menu`,
  `footer-widgets`, `ast-header-widget-area`, `et_pb_widget`). Elementor widgets
  are treated as content, except `elementor-widget-wp-widget-*`, which are
  classic WordPress sidebar widgets dropped into the layout. The trade is
  precision: an Elementor boilerplate widget whose slug is not independently
  caught now survives `onlyMainContent`. Recall wins over precision.
- An indented run is left unfenced only when it contains a list marker **and**
  continues a list. A genuine code block containing a list-looking line is still
  fenced.
- `drop_repeated_nav_lines` collapses repeated navigation. A line is dropped only
  when it is >= 30 chars, actually contains a link, stripping the links leaves
  exactly one list marker, and its block repeats in the order it first appeared.
  Headings, table rows, table separators, paragraphs, horizontal rules,
  standalone links and code keep every occurrence. It runs after candidate
  selection so scoring is unaffected, and is skipped when `onlyMainContent` is
  false.

## Verification

The repo has no offline scrape-recall harness, so one was built for this: 228
pages of raw HTML cached from `firecrawl/scrape-content-dataset-v1` (the dataset
behind the extraction headline), replayed through `extract()`, scored with the
same rule as `bench/diagnose_3way.py`.

```
before   n=204  mean_recall=0.4831  found=117 (57.4%)  mean_dup_ratio=0.1437
after    n=204  mean_recall=0.4831  found=117 (57.4%)  mean_dup_ratio=0.1209
regressions: 0
```

Recall is identical page for page. Because that metric only asks whether a
phrase appears at least once, structure was checked separately: markdown links
20909 -> 19022 (the removed nav repeats), no page lost a heading.

On the reported page: 789 lines -> 588, 16 stray fences -> 0, main menu 6 copies
-> 1, product title / description / spec table all present.

Three approaches that would have made the output cleaner still were measured and
rejected because each cost recall: dropping `basic_clean` under `onlyMainContent`
(18 regressions), gating it behind a word floor (7), and a duplicate-line penalty
in `quality::analyze` (3). `basic_clean` is load-bearing because other
over-broad noise patterns delete content the same way `widget` did; cleaning
those up is the follow-up that would make restricting it safe.

## Notes for merging

- 9 regression tests added, including one end-to-end through `extract()` with the
  reported page's shape.
- Engine Docker images build only on releases, so merging this does not put it on
  prod until the next release-please release.