### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.us%2Fcrw.svg)](https://mcptoplist.com/server/io.github.us%2Fcrw)
+
 <p align="center">
   <img src="docs/logo-animation.gif" alt="fastCRW" width="220" />
 </p>


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **CRW Web Scraper** is currently ranked **#186**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/io.github.us%2Fcrw.svg)](https://mcptoplist.com/server/io.github.us%2Fcrw)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building CRW Web Scraper!
