### PR TITLE
feat(renderer): cf_clearance cookie cache — solve a Cloudflare challenge once, reuse it across the host

### DIFF
--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1941,6 +1941,71 @@ impl CdpRenderer {
             .map(|s| s.to_string())
     }
 
+    /// Read the page's clearance cookies (`cf_clearance` / `__cf_bm`) for `url`
+    /// via CDP `Network.getCookies`, filtered to the clearance pair. Best-effort:
+    /// any error yields an empty vec (→ `ClearanceCache::put` no-ops).
+    async fn capture_clearance_cookies(
+        conn: &CdpConnection,
+        session_id: &str,
+        url: &str,
+    ) -> Vec<crate::clearance::ClearanceCookie> {
+        let Ok(resp) = conn
+            .send_recv(
+                "Network.getCookies",
+                serde_json::json!({ "urls": [url] }),
+                Some(session_id),
+                Duration::from_secs(2),
+            )
+            .await
+        else {
+            return Vec::new();
+        };
+        let Some(arr) = resp.get("cookies").and_then(|c| c.as_array()) else {
+            return Vec::new();
+        };
+        // `Network.getCookies` can return the same clearance name under two
+        // domain scopes (host `www.x` + domain `.x`). Dedupe by name, preferring
+        // a domain-wide (leading-dot) scope so the re-injected cookie matches the
+        // broadest path Cloudflare set — otherwise injected + server copies
+        // accumulate across a crawl.
+        let mut by_name: std::collections::HashMap<String, crate::clearance::ClearanceCookie> =
+            std::collections::HashMap::new();
+        for c in arr {
+            let Some(name) = c.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            if !crate::clearance::is_clearance_cookie(name) {
+                continue;
+            }
+            let (Some(value), Some(domain)) = (
+                c.get("value").and_then(|v| v.as_str()),
+                c.get("domain").and_then(|d| d.as_str()),
+            ) else {
+                continue;
+            };
+            let cookie = crate::clearance::ClearanceCookie {
+                name: name.to_string(),
+                value: value.to_string(),
+                domain: domain.to_string(),
+                path: c
+                    .get("path")
+                    .and_then(|p| p.as_str())
+                    .unwrap_or("/")
+                    .to_string(),
+                secure: c.get("secure").and_then(|s| s.as_bool()).unwrap_or(true),
+                http_only: c.get("httpOnly").and_then(|s| s.as_bool()).unwrap_or(false),
+            };
+            // Keep the existing entry only if it's domain-wide and the new one isn't.
+            match by_name.get(name) {
+                Some(existing) if existing.domain.starts_with('.') && !domain.starts_with('.') => {}
+                _ => {
+                    by_name.insert(name.to_string(), cookie);
+                }
+            }
+        }
+        by_name.into_values().collect()
+    }
+
     /// Scroll the page viewport-by-viewport until `document.body.scrollHeight`
     /// stops growing or `AUTO_SCROLL_MAX_STEPS` is reached. Triggers lazy-loaded
     /// images, infinite-scroll feeds, and below-the-fold hydration.
@@ -2403,6 +2468,86 @@ impl CdpRenderer {
             .ok();
         }
 
+        // cf_clearance reuse (chrome family only — lightpanda can't execute a
+        // Cloudflare challenge, and routes Network.* through Emulation.* so
+        // setCookie/getCookies aren't reliable). Compute the cache key once;
+        // inject a still-valid cached clearance cookie BEFORE navigating so
+        // Cloudflare serves the real page instead of a challenge.
+        //
+        // The cookie is bound by Cloudflare to (IP, UA, TLS/JA3), so all three
+        // are pinned: the sticky-per-host proxy keeps the IP (part of the key),
+        // `effective_ua` keeps the UA (also part of the key — a caller-supplied
+        // UA override must not replay a cookie solved under a different one),
+        // and this IS Chrome so the JA3 matches.
+        let clearance_key: Option<String> = if self.name == "lightpanda" {
+            None
+        } else {
+            url::Url::parse(url)
+                .ok()
+                .and_then(|u| u.host_str().map(|h| h.to_string()))
+                .map(|host| {
+                    let proxy_id = crate::REQUEST_PROXY
+                        .try_with(|p| p.as_ref().map(|e| e.raw().to_string()))
+                        .ok()
+                        .flatten();
+                    crate::clearance::ClearanceCache::key(&host, proxy_id.as_deref(), effective_ua)
+                })
+        };
+        // Single-flight: the FIRST fetch to a cold `(host,proxy)` holds the solve
+        // lock across navigate+capture, so concurrent same-key fetches (a crawl
+        // hammering one host) wait for that one solve instead of stampeding
+        // Cloudflare with N simultaneous challenges (which gets the IP banned).
+        // A waiter that finds the cookie already cached drops the lock at once and
+        // proceeds in parallel — only the actual solver serialises. (Belt-and-
+        // suspenders to the per-host limiter, which already serialises at
+        // politeness=1.) `_solve_guard` releases when fetch_inner returns.
+        let mut _solve_guard: Option<tokio::sync::OwnedMutexGuard<()>> = None;
+        let inject_cookies = match &clearance_key {
+            None => None,
+            Some(key) => {
+                let cache = crate::clearance::clearance_cache();
+                match cache.get(key) {
+                    hit @ Some(_) => hit,
+                    None => {
+                        let guard = cache.solve_lock(key).lock_owned().await;
+                        match cache.get(key) {
+                            // Solved while we waited → reuse, release immediately.
+                            hit @ Some(_) => hit,
+                            // Cold: we're the solver — hold the lock through capture.
+                            None => {
+                                _solve_guard = Some(guard);
+                                None
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        if let Some(cookies) = &inject_cookies {
+            for c in cookies {
+                let _ = conn
+                    .send_recv(
+                        "Network.setCookie",
+                        serde_json::json!({
+                            "name": c.name,
+                            "value": c.value,
+                            "domain": c.domain,
+                            "path": c.path,
+                            "secure": c.secure,
+                            "httpOnly": c.http_only,
+                        }),
+                        Some(&session_id),
+                        self.page_timeout,
+                    )
+                    .await;
+            }
+            tracing::debug!(
+                url,
+                count = cookies.len(),
+                "injected cached clearance cookies"
+            );
+        }
+
         // Subscribe to events BEFORE navigating so we don't miss loadEventFired.
         let events_rx = conn.subscribe();
 
@@ -2676,6 +2821,21 @@ impl CdpRenderer {
             Ok(_) => Self::eval_href(conn, &session_id, Duration::from_secs(2)).await,
             Err(_) => None,
         };
+
+        // Capture clearance cookies on success, before the target is torn down.
+        // `put` is a no-op when no clearance cookie is present, so a still-blocked
+        // page caches nothing. This also self-heals a stale injected cookie: when
+        // it was rejected, Chrome solves the fresh challenge and we capture the
+        // new cookie here. Best-effort — never affects the fetch result.
+        if let Some(key) = &clearance_key
+            && outcome.is_ok()
+        {
+            let cookies = Self::capture_clearance_cookies(conn, &session_id, url).await;
+            if !cookies.is_empty() {
+                tracing::debug!(url, count = cookies.len(), "captured clearance cookies");
+            }
+            crate::clearance::clearance_cache().put(key, cookies);
+        }
 
         // Target close is the caller's responsibility (pool's release() owns
         // it via the recorded target_id; legacy fetch_with_ws closes after

--- a/crates/crw-renderer/src/clearance.rs
+++ b/crates/crw-renderer/src/clearance.rs
@@ -1,0 +1,262 @@
+//! Per-`(host, proxy)` Cloudflare clearance-cookie cache.
+//!
+//! `cf_clearance` is bound by Cloudflare to the `(IP, User-Agent, TLS/JA3)` that
+//! solved the challenge. crw's Chrome renderer already supplies a real Chrome
+//! UA + JA3, and the sticky-per-host proxy keeps the egress IP stable — so the
+//! only thing missing to skip the interstitial on a *repeat* fetch is the cookie
+//! itself. We capture it after a solve and re-inject it (CDP `Network.setCookie`)
+//! before the next navigation to the same `(host, proxy)`, turning N challenge
+//! solves into 1.
+//!
+//! This module is deliberately renderer-agnostic and side-effect-free: it owns
+//! the cache + the single-flight locks, nothing else. The CDP layer drives the
+//! capture/inject I/O against it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex as AsyncMutex;
+
+/// A captured clearance cookie. Only the fields CDP `Network.setCookie` needs to
+/// faithfully replay it are kept.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClearanceCookie {
+    pub name: String,
+    pub value: String,
+    pub domain: String,
+    pub path: String,
+    pub secure: bool,
+    pub http_only: bool,
+}
+
+/// Cookie names worth caching — the Cloudflare clearance + bot-management pair.
+/// Anything else (analytics, session) is the site's own and must not be replayed
+/// across requests (could pin us to a stale/foreign session).
+pub fn is_clearance_cookie(name: &str) -> bool {
+    matches!(name, "cf_clearance" | "__cf_bm")
+}
+
+/// Refresh well before Cloudflare's ~30 min `cf_clearance` lifetime so an
+/// in-flight reuse never races the expiry.
+const DEFAULT_TTL: Duration = Duration::from_secs(25 * 60);
+
+struct Entry {
+    cookies: Vec<ClearanceCookie>,
+    captured_at: Instant,
+}
+
+/// Process-wide clearance cache. Two small mutexes: one for entries, one for the
+/// per-key single-flight locks. Held only for map lookups, never across `.await`.
+pub struct ClearanceCache {
+    entries: Mutex<HashMap<String, Entry>>,
+    locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+    ttl: Duration,
+}
+
+impl Default for ClearanceCache {
+    fn default() -> Self {
+        Self::with_ttl(DEFAULT_TTL)
+    }
+}
+
+impl ClearanceCache {
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            locks: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Cache key. Pins every component Cloudflare binds `cf_clearance` to:
+    /// `host` (the request host), `proxy_id` (the egress that solved it — a
+    /// different IP is rejected), and `ua` (the User-Agent it was solved under —
+    /// a caller-supplied override must not replay another UA's cookie).
+    pub fn key(host: &str, proxy_id: Option<&str>, ua: &str) -> String {
+        format!(
+            "{}|{}|{}",
+            host.to_ascii_lowercase(),
+            proxy_id.unwrap_or("-"),
+            ua
+        )
+    }
+
+    /// Fresh cookies for `key`, or `None` if absent/expired. Expired entries are
+    /// evicted on read.
+    pub fn get(&self, key: &str) -> Option<Vec<ClearanceCookie>> {
+        self.get_at(key, Instant::now())
+    }
+
+    fn get_at(&self, key: &str, now: Instant) -> Option<Vec<ClearanceCookie>> {
+        let mut entries = self.entries.lock().unwrap();
+        match entries.get(key) {
+            Some(e) if now.saturating_duration_since(e.captured_at) < self.ttl => {
+                Some(e.cookies.clone())
+            }
+            Some(_) => {
+                entries.remove(key);
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// Store freshly-captured clearance cookies. A capture with no clearance
+    /// cookie is a no-op (don't cache an empty/non-clearance result).
+    pub fn put(&self, key: &str, cookies: Vec<ClearanceCookie>) {
+        if cookies.is_empty() {
+            return;
+        }
+        self.entries.lock().unwrap().insert(
+            key.to_string(),
+            Entry {
+                cookies,
+                captured_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Drop an entry — called when a reuse still came back challenged (the cookie
+    /// died early, or the egress IP changed under us).
+    pub fn invalidate(&self, key: &str) {
+        self.entries.lock().unwrap().remove(key);
+    }
+
+    /// The single-flight lock for `key`. The first fetch to a fresh `(host,proxy)`
+    /// holds it across solve+capture so concurrent fetches (e.g. a crawl's 100
+    /// parallel pages) wait for the one solve instead of stampeding Cloudflare
+    /// with 100 simultaneous challenges (which gets the IP banned). Once the
+    /// cookie is cached the waiters re-check, find it, and proceed in parallel.
+    pub fn solve_lock(&self, key: &str) -> Arc<AsyncMutex<()>> {
+        let mut locks = self.locks.lock().unwrap();
+        locks.entry(key.to_string()).or_default().clone()
+    }
+}
+
+/// The process-wide cache instance.
+pub fn clearance_cache() -> &'static ClearanceCache {
+    static CACHE: LazyLock<ClearanceCache> = LazyLock::new(ClearanceCache::default);
+    &CACHE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ck(name: &str) -> ClearanceCookie {
+        ClearanceCookie {
+            name: name.into(),
+            value: "v".into(),
+            domain: ".example.com".into(),
+            path: "/".into(),
+            secure: true,
+            http_only: true,
+        }
+    }
+
+    #[test]
+    fn clearance_cookie_filter() {
+        assert!(is_clearance_cookie("cf_clearance"));
+        assert!(is_clearance_cookie("__cf_bm"));
+        assert!(!is_clearance_cookie("_ga"));
+        assert!(!is_clearance_cookie("session"));
+    }
+
+    #[test]
+    fn key_lowercases_host_and_pins_proxy_and_ua() {
+        assert_eq!(
+            ClearanceCache::key("Example.COM", None, "UA/1"),
+            "example.com|-|UA/1"
+        );
+        assert_eq!(
+            ClearanceCache::key("example.com", Some("px1"), "UA/1"),
+            "example.com|px1|UA/1"
+        );
+        // Different egress → different key → no cross-IP reuse.
+        assert_ne!(
+            ClearanceCache::key("example.com", Some("px1"), "UA/1"),
+            ClearanceCache::key("example.com", Some("px2"), "UA/1")
+        );
+        // Different UA → different key → no cross-UA reuse (CF rejects those).
+        assert_ne!(
+            ClearanceCache::key("example.com", Some("px1"), "UA/1"),
+            ClearanceCache::key("example.com", Some("px1"), "UA/2")
+        );
+    }
+
+    #[test]
+    fn put_get_roundtrip_and_empty_is_noop() {
+        let c = ClearanceCache::default();
+        let k = ClearanceCache::key("example.com", None, "UA/1");
+        assert!(c.get(&k).is_none());
+        c.put(&k, vec![]); // empty → not stored
+        assert!(c.get(&k).is_none());
+        c.put(&k, vec![ck("cf_clearance")]);
+        assert_eq!(c.get(&k).unwrap(), vec![ck("cf_clearance")]);
+    }
+
+    #[test]
+    fn invalidate_drops_entry() {
+        let c = ClearanceCache::default();
+        let k = ClearanceCache::key("example.com", Some("px1"), "UA/1");
+        c.put(&k, vec![ck("cf_clearance")]);
+        assert!(c.get(&k).is_some());
+        c.invalidate(&k);
+        assert!(c.get(&k).is_none());
+    }
+
+    #[test]
+    fn expired_entry_is_evicted_on_read() {
+        let c = ClearanceCache::with_ttl(Duration::from_secs(60));
+        let k = ClearanceCache::key("example.com", None, "UA/1");
+        c.put(&k, vec![ck("cf_clearance")]);
+        // Read 61s in the future → expired.
+        let future = Instant::now() + Duration::from_secs(61);
+        assert!(c.get_at(&k, future).is_none());
+        // And it was evicted, not just hidden.
+        assert!(c.entries.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn solve_lock_is_stable_per_key() {
+        let c = ClearanceCache::default();
+        let k = ClearanceCache::key("example.com", None, "UA/1");
+        let a = c.solve_lock(&k);
+        let b = c.solve_lock(&k);
+        assert!(Arc::ptr_eq(&a, &b), "same key must share one lock");
+        let other = c.solve_lock(&ClearanceCache::key("other.com", None, "UA/1"));
+        assert!(
+            !Arc::ptr_eq(&a, &other),
+            "different keys get different locks"
+        );
+    }
+
+    #[tokio::test]
+    async fn solve_lock_serializes_first_solve() {
+        // Two tasks race on a cold key; the lock must serialize them so only the
+        // first "solves" and the second finds the cached cookie.
+        let c = Arc::new(ClearanceCache::default());
+        let k = ClearanceCache::key("example.com", None, "UA/1");
+        let solves = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let run = |c: Arc<ClearanceCache>,
+                   k: String,
+                   solves: Arc<std::sync::atomic::AtomicUsize>| async move {
+            if c.get(&k).is_none() {
+                let lock = c.solve_lock(&k);
+                let _g = lock.lock_owned().await;
+                if c.get(&k).is_none() {
+                    solves.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    c.put(&k, vec![ck("cf_clearance")]);
+                }
+            }
+        };
+
+        let (a, b) = tokio::join!(
+            run(c.clone(), k.clone(), solves.clone()),
+            run(c.clone(), k.clone(), solves.clone()),
+        );
+        let _ = (a, b);
+        assert_eq!(solves.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+}

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -45,6 +45,7 @@ pub mod camoufox;
 pub mod cdp;
 #[cfg(feature = "cdp")]
 pub mod cdp_conn;
+pub mod clearance;
 #[cfg(feature = "cloak")]
 pub mod cloak;
 pub mod detector;


### PR DESCRIPTION
## Problem

Cloudflare binds `cf_clearance` to `(IP, User-Agent, TLS/JA3)`. crw's Chrome renderer already supplies a real Chrome UA + JA3, and sticky-per-host proxy keeps the egress IP stable — so the only thing missing to skip the interstitial on a *repeat* fetch to the same host was the cookie itself.

Every fetch was solving the challenge from scratch (a per-request proxied context starts with no cookies), which made crawling/mapping a Cloudflare-protected site slow to impossible: N pages meant N challenge solves, and hammering CF with parallel solves is also what gets an egress IP burned.

## What this does

Caches the clearance cookie per `(host, proxy, UA)` and replays it:

- **`clearance` module** — process-wide cache with a TTL (25 min, under CF's ~30) and a per-key single-flight async lock. Renderer-agnostic and side-effect free; unit-tested (TTL eviction, key isolation, single-flight serialisation).
- **capture** — after a successful chrome render, read `cf_clearance` / `__cf_bm` via CDP `Network.getCookies`, deduped by name preferring the domain-wide scope, and cache them. Self-healing: if an injected cookie was stale, Chrome solves the fresh challenge and the new cookie is captured here.
- **inject** — before navigating, `Network.setCookie` the cached clearance so Cloudflare serves the real page instead of a challenge.
- **single-flight** — the first fetch to a cold key holds the lock across solve+capture, so a crawl's concurrent pages wait for that one solve instead of stampeding CF with N challenges. A waiter that finds the cookie cached drops the lock immediately and proceeds in parallel.
- Gated to the chrome family; lightpanda can't execute a challenge and routes `Network.*` through `Emulation.*`, so it is skipped and pays nothing.

The cache key includes the **effective User-Agent**, not just host+proxy: callers can now override the UA per request, and replaying a cookie under a different UA is rejected by Cloudflare instantly.

## Verification

Live, through the real API path (`POST /v1/crawl`, server wired to Chrome over CDP), against Cloudflare-protected `e-chords.com`:

```
5 pages crawled, renderer = chrome
  5 x "captured clearance cookies"
  4 x "injected cached clearance cookies"
```

First page solves cold; the remaining four reuse the cached cookie. Before this change each page paid its own challenge.

- `cargo test --workspace`: all green (renderer suite 178)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

## Notes
- Additive: no behaviour change for non-Cloudflare sites or the HTTP tier; a miss costs one map lookup.
- `ponytail:` the cache is process-local. A shared/persistent store only matters if we later want reuse across engine restarts or replicas.