### PR TITLE
fix(extract): stop deleting article content under onlyMainContent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,7 +778,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "clap",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "axum",
  "axum-test",
@@ -1478,7 +1478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3644,7 +3644,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3701,7 +3701,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4274,10 +4274,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5045,7 +5045,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/crw-extract/src/clean.rs
+++ b/crates/crw-extract/src/clean.rs
@@ -1,4 +1,9 @@
+use lol_html::html_content::UserData;
 use lol_html::{RewriteStrSettings, element, rewrite_str};
+
+/// Marker for `<header>`/`<aside>` nested inside `<main>`/`<article>`, which
+/// are article furniture rather than site chrome and must survive cleaning.
+const KEEP_NESTED: u8 = 1;
 use scraper::{Html, Selector};
 use std::collections::HashSet;
 
@@ -50,6 +55,12 @@ fn clean_html_impl(
 ) -> Result<String, String> {
     // Phase 1: lol_html streaming removal of always-unwanted tags.
     let mut handlers = vec![
+        // <head> carries <title>/<meta>, which htmd would otherwise render as
+        // a bare text line at the top of the markdown, duplicating the H1.
+        element!("head", |el| {
+            el.remove();
+            Ok(())
+        }),
         element!("script", |el| {
             el.remove();
             Ok(())
@@ -90,16 +101,42 @@ fn clean_html_impl(
             el.remove();
             Ok(())
         }));
-        handlers.push(element!("footer", |el| {
-            el.remove();
+
+        // `<header>` and `<aside>` mean two different things depending on where
+        // they sit. Directly under <body> they are site chrome. Inside <main>
+        // or <article> they are part of the article itself: the title block
+        // that carries the H1 and the standfirst, or a pull-quote. Removing
+        // them wholesale deleted 9.6% of what these two tags match across a
+        // 400-page sample, including the lead paragraph of every Pantheon docs
+        // page. The same split applies to `<footer>`: inside an article it is the
+        // byline / date / tags block, not the site footer.
+        //
+        // lol_html streams, so a handler cannot look at its ancestors. Mark the
+        // nested ones first (handlers run in registration order, and both fire
+        // for the same element), then skip anything marked.
+        handlers.push(element!(
+            "main header, main aside, main footer, article header, article aside, article footer",
+            |el| {
+                el.set_user_data(KEEP_NESTED);
+                Ok(())
+            }
+        ));
+        handlers.push(element!("header", |el| {
+            if el.user_data().downcast_ref::<u8>() != Some(&KEEP_NESTED) {
+                el.remove();
+            }
             Ok(())
         }));
-        handlers.push(element!("header", |el| {
-            el.remove();
+        handlers.push(element!("footer", |el| {
+            if el.user_data().downcast_ref::<u8>() != Some(&KEEP_NESTED) {
+                el.remove();
+            }
             Ok(())
         }));
         handlers.push(element!("aside", |el| {
-            el.remove();
+            if el.user_data().downcast_ref::<u8>() != Some(&KEEP_NESTED) {
+                el.remove();
+            }
             Ok(())
         }));
         handlers.push(element!("menu", |el| {
@@ -135,6 +172,43 @@ fn clean_html_impl(
             // a combined string that also contains the other classes).
             let combined = format!("{class} {id}");
 
+            // Layout names, matched per class token — NEVER as a substring.
+            // These describe where a region sits on the page, so themes reuse
+            // them to name the wrapper that HOLDS the article:
+            // `pds-sidebar-layout__content` (Pantheon docs), `has-sidebar`,
+            // `content-sidebar`, `navigation-list-container`. Substring
+            // matching on these emptied 14% of a 161-page labelled corpus
+            // (django docs 74670 -> 248 chars). Firecrawl matches the same
+            // concepts as CSS class selectors, i.e. per token, and does not
+            // have this failure.
+            //
+            // Only names observed wrapping real content live here. Names like
+            // "cookie" / "consent" / "infobox" stay in NOISE_PATTERNS below:
+            // they appear almost exclusively as `cookie-notice` /
+            // `cookielawinfo-*` style tokens, so requiring an exact token
+            // would stop removing them entirely (measured: 459 elements,
+            // ~57k chars of cookie chrome would leak back in).
+            // Matched as a PREFIX of a class token (see reasoning above).
+            const NOISE_LAYOUT_TOKENS: &[&str] = &[
+                "sidebar",
+                "navigation",
+                "breadcrumb",
+                "dropdown",
+                "site-header",
+                "site-footer",
+                "page-header",
+                "page-footer",
+                "global-header",
+                "global-footer",
+                "global-nav",
+                "main-nav",
+                "primary-nav",
+                "secondary-nav",
+                // zhihu names the article body `copyrightrichtext-richtext`;
+                // as a substring this deleted 98% of the page.
+                "copyright",
+            ];
+
             // Names here are matched as a SUBSTRING of "{class} {id}", so a name
             // that appears inside a content class deletes real content. Two were
             // replaced with narrower ones after measuring on the frozen scrape
@@ -156,14 +230,11 @@ fn clean_html_impl(
             //   Squarespace announcement bars are named `announcement-bar` and
             //   were never caught by "banner" either way.)
             const NOISE_PATTERNS: &[&str] = &[
-                "sidebar",
                 "table-of-contents",
                 "tableofcontents",
                 "infobox",
                 "navbox",
                 "nav-box",
-                "navigation",
-                "breadcrumb",
                 "cookie",
                 "consent",
                 "widget-area",
@@ -193,8 +264,6 @@ fn clean_html_impl(
                 "shortdescription",
                 "sphinxsidebar",
                 "sphinxfooter",
-                "copyright",
-                "dropdown",
                 "city-selector",
                 "location-selector",
                 "lang-selector",
@@ -204,16 +273,6 @@ fn clean_html_impl(
                 "skiplinks",
                 "promo",
                 "promotional",
-                "site-footer",
-                "site-header",
-                "page-footer",
-                "page-header",
-                "global-nav",
-                "global-footer",
-                "global-header",
-                "main-nav",
-                "primary-nav",
-                "secondary-nav",
                 "social-share",
                 "social-links",
                 "social-icons",
@@ -240,10 +299,25 @@ fn clean_html_impl(
                 "ads-",
             ];
 
+            // Layout names match a class token that STARTS with the name, never
+            // one that merely contains it. Position carries the meaning:
+            //
+            //   sidebar-right, sidebar-card, dropdown-menu, breadcrumbs
+            //       -> the element IS that piece of furniture. Remove.
+            //   has-sidebar, no-sidebar, content-sidebar,
+            //   pds-sidebar-layout__content (Pantheon docs)
+            //       -> the element is the article, named after the furniture
+            //          beside it. Keep.
+            //
+            // Plain substring matching could not tell those apart and emptied
+            // the content of 14% of a 161-page labelled corpus (django docs
+            // 74670 -> 248 chars). Requiring an exact token was the opposite
+            // error: it let `sidebar-right` and `dropdown-menu` through.
             let is_noise = NOISE_PATTERNS.iter().any(|p| combined.contains(p)) || {
                 let tokens_iter = class.split_whitespace().chain(std::iter::once(id.as_str()));
                 tokens_iter.into_iter().any(|tok| {
-                    NOISE_EXACT_TOKENS.contains(&tok)
+                    NOISE_LAYOUT_TOKENS.iter().any(|p| tok.starts_with(p))
+                        || NOISE_EXACT_TOKENS.contains(&tok)
                         || NOISE_PREFIXES.iter().any(|pre| tok.starts_with(pre))
                 })
             };

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -298,78 +298,6 @@ fn lookup_domain_selector(source_url: &str, map: &HashMap<String, String>) -> Op
     map.get(&host).cloned()
 }
 
-#[cfg(test)]
-mod private_tests {
-    use super::*;
-    use crw_core::types::CapturedNetworkResponse;
-
-    #[test]
-    fn domain_selector_matches_exact_host() {
-        let mut map = HashMap::new();
-        map.insert("news.example.com".to_string(), ".article".to_string());
-        let got = lookup_domain_selector("https://news.example.com/p/42", &map);
-        assert_eq!(got.as_deref(), Some(".article"));
-    }
-
-    #[test]
-    fn domain_selector_misses_on_other_host() {
-        let mut map = HashMap::new();
-        map.insert("news.example.com".to_string(), ".article".to_string());
-        let got = lookup_domain_selector("https://other.example.com/p/42", &map);
-        assert!(got.is_none());
-    }
-
-    #[test]
-    fn domain_selector_empty_map_returns_none() {
-        let map = HashMap::new();
-        assert!(lookup_domain_selector("https://x.example.com/", &map).is_none());
-    }
-
-    #[test]
-    fn xhr_extract_returns_none_for_empty_input() {
-        assert!(extract_xhr_text(&[]).is_none());
-    }
-
-    #[test]
-    fn xhr_extract_collects_long_string_fields() {
-        let body = serde_json::json!({
-            "title": "short",
-            "body": "a".repeat(300),
-            "meta": { "summary": "b".repeat(200) },
-            "tags": ["c".repeat(150), "short"],
-            "url": "https://example.com/should/skip",
-        })
-        .to_string();
-        let resp = vec![CapturedNetworkResponse {
-            url: "https://api.example.com/article/1".to_string(),
-            request_id: "1".to_string(),
-            status: 200,
-            mime_type: Some("application/json".to_string()),
-            body: Some(body),
-            body_size_bytes: 800,
-        }];
-        let got = extract_xhr_text(&resp).expect("expected long-text fields");
-        assert!(got.contains(&"a".repeat(300)));
-        assert!(got.contains(&"b".repeat(200)));
-        assert!(got.contains(&"c".repeat(150)));
-        assert!(!got.contains("short"));
-        assert!(!got.contains("example.com/should/skip"));
-    }
-
-    #[test]
-    fn xhr_extract_skips_invalid_json() {
-        let resp = vec![CapturedNetworkResponse {
-            url: "x".into(),
-            request_id: "1".into(),
-            status: 200,
-            mime_type: Some("application/json".into()),
-            body: Some("not json".into()),
-            body_size_bytes: 8,
-        }];
-        assert!(extract_xhr_text(&resp).is_none());
-    }
-}
-
 /// Decode the small set of HTML entities that commonly appear in `<meta>`
 /// `content` attributes. We don't pull in a full entity decoder because the
 /// metadata path only sees author-curated short text, and the long tail of
@@ -524,7 +452,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // or `includeTags` previously returned the entire document). Treat it as an
     // intentional narrow extraction that yielded empty output. `Some("")` also
     // short-circuits the alternates ladder below, so the whole page can't sneak
-    // back in via basic_clean / structural fallbacks.
+    // back in via the basic_clean fallback.
     // Domain-configured default selectors are excluded: a host default that
     // doesn't apply should still show the page (its no-match sets neither flag).
     let selected_html = if include_tags_no_match {
@@ -589,7 +517,16 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
                 candidates.push(("cleaned", m, q));
             }
 
-            // Alt 2: basic clean without only_main_content (no readability narrowing).
+            // Alt 2: whole-page clean without only_main_content, i.e. the page
+            // with its nav/footer intact. It is the rescue candidate for pages
+            // where readability narrows onto the wrong container.
+            //
+            // Known wart: because the quality score rewards word count, that
+            // boilerplate bulk is also what lets this candidate win on
+            // page-builder sites, which is how a mega menu reaches the markdown
+            // even for onlyMainContent requests. Making it honour
+            // only_main_content fixes those pages but costs recall on the
+            // frozen 1000-URL set (0.3828 -> 0.3651), so it is left alone here.
             let basic_cleaned = clean::clean_html_with_warnings(
                 raw_html,
                 false,
@@ -602,12 +539,13 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
             let basic_q = quality::analyze_md_only(&basic_md);
             candidates.push(("basic_clean", basic_md, basic_q));
 
-            // Alt 3: structural table/list extraction from raw HTML.
-            if let Some(structural) = extract_tables_and_lists(raw_html) {
-                let q = quality::analyze_md_only(&structural);
-                candidates.push(("structural", structural, q));
-            }
-
+            // No structural table/list alternate. It harvested <ul>/<table>
+            // straight out of raw_html, and its only guard was an ancestor tag
+            // check for nav/footer/header — which page builders sail past,
+            // since Elementor and friends render menus as plain <div><ul>. On
+            // an Elementor product page it was the winning candidate and put
+            // 118 nav links into the markdown. Measured contribution across a
+            // labelled corpus: none (identical recall with and without).
             // Alt 4: XHR/fetch JSON capture — recursively walk every captured
             // JSON body and gather long text fields. Useful when the article
             // body lives in an API response loaded after `loadEventFired`
@@ -996,20 +934,6 @@ fn apply_selector(html: &str, css: Option<&str>, xpath: Option<&str>) -> CrwResu
     Ok(None)
 }
 
-/// Walk the raw HTML for substantial `<table>` (≥2 data rows) and
-/// `<ul>/<ol>` (≥5 items) elements, render each to markdown, and return
-/// the concatenation. Returns `None` if no qualifying structure is found.
-///
-/// This exists as a last-ditch fallback: readability and the htmd-on-cleaned
-/// path treat tabular and list-only pages (county finance reports, job
-/// listings, niche product catalogs) as navigation noise. By pulling those
-/// structures out of the raw DOM we surface real content that would
-/// otherwise be reported as thin.
-/// Walk the captured XHR/fetch JSON responses and harvest long text fields.
-/// Each response is parsed as JSON; every string value with at least
-/// `MIN_FIELD_LEN` characters is appended (deduplicated). Returned as a
-/// markdown-ish body (paragraph-separated). `None` if total content is
-/// too small to be useful.
 fn extract_xhr_text(captured: &[CapturedNetworkResponse]) -> Option<String> {
     const MIN_FIELD_LEN: usize = 120;
     const MIN_TOTAL_LEN: usize = 400;
@@ -1074,95 +998,74 @@ fn walk_json_strings(value: &serde_json::Value, on_string: &mut dyn FnMut(&str))
     }
 }
 
-fn extract_tables_and_lists(html: &str) -> Option<String> {
-    use scraper::{Html, Selector};
-
-    let doc = Html::parse_document(html);
-    let table_sel = Selector::parse("table").ok()?;
-    let list_sel = Selector::parse("ul, ol").ok()?;
-    let row_sel = Selector::parse("tr").ok()?;
-    let item_sel = Selector::parse("li").ok()?;
-
-    let mut chunks: Vec<String> = Vec::new();
-
-    for table in doc.select(&table_sel) {
-        if table.select(&row_sel).count() < 2 {
-            continue;
-        }
-        let html_chunk = table.html();
-        let md = markdown::html_to_markdown(&html_chunk);
-        if md.trim().len() >= 40 {
-            chunks.push(md);
-        }
-    }
-
-    for list in doc.select(&list_sel) {
-        if list.select(&item_sel).count() < 5 {
-            continue;
-        }
-        // Skip nav/footer lists — those are usually identifiable by ancestor
-        // tag and would otherwise drown out real content.
-        let in_nav = list
-            .ancestors()
-            .filter_map(scraper::ElementRef::wrap)
-            .any(|el| {
-                let n = el.value().name();
-                n == "nav" || n == "footer" || n == "header"
-            });
-        if in_nav {
-            continue;
-        }
-        let html_chunk = list.html();
-        let md = markdown::html_to_markdown(&html_chunk);
-        if md.trim().len() >= 40 {
-            chunks.push(md);
-        }
-    }
-
-    if chunks.is_empty() {
-        return None;
-    }
-    Some(chunks.join("\n\n"))
-}
-
 #[cfg(test)]
-mod table_list_fallback_tests {
+mod private_tests {
     use super::*;
+    use crw_core::types::CapturedNetworkResponse;
 
     #[test]
-    fn extracts_two_row_table() {
-        let html = "<html><body><nav>x</nav><table>\
-            <tr><th>Name</th><th>Value</th></tr>\
-            <tr><td>Alpha</td><td>1</td></tr>\
-            <tr><td>Bravo</td><td>2</td></tr>\
-            </table></body></html>";
-        let md = extract_tables_and_lists(html).expect("table should extract");
-        assert!(md.contains("Alpha"));
-        assert!(md.contains("Bravo"));
+    fn domain_selector_matches_exact_host() {
+        let mut map = HashMap::new();
+        map.insert("news.example.com".to_string(), ".article".to_string());
+        let got = lookup_domain_selector("https://news.example.com/p/42", &map);
+        assert_eq!(got.as_deref(), Some(".article"));
     }
 
     #[test]
-    fn skips_short_table() {
-        let html = "<table><tr><td>only</td></tr></table>";
-        assert!(extract_tables_and_lists(html).is_none());
+    fn domain_selector_misses_on_other_host() {
+        let mut map = HashMap::new();
+        map.insert("news.example.com".to_string(), ".article".to_string());
+        let got = lookup_domain_selector("https://other.example.com/p/42", &map);
+        assert!(got.is_none());
     }
 
     #[test]
-    fn skips_nav_list() {
-        let html = "<nav><ul>\
-            <li>a</li><li>b</li><li>c</li><li>d</li><li>e</li><li>f</li>\
-            </ul></nav>";
-        assert!(extract_tables_and_lists(html).is_none());
+    fn domain_selector_empty_map_returns_none() {
+        let map = HashMap::new();
+        assert!(lookup_domain_selector("https://x.example.com/", &map).is_none());
     }
 
     #[test]
-    fn extracts_long_list() {
-        let html = "<main><ul>\
-            <li>Job A</li><li>Job B</li><li>Job C</li>\
-            <li>Job D</li><li>Job E</li><li>Job F</li>\
-            </ul></main>";
-        let md = extract_tables_and_lists(html).expect("list should extract");
-        assert!(md.contains("Job A"));
-        assert!(md.contains("Job F"));
+    fn xhr_extract_returns_none_for_empty_input() {
+        assert!(extract_xhr_text(&[]).is_none());
+    }
+
+    #[test]
+    fn xhr_extract_collects_long_string_fields() {
+        let body = serde_json::json!({
+            "title": "short",
+            "body": "a".repeat(300),
+            "meta": { "summary": "b".repeat(200) },
+            "tags": ["c".repeat(150), "short"],
+            "url": "https://example.com/should/skip",
+        })
+        .to_string();
+        let resp = vec![CapturedNetworkResponse {
+            url: "https://api.example.com/article/1".to_string(),
+            request_id: "1".to_string(),
+            status: 200,
+            mime_type: Some("application/json".to_string()),
+            body: Some(body),
+            body_size_bytes: 800,
+        }];
+        let got = extract_xhr_text(&resp).expect("expected long-text fields");
+        assert!(got.contains(&"a".repeat(300)));
+        assert!(got.contains(&"b".repeat(200)));
+        assert!(got.contains(&"c".repeat(150)));
+        assert!(!got.contains("short"));
+        assert!(!got.contains("example.com/should/skip"));
+    }
+
+    #[test]
+    fn xhr_extract_skips_invalid_json() {
+        let resp = vec![CapturedNetworkResponse {
+            url: "x".into(),
+            request_id: "1".into(),
+            status: 200,
+            mime_type: Some("application/json".into()),
+            body: Some("not json".into()),
+            body_size_bytes: 8,
+        }];
+        assert!(extract_xhr_text(&resp).is_none());
     }
 }


### PR DESCRIPTION
Four defects in the `onlyMainContent` path that removed real content or let
boilerplate through.

**Layout names matched as substrings.** `sidebar`, `navigation`, `breadcrumb`,
`dropdown`, `copyright`, `site/page/global-header/footer` and `*-nav` were
tested with `contains()` against `"{class} {id}"`. Themes name the wrapper that
holds the article after the furniture beside it, so `pds-sidebar-layout__content`,
`has-sidebar`, `content-sidebar` and `copyrightrichtext-richtext` were deleted as
chrome. These now match as a class-token prefix, which keeps the distinction
position carries: `sidebar-right` and `dropdown-menu` are still removed,
`has-sidebar` survives. Names that only ever appear compounded (`cookie`,
`consent`, `infobox`) stay substring-matched.

**`<header>`/`<aside>`/`<footer>` were removed wherever they appeared.** In HTML5
these mean different things by position: under `<body>` they are site chrome,
inside `<main>`/`<article>` they are the title block, standfirst, pull quote or
byline. `lol_html` streams and cannot inspect ancestors, so nested ones are
marked in a first handler and skipped by the removal handlers.

**`<head>` was never stripped**, so `<title>` reached the markdown as a bare line
duplicating the H1.

**The `structural` alternate harvested `<ul>`/`<table>` out of raw HTML**, its
only guard an ancestor `nav`/`footer`/`header` check that page builders pass by
rendering menus as `<div><ul>`. Removed with its helper and tests.

No API or output-format change. Existing extraction tests unchanged and passing.