### PR TITLE
fix(renderer): reap orphaned chrome targets on cancelled renders

### DIFF
--- a/crates/crw-renderer/src/browser_pool.rs
+++ b/crates/crw-renderer/src/browser_pool.rs
@@ -46,7 +46,7 @@ impl ChromeConnOps for CdpConnection {
         let v = self
             .send_recv(
                 "Target.createBrowserContext",
-                json!({}),
+                crate::cdp_conn::browser_ctx_params(None),
                 None,
                 Duration::from_secs(2),
             )

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1794,9 +1794,7 @@ impl CdpRenderer {
                     let v = conn
                         .send_recv(
                             "Target.createBrowserContext",
-                            // No proxyBypassList: Chrome bypasses loopback by default,
-                            // which is what we want (don't route localhost via proxy).
-                            serde_json::json!({ "proxyServer": entry.chrome_proxy_server() }),
+                            crate::cdp_conn::browser_ctx_params(Some(entry.chrome_proxy_server())),
                             None,
                             Duration::from_secs(2),
                         )

--- a/crates/crw-renderer/src/cdp_conn.rs
+++ b/crates/crw-renderer/src/cdp_conn.rs
@@ -400,10 +400,51 @@ fn dispatch(
     }
 }
 
+/// Params for `Target.createBrowserContext`, shared by both callers (the pool
+/// and the legacy per-request proxy path).
+///
+/// `disposeOnDetach` is the load-bearing bit: targets created via
+/// `Target.createTarget` are owned by the *browser*, not the CDP client, so
+/// dropping the WebSocket leaves the renderer process alive forever. Every
+/// explicit cleanup we do (`closeTarget` + `disposeBrowserContext`) is
+/// best-effort and is skipped outright when the future is cancelled mid-fetch
+/// — a timeout, a lost hedge race, a client disconnect — which is exactly when
+/// cleanup matters most. With this flag Chrome disposes the context itself the
+/// moment the session disconnects, closing every page in it without running
+/// beforeunload. That makes the reap unconditional instead of best-effort.
+///
+/// Measured against prod Chrome 150 (2026-07-25): without the flag a dropped
+/// socket left the renderer resident indefinitely; with it the renderer was
+/// gone within seconds.
+pub(crate) fn browser_ctx_params(proxy_server: Option<&str>) -> serde_json::Value {
+    let mut v = serde_json::json!({ "disposeOnDetach": true });
+    if let Some(p) = proxy_server {
+        // No proxyBypassList: Chrome bypasses loopback by default, which is
+        // what we want (don't route localhost via proxy).
+        v["proxyServer"] = serde_json::Value::String(p.to_string());
+    }
+    v
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tokio::sync::oneshot;
+
+    /// Guards the leak fix: both createBrowserContext callers must ask Chrome
+    /// to dispose the context on disconnect, with or without a proxy. Dropping
+    /// this flag silently reintroduces the orphaned-renderer leak, which only
+    /// shows up hours later as leaked chrome processes on the host.
+    #[test]
+    fn browser_ctx_params_always_dispose_on_detach() {
+        let plain = browser_ctx_params(None);
+        assert_eq!(plain["disposeOnDetach"], true);
+        assert!(plain.get("proxyServer").is_none());
+
+        let proxied = browser_ctx_params(Some("http://gw.example:823"));
+        assert_eq!(proxied["disposeOnDetach"], true);
+        assert_eq!(proxied["proxyServer"], "http://gw.example:823");
+    }
 
     fn parse(json: &str) -> RawCdpMessage {
         serde_json::from_str(json).expect("valid RawCdpMessage")


### PR DESCRIPTION
Chrome renderer processes accumulate on the host until an external watchdog
restarts the browser. Root cause is in the CDP target lifecycle, not the
watchdog.

## What leaks

Targets opened with `Target.createTarget` are owned by the browser, not by the
CDP client, so dropping the WebSocket does not close them. The explicit
`closeTarget` + `disposeBrowserContext` cleanup is best-effort straight-line
code, so it is skipped entirely when the fetch future is cancelled: a timeout,
a lost hedge race, a client disconnect. That is exactly when it is needed.

Prod, over one 7h window:

```
crw_target_lifecycle_total{phase="created", renderer="chrome_proxy"}  9
crw_target_lifecycle_total{phase="closed",  renderer="chrome_proxy"}  4
crw_target_lifecycle_total{phase="created", renderer="lightpanda"}   80
crw_target_lifecycle_total{phase="closed",  renderer="lightpanda"}   80
crw_chrome_pool_recycle_total{outcome="emergency_drop"}              48
```

## Change

Pass `disposeOnDetach` on `Target.createBrowserContext`. Chrome then disposes
the context itself the moment the session disconnects, closing every page in it
without running beforeunload, so the reap is unconditional rather than
best-effort. Both callers (the context pool and the legacy per-request proxy
path) now go through one params builder, with a unit test pinning the flag.

No behavior change on the success path: normal releases still close the target
and dispose the context explicitly.

## Verification

Against Chrome 150, with the context pool enabled, SIGKILLing the server
mid-render so that no Rust cleanup path can run:

```
before change   target after kill: 1   leaked
after change    target after kill: 0   clean
```

Raw CDP A/B on the same browser showed the same split: a dropped socket left the
renderer resident without the flag and reaped it within seconds with it.

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test
--workspace` (1503 tests) all green.

## Not covered

The legacy non-pooled, non-proxied path opens its target in the *default*
browser context, which cannot be disposed, so it is unaffected by this flag.
That path is not used in the managed stack (`config.docker.toml` enables the
pool) but is the self-host default. Closing it means giving every request its
own context, which interacts with the `cf_clearance` cookie cache, so it is left
for a separate change.