### PR TITLE
fix(scrape): stop reporting a thin page as an anti-bot block

### DIFF
--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -787,11 +787,33 @@ pub struct BlockOutcome {
     pub reason: String,
 }
 
+/// `AntibotSignal::StructuralFailure`'s `class_name()`. Not a vendor: it is the
+/// "we got a page but there is nothing usable in it" verdict, which the classifier
+/// keeps inside `AntibotSignal` because `is_blocked()` drives renderer escalation.
+/// See `message()` for why the customer-facing wording splits here.
+pub const STRUCTURAL_FAILURE_VENDOR: &str = "structural_failure";
+
 impl BlockOutcome {
     /// Standard anti-bot block error string shared by the v1 and v2 handlers so
     /// the two API surfaces label the same block identically.
+    ///
+    /// `structural_failure` is deliberately worded differently. It is not a
+    /// vendor wall — it fires on a thin or empty document (`antibot.rs` structural
+    /// arms), which is most often a broken TLS page, an error stub, or a JS shell
+    /// we could not hydrate. Reporting that as "Blocked by anti-bot" sent
+    /// customers to buy proxies and stealth for what was a certificate problem
+    /// (`wrong.host.badssl.com`: 21 visible characters, reported as a block).
+    ///
+    /// Wording only. The verdict stays inside `AntibotSignal`, `is_blocked()` is
+    /// untouched, and the escalation ladder behaves identically — a thin page must
+    /// still escalate to the next renderer tier, which is what `is_blocked()`
+    /// drives.
     pub fn message(&self) -> String {
-        format!("Blocked by anti-bot ({}): {}", self.vendor, self.reason)
+        if self.vendor == STRUCTURAL_FAILURE_VENDOR {
+            format!("No usable content could be extracted ({})", self.reason)
+        } else {
+            format!("Blocked by anti-bot ({}): {}", self.vendor, self.reason)
+        }
     }
 }
 
@@ -1241,6 +1263,69 @@ mod tests {
     #[test]
     fn chrome_proxy_as_str() {
         assert_eq!(RendererKind::ChromeProxy.as_str(), "chrome_proxy");
+    }
+
+    #[test]
+    fn block_message_keeps_anti_bot_wording_for_a_real_vendor() {
+        let b = BlockOutcome {
+            vendor: "cloudflare".into(),
+            reason: "CF challenge".into(),
+        };
+        assert_eq!(
+            b.message(),
+            "Blocked by anti-bot (cloudflare): CF challenge"
+        );
+    }
+
+    /// A thin document is not a vendor wall. Reporting it as one sent customers
+    /// to buy proxies for what was a broken certificate — `wrong.host.badssl.com`
+    /// renders 21 visible characters and was labelled "Blocked by anti-bot".
+    #[test]
+    fn block_message_does_not_call_a_thin_page_a_block() {
+        let b = BlockOutcome {
+            // The LITERAL, not the constant. Building the fixture from
+            // `STRUCTURAL_FAILURE_VENDOR` would make this test pass even if the
+            // constant were a typo, since both sides would then be wrong
+            // together and the branch would silently never fire in production.
+            // The constant is pinned to its real producer separately, by
+            // `structural_failure_vendor_matches_classifier` in crw-extract.
+            vendor: "structural_failure".into(),
+            reason: "Structural: minimal_text on small page (500 bytes, 21 chars visible)".into(),
+        };
+        let m = b.message();
+        assert!(
+            !m.contains("Blocked by anti-bot"),
+            "structural failure must not read as a vendor block: {m}"
+        );
+        assert!(m.starts_with("No usable content could be extracted"), "{m}");
+        // The diagnostic detail still reaches the caller.
+        assert!(m.contains("21 chars visible"), "{m}");
+    }
+
+    /// Every other vendor string must keep the historical wording verbatim: it is
+    /// documented customer contract and is shared byte-for-byte with the
+    /// Firecrawl-compat surface.
+    #[test]
+    fn block_message_split_is_scoped_to_structural_failure_only() {
+        for vendor in [
+            "cloudflare",
+            "datadome",
+            "perimeterx",
+            "akamai",
+            "imperva",
+            "sucuri",
+            "kasada",
+            "vercel",
+            "network_security",
+            "rate_limited",
+            "generic_block",
+        ] {
+            let b = BlockOutcome {
+                vendor: vendor.into(),
+                reason: "r".into(),
+            };
+            assert_eq!(b.message(), format!("Blocked by anti-bot ({vendor}): r"));
+        }
     }
 }
 

--- a/crates/crw-extract/src/antibot.rs
+++ b/crates/crw-extract/src/antibot.rs
@@ -677,4 +677,18 @@ mod tests {
         assert_eq!(AntibotSignal::Cloudflare.class_name(), "cloudflare");
         assert_eq!(AntibotSignal::None.class_name(), "none");
     }
+
+    /// `BlockOutcome::message()` words a structural failure differently from a
+    /// real vendor wall, and it selects on this exact string. The producer lives
+    /// here and the consumer lives in crw-core, which cannot depend on this
+    /// crate — so nothing but this test stops the two drifting apart. If they
+    /// do, the branch silently never fires and thin pages go back to being
+    /// reported as "Blocked by anti-bot".
+    #[test]
+    fn structural_failure_vendor_matches_classifier() {
+        assert_eq!(
+            AntibotSignal::StructuralFailure.class_name(),
+            crw_core::types::STRUCTURAL_FAILURE_VENDOR
+        );
+    }
 }

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -65,6 +65,15 @@ print(result["markdown"][:300])
 
 **Cause:** The target site fingerprints the request as non-browser traffic. Common triggers: missing `User-Agent`, no `Sec-Fetch-*` headers, a datacenter IP, or a detectable headless browser.
 
+> **Not a block: `"No usable content could be extracted (...)"`.** The same
+> `error_code: "anti_bot"` also covers the case where we fetched the page fine
+> but it held nothing usable — a handful of visible characters, no content
+> elements. That is usually a broken TLS certificate serving an error stub, a
+> parked domain, or a JS shell that never hydrated. The staged anti-bot fixes
+> below will not help it. Check the URL in a browser first; if it renders a real
+> page there, raise `waitFor` or try `renderJs: true`. Either way you are not
+> charged for it.
+
 **Fix (staged):**
 
 1. Add `"stealth": true` to route through randomized headers and a pooled real-browser UA.


### PR DESCRIPTION
## What

`BlockOutcome::message()` labelled every block verdict "Blocked by anti-bot
(vendor)". The `structural_failure` verdict is not a vendor wall: it fires on a
document with almost no visible text, which in practice is a broken TLS
certificate serving an error stub, a parked domain, or a JS shell that never
hydrated.

Customers read "blocked" and went and bought proxies and stealth for what was a
certificate problem. Verified live before the change: `wrong.host.badssl.com`
returns 21 visible characters and was reported as `Blocked by anti-bot
(structural_failure)`.

## Recall is not affected

Wording only. The verdict stays inside `AntibotSignal`, `is_blocked()` is
untouched, and the escalation ladder behaves identically — a thin page must
still escalate to the next renderer tier, which is exactly what `is_blocked()`
drives (`crw-renderer/src/lib.rs:1948,1955,2575,2587,2705,2747`,
`crw-crawl/src/single.rs:1241`).

Verified rather than assumed: `message()` has exactly two call sites,
`routes/scrape.rs:122` and `routes/v2/scrape.rs:295`. Both assign the string
straight into the response `error` field and neither branches on it. Escalation
finishes before either runs.

## v1 and v2 move together

The string is shared by both surfaces by design (its own doc comment says so),
so a blocked page is labelled identically on `/v1` and `/firecrawl/v2`. That is
the one intended customer-visible change here.

`error_code` stays `anti_bot` on both. `v2/scrape.rs` hand-duplicates the
classification, so moving the code would have to happen in two places to avoid
the surfaces diverging, and it buys nothing the message does not.

## The constant is pinned

`crw-core` cannot depend on `crw-extract`, so the vendor string is a constant on
one side and produced by `class_name()` on the other. A cross-crate test pins
them together. Without it a typo would silently disable the branch and thin
pages would quietly go back to reading as blocks — mutation-tested to confirm
the test actually catches that.

## Checks

- `cargo test --workspace` 1508 pass / 0 fail
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `scripts/docs-guards.sh` clean

The troubleshooting page gains a note that this wording is not a block and that
the staged anti-bot fixes below it will not help. The generated HTML is not
committed — `google-indexing.yml` regenerates and commits it on push to main.

## Deploy note

A merge here reaches production within the hour via the pin bump and deploq. The
change cannot alter which tier runs or when it escalates, so the scrape-success
line is not in play, but that is the reason to say it out loud rather than
assume it.