### PR TITLE
feat(extract): support openai-responses LLM provider

### DIFF
--- a/config.default.toml
+++ b/config.default.toml
@@ -193,7 +193,7 @@ always_run = false
 # return HTTP 400 with a clear error pointing back here.
 #
 # [extraction.llm]
-# provider = "anthropic"        # "anthropic" | "openai" | "deepseek" | "azure" | "openai-compatible"
+# provider = "anthropic"        # "anthropic" | "openai" | "openai-responses" | "deepseek" | "azure" | "openai-compatible"
 # api_key = "sk-..."            # or use CRW_EXTRACTION__LLM__API_KEY env var
 # model = "claude-sonnet-4-20250514"
 # max_tokens = 4096
@@ -208,6 +208,12 @@ always_run = false
 #   api_key = "..."
 #   model = "deepseek-chat"
 #   base_url = "https://api.deepseek.com/v1"
+#
+# OpenAI Responses-compatible example:
+#   provider = "openai-responses"
+#   api_key = "..."
+#   model = "provider-model-id"
+#   base_url = "https://gateway.example.com/v1"         # CRW appends /responses
 #
 # Azure OpenAI example:
 #   provider = "azure"

--- a/crates/crw-cli/src/commands/scrape.rs
+++ b/crates/crw-cli/src/commands/scrape.rs
@@ -70,7 +70,7 @@ pub struct ScrapeArgs {
     #[arg(long, value_name = "SCHEMA")]
     pub extract: Option<String>,
 
-    /// Override LLM provider for this request (anthropic, openai, deepseek, azure, openrouter).
+    /// Override LLM provider (anthropic, openai, openai-responses, deepseek, azure, openrouter).
     #[arg(long, value_name = "NAME")]
     pub llm_provider: Option<String>,
 
@@ -82,7 +82,7 @@ pub struct ScrapeArgs {
     #[arg(long, value_name = "MODEL")]
     pub llm_model: Option<String>,
 
-    /// Override LLM base URL (for OpenAI-compatible or Azure endpoints).
+    /// Override LLM base URL (for Chat Completions-compatible, Responses-compatible, or Azure endpoints).
     #[arg(long, value_name = "URL")]
     pub llm_base_url: Option<String>,
 }

--- a/crates/crw-cli/src/commands/setup/llm.rs
+++ b/crates/crw-cli/src/commands/setup/llm.rs
@@ -10,6 +10,7 @@ use dialoguer::{Input, Select};
 pub enum LlmProvider {
     Anthropic,
     OpenAI,
+    Responses,
     DeepSeek,
     Azure,
     OpenRouter,
@@ -22,6 +23,7 @@ impl LlmProvider {
         match self {
             LlmProvider::Anthropic => "Anthropic (Claude)",
             LlmProvider::OpenAI => "OpenAI (GPT)",
+            LlmProvider::Responses => "OpenAI Responses-compatible",
             LlmProvider::DeepSeek => "DeepSeek",
             LlmProvider::Azure => "Azure OpenAI",
             LlmProvider::OpenRouter => "OpenRouter",
@@ -34,6 +36,7 @@ impl LlmProvider {
         match self {
             LlmProvider::Anthropic => "anthropic",
             LlmProvider::OpenAI => "openai",
+            LlmProvider::Responses => "openai-responses",
             LlmProvider::DeepSeek => "deepseek",
             LlmProvider::Azure => "azure",
             LlmProvider::OpenRouter => "openai", // OpenRouter uses OpenAI protocol
@@ -46,6 +49,7 @@ impl LlmProvider {
         match self {
             LlmProvider::Anthropic => None, // Uses default
             LlmProvider::OpenAI => None,    // Uses default
+            LlmProvider::Responses => None, // User must provide (OpenAI or gateway base)
             LlmProvider::DeepSeek => Some("https://api.deepseek.com/v1"),
             LlmProvider::Azure => None, // User must provide
             LlmProvider::OpenRouter => Some("https://openrouter.ai/api/v1"),
@@ -78,6 +82,7 @@ impl LlmProvider {
                 ("gpt-4o", "GPT-4o (More capable, $2.5/$10 per M tokens)"),
                 ("gpt-4-turbo", "GPT-4 Turbo"),
             ],
+            LlmProvider::Responses => vec![],
             LlmProvider::DeepSeek => vec![
                 (
                     "deepseek-chat",
@@ -108,6 +113,7 @@ impl LlmProvider {
         match self {
             LlmProvider::Anthropic => "sk-ant-... (from console.anthropic.com)",
             LlmProvider::OpenAI => "sk-... (from platform.openai.com)",
+            LlmProvider::Responses => "Provider API key",
             LlmProvider::DeepSeek => "sk-... (from platform.deepseek.com)",
             LlmProvider::Azure => "Azure API key (from Azure Portal)",
             LlmProvider::OpenRouter => "sk-or-... (from openrouter.ai)",
@@ -120,6 +126,7 @@ impl LlmProvider {
         match self {
             LlmProvider::Anthropic => Some("https://console.anthropic.com/settings/keys"),
             LlmProvider::OpenAI => Some("https://platform.openai.com/api-keys"),
+            LlmProvider::Responses => None,
             LlmProvider::DeepSeek => Some("https://platform.deepseek.com/api_keys"),
             LlmProvider::Azure => Some("https://portal.azure.com"),
             LlmProvider::OpenRouter => Some("https://openrouter.ai/keys"),
@@ -215,6 +222,10 @@ fn prompt_provider() -> Result<LlmProvider, SetupError> {
             "OpenAI (GPT)"
         ),
         format!(
+            "{}\n      • Native /v1/responses protocol\n      • OpenAI or any Responses-compatible gateway",
+            "OpenAI Responses-compatible"
+        ),
+        format!(
             "{}\n      • Best value, excellent performance\n      • Models: DeepSeek Chat, Reasoner",
             "DeepSeek"
         ),
@@ -239,6 +250,7 @@ fn prompt_provider() -> Result<LlmProvider, SetupError> {
     let providers = [
         LlmProvider::Anthropic,
         LlmProvider::OpenAI,
+        LlmProvider::Responses,
         LlmProvider::DeepSeek,
         LlmProvider::Azure,
         LlmProvider::OpenRouter,
@@ -311,13 +323,18 @@ fn prompt_base_url(provider: LlmProvider) -> Result<Option<String>, SetupError> 
         return Ok(Some(url.to_string()));
     }
 
-    // Only ask for custom and Azure
-    if provider != LlmProvider::Custom && provider != LlmProvider::Azure {
+    // Only ask for custom, Responses-compatible, and Azure providers.
+    if provider != LlmProvider::Custom
+        && provider != LlmProvider::Responses
+        && provider != LlmProvider::Azure
+    {
         return Ok(None);
     }
 
     let prompt = if provider == LlmProvider::Azure {
         "  Enter your Azure OpenAI endpoint (e.g., https://myresource.openai.azure.com)"
+    } else if provider == LlmProvider::Responses {
+        "  Enter the Responses API base URL (e.g., https://gateway.example.com/v1)"
     } else {
         "  Enter the API base URL (e.g., http://localhost:11434/v1)"
     };

--- a/crates/crw-cli/src/main.rs
+++ b/crates/crw-cli/src/main.rs
@@ -110,7 +110,7 @@ struct Cli {
     #[arg(long, value_name = "SCHEMA")]
     extract: Option<String>,
 
-    /// Override LLM provider for this request (anthropic, openai, deepseek, azure, openrouter)
+    /// Override LLM provider (anthropic, openai, openai-responses, deepseek, azure, openrouter)
     #[arg(long, value_name = "NAME")]
     llm_provider: Option<String>,
 
@@ -122,7 +122,7 @@ struct Cli {
     #[arg(long, value_name = "MODEL")]
     llm_model: Option<String>,
 
-    /// Override LLM base URL (for OpenAI-compatible or Azure endpoints)
+    /// Override LLM base URL (for Chat Completions-compatible, Responses-compatible, or Azure endpoints)
     #[arg(long, value_name = "URL")]
     llm_base_url: Option<String>,
 

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1612,7 +1612,8 @@ pub struct LlmConfig {
     #[serde(default)]
     pub temperature: Option<f32>,
     /// Optional reasoning-effort hint forwarded to OpenAI-compatible providers
-    /// that support it. `None` (default) and the empty string send no key,
+    /// (`reasoning_effort`) and Responses-compatible providers
+    /// (`reasoning.effort`). `None` (default) and the empty string send no key,
     /// preserving each provider's default behavior.
     #[serde(default)]
     pub reasoning_effort: Option<String>,

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -254,14 +254,15 @@ pub struct ScrapeRequest {
     /// Per-request LLM API key for structured extraction (BYOK).
     #[serde(default, alias = "llm_api_key")]
     pub llm_api_key: Option<String>,
-    /// Per-request LLM provider override ("anthropic", "openai", "deepseek", "azure", or "openai-compatible").
+    /// Per-request LLM provider override ("anthropic", "openai",
+    /// "openai-responses", "deepseek", "azure", or "openai-compatible").
     #[serde(default, alias = "llm_provider")]
     pub llm_provider: Option<String>,
     /// Per-request LLM model override.
     #[serde(default, alias = "llm_model")]
     pub llm_model: Option<String>,
-    /// Per-request LLM base URL override (OpenAI-compatible providers
-    /// like DeepSeek). Example: `"https://api.deepseek.com/v1"`.
+    /// Per-request LLM base URL override for Chat Completions-compatible or
+    /// Responses-compatible providers. Example: `"https://gateway.example/v1"`.
     #[serde(default, alias = "base_url")]
     pub base_url: Option<String>,
     /// Optional user-supplied instructions appended to the summary system

--- a/crates/crw-extract/src/judge.rs
+++ b/crates/crw-extract/src/judge.rs
@@ -11,7 +11,9 @@
 //! the system instruction tells the model to treat it strictly as data and
 //! ignore any instructions inside it.
 
-use crate::structured::{call_anthropic, call_openai, truncate_md, validate_against_schema};
+use crate::structured::{
+    call_anthropic, call_openai, call_responses, truncate_md, validate_against_schema,
+};
 use crate::untrusted;
 use crw_core::config::LlmConfig;
 use crw_core::error::{CrwError, CrwResult};
@@ -145,8 +147,19 @@ pub async fn judge_change(
             )
             .await
         }
+        "openai-responses" => {
+            call_responses(
+                &prompt,
+                schema,
+                llm,
+                JUDGE_TOOL_NAME,
+                JUDGE_TOOL_DESC,
+                timeout,
+            )
+            .await
+        }
         other => Err(CrwError::ExtractionError(format!(
-            "Unsupported LLM provider for judge: {other}. Use 'anthropic', 'openai', 'deepseek', or 'openai-compatible'."
+            "Unsupported LLM provider for judge: {other}. Use 'anthropic', 'openai', 'deepseek', 'openai-compatible', or 'openai-responses'."
         ))),
     }?;
 

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -24,6 +24,7 @@ pub mod pdf;
 pub mod plaintext;
 pub mod quality;
 pub mod readability;
+mod responses;
 pub mod selector;
 pub mod structured;
 pub mod tables;

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -1,4 +1,5 @@
-//! LLM provider dispatch (Anthropic, OpenAI, OpenAI-compatible, Azure).
+//! LLM provider dispatch (Anthropic, OpenAI Chat Completions, OpenAI
+//! Responses, OpenAI-compatible, Azure).
 //!
 //! Two surfaces:
 //!
@@ -26,6 +27,7 @@ pub const SUPPORTED_PROVIDERS: &[&str] = &[
     "openai",
     "deepseek",
     "openai-compatible",
+    "openai-responses",
     "azure",
 ];
 
@@ -306,6 +308,19 @@ async fn dispatch(
                 provider_tag,
             )
             .await
+        }
+        "openai-responses" => {
+            let cfg = LlmConfig {
+                provider: "openai-responses".to_string(),
+                api_key: api_key.to_string(),
+                model: model.to_string(),
+                base_url: base_url.map(str::to_string),
+                max_tokens,
+                temperature,
+                reasoning_effort: reasoning_effort.map(str::to_string),
+                ..LlmConfig::default()
+            };
+            crate::responses::call_text(&cfg, system_prompt, user_msg, REQUEST_TIMEOUT).await
         }
         "azure" => {
             let endpoint = base_url.ok_or_else(|| {

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -62,7 +62,11 @@ pub struct LlmCallResult {
     pub warning: Option<String>,
 }
 
-fn shared_client() -> &'static reqwest::Client {
+/// The crate's pooled LLM client. Shared with [`crate::responses`] so the
+/// Responses transport does not open a second connection pool; callers that
+/// need a different budget set a per-request `.timeout(..)`, which overrides
+/// the builder default below.
+pub(crate) fn shared_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()

--- a/crates/crw-extract/src/responses.rs
+++ b/crates/crw-extract/src/responses.rs
@@ -6,36 +6,33 @@
 //! usage uses `input_tokens` / `output_tokens`. Keep that translation isolated
 //! here so OpenAI-compatible Chat Completions providers remain unchanged.
 
-use crate::llm::LlmCallResult;
+use crate::llm::{LlmCallResult, shared_client};
 use crate::pricing;
 use crw_core::config::LlmConfig;
 use crw_core::error::{CrwError, CrwResult};
 use crw_core::types::LlmUsage;
-use std::sync::OnceLock;
 use std::time::Duration;
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
-
-fn shared_client() -> &'static reqwest::Client {
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
-            .timeout(DEFAULT_TIMEOUT)
-            .build()
-            .expect("reqwest client build (Responses shared)")
-    })
-}
 
 /// Resolve a Responses endpoint from either a versioned API base or a complete
 /// endpoint. A base such as `https://gateway.example/v1` therefore becomes
 /// `https://gateway.example/v1/responses`, while a complete endpoint is idempotent.
+///
+/// The `/responses` suffix check runs on the PATH only: a query string or
+/// fragment must be preserved and re-attached after the path, never treated as
+/// part of it. Azure-style Responses endpoints carry a required
+/// `?api-version=…`, and appending after it (`…?api-version=x/responses`)
+/// corrupts the parameter instead of building a path.
 pub(crate) fn responses_url(base_url: Option<&str>) -> String {
-    let base = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
-    if base.ends_with("/responses") {
-        base.to_string()
+    let raw = base_url.unwrap_or(DEFAULT_BASE_URL);
+    let split = raw.find(['?', '#']).unwrap_or(raw.len());
+    let (path, suffix) = raw.split_at(split);
+    let path = path.trim_end_matches('/');
+    if path.ends_with("/responses") {
+        format!("{path}{suffix}")
     } else {
-        format!("{base}/responses")
+        format!("{path}/responses{suffix}")
     }
 }
 
@@ -69,19 +66,72 @@ async fn post(
         CrwError::ExtractionError(format!("Failed to read Responses API response: {e}"))
     })?;
     if !status.is_success() {
+        // The HTTP status code is enough — do not leak the body. A gateway that
+        // echoes the request back in an error body would otherwise surface the
+        // bearer key or the prompt to the API caller.
         return Err(CrwError::ExtractionError(format!(
-            "Responses API error ({status}): {}",
-            truncate_for_error(&text)
+            "Responses API error ({status})"
         )));
     }
 
-    serde_json::from_str(&text).map_err(|e| {
+    let payload: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
         CrwError::ExtractionError(format!("Failed to parse Responses API response: {e}"))
-    })
+    })?;
+    check_response_status(&payload)?;
+    Ok(payload)
 }
 
-fn output_text(payload: &serde_json::Value) -> String {
-    payload
+/// A Responses payload carries its own terminal state, so an HTTP 200 is not by
+/// itself a success. Only an absent status (compatibility gateways that omit
+/// the field), `completed`, and `incomplete` carry usable output; `failed`,
+/// `cancelled`, `queued`, `in_progress` and anything unrecognised must not be
+/// mistaken for a result.
+///
+/// `incomplete` (the provider stopped at `max_output_tokens` or a content
+/// filter) stays a success with whatever was produced, matching the Chat
+/// Completions path, which likewise does not reject `finish_reason == "length"`.
+/// The failure is named by its status only. `error.message` is gateway-supplied
+/// and reaches the API caller verbatim through the 422 body, so echoing it would
+/// reopen on this path exactly the leak [`post`] refuses to open on the non-2xx
+/// one — and with no size bound at all. The status word is echoed only when it
+/// is one the API actually defines, keeping even that string bounded.
+fn check_response_status(payload: &serde_json::Value) -> CrwResult<()> {
+    let Some(status) = payload.get("status").and_then(serde_json::Value::as_str) else {
+        return Ok(());
+    };
+    if matches!(status, "completed" | "incomplete") {
+        return Ok(());
+    }
+    Err(CrwError::ExtractionError(
+        if matches!(status, "failed" | "cancelled" | "queued" | "in_progress") {
+            format!("Responses API returned status '{status}'")
+        } else {
+            // Server-side only: an operator debugging a gateway that speaks a
+            // dialect of the status vocabulary needs the actual word, and the
+            // caller-facing string above deliberately withholds it.
+            tracing::warn!(
+                status = %status,
+                "Responses API returned an unrecognised status"
+            );
+            "Responses API returned an unrecognised status".to_string()
+        },
+    ))
+}
+
+/// Join every `output_text` part the assistant produced.
+///
+/// The Chat Completions paths key on one field: an absent `message.content`
+/// errors, a present-but-empty one succeeds. `output_text` is the Responses
+/// analogue of that field, so presence is keyed on the PART, not on the
+/// enclosing `message` item — a message carrying only a `refusal` part is
+/// "content absent" exactly as a Chat Completions refusal (which nulls
+/// `content`) is, and must not read as an empty answer.
+///
+/// `None`: no usable `output_text` part anywhere (reasoning-only, refusal-only,
+/// or a malformed part whose `text` is missing or not a string).
+/// `Some("")`: a real `output_text` part whose text is genuinely empty.
+fn output_text(payload: &serde_json::Value) -> Option<String> {
+    let mut parts = payload
         .get("output")
         .and_then(serde_json::Value::as_array)
         .into_iter()
@@ -91,8 +141,9 @@ fn output_text(payload: &serde_json::Value) -> String {
         .flatten()
         .filter(|part| part.get("type").and_then(serde_json::Value::as_str) == Some("output_text"))
         .filter_map(|part| part.get("text").and_then(serde_json::Value::as_str))
-        .collect::<Vec<_>>()
-        .join("")
+        .peekable();
+    parts.peek()?;
+    Some(parts.collect::<Vec<_>>().join(""))
 }
 
 fn parse_usage(payload: &serde_json::Value, llm: &LlmConfig) -> Option<LlmUsage> {
@@ -144,12 +195,9 @@ pub(crate) async fn call_text(
     apply_optional_generation_fields(&mut body, llm);
 
     let payload = post(llm, &body, timeout).await?;
-    let content = output_text(&payload);
-    if content.is_empty() {
-        return Err(CrwError::ExtractionError(
-            "Responses API response missing output_text".into(),
-        ));
-    }
+    let content = output_text(&payload).ok_or_else(|| {
+        CrwError::ExtractionError("Responses API response missing output_text".into())
+    })?;
     Ok(LlmCallResult {
         content,
         usage: parse_usage(&payload, llm),
@@ -211,17 +259,9 @@ pub(crate) async fn call_tool(
     // Some compatibility gateways ignore tool_choice and return JSON text.
     // Preserve CRW's existing fallback behavior, then apply normal schema
     // validation in the caller.
-    let raw_text = output_text(&payload);
+    let raw_text = output_text(&payload).unwrap_or_default();
     let value = crate::structured::parse_json_response(&raw_text)?;
     Ok((value, usage))
-}
-
-fn truncate_for_error(text: &str) -> &str {
-    if text.len() > 200 {
-        &text[..text.floor_char_boundary(200)]
-    } else {
-        text
-    }
 }
 
 #[cfg(test)]
@@ -241,6 +281,107 @@ mod tests {
         assert_eq!(
             responses_url(Some("https://example.test/v1/responses/")),
             "https://example.test/v1/responses"
+        );
+    }
+
+    #[test]
+    fn endpoint_keeps_query_and_fragment_after_the_path() {
+        // Azure-style Responses endpoints carry a required api-version. The
+        // suffix must survive on both the append and the idempotent branch.
+        assert_eq!(
+            responses_url(Some("https://gateway.example/v1?api-version=2026-01-01")),
+            "https://gateway.example/v1/responses?api-version=2026-01-01"
+        );
+        assert_eq!(
+            responses_url(Some(
+                "https://gateway.example/v1/responses?api-version=2026-01-01"
+            )),
+            "https://gateway.example/v1/responses?api-version=2026-01-01"
+        );
+        assert_eq!(
+            responses_url(Some("https://gateway.example/v1#frag")),
+            "https://gateway.example/v1/responses#frag"
+        );
+    }
+
+    #[test]
+    fn status_gate_admits_only_usable_terminal_states() {
+        // Absent status: compatibility gateways that omit the field.
+        assert!(check_response_status(&serde_json::json!({})).is_ok());
+        assert!(check_response_status(&serde_json::json!({ "status": "completed" })).is_ok());
+        // Stopped at max_output_tokens: keep whatever was produced, like the
+        // Chat Completions path does for finish_reason == "length".
+        assert!(check_response_status(&serde_json::json!({ "status": "incomplete" })).is_ok());
+
+        for status in ["failed", "cancelled", "queued", "in_progress"] {
+            let err = check_response_status(&serde_json::json!({ "status": status }))
+                .expect_err("non-terminal or failed status must not pass as a result");
+            assert!(err.to_string().contains(status), "status named in error");
+        }
+    }
+
+    #[test]
+    fn status_gate_never_echoes_gateway_controlled_strings() {
+        // `error.message` is written by the gateway and would reach the API
+        // caller through the 422 body — the same leak the non-2xx branch of
+        // `post` refuses to open.
+        let err = check_response_status(&serde_json::json!({
+            "status": "failed",
+            "error": { "code": "server_error", "message": "Bearer SENTINEL-LEAK-TOKEN" }
+        }))
+        .expect_err("failed status must error");
+        let msg = err.to_string();
+        assert!(msg.contains("failed"), "status is named: {msg}");
+        assert!(!msg.contains("SENTINEL-LEAK-TOKEN"), "body echoed: {msg}");
+
+        // An unrecognised status is itself gateway-controlled, so it is not
+        // echoed either — no unbounded string reaches the caller.
+        let err = check_response_status(&serde_json::json!({ "status": "SENTINEL-LEAK-TOKEN" }))
+            .expect_err("unknown status must error");
+        assert!(!err.to_string().contains("SENTINEL-LEAK-TOKEN"));
+    }
+
+    #[test]
+    fn output_text_distinguishes_absent_from_empty() {
+        // A message item whose text is empty is "present but empty" -> Some("").
+        assert_eq!(
+            output_text(&serde_json::json!({
+                "output": [{
+                    "type": "message",
+                    "content": [{ "type": "output_text", "text": "" }]
+                }]
+            })),
+            Some(String::new())
+        );
+        // No message item at all -> nothing textual was produced.
+        assert_eq!(
+            output_text(&serde_json::json!({
+                "output": [{ "type": "reasoning", "summary": [] }]
+            })),
+            None
+        );
+        assert_eq!(output_text(&serde_json::json!({})), None);
+        // A refusal is carried as a message with no output_text part. Chat
+        // Completions nulls `content` for the same case and errors, so this
+        // must be "absent", never an empty answer.
+        assert_eq!(
+            output_text(&serde_json::json!({
+                "output": [{
+                    "type": "message",
+                    "content": [{ "type": "refusal", "refusal": "I cannot help with that." }]
+                }]
+            })),
+            None
+        );
+        // Malformed part: type says output_text but text is not a string.
+        assert_eq!(
+            output_text(&serde_json::json!({
+                "output": [{
+                    "type": "message",
+                    "content": [{ "type": "output_text", "text": null }]
+                }]
+            })),
+            None
         );
     }
 }

--- a/crates/crw-extract/src/responses.rs
+++ b/crates/crw-extract/src/responses.rs
@@ -1,0 +1,246 @@
+//! OpenAI Responses API transport shared by text generation and structured
+//! extraction.
+//!
+//! The Responses wire format is not Chat Completions with a different path:
+//! function tools are flat objects, generated calls live in `output`, and token
+//! usage uses `input_tokens` / `output_tokens`. Keep that translation isolated
+//! here so OpenAI-compatible Chat Completions providers remain unchanged.
+
+use crate::llm::LlmCallResult;
+use crate::pricing;
+use crw_core::config::LlmConfig;
+use crw_core::error::{CrwError, CrwResult};
+use crw_core::types::LlmUsage;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn shared_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(DEFAULT_TIMEOUT)
+            .build()
+            .expect("reqwest client build (Responses shared)")
+    })
+}
+
+/// Resolve a Responses endpoint from either a versioned API base or a complete
+/// endpoint. A base such as `https://gateway.example/v1` therefore becomes
+/// `https://gateway.example/v1/responses`, while a complete endpoint is idempotent.
+pub(crate) fn responses_url(base_url: Option<&str>) -> String {
+    let base = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
+    if base.ends_with("/responses") {
+        base.to_string()
+    } else {
+        format!("{base}/responses")
+    }
+}
+
+fn apply_optional_generation_fields(body: &mut serde_json::Value, llm: &LlmConfig) {
+    if let Some(temperature) = llm.temperature {
+        body["temperature"] = serde_json::json!(temperature);
+    }
+    if let Some(effort) = llm.reasoning_effort.as_deref().filter(|s| !s.is_empty()) {
+        body["reasoning"] = serde_json::json!({ "effort": effort });
+    }
+}
+
+async fn post(
+    llm: &LlmConfig,
+    body: &serde_json::Value,
+    timeout: Duration,
+) -> CrwResult<serde_json::Value> {
+    let url = responses_url(llm.base_url.as_deref());
+    let resp = shared_client()
+        .post(&url)
+        .timeout(timeout)
+        .bearer_auth(&llm.api_key)
+        .header("content-type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| CrwError::ExtractionError(format!("Responses API request failed: {e}")))?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| {
+        CrwError::ExtractionError(format!("Failed to read Responses API response: {e}"))
+    })?;
+    if !status.is_success() {
+        return Err(CrwError::ExtractionError(format!(
+            "Responses API error ({status}): {}",
+            truncate_for_error(&text)
+        )));
+    }
+
+    serde_json::from_str(&text).map_err(|e| {
+        CrwError::ExtractionError(format!("Failed to parse Responses API response: {e}"))
+    })
+}
+
+fn output_text(payload: &serde_json::Value) -> String {
+    payload
+        .get("output")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("type").and_then(serde_json::Value::as_str) == Some("message"))
+        .filter_map(|item| item.get("content").and_then(serde_json::Value::as_array))
+        .flatten()
+        .filter(|part| part.get("type").and_then(serde_json::Value::as_str) == Some("output_text"))
+        .filter_map(|part| part.get("text").and_then(serde_json::Value::as_str))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn parse_usage(payload: &serde_json::Value, llm: &LlmConfig) -> Option<LlmUsage> {
+    let usage = payload.get("usage")?;
+    let input_tokens = usage.get("input_tokens")?.as_u64()? as u32;
+    let output_tokens = usage.get("output_tokens")?.as_u64()? as u32;
+    let total_tokens = usage
+        .get("total_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .map(|n| n as u32)
+        .unwrap_or(input_tokens.saturating_add(output_tokens));
+    let cached = usage
+        .get("input_tokens_details")
+        .and_then(|details| details.get("cached_tokens"))
+        .and_then(serde_json::Value::as_u64)
+        .map(|n| n as u32);
+
+    Some(LlmUsage {
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        estimated_cost_usd: pricing::calculate_cost(&llm.model, input_tokens, output_tokens),
+        model: llm.model.clone(),
+        provider: "openai-responses".to_string(),
+        cache_hit_input_tokens: cached,
+        cache_miss_input_tokens: cached.map(|n| input_tokens.saturating_sub(n)),
+        truncated: false,
+        calls: 1,
+        executed_summaries: 0,
+        answer_executed: false,
+    })
+}
+
+/// One non-streaming text response. `instructions` carries the trusted system
+/// prompt and `input` carries the user/content message.
+pub(crate) async fn call_text(
+    llm: &LlmConfig,
+    instructions: &str,
+    input: &str,
+    timeout: Duration,
+) -> CrwResult<LlmCallResult> {
+    let mut body = serde_json::json!({
+        "model": llm.model,
+        "instructions": instructions,
+        "input": input,
+        "max_output_tokens": llm.max_tokens,
+        "store": false,
+    });
+    apply_optional_generation_fields(&mut body, llm);
+
+    let payload = post(llm, &body, timeout).await?;
+    let content = output_text(&payload);
+    if content.is_empty() {
+        return Err(CrwError::ExtractionError(
+            "Responses API response missing output_text".into(),
+        ));
+    }
+    Ok(LlmCallResult {
+        content,
+        usage: parse_usage(&payload, llm),
+        warning: None,
+    })
+}
+
+/// One forced function call used as the structured-output envelope. CRW does
+/// not execute the function; its JSON arguments are the extraction result.
+pub(crate) async fn call_tool(
+    llm: &LlmConfig,
+    input: &str,
+    schema: &serde_json::Value,
+    tool_name: &str,
+    tool_desc: &str,
+    timeout: Duration,
+) -> CrwResult<(serde_json::Value, Option<LlmUsage>)> {
+    let mut body = serde_json::json!({
+        "model": llm.model,
+        "input": input,
+        "max_output_tokens": llm.max_tokens,
+        "store": false,
+        "parallel_tool_calls": false,
+        "tools": [{
+            "type": "function",
+            "name": tool_name,
+            "description": tool_desc,
+            "parameters": schema,
+        }],
+        "tool_choice": {
+            "type": "function",
+            "name": tool_name,
+        },
+    });
+    apply_optional_generation_fields(&mut body, llm);
+
+    let payload = post(llm, &body, timeout).await?;
+    let usage = parse_usage(&payload, llm);
+    if let Some(arguments) = payload
+        .get("output")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|item| {
+            item.get("type").and_then(serde_json::Value::as_str) == Some("function_call")
+                && item.get("name").and_then(serde_json::Value::as_str) == Some(tool_name)
+        })
+        .and_then(|item| item.get("arguments"))
+        .and_then(serde_json::Value::as_str)
+    {
+        let value = serde_json::from_str(arguments).map_err(|e| {
+            CrwError::ExtractionError(format!(
+                "Failed to parse Responses function call arguments: {e}"
+            ))
+        })?;
+        return Ok((value, usage));
+    }
+
+    // Some compatibility gateways ignore tool_choice and return JSON text.
+    // Preserve CRW's existing fallback behavior, then apply normal schema
+    // validation in the caller.
+    let raw_text = output_text(&payload);
+    let value = crate::structured::parse_json_response(&raw_text)?;
+    Ok((value, usage))
+}
+
+fn truncate_for_error(text: &str) -> &str {
+    if text.len() > 200 {
+        &text[..text.floor_char_boundary(200)]
+    } else {
+        text
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_appends_responses_to_versioned_base() {
+        assert_eq!(
+            responses_url(Some("https://gateway.example/v1")),
+            "https://gateway.example/v1/responses"
+        );
+    }
+
+    #[test]
+    fn endpoint_preserves_complete_url() {
+        assert_eq!(
+            responses_url(Some("https://example.test/v1/responses/")),
+            "https://example.test/v1/responses"
+        );
+    }
+}

--- a/crates/crw-extract/src/structured.rs
+++ b/crates/crw-extract/src/structured.rs
@@ -256,8 +256,19 @@ async fn extract_inner(
             )
             .await
         }
+        "openai-responses" => {
+            call_responses(
+                &prompt,
+                tool_schema,
+                llm,
+                "extract_data",
+                "Extract structured data from the content",
+                timeout,
+            )
+            .await
+        }
         other => Err(CrwError::ExtractionError(format!(
-            "Unsupported LLM provider: {other}. Use 'anthropic', 'openai', 'deepseek', or 'openai-compatible'."
+            "Unsupported LLM provider: {other}. Use 'anthropic', 'openai', 'deepseek', 'openai-compatible', or 'openai-responses'."
         ))),
     }?;
 
@@ -741,8 +752,23 @@ pub(crate) async fn call_openai(
     Ok((value, usage))
 }
 
+/// Call an OpenAI Responses-compatible provider with a forced function tool.
+/// The transport is shared with the text-generation path; this wrapper owns the
+/// structured/judge concurrency permit just like [`call_openai`].
+pub(crate) async fn call_responses(
+    prompt: &str,
+    schema: &serde_json::Value,
+    llm: &LlmConfig,
+    tool_name: &str,
+    tool_desc: &str,
+    timeout: Duration,
+) -> CrwResult<(serde_json::Value, Option<LlmUsage>)> {
+    let _llm_permit = crate::llm_gate::acquire_llm().await;
+    crate::responses::call_tool(llm, prompt, schema, tool_name, tool_desc, timeout).await
+}
+
 /// Parse JSON from LLM response, stripping markdown fences if present.
-fn parse_json_response(text: &str) -> CrwResult<serde_json::Value> {
+pub(crate) fn parse_json_response(text: &str) -> CrwResult<serde_json::Value> {
     let trimmed = text.trim();
 
     // Strip ```json ... ``` fences if LLM wrapped it

--- a/crates/crw-extract/src/structured.rs
+++ b/crates/crw-extract/src/structured.rs
@@ -425,9 +425,12 @@ pub(crate) async fn call_anthropic(
     })?;
 
     if !status.is_success() {
+        // NOTE: body may contain the request echoed back by some gateways.
+        // The HTTP status code is enough — do not leak the body. This error
+        // text reaches the API caller verbatim in the response envelope, and
+        // on the managed path the echoed request carries the SERVER key.
         return Err(CrwError::ExtractionError(format!(
-            "Anthropic API error ({status}): {}",
-            truncate_for_error(&text)
+            "Anthropic API error ({status})"
         )));
     }
 
@@ -673,9 +676,10 @@ pub(crate) async fn call_openai(
         .map_err(|e| CrwError::ExtractionError(format!("Failed to read OpenAI response: {e}")))?;
 
     if !status.is_success() {
+        // Same rule as the Anthropic branch above: never echo the provider
+        // body back to the API caller.
         return Err(CrwError::ExtractionError(format!(
-            "OpenAI API error ({status}): {}",
-            truncate_for_error(&text)
+            "OpenAI API error ({status})"
         )));
     }
 

--- a/crates/crw-extract/tests/responses_tests.rs
+++ b/crates/crw-extract/tests/responses_tests.rs
@@ -142,3 +142,171 @@ async fn structured_call_still_validates_function_arguments_locally() {
         .expect_err("schema-invalid arguments must fail");
     assert!(error.to_string().contains("schema validation"));
 }
+
+/// Mount one Responses payload and run a text call against it.
+async fn text_call_returning(
+    payload: serde_json::Value,
+) -> (
+    MockServer,
+    Result<crw_extract::llm::LlmCallResult, crw_core::error::CrwError>,
+) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(payload))
+        .mount(&server)
+        .await;
+
+    let llm = responses_llm(format!("{}/v1", server.uri()));
+    let result = chat(&llm, "sys", "user").await;
+    (server, result)
+}
+
+fn message_output(text: &str) -> serde_json::Value {
+    json!([{
+        "type": "message",
+        "role": "assistant",
+        "content": [{ "type": "output_text", "text": text }]
+    }])
+}
+
+#[tokio::test]
+async fn failed_status_inside_http_200_is_an_error_not_a_result() {
+    // The Responses API reports terminal failure in the payload, so an HTTP 200
+    // is not by itself a success. The gateway-written error body must not ride
+    // along into the caller-facing error — same rule as the non-2xx path.
+    let (_server, result) = text_call_returning(json!({
+        "status": "failed",
+        "error": {
+            "code": "server_error",
+            "message": "rejected: Authorization: Bearer SENTINEL-LEAK-TOKEN"
+        },
+        "output": []
+    }))
+    .await;
+
+    let err = result.expect_err("failed status must not be reported as success");
+    let msg = err.to_string();
+    assert!(msg.contains("failed"), "status is surfaced: {msg}");
+    assert!(
+        !msg.contains("SENTINEL-LEAK-TOKEN"),
+        "provider error body must not be echoed: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn failed_status_without_a_message_still_errors() {
+    let (_server, result) = text_call_returning(json!({ "status": "failed", "output": [] })).await;
+    let err = result.expect_err("failed status must error even with no error.message");
+    assert!(err.to_string().contains("failed"));
+}
+
+#[tokio::test]
+async fn non_terminal_status_is_not_mistaken_for_output() {
+    // A gateway emitting a still-running response must not read as an empty
+    // success — the call produced nothing.
+    for status in ["queued", "in_progress", "cancelled"] {
+        let (_server, result) = text_call_returning(json!({
+            "status": status,
+            "output": []
+        }))
+        .await;
+        let err = result.expect_err("non-terminal status must error");
+        assert!(err.to_string().contains(status), "status named in error");
+    }
+}
+
+#[tokio::test]
+async fn incomplete_status_keeps_the_partial_output() {
+    // Stopped at max_output_tokens: same contract as Chat Completions'
+    // finish_reason == "length", which is not an error either.
+    let (_server, result) = text_call_returning(json!({
+        "status": "incomplete",
+        "incomplete_details": { "reason": "max_output_tokens" },
+        "output": message_output("partial answer"),
+        "usage": { "input_tokens": 10, "output_tokens": 4, "total_tokens": 14 }
+    }))
+    .await;
+
+    let ok = result.expect("incomplete response still carries usable content");
+    assert_eq!(ok.content, "partial answer");
+    // `truncated` means "the markdown INPUT was clipped before the call" for
+    // every provider. An output-side cut must not repurpose it, or the field
+    // would mean two different things depending on the provider.
+    let usage = ok.usage.expect("usage is surfaced");
+    assert!(!usage.truncated, "output-side cut must not set `truncated`");
+}
+
+#[tokio::test]
+async fn message_with_empty_text_succeeds_like_the_chat_completions_path() {
+    // Sibling providers treat a present-but-empty content string as a valid
+    // response; only a missing one errors. Switching provider must not turn a
+    // working request into a hard failure.
+    let (_server, result) = text_call_returning(json!({
+        "status": "completed",
+        "output": message_output("")
+    }))
+    .await;
+
+    let ok = result.expect("empty-but-present content is a success");
+    assert_eq!(ok.content, "");
+}
+
+#[tokio::test]
+async fn response_without_any_message_item_errors() {
+    // Nothing textual was produced (reasoning-only): that is "content absent",
+    // which the sibling paths reject too.
+    let (_server, result) = text_call_returning(json!({
+        "status": "completed",
+        "output": [{ "type": "reasoning", "summary": [] }]
+    }))
+    .await;
+
+    let err = result.expect_err("a response with no message item must error");
+    assert!(err.to_string().contains("missing output_text"));
+}
+
+#[tokio::test]
+async fn refusal_only_response_errors_instead_of_returning_an_empty_answer() {
+    // A refusal arrives as a message whose content holds no output_text part.
+    // Chat Completions nulls `content` for the same case and errors, so this
+    // must not surface as a successful empty answer.
+    let (_server, result) = text_call_returning(json!({
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "refusal", "refusal": "I cannot help with that." }]
+        }]
+    }))
+    .await;
+
+    let err = result.expect_err("a refusal-only response must error");
+    assert!(err.to_string().contains("missing output_text"));
+}
+
+#[tokio::test]
+async fn http_error_body_is_never_echoed_to_the_caller() {
+    // A gateway that mirrors the request back in its error body would otherwise
+    // hand the bearer key or the prompt to the API caller.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            "{\"error\":{\"message\":\"echoed Authorization: Bearer SENTINEL-LEAK-TOKEN\"}}",
+        ))
+        .mount(&server)
+        .await;
+
+    let llm = responses_llm(format!("{}/v1", server.uri()));
+    let err = chat(&llm, "sys", "user")
+        .await
+        .expect_err("non-2xx must error");
+
+    let msg = err.to_string();
+    assert!(msg.contains("400"), "status is surfaced: {msg}");
+    assert!(
+        !msg.contains("SENTINEL-LEAK-TOKEN"),
+        "error body must not be echoed: {msg}"
+    );
+}

--- a/crates/crw-extract/tests/responses_tests.rs
+++ b/crates/crw-extract/tests/responses_tests.rs
@@ -1,0 +1,144 @@
+//! Wire-level coverage for the OpenAI Responses provider. These tests lock the
+//! protocol boundary separately from the existing Chat Completions tests.
+
+use crw_core::config::LlmConfig;
+use crw_extract::llm::chat;
+use crw_extract::structured::extract_structured;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn responses_llm(base_url: String) -> LlmConfig {
+    LlmConfig {
+        provider: "openai-responses".into(),
+        api_key: "test-key".into(),
+        model: "test-model".into(),
+        base_url: Some(base_url),
+        max_tokens: 512,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn text_call_uses_responses_wire_shape_and_parses_usage() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_test",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "hello from provider" }]
+            }],
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 5,
+                "total_tokens": 25,
+                "input_tokens_details": { "cached_tokens": 8 }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let mut llm = responses_llm(format!("{}/v1", server.uri()));
+    llm.reasoning_effort = Some("low".into());
+    let result = chat(&llm, "trusted instructions", "user input")
+        .await
+        .expect("Responses text call succeeds");
+
+    assert_eq!(result.content, "hello from provider");
+    let usage = result.usage.expect("usage is surfaced");
+    assert_eq!(usage.provider, "openai-responses");
+    assert_eq!(usage.input_tokens, 20);
+    assert_eq!(usage.cache_hit_input_tokens, Some(8));
+    assert_eq!(usage.cache_miss_input_tokens, Some(12));
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(body["model"], "test-model");
+    assert_eq!(body["instructions"], "trusted instructions");
+    assert_eq!(body["input"], "user input");
+    assert_eq!(body["max_output_tokens"], 512);
+    assert_eq!(body["store"], false);
+    assert_eq!(body["reasoning"]["effort"], "low");
+    assert!(body.get("messages").is_none());
+}
+
+#[tokio::test]
+async fn structured_call_forces_flat_function_tool_and_parses_arguments() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_structured",
+            "status": "completed",
+            "output": [{
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "extract_data",
+                "arguments": "{\"name\":\"Ada\",\"count\":3}",
+                "status": "completed"
+            }],
+            "usage": { "input_tokens": 100, "output_tokens": 12, "total_tokens": 112 }
+        })))
+        .mount(&server)
+        .await;
+
+    let llm = responses_llm(format!("{}/v1/", server.uri()));
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "count": { "type": "integer" }
+        },
+        "required": ["name", "count"]
+    });
+    let value = extract_structured("Ada has 3 entries.", &schema, &llm)
+        .await
+        .expect("Responses structured extraction succeeds");
+    assert_eq!(value, json!({ "name": "Ada", "count": 3 }));
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert_eq!(body["tools"][0]["name"], "extract_data");
+    assert_eq!(body["tools"][0]["parameters"], schema);
+    assert_eq!(
+        body["tool_choice"],
+        json!({ "type": "function", "name": "extract_data" })
+    );
+    assert_eq!(body["parallel_tool_calls"], false);
+    assert!(body["tools"][0].get("function").is_none());
+}
+
+#[tokio::test]
+async fn structured_call_still_validates_function_arguments_locally() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "output": [{
+                "type": "function_call",
+                "name": "extract_data",
+                "arguments": "{\"count\":\"not-an-integer\"}"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let llm = responses_llm(format!("{}/v1", server.uri()));
+    let schema = json!({
+        "type": "object",
+        "properties": { "count": { "type": "integer" } },
+        "required": ["count"]
+    });
+    let error = extract_structured("count", &schema, &llm)
+        .await
+        .expect_err("schema-invalid arguments must fail");
+    assert!(error.to_string().contains("schema validation"));
+}

--- a/crates/crw-extract/tests/structured_tests.rs
+++ b/crates/crw-extract/tests/structured_tests.rs
@@ -1,4 +1,53 @@
+use crw_core::config::LlmConfig;
+use crw_extract::structured::extract_structured;
 use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// The structured path runs with the SERVER's LLM key on the managed
+/// configuration, so a gateway that mirrors the request into its error body
+/// would hand that key (and the prompt) to whoever called the public API.
+/// The HTTP status is all the caller gets.
+#[tokio::test]
+async fn provider_error_body_is_never_echoed_to_the_caller() {
+    for (provider, api_path) in [
+        ("openai", "/v1/chat/completions"),
+        ("anthropic", "/v1/messages"),
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(api_path))
+            .respond_with(ResponseTemplate::new(400).set_body_string(
+                "{\"error\":\"echoed Authorization: Bearer SENTINEL-LEAK-TOKEN\"}",
+            ))
+            .mount(&server)
+            .await;
+
+        let llm = LlmConfig {
+            provider: provider.into(),
+            api_key: "test-key".into(),
+            model: "test-model".into(),
+            base_url: Some(format!("{}/v1", server.uri())),
+            max_tokens: 256,
+            ..Default::default()
+        };
+        let schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"]
+        });
+
+        let err = extract_structured("content", &schema, &llm)
+            .await
+            .expect_err("a 400 from the provider must error");
+        let msg = err.to_string();
+        assert!(msg.contains("400"), "{provider}: status is surfaced: {msg}");
+        assert!(
+            !msg.contains("SENTINEL-LEAK-TOKEN"),
+            "{provider}: provider error body must not be echoed: {msg}"
+        );
+    }
+}
 
 #[test]
 fn parse_json_response_invalid_json() {

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -497,6 +497,7 @@
                             "openai",
                             "deepseek",
                             "openai-compatible",
+                            "openai-responses",
                             "azure"
                           ]
                         },
@@ -1313,7 +1314,8 @@
               "openai",
               "deepseek",
               "azure",
-              "openai-compatible"
+              "openai-compatible",
+              "openai-responses"
             ],
             "description": "Per-request LLM provider override"
           },
@@ -1323,7 +1325,7 @@
           },
           "baseUrl": {
             "type": "string",
-            "description": "Per-request LLM base URL override for OpenAI-compatible providers (e.g. https://api.deepseek.com/v1)"
+            "description": "Per-request LLM base URL override for Chat Completions-compatible or Responses-compatible providers (e.g. https://api.deepseek.com/v1)"
           },
           "summaryPrompt": {
             "type": "string",

--- a/crates/crw-server/tests/capabilities.rs
+++ b/crates/crw-server/tests/capabilities.rs
@@ -400,6 +400,46 @@ async fn llm_providers_match_the_dispatcher() {
     }
 }
 
+#[test]
+fn openapi_provider_lists_match_the_dispatcher() {
+    // The spec is hand-maintained, so a new dispatcher provider silently leaves
+    // the published contract behind: the `llmProvider` enum then forbids a
+    // value the server accepts, and generated clients reject valid requests.
+    // `check-openapi.sh` only proves the served spec matches the committed one,
+    // which stays true while both are stale — this is the check that doesn't.
+    let spec: Value =
+        serde_json::from_str(include_str!("../openapi/openapi.json")).expect("valid OpenAPI");
+
+    let example =
+        spec["paths"]["/v1/capabilities"]["get"]["responses"]["200"]["content"]["application/json"]
+            ["schema"]["properties"]["llm"]["properties"]["providers"]["example"]
+            .as_array()
+            .expect("capabilities llm.providers example is an array");
+    let enumerated =
+        spec["components"]["schemas"]["ScrapeRequest"]["properties"]["llmProvider"]["enum"]
+            .as_array()
+            .expect("ScrapeRequest.llmProvider enum is an array");
+
+    for (label, values) in [
+        ("llm.providers example", example),
+        ("llmProvider enum", enumerated),
+    ] {
+        let listed: Vec<&str> = values.iter().filter_map(Value::as_str).collect();
+        for provider in crw_extract::llm::SUPPORTED_PROVIDERS {
+            assert!(
+                listed.contains(provider),
+                "{label} in openapi.json is missing `{provider}`, which the dispatcher accepts"
+            );
+        }
+        for provider in &listed {
+            assert!(
+                crw_extract::llm::is_supported_provider(provider),
+                "{label} in openapi.json advertises `{provider}`, which the dispatcher rejects"
+            );
+        }
+    }
+}
+
 #[tokio::test]
 async fn llm_required_formats_are_declared() {
     let body = caps(&app_from("")).await;

--- a/docs/docs/capabilities.md
+++ b/docs/docs/capabilities.md
@@ -17,7 +17,7 @@ No request body. No query parameters.
 {
   "version": "0.23.0",
   "llm": {
-    "providers": ["anthropic", "openai", "deepseek", "openai-compatible", "azure"],
+    "providers": ["anthropic", "openai", "deepseek", "openai-compatible", "openai-responses", "azure"],
     "supportsBaseUrl": true,
     "serverKeyConfigured": false,
     "maxConcurrency": 0

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -81,15 +81,20 @@ only_main_content = true
 # always_run = false         # true = LLM on every page (higher cost, higher recall)
 
 [extraction.llm]
-provider = "anthropic"       # "anthropic", "openai", "deepseek", "azure", or "openai-compatible"
+provider = "anthropic"       # also: "openai", "openai-responses", "deepseek", "azure", "openai-compatible"
 api_key = ""
 model = "claude-sonnet-4-20250514"
 max_tokens = 4096
 max_html_bytes = 100000      # content fed to LLM is truncated at this byte count
 max_concurrency = 4          # bounded fan-out for per-result summaries in /v1/search
-# base_url = ""              # for OpenAI-compatible endpoints (DeepSeek, Azure, …)
+# base_url = ""              # for custom Chat Completions or Responses endpoints
 # azure_api_version = ""     # required when provider = "azure"
 # require_byok_header = ""   # tenant guard: reject LLM requests missing this header AND without llmApiKey
+
+# Responses-compatible gateway:
+# provider = "openai-responses"
+# model = "provider-model-id"
+# base_url = "https://gateway.example.com/v1"  # /responses is appended
 
 # /v1/search endpoint — proxies to a SearXNG instance.
 # Absence of searxng_url disables /v1/search with HTTP 503 (error_code: "search_disabled").

--- a/docs/docs/extract.md
+++ b/docs/docs/extract.md
@@ -161,9 +161,9 @@ curl -X POST https://api.fastcrw.com/v1/scrape \
 | `jsonSchema` | object | required | JSON schema describing the fields you want back |
 | `extract` | object | -- | Firecrawl-compatible wrapper; `extract.schema` is accepted |
 | `llmApiKey` | string | -- | Per-request LLM API key |
-| `llmProvider` | string | server default | `anthropic`, `openai`, `deepseek`, `azure`, or `openai-compatible` |
+| `llmProvider` | string | server default | `anthropic`, `openai`, `openai-responses`, `deepseek`, `azure`, or `openai-compatible` |
 | `llmModel` | string | server default | Extraction model override |
-| `baseUrl` | string | -- | OpenAI-compatible endpoint base, e.g. `https://api.deepseek.com/v1` (also used by Azure). crw appends `/chat/completions` automatically if you omit it. |
+| `baseUrl` | string | -- | Provider endpoint base. CRW appends `/chat/completions` for Chat Completions providers or `/responses` for `openai-responses`; complete endpoint URLs are accepted. |
 | `onlyMainContent` | boolean | `true` | Keep extraction focused on the main content block |
 | `cssSelector` | string | -- | Narrow the page before extraction |
 | `xpath` | string | -- | Narrow the page before extraction |
@@ -199,7 +199,7 @@ If the underlying page scrape is weak, the JSON extraction will also be weak.
 
 ## Self-hosted LLM and provider control
 
-**Self-hosted:** set `[extraction.llm]` in `config.toml` for a server-wide default, or pass `llmApiKey` + `llmProvider` + `llmModel` per request to override it. Supported providers: `anthropic`, `openai`, `deepseek`, `azure`, and `openai-compatible`. Use `baseUrl` for any OpenAI-compatible endpoint (DeepSeek, Azure, local models).
+**Self-hosted:** set `[extraction.llm]` in `config.toml` for a server-wide default, or pass `llmApiKey` + `llmProvider` + `llmModel` per request to override it. Supported providers: `anthropic`, `openai`, `openai-responses`, `deepseek`, `azure`, and `openai-compatible`. Use `baseUrl` for compatible Chat Completions or Responses endpoints.
 
 ## Common production patterns
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -42,7 +42,7 @@ A credit is the billing unit for the hosted cloud at `fastcrw.com`. Every scrape
 
 ## llmProvider
 
-`llmProvider` is a request field that selects which LLM provider fastCRW routes extraction or summarization calls to. Accepted values are `"anthropic"`, `"openai"`, `"deepseek"`, `"azure"`, and `"openai-compatible"`. Use it together with `llmApiKey` and `llmModel` to pin a specific provider per request, or set the server-wide default in `config.toml` under `[extraction.llm]`. When using Azure or a custom OpenAI-compatible endpoint, also supply `baseUrl`. See [Extract](/docs/extract) and [Output Formats](/docs/output-formats) for full field references.
+`llmProvider` is a request field that selects which LLM provider fastCRW routes extraction or summarization calls to. Accepted values are `"anthropic"`, `"openai"`, `"openai-responses"`, `"deepseek"`, `"azure"`, and `"openai-compatible"`. Use it together with `llmApiKey` and `llmModel` to pin a specific provider per request, or set the server-wide default in `config.toml` under `[extraction.llm]`. When using Azure or a custom Chat Completions/Responses endpoint, also supply `baseUrl`. See [Extract](/docs/extract) and [Output Formats](/docs/output-formats) for full field references.
 
 ---
 

--- a/docs/docs/output-formats.md
+++ b/docs/docs/output-formats.md
@@ -148,18 +148,23 @@ The LLM response is validated against the provided schema using the `jsonschema`
 | Provider | Tool mechanism |
 |----------|---------------|
 | Anthropic | `tool_use` with `input_schema` |
-| OpenAI | Function calling with `parameters` |
+| OpenAI / OpenAI-compatible | Chat Completions function calling with `parameters` |
+| OpenAI Responses-compatible | Forced Responses function call; arguments are validated locally |
 
 Configure in `config.toml`:
 
 ```toml
 [extraction.llm]
-provider = "anthropic"          # or "openai"
+provider = "anthropic"          # or "openai", "openai-responses", …
 api_key = "sk-..."
 model = "claude-sonnet-4-20250514"
 max_tokens = 4096
-# base_url = "https://..."     # for OpenAI-compatible endpoints
+# base_url = "https://..."     # for compatible Chat or Responses endpoints
 ```
+
+For a Responses-compatible endpoint, set `provider = "openai-responses"` and
+use a versioned HTTPS API base such as `https://gateway.example.com/v1`. CRW
+appends `/responses`; a complete endpoint URL is also accepted unchanged.
 
 ## Response Shape
 
@@ -236,7 +241,7 @@ The exact shape of `data` depends on what you requested. Do not assume every fie
 | `totalTokens` | `number` | Sum of input + output |
 | `estimatedCostUsd` | `number / null` | Best-effort cost using a snapshot pricing table. `null` for unknown models. Not for accounting — provider pricing drifts. |
 | `model` | `string` | Model that produced the output |
-| `provider` | `string` | `anthropic` / `openai` / `azure` / `openai-compatible` |
+| `provider` | `string` | `anthropic` / `openai` / `openai-responses` / `deepseek` / `azure` / `openai-compatible` |
 
 ### `ChunkResult` object
 

--- a/docs/docs/scraping.md
+++ b/docs/docs/scraping.md
@@ -148,9 +148,9 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `jsonSchema` | object | -- | Schema for structured extraction |
 | `extract` | object | -- | Firecrawl-compatible alias wrapper for extraction schema |
 | `llmApiKey` | string | -- | Per-request LLM API key |
-| `llmProvider` | string | server default | `anthropic`, `openai`, `deepseek`, `azure`, or `openai-compatible` |
+| `llmProvider` | string | server default | `anthropic`, `openai`, `openai-responses`, `deepseek`, `azure`, or `openai-compatible` |
 | `llmModel` | string | server default | Model override (extraction and summary) |
-| `baseUrl` | string | -- | OpenAI-compatible endpoint base, e.g. `https://api.deepseek.com/v1` (also used by Azure). crw appends `/chat/completions` automatically if you omit it. |
+| `baseUrl` | string | -- | Provider endpoint base. CRW appends `/chat/completions` for Chat Completions providers or `/responses` for `openai-responses`; complete endpoint URLs are accepted. |
 | `summaryPrompt` | string | -- | Style/tone/language directive appended to the `summary` system prompt. Safety wrapper kept intact. Capped at 500 chars. |
 | `maxContentChars` | number | `[extraction.llm].max_html_bytes` (100 KB) | Per-request byte cap on content sent to the LLM for `summary`. Clamped to 200 KB server-side. |
 | `deadlineMs` | number | `8000` | End-to-end request deadline in milliseconds. Must be in `(0, 60000]`. Requests above 8 000 ms land in a separate slow-path histogram and are excluded from the standard SLO p95 metric. |

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -154,9 +154,9 @@ That is the flat response shape used when `sources` is not set.
 | `multiRound` | boolean | server config | When `true`, fires an adaptive evidence-scout round if the first-round answer abstains. Overrides `[search].multi_round` for this request. |
 | `answerListFormat` | boolean | server config | When `true` (and the query has list intent such as "best/top X"), renders the answer as a ranked list instead of prose. `false` forces prose. Overrides `[search].answer_list_format`. |
 | `llmApiKey` | string | -- | Per-request LLM API key |
-| `llmProvider` | string | server default | `anthropic`, `openai`, `deepseek`, `azure`, or `openai-compatible` |
+| `llmProvider` | string | server default | `anthropic`, `openai`, `openai-responses`, `deepseek`, `azure`, or `openai-compatible` |
 | `llmModel` | string | server default | Model override |
-| `baseUrl` | string | -- | OpenAI-compatible endpoint base (e.g. DeepSeek, Azure) |
+| `baseUrl` | string | -- | Provider endpoint base for Azure, Chat Completions-compatible, or Responses-compatible APIs |
 
 `scrapeOptions`:
 

--- a/docs/docs/v2-api.md
+++ b/docs/docs/v2-api.md
@@ -86,7 +86,7 @@ Scrape one URL synchronously. Returns immediately with a `V2Document`.
 | `renderJs` | `boolean` | — | `true` forces JS rendering, `false` keeps the request HTTP-only, omitted uses auto-detection. Same semantics as on `/v1/scrape`, see [JS Rendering](js-rendering.md) |
 | `parsers` | `ParserSpec[]` | — | Document parser directives (e.g. `["pdf"]`) |
 | `llmApiKey` | `string` | — | Per-request LLM API key (required for `summary` / `json` if no server key) |
-| `llmProvider` | `"anthropic" \| "openai" \| "deepseek" \| "azure" \| "openai-compatible"` | — | Per-request LLM provider |
+| `llmProvider` | `"anthropic" \| "openai" \| "openai-responses" \| "deepseek" \| "azure" \| "openai-compatible"` | — | Per-request LLM provider |
 | `llmModel` | `string` | — | Per-request LLM model name |
 | `summaryPrompt` | `string` | — | Custom prompt for the `summary` format |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -105,9 +105,9 @@ Key parameters:
   headers         object    opt       Custom HTTP headers forwarded to the target
   jsonSchema      object    opt       JSON Schema for structured extraction (formats:["json"])
   llmApiKey       string    opt       BYOK LLM key for json/summary formats
-  llmProvider     string    opt       "anthropic"|"openai"|"deepseek"|"azure"|"openai-compatible"
+  llmProvider     string    opt       "anthropic"|"openai"|"openai-responses"|"deepseek"|"azure"|"openai-compatible"
   llmModel        string    opt       Model override
-  baseUrl         string    opt       OpenAI-compatible endpoint base URL
+  baseUrl         string    opt       Chat Completions or Responses endpoint base URL
   summaryPrompt   string    opt       Style/tone directive for summary (≤500 chars)
   maxContentChars number    opt       Byte cap for content sent to LLM (default 100KB, max 200KB)
   proxy           string    opt       Per-request proxy URL

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -497,6 +497,7 @@
                             "openai",
                             "deepseek",
                             "openai-compatible",
+                            "openai-responses",
                             "azure"
                           ]
                         },
@@ -1313,7 +1314,8 @@
               "openai",
               "deepseek",
               "azure",
-              "openai-compatible"
+              "openai-compatible",
+              "openai-responses"
             ],
             "description": "Per-request LLM provider override"
           },
@@ -1323,7 +1325,7 @@
           },
           "baseUrl": {
             "type": "string",
-            "description": "Per-request LLM base URL override for OpenAI-compatible providers (e.g. https://api.deepseek.com/v1)"
+            "description": "Per-request LLM base URL override for Chat Completions-compatible or Responses-compatible providers (e.g. https://api.deepseek.com/v1)"
           },
           "summaryPrompt": {
             "type": "string",

--- a/skills/crw-self-host/SKILL.md
+++ b/skills/crw-self-host/SKILL.md
@@ -219,11 +219,11 @@ and `/v1/search` with `answer: true`.
 
 ```toml
 [extraction.llm]
-provider = "anthropic"          # "anthropic" | "openai" | "deepseek" | "azure" | "openai-compatible"
+provider = "anthropic"          # "anthropic" | "openai" | "openai-responses" | "deepseek" | "azure" | "openai-compatible"
 api_key = "sk-..."              # or CRW_EXTRACTION__LLM__API_KEY env var
 model = "claude-sonnet-4-20250514"
 max_tokens = 4096
-# base_url = "https://custom-endpoint.example.com"   # for openai-compatible APIs
+# base_url = "https://custom-endpoint.example.com"   # Chat Completions or Responses endpoints
 max_concurrency = 4
 max_html_bytes = 100000
 


### PR DESCRIPTION
Carries @AsheTheWings' commit from #388 unchanged and adds a second commit fixing what came out of review. Opened here because #388 has maintainer edits disabled, so the follow-up could not be pushed to its branch. ref #388

## What #388 adds

An OpenAI Responses API transport (`provider = "openai-responses"`) for text generation, structured extraction and judge calls, wired through the CLI, core config and docs.

## What the second commit changes

- **Terminal status was never read.** A payload whose own `status` is `failed`, `cancelled`, `queued` or `in_progress` arrives inside an HTTP 200 and was treated as a successful, empty result: the call produced nothing and still reported success. Only an absent status (compat gateways that omit it), `completed` and `incomplete` now proceed. `incomplete` keeps its partial output, matching the Chat Completions path, which does not reject `finish_reason == "length"` either.
- **`responses_url()` corrupted a base URL carrying a query or fragment.** The `/responses` suffix check ran on the raw string, so `https://gw/v1?api-version=2026-01-01` became `.../v1?api-version=2026-01-01/responses`. Azure-style Responses endpoints require that parameter. The check now runs on the path and re-attaches the suffix.
- **Empty output hard-errored, unlike every sibling provider.** `call_openai` and `call_anthropic` accept a present-but-empty `content` and only error when it is absent, so switching `llmProvider` alone turned working requests into failures. Presence is now keyed on the `output_text` part, which is the real analogue of that field: an empty part succeeds, and a refusal-only message (no `output_text` part at all) errors, exactly as a Chat Completions refusal does by nulling `content`.
- **Provider error bodies reached the API caller.** A gateway that mirrors the request into its error body would hand back the bearer key or the prompt. The Responses path now surfaces the status alone. The same leak was open on the structured Chat Completions path, where the managed configuration uses the **server** key, so it is closed there too; an unrecognised status is logged server-side instead.
- **A third `reqwest` pool.** `responses.rs` built its own client next to the two the crate already has. It now uses the pooled one; every caller sets a per-request timeout, so the builder default is not observable.
- **Spec and docs drift.** Both `openapi.json` copies, `docs/llms-full.txt` and the self-host skill still listed the pre-PR providers, so a generated client would reject a value the server accepts. A test now ties both spec lists to `crw_extract::llm::SUPPORTED_PROVIDERS` in each direction, which is the check `check-openapi.sh` cannot make (it only proves the served spec matches the committed one, which stays true while both are stale).

Retry on 429/503 was considered and left out. `post()` is shared by callers running with 30s, 60s and 300s budgets, and the retry loop in `llm::call_openai` is explicitly justified by its fixed 30s timeout; copying it would put the basis-extraction path at roughly three times 300s while holding an LLM concurrency permit. The structured-path siblings have no retry either.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (1527 passing), `scripts/docs-guards.sh`, `scripts/check-format-tables.sh`, and `scripts/check-openapi.sh` against a freshly built release binary.

Each fix was checked by reverting it and confirming a test fails: the status gate, the URL suffix, the output_text semantics, both error-body paths and the spec drift check are all covered by a test that goes red without the fix.