### PR TITLE
docs: correct the SDK loader's default-backend claims

### DIFF
--- a/.github/workflows/examples-test.yml
+++ b/.github/workflows/examples-test.yml
@@ -117,3 +117,35 @@ jobs:
 
       - name: Validate JSON blocks in MCP example READMEs
         run: bash scripts/check-mcp-example-json.sh
+
+  # ---------------------------------------------------------------------------
+  # Downstream package: langchain-crw re-exports crw.integrations.langchain, so
+  # an SDK change or an ecosystem move can break it without any signal in its own
+  # repo. That repo is dormant for months at a time and GitHub disables cron in
+  # repos idle for 60 days, so this weekly check has to live here, where the
+  # schedule stays alive.
+  # ---------------------------------------------------------------------------
+  downstream-langchain-crw:
+    name: langchain-crw resolves against current LangChain
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Install the published package next to current LangChain
+        run: |
+          set -euo pipefail
+          uv venv .venv --python 3.13
+          uv pip install --python .venv/bin/python langchain-crw "langchain>=1,<2"
+
+      - name: Assert the loader imports and is the SDK's
+        run: |
+          set -euo pipefail
+          .venv/bin/python -c "
+          from importlib.metadata import version
+          from langchain_crw import CrwLoader
+          from crw.integrations.langchain import CrwLoader as SdkLoader
+          print('langchain-core=' + version('langchain-core'), 'crw=' + version('crw'))
+          assert version('langchain-core').startswith('1.'), version('langchain-core')
+          assert CrwLoader is SdkLoader, 'langchain-crw re-forked the loader'
+          "

--- a/blog/crewai-web-scraping.md
+++ b/blog/crewai-web-scraping.md
@@ -43,7 +43,7 @@ The `crewai-crw` package gives you three tools out of the box:
 ```
 from crewai_crw import CrwScrapeWebsiteTool, CrwCrawlWebsiteTool, CrwMapWebsiteTool
 
-# Self-hosted (default: localhost:3000)
+# Managed cloud by default (api.fastcrw.com), reads CRW_API_KEY
 scrape_tool = CrwScrapeWebsiteTool()
 crawl_tool = CrwCrawlWebsiteTool()
 map_tool = CrwMapWebsiteTool()

--- a/blog/langchain-crw-rag-tutorial.md
+++ b/blog/langchain-crw-rag-tutorial.md
@@ -35,10 +35,13 @@ Pick one:
 ```
 # Install and start CRW
 curl -fsSL https://fastcrw.com/install | bash
-crw  # runs on http://localhost:3000
+crw serve  # runs on http://localhost:3000
 
 # Or Docker
 docker run -p 3000:3000 ghcr.io/us/crw:latest
+
+# Point the loader at it
+export CRW_API_URL=http://localhost:3000
 ```
 
 ### Option B: Cloud (fastCRW)
@@ -225,8 +228,12 @@ docs = loader.load()
 The code is identical — only the backend changes:
 
 ```
-# Self-hosted: no args needed (localhost:3000)
-loader = CrwLoader(url="https://example.com", mode="scrape")
+# Self-hosted: point at your own server
+loader = CrwLoader(
+    url="https://example.com",
+    api_url="http://localhost:3000",
+    mode="scrape",
+)
 
 # Cloud: pass api_url and api_key
 loader = CrwLoader(
@@ -247,7 +254,7 @@ loader = CrwLoader(url="https://example.com", mode="scrape")
 - **Clean markdown by default.** CRW strips nav, footers, and boilerplate. Your chunks contain actual content, not HTML noise — which means better embeddings and more relevant retrieval.
 - **Low-latency, local-first crawling.** Running the engine next to your pipeline avoids remote API round trips, so crawling a large docs site stays quick. See the full latency distribution on our [public benchmark](/benchmarks).
 - **Native LangChain integration.** `CrwLoader` implements `BaseLoader` with `lazy_load()` — works with every LangChain component out of the box.
-- **Self-hosted for free.** No API keys, no rate limits, no per-page costs during development. Switch to [fastCRW](https://fastcrw.com) cloud when you need production reliability.
+- **Self-hosted for free.** No API key, no rate limits, no per-page costs during development. Switch to [fastCRW](https://fastcrw.com) cloud when you need production reliability.
 
 ## Next Steps
 

--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -21,7 +21,7 @@ from crw.integrations.crewai import (
     CrwSearchWebTool,
 )
 
-# Self-hosted (default: localhost:3000)
+# Managed cloud by default (api.fastcrw.com), reads CRW_API_KEY
 scrape_tool = CrwScrapeWebsiteTool()
 
 # Or use fastCRW cloud
@@ -52,16 +52,20 @@ result = crew.kickoff()
 
 ## LangChain
 
-LangChain support is bundled as an **extra** in the `crw` Python package — no separate package needed.
+LangChain support ships as an **extra** in the `crw` Python package. The same
+loader is also published under the conventional LangChain name, so either
+install works and you get the identical `CrwLoader`.
 
 ```bash
 pip install "crw[langchain]"
+# or
+pip install langchain-crw
 ```
 
 ```python
 from crw.integrations.langchain import CrwLoader
 
-# Self-hosted (default: localhost:3000)
+# Managed cloud by default (api.fastcrw.com), reads CRW_API_KEY
 loader = CrwLoader(url="https://example.com", mode="scrape")
 docs = loader.load()
 
@@ -222,7 +226,7 @@ Not every integration supports every endpoint. Search requires a cloud API backe
 | Integration | Scrape | Crawl | Map | Search | Extract |
 |-------------|--------|-------|-----|--------|---------|
 | [CrewAI](https://pypi.org/project/crw/) (`crw[crewai]`) | Yes | Yes | Yes | Yes (cloud) | -- |
-| [LangChain](https://pypi.org/project/crw/) (`crw[langchain]`) | Yes | Yes | Yes | Yes (cloud) | -- |
+| [LangChain](https://pypi.org/project/crw/) (`crw[langchain]` or `langchain-crw`) | Yes | Yes | Yes | Yes (cloud) | Yes (cloud) |
 | [n8n](https://www.npmjs.com/package/n8n-nodes-crw) | Yes | Yes | Yes | Yes (cloud) | -- |
 | [Dify](https://github.com/us/dify-plugin-crw) | Yes | Yes | Yes | Yes (cloud) | -- |
 | MCP Server (proxy mode) | Yes | Yes | Yes | Yes | -- |

--- a/docs/integrations/index.html
+++ b/docs/integrations/index.html
@@ -296,7 +296,7 @@ from crw.integrations.crewai import (
     CrwSearchWebTool,
 )
 
-# Self-hosted (default: localhost:3000)
+# Managed cloud by default (api.fastcrw.com), reads CRW_API_KEY
 scrape_tool = CrwScrapeWebsiteTool()
 
 # Or use fastCRW cloud
@@ -324,11 +324,15 @@ task = Task(
 crew = Crew(agents=[researcher], tasks=[task])
 result = crew.kickoff()</code></pre>
 <h2 id="langchain">LangChain</h2>
-<p>LangChain support is bundled as an <strong>extra</strong> in the <code>crw</code> Python package — no separate package needed.</p>
-<pre data-lang="bash"><code class="language-bash">pip install &quot;crw[langchain]&quot;</code></pre>
+<p>LangChain support ships as an <strong>extra</strong> in the <code>crw</code> Python package. The same
+loader is also published under the conventional LangChain name, so either
+install works and you get the identical <code>CrwLoader</code>.</p>
+<pre data-lang="bash"><code class="language-bash">pip install &quot;crw[langchain]&quot;
+# or
+pip install langchain-crw</code></pre>
 <pre data-lang="python"><code class="language-python">from crw.integrations.langchain import CrwLoader
 
-# Self-hosted (default: localhost:3000)
+# Managed cloud by default (api.fastcrw.com), reads CRW_API_KEY
 loader = CrwLoader(url=&quot;https://example.com&quot;, mode=&quot;scrape&quot;)
 docs = loader.load()
 
@@ -510,12 +514,12 @@ console.log(data.markdown);</code></pre>
 <td>--</td>
 </tr>
 <tr>
-<td><a href="https://pypi.org/project/crw/">LangChain</a> (<code>crw[langchain]</code>)</td>
+<td><a href="https://pypi.org/project/crw/">LangChain</a> (<code>crw[langchain]</code> or <code>langchain-crw</code>)</td>
 <td>Yes</td>
 <td>Yes</td>
 <td>Yes</td>
 <td>Yes (cloud)</td>
-<td>--</td>
+<td>Yes (cloud)</td>
 </tr>
 <tr>
 <td><a href="https://www.npmjs.com/package/n8n-nodes-crw">n8n</a></td>

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Runnable snippets showing how to use CRW from popular frameworks. These are
 
 | Dir | Framework | How it talks to CRW | Replaces |
 |---|---|---|---|
-| `langchain/` | LangChain | `crw[langchain]` extra (`crw.integrations.langchain`) | the old `langchain-crw` package |
+| `langchain/` | LangChain | `crw[langchain]` extra (`crw.integrations.langchain`) | nothing; `langchain-crw` re-exports this same loader |
 | `crewai/` | CrewAI | `crw[crewai]` extra (`crw.integrations.crewai`) | the old `crewai-crw` package |
 | `openclaw/` | OpenClaw | the `crw-mcp` MCP server (MCP-native) | the old `openclaw-plugin-crw` package |
 | `pi/` | Pi | the `crw-mcp` MCP server (MCP-native) | the old `pi-crw` package |

--- a/sdks/python/src/crw/integrations/langchain.py
+++ b/sdks/python/src/crw/integrations/langchain.py
@@ -86,10 +86,13 @@ class CrwLoader(BaseLoader):
                 Not required for search mode.
             api_key: Bearer token for authentication.
                 Read from CRW_API_KEY env var if not provided.
-                Not required for subprocess mode or self-hosted without auth.
+                Not required with CRW_LOCAL=1 or a self-hosted server
+                without auth.
             api_url: Base URL of CRW server for HTTP mode.
                 Read from CRW_API_URL env var if not provided.
-                Defaults to None (subprocess mode — spawns crw-mcp binary).
+                Defaults to None, which uses the managed cloud at
+                api.fastcrw.com. Ignored when CRW_LOCAL=1 is set, which
+                runs a local engine instead.
             mode: Operation mode - "scrape", "crawl", "map", "search", "parse"
                 (local PDF → markdown/JSON), or "extract" (structured LLM
                 extraction across URLs; HTTP/cloud mode only).


### PR DESCRIPTION
## Problem

`crw.integrations.langchain`'s docstring still described `api_url=None` as "subprocess mode, spawns crw-mcp binary", and several docs pages showed `localhost:3000` as the default. The SDK has been cloud-first for a while: `api_url=None` resolves to the managed cloud, and `CRW_LOCAL=1` selects the local engine and silently overrides `api_url` (`client.py:151-163`).

This surfaced while fixing the downstream `langchain-crw` package (us/langchain-crw#11), which now re-exports this loader, so this docstring is what `help(langchain_crw.CrwLoader)` and every IDE hover shows.

## Change

- `sdks/python/src/crw/integrations/langchain.py`: correct the `api_key` and `api_url` docstrings.
- `docs/docs/integrations.md`: the LangChain and CrewAI snippets both claimed `localhost:3000` was the default. Also stop presenting `langchain-crw` as superseded, since it re-exports this same loader, and fill in the Extract cell for the LangChain row (the loader does support `extract`, HTTP mode only, `client.py:552`).
- `blog/langchain-crw-rag-tutorial.md`: the self-host path told you to run the engine but never to point the loader at it, so following Option A verbatim failed with `CrwError: No CRW API key found`. Also `crw` is scrape, the server needs `crw serve`.
- `blog/crewai-web-scraping.md`: same wrong default, second site.
- `docs/integrations/index.html` regenerated via `scripts/build-docs-pages.mjs`.

## New CI job

`examples-test.yml` gains `downstream-langchain-crw`, which weekly installs the published `langchain-crw` next to LangChain 1.x and asserts the re-export identity holds.

It lives here rather than in that repo on purpose: GitHub disables scheduled workflows in repos idle for 60 days, and `langchain-crw` had been idle 114 days when its `langchain-core<1.0.0` cap made it uninstallable, with nothing to notice. opencore commits constantly, so this cron stays alive. It also catches the inverse risk: if a future `crw` release moves or renames `crw.integrations.langchain`, the identity assert fails here within a week.

## Merge ordering

**Do not merge before `langchain-crw` 0.5.0 is published to PyPI.** The new job installs the published package, and 0.4.0 is still capped at `langchain-core<1.0.0`, so it cannot resolve next to LangChain 1.x. Merging early paints the weekly run (and every release-tag run, since the workflow also triggers on `tags: v*`) red on purpose. us/langchain-crw#11 is merged; the release PR is queued at 0.5.0.

The job does not trigger on `pull_request`, so it does not gate this PR.

## Verification

- Every corrected claim checked against `client.py` line by line.
- SDK unit tests: 83 passed, 9 skipped.
- No Rust touched.