### PR TITLE
fix(mcp): stop advertising an output schema the proxy cannot honour

### DIFF
--- a/COMPATIBILITY-firecrawl.md
+++ b/COMPATIBILITY-firecrawl.md
@@ -122,7 +122,7 @@ This is a **capability matrix**, not an API-shape compatibility matrix (which th
 
 **Surface match:** both products ship MCP. Tool names differ (Firecrawl uses `firecrawl_*`, fastCRW uses `crw_*`); semantic mapping is straightforward.
 
-**Structured output:** `crw_search` additionally emits MCP-2025-06-18 `structuredContent` shaped to fastCRW's own `/v1/search` envelope (`data.results`), **not** Firecrawl's `data.web` shape — it mirrors the body fastCRW clients already consume, so this is not a Firecrawl-shape parity claim. The legacy text content block is retained for lenient clients.
+**Structured output:** `crw_search` additionally emits MCP-2025-06-18 `structuredContent` shaped to whichever fastCRW `/v1/search` body served the call — `data.results` from a self-hosted engine, results directly in `data` from the hosted API — and **not** Firecrawl's `data.web` shape. It mirrors the body fastCRW clients already consume, so this is not a Firecrawl-shape parity claim. An `outputSchema` is advertised by the surfaces that produce the body themselves (embedded stdio and the engine's own HTTP `/mcp`), but not by the stdio proxy, where the body comes from a remote the MCP server does not author. The legacy text content block is retained for lenient clients.
 
 ---
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -159,12 +159,17 @@ class CrwTavilyShim:
             body["answer"] = True  # CRW has no basic/advanced depth knob
         r = requests.post(f"{self.base_url}/v1/search", json=body, headers=self.headers)
         r.raise_for_status()
-        data = r.json()["data"]
-        results = data["results"]
+        body_json = r.json()
+        data = body_json["data"]
+        # Hosted returns the results as `data` and hoists `answer` to the top
+        # level; a self-hosted engine nests both inside `data`. Handle both.
+        nested = isinstance(data, dict) and "results" in data
+        results = data["results"] if nested else data
+        answer = (data if nested else body_json).get("answer", "")
         web = results["web"] if isinstance(results, dict) and "web" in results else results
         return {
             "query": query,
-            "answer": data.get("answer", ""),  # present only when answer: true
+            "answer": answer,  # present only when answer: true
             "results": [
                 {
                     "title": item["title"],

--- a/crates/crw-cli/src/commands/mcp.rs
+++ b/crates/crw-cli/src/commands/mcp.rs
@@ -245,6 +245,20 @@ async fn proxy_call_tool(
                 .map_err(|e| format!("HTTP request failed: {e}"))?;
             parse_response(resp).await
         }
+        "crw_cancel_extract" => {
+            let id = args
+                .get("id")
+                .and_then(|v| v.as_str())
+                .ok_or("missing required parameter: id")?;
+            let resp = client
+                .delete(format!("{base_url}/v1/extract/{id}"))
+                .headers(headers)
+                .timeout(TIMEOUT_CRAWL_STATUS)
+                .send()
+                .await
+                .map_err(|e| format!("HTTP request failed: {e}"))?;
+            parse_response(resp).await
+        }
         "crw_parse_file" => {
             use base64::Engine;
             let b64 = args

--- a/crates/crw-mcp-proto/src/lib.rs
+++ b/crates/crw-mcp-proto/src/lib.rs
@@ -400,8 +400,8 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
     // decided one level up, in `handle_protocol_method`'s `tools/list` arm, which
     // retains it out when `search_available` is false (an embedded install with no
     // search backend configured). Proxy mode always has it: the remote decides.
-    // The tool set itself does not depend on the mode, hence the discard.
-    let _ = proxy_mode;
+    // The tool SET does not depend on the mode; the advertised output contract does
+    // (see the `proxy_mode` strip below the last push).
     tools.push(json!({
         "name": "crw_search",
         "title": "Web search",
@@ -539,15 +539,50 @@ pub fn tool_definitions(proxy_mode: bool) -> Value {
         }
     }));
 
+    // In proxy mode the body is whatever the REMOTE returns, and we do not control that
+    // remote: `--api-url` may point at a self-hosted crw-server (which nests the results
+    // under `data.results`) or at the managed API (whose public REST contract puts them
+    // directly in `data`). A declared `outputSchema` is a promise about a body we do not
+    // author, and the spec says a server MUST conform to a schema it declares. A strict
+    // client then hard-fails the ENTIRE call when it does not: the official SDKs raise
+    // `-32602 Structured content does not match the tool's output schema` (issue #391).
+    // Stripping it is spec-legal — `outputSchema` is optional — and callers lose no data:
+    // `structuredContent` is still emitted, it just carries no advertised schema for a
+    // client to validate it against. The managed connector reached the same rule
+    // independently for the same reason (crw-saas `src/lib/mcp/dispatch.ts`,
+    // `managedSearchTool`).
+    //
+    // Applied to EVERY tool rather than a hand-picked list: "we do not author this body"
+    // is true of all of them in proxy mode, and a per-tool list has to be re-audited on
+    // every future shape change — which is exactly how `crw_extract` stayed broken after
+    // `crw_search` was already known to be.
+    //
+    // Embedded/engine mode (`proxy_mode == false`) keeps its schemas: there the body is
+    // ours and its shape is locked by tests.
+    if proxy_mode {
+        for tool in &mut tools {
+            if let Some(obj) = tool.as_object_mut() {
+                obj.remove("outputSchema");
+            }
+        }
+    }
+
     json!({ "tools": tools })
 }
 
-/// Returns the declared `outputSchema` for a tool, if it declares one.
+/// Returns the ENGINE's declared `outputSchema` for a tool, if it declares one.
 ///
-/// Single source of truth: `structuredContent` emission is derived from the
-/// same `tool_definitions` declaration that `tools/list` advertises, so the two
-/// can never drift. Recomputes `tool_definitions` per call — `tools/call` is not
-/// hot; memoize behind a `OnceLock` only if profiling ever demands it.
+/// Reads `tool_definitions(false)` deliberately, and that asymmetry is the point:
+/// it is the "does this tool have a structured shape at all" question, which drives
+/// `structuredContent` emission in [`tool_result_response`]. In proxy mode the schema
+/// is not *advertised* (we do not author the remote's body — see the strip in
+/// `tool_definitions`), but the structured value is still emitted, unvalidated. Do
+/// not "fix" this into taking `proxy_mode`: that would silently stop emitting
+/// `structuredContent` on the proxy. Pinned by
+/// `proxy_mode_still_emits_structured_content_without_a_schema`.
+///
+/// Recomputes `tool_definitions` per call — `tools/call` is not hot; memoize behind a
+/// `OnceLock` only if profiling ever demands it.
 pub fn tool_output_schema(tool_name: &str) -> Option<Value> {
     tool_definitions(false)["tools"]
         .as_array()?
@@ -644,11 +679,17 @@ pub fn handle_protocol_method(
 ///
 /// On success the structured `value` is emitted **both** as a text content block
 /// (verbatim, for backward compatibility with lenient clients and clients that
-/// negotiated an older protocol revision) **and**, when the called tool declares
-/// an `outputSchema`, as a top-level `structuredContent` field (MCP 2025-06-18)
-/// so strict clients can validate it. Both representations derive from the same
-/// `value` binding, so `serde_json::from_str(content[0].text) == structuredContent`
+/// negotiated an older protocol revision) **and**, when the called tool has a
+/// structured shape at all ([`tool_output_schema`]), as a top-level
+/// `structuredContent` field (MCP 2025-06-18). Both representations derive from the
+/// same `value` binding, so `serde_json::from_str(content[0].text) == structuredContent`
 /// holds by construction — the two can never disagree.
+///
+/// Note the deliberate asymmetry in proxy mode: the schema is not advertised in
+/// `tools/list` (see the `proxy_mode` strip in [`tool_definitions`]) yet
+/// `structuredContent` is still emitted. That is spec-legal — the spec asks clients to
+/// validate only when a schema was advertised — and it means proxy callers keep the
+/// structured value without the hard failure that a promise we cannot keep would cause.
 pub fn tool_result_response(
     id: Value,
     tool_name: &str,
@@ -789,11 +830,20 @@ fn bound_map_links(value: &mut Value, limit: usize) {
 }
 
 /// Truncate any scrape content inlined into `crw_search` results (via
-/// `scrapeOptions`). `results` lives at `data.results` and is either a flat array
-/// of items or a grouped `{web,news,images}` object of arrays.
+/// `scrapeOptions`). The results are either a flat array of items or a grouped
+/// `{web,news,images}` object of arrays, and they live in one of two places: under
+/// `data.results` on the engine's own envelope, or **directly** in `data` on the
+/// managed REST contract, which hoists them one level. Bound both — the proxy fronts
+/// either, and on the shape this helper did not handle the default bound was a silent
+/// no-op that let whole scraped pages through (issue #391).
 fn bound_search_results(value: &mut Value, max: usize) {
-    let Some(results) = value.get_mut("data").and_then(|d| d.get_mut("results")) else {
+    let Some(data) = value.get_mut("data") else {
         return;
+    };
+    let results = if data.get("results").is_some() {
+        data.get_mut("results").expect("presence checked above")
+    } else {
+        data
     };
     match results {
         Value::Array(items) => {
@@ -863,10 +913,17 @@ pub fn apply_bounds(tool_name: &str, args: &Value, mut value: Value) -> Value {
 /// are intentionally NOT stripped: `/v1/map` now drives sitemap discovery depth
 /// from `limit`, so forwarding it lets a deliberate large limit actually find
 /// (not just slice) more URLs. `apply_bounds` still caps the response.
+///
+/// `crw_search` strips `maxLength` even though its `inputSchema` does not advertise
+/// the knob: `apply_bounds` honours it for every tool (see [`resolve_bound`]), so a
+/// hand-written client can still send one, and it must not reach the REST body.
+/// Advertising it on `crw_search` would push `tools/list` past the token ceiling
+/// guarded by `tools_list_token_budget`; search results are bounded by the default
+/// either way.
 pub fn strip_mcp_only_args(tool_name: &str, mut args: Value) -> Value {
     if let Some(obj) = args.as_object_mut() {
         match tool_name {
-            "crw_scrape" | "crw_parse_file" | "crw_check_crawl_status" => {
+            "crw_scrape" | "crw_parse_file" | "crw_check_crawl_status" | "crw_search" => {
                 obj.remove("maxLength");
             }
             _ => {}
@@ -1338,9 +1395,14 @@ mod tests {
         let map = strip_mcp_only_args("crw_map", json!({ "url": "u", "limit": 50 }));
         assert_eq!(map["limit"], json!(50));
 
-        // crw_search.limit is a real backend param — must NOT be stripped.
-        let search = strip_mcp_only_args("crw_search", json!({ "query": "q", "limit": 5 }));
+        // crw_search.limit is a real backend param — must NOT be stripped. Its
+        // maxLength, like crw_scrape's, is MCP-only and must be.
+        let search = strip_mcp_only_args(
+            "crw_search",
+            json!({ "query": "q", "limit": 5, "maxLength": 100 }),
+        );
         assert_eq!(search["limit"], json!(5));
+        assert!(search.get("maxLength").is_none());
     }
 
     /// B10 — unknown/other tools pass through apply_bounds unchanged.
@@ -1550,5 +1612,185 @@ mod tests {
         let out = apply_bounds("crw_search", &json!({}), grouped);
         assert_eq!(out["data"]["results"]["web"][0]["truncated"], json!(true));
         assert!(out["data"]["results"]["news"][0].get("truncated").is_none());
+    }
+
+    // --- Proxy-mode output contract (issue #391) ---
+
+    /// The managed `/v1/search` body: results sit DIRECTLY in `data`, because the
+    /// public REST contract hoists them one level out of the engine's envelope.
+    fn managed_search_value() -> Value {
+        json!({
+            "success": true,
+            "data": [search_result_item(1), search_result_item(2)]
+        })
+    }
+
+    /// The managed `/v1/extract` body: the proxy resolves the job synchronously and
+    /// returns results inline instead of the engine's `{id, status, urls}` accept.
+    fn managed_extract_value() -> Value {
+        json!({
+            "success": true,
+            "results": [{
+                "url": "https://example.com/",
+                "status": "completed",
+                "data": { "title": "Example Domain" }
+            }]
+        })
+    }
+
+    /// P1 — proxy mode advertises no output contract at all, embedded mode keeps
+    /// every one it has. A remote we do not author must not be promised a shape.
+    #[test]
+    fn p1_proxy_mode_advertises_no_output_schema() {
+        let proxied = tool_definitions(true);
+        for tool in proxied["tools"].as_array().expect("tools array") {
+            assert!(
+                tool.get("outputSchema").is_none(),
+                "{} must not advertise an outputSchema in proxy mode",
+                tool["name"]
+            );
+        }
+
+        let embedded = tool_definitions(false);
+        let declared: Vec<&str> = embedded["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .filter(|t| t.get("outputSchema").is_some())
+            .map(|t| t["name"].as_str().expect("name"))
+            .collect();
+        assert_eq!(
+            declared,
+            vec![
+                "crw_extract",
+                "crw_check_extract_status",
+                "crw_cancel_extract",
+                "crw_search"
+            ],
+            "embedded mode must keep the schemas it can honour"
+        );
+    }
+
+    /// P2 — the deliberate asymmetry: no schema advertised in proxy mode, yet
+    /// `structuredContent` is still emitted. Threading `proxy_mode` into
+    /// `tool_output_schema` in the name of consistency would silently stop that,
+    /// with every other test still green. This is the guard against that refactor.
+    #[test]
+    fn p2_proxy_mode_still_emits_structured_content_without_a_schema() {
+        let proxied = tool_definitions(true);
+        let search = tool_by_name(&proxied, "crw_search");
+        assert!(search.get("outputSchema").is_none());
+
+        let resp = tool_result_response(json!(1), "crw_search", Ok(managed_search_value()));
+        let result = result_of(&resp);
+        assert_eq!(result["structuredContent"], managed_search_value());
+        assert_eq!(
+            serde_json::from_str::<Value>(result["content"][0]["text"].as_str().expect("text"))
+                .expect("text block is the same JSON"),
+            managed_search_value()
+        );
+    }
+
+    /// P3 — why P1 is not cosmetic: neither managed body can satisfy the schema the
+    /// engine declares, so advertising it to a proxy caller is a promise that hard-
+    /// fails the whole call on every strict client. Asserts the SPECIFIC mismatch,
+    /// not merely "some validation error" — a vaguer assertion would keep passing if
+    /// the fixture drifted or the schema started rejecting an unrelated field.
+    /// The managed synchronous extract body has no coverage anywhere else (the
+    /// existing extract locks in `crw-server/tests/mcp.rs` all exercise the ENGINE's
+    /// async accept envelope, which does satisfy the schema).
+    #[test]
+    fn p3_managed_bodies_cannot_satisfy_the_engine_schemas() {
+        // `crw_search`: `data` is an array, the schema demands an object with `results`.
+        let search_errors = schema_errors("crw_search", &managed_search_value());
+        assert!(
+            search_errors
+                .iter()
+                .any(|(path, msg)| path == "/data" && msg.contains("object")),
+            "crw_search: expected `/data` to fail the object requirement, got {search_errors:?}"
+        );
+
+        // `crw_extract`: the engine's accept envelope requires `id`/`status`/`urls`,
+        // none of which a synchronously-resolved managed body carries, and `results`
+        // is rejected outright by `additionalProperties: false`.
+        let extract_errors = schema_errors("crw_extract", &managed_extract_value());
+        let joined = extract_errors
+            .iter()
+            .map(|(p, m)| format!("{p}: {m}"))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        for missing in ["id", "status", "urls"] {
+            assert!(
+                joined.contains(missing),
+                "crw_extract: expected a complaint about the missing `{missing}`, got {joined}"
+            );
+        }
+        assert!(
+            joined.contains("results"),
+            "crw_extract: expected `results` to be rejected by additionalProperties:false, \
+             got {joined}"
+        );
+
+        // And therefore proxy mode must advertise neither.
+        for tool in ["crw_search", "crw_extract"] {
+            assert!(
+                tool_by_name(&tool_definitions(true), tool)
+                    .get("outputSchema")
+                    .is_none(),
+                "{tool}: proxy mode must not advertise a schema it cannot honour"
+            );
+        }
+    }
+
+    /// `(instance_path, message)` for every way `body` fails `tool`'s engine schema.
+    fn schema_errors(tool: &str, body: &Value) -> Vec<(String, String)> {
+        let schema = tool_output_schema(tool).expect("engine declares a schema");
+        let validator = jsonschema::validator_for(&schema).expect("schema compiles");
+        let errors: Vec<(String, String)> = validator
+            .iter_errors(body)
+            .map(|e| (e.instance_path().to_string(), e.to_string()))
+            .collect();
+        assert!(
+            !errors.is_empty(),
+            "{tool}: the managed body was expected to FAIL the engine schema; if this starts \
+             passing the surfaces have converged and the proxy strip can be revisited"
+        );
+        errors
+    }
+
+    /// P4 — the default bound also has to bite on the managed shape. It used to
+    /// silently no-op there, so a `crw_search` with `scrapeOptions` shipped whole
+    /// pages into the model's context.
+    #[test]
+    fn p4_search_inlined_content_is_bounded_on_the_managed_shape() {
+        // Flat: results directly in `data`.
+        let flat = json!({
+            "success": true,
+            "data": [
+                { "url": "https://e.com/1", "markdown": long_md(DEFAULT_MAX_LENGTH + 100) },
+                { "url": "https://e.com/2", "description": "no scrape content" }
+            ]
+        });
+        let out = apply_bounds("crw_search", &json!({}), flat);
+        assert!(
+            out["data"][0]["markdown"]
+                .as_str()
+                .expect("markdown")
+                .contains("[truncated")
+        );
+        assert_eq!(out["data"][0]["truncated"], json!(true));
+        assert!(out["data"][1].get("truncated").is_none());
+
+        // Grouped: `{web,news,images}` directly in `data`.
+        let grouped = json!({
+            "success": true,
+            "data": {
+                "web": [{ "url": "https://e.com/w", "html": long_md(DEFAULT_MAX_LENGTH + 100) }],
+                "news": [{ "url": "https://e.com/n", "description": "short" }]
+            }
+        });
+        let out = apply_bounds("crw_search", &json!({}), grouped);
+        assert_eq!(out["data"]["web"][0]["truncated"], json!(true));
+        assert!(out["data"]["news"][0].get("truncated").is_none());
     }
 }

--- a/crates/crw-server/openapi/openapi-3.0.json
+++ b/crates/crw-server/openapi/openapi-3.0.json
@@ -637,9 +637,92 @@
             "type": "boolean"
           },
           "data": {
+            "description": "Search results. On the hosted API (https://api.fastcrw.com) the results ARE the value of `data`. A self-hosted engine wraps them one level deeper as `data.results`, and carries `answer`/`citations`/`llmUsage`/`warnings` inside `data` instead of at the top level. Clients that must work against both should read `data.results` when present and fall back to `data`.",
+            "anyOf": [
+              {
+                "title": "Flat results",
+                "description": "Returned when `sources` is not set.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SearchResult"
+                }
+              },
+              {
+                "title": "Grouped results",
+                "description": "Returned when `sources` is set.",
+                "type": "object",
+                "properties": {
+                  "web": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "news": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "Self-hosted wrapper",
+                "description": "The self-hosted engine nests the flat or grouped results under `results`.",
+                "type": "object",
+                "required": [
+                  "results"
+                ],
+                "properties": {
+                  "results": {},
+                  "answer": {
+                    "type": "string"
+                  },
+                  "citations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "llmUsage": {
+                    "type": "object"
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "answer": {
+            "type": "string",
+            "description": "Hosted API only — synthesized answer over the top results, present when `answer: true` was set. A self-hosted engine returns this inside `data`."
+          },
+          "citations": {
             "type": "array",
+            "description": "Hosted API only — sources for `answer`, in citation order. A self-hosted engine returns this inside `data`.",
             "items": {
-              "$ref": "#/components/schemas/SearchResult"
+              "type": "object"
+            }
+          },
+          "llmUsage": {
+            "type": "object",
+            "description": "Hosted API only — token usage for the answer synthesis. A self-hosted engine returns this inside `data`."
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Hosted API only — soft-failure notices (e.g. an answer leg that was rate-limited). A self-hosted engine returns this inside `data`.",
+            "items": {
+              "type": "string"
             }
           }
         }

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -1009,9 +1009,92 @@
             "type": "boolean"
           },
           "data": {
+            "description": "Search results. On the hosted API (https://api.fastcrw.com) the results ARE the value of `data`. A self-hosted engine wraps them one level deeper as `data.results`, and carries `answer`/`citations`/`llmUsage`/`warnings` inside `data` instead of at the top level. Clients that must work against both should read `data.results` when present and fall back to `data`.",
+            "anyOf": [
+              {
+                "title": "Flat results",
+                "description": "Returned when `sources` is not set.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SearchResult"
+                }
+              },
+              {
+                "title": "Grouped results",
+                "description": "Returned when `sources` is set.",
+                "type": "object",
+                "properties": {
+                  "web": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "news": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "Self-hosted wrapper",
+                "description": "The self-hosted engine nests the flat or grouped results under `results`.",
+                "type": "object",
+                "required": [
+                  "results"
+                ],
+                "properties": {
+                  "results": {},
+                  "answer": {
+                    "type": "string"
+                  },
+                  "citations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "llmUsage": {
+                    "type": "object"
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "answer": {
+            "type": "string",
+            "description": "Hosted API only — synthesized answer over the top results, present when `answer: true` was set. A self-hosted engine returns this inside `data`."
+          },
+          "citations": {
             "type": "array",
+            "description": "Hosted API only — sources for `answer`, in citation order. A self-hosted engine returns this inside `data`.",
             "items": {
-              "$ref": "#/components/schemas/SearchResult"
+              "type": "object"
+            }
+          },
+          "llmUsage": {
+            "type": "object",
+            "description": "Hosted API only — token usage for the answer synthesis. A self-hosted engine returns this inside `data`."
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Hosted API only — soft-failure notices (e.g. an answer leg that was rate-limited). A self-hosted engine returns this inside `data`.",
+            "items": {
+              "type": "string"
             }
           }
         }

--- a/crates/crw-server/src/routes/extract.rs
+++ b/crates/crw-server/src/routes/extract.rs
@@ -64,8 +64,10 @@ pub struct ExtractRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ExtractStartResponse {
     /// Response envelope carried by every native `/v1` response (and required by
-    /// the MCP `crw_extract` outputSchema, which the stdio/CLI proxies validate
-    /// this body against). Always `true` here — a rejected start is a 4xx error.
+    /// the MCP `crw_extract` outputSchema, which the engine's own `/mcp` advertises
+    /// and emits this body against — proxy mode advertises no schema, since the body
+    /// there comes from a remote we do not author). Always `true` here — a rejected
+    /// start is a 4xx error.
     pub success: bool,
     pub id: String,
     pub status: String,
@@ -268,9 +270,10 @@ impl From<UrlResult> for ExtractUrlResult {
 #[serde(rename_all = "camelCase")]
 pub struct ExtractStatusResponse {
     /// Response envelope carried by every native `/v1` response (and required by
-    /// the MCP `crw_check_extract_status` / `crw_cancel_extract` outputSchema,
-    /// which the stdio/CLI proxies validate this body against). `false` only when
-    /// the whole job failed.
+    /// the MCP `crw_check_extract_status` / `crw_cancel_extract` outputSchema, which
+    /// the engine's own `/mcp` advertises and emits this body against — proxy mode
+    /// advertises no schema, since the body there comes from a remote we do not
+    /// author). `false` only when the whole job failed.
     pub success: bool,
     pub id: String,
     pub status: String,

--- a/docs/agent-onboarding/SKILL.md
+++ b/docs/agent-onboarding/SKILL.md
@@ -37,7 +37,7 @@ npx crw-mcp@latest init      # skill only
 
 ## MCP Tools
 
-> **Output bounds:** By default, content is truncated to ~15 000 chars (`crw_scrape`, `crw_check_crawl_status`, `crw_parse_file`) and `crw_map` returns ≤ 100 URLs. Truncated results carry a `truncated: true` marker (`crw_map` also adds `totalDiscovered`). Pass `maxLength: 0` or `limit: 0` to opt out of bounding.
+> **Output bounds:** By default, content is truncated to ~15 000 chars (`crw_scrape`, `crw_check_crawl_status`, `crw_parse_file`, and any page content inlined into `crw_search` results via `scrapeOptions`) and `crw_map` returns ≤ 100 URLs. Truncated results carry a `truncated: true` marker (`crw_map` also adds `totalDiscovered`). Pass `maxLength: 0` or `limit: 0` to opt out of bounding. `crw_search` does not advertise `maxLength`, so an agent will not discover it, but a hand-written client may still pass it.
 
 ### crw_scrape
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -48,7 +48,7 @@ A credit is the billing unit for the hosted cloud at `fastcrw.com`. Every scrape
 
 ## MCP (Model Context Protocol)
 
-Model Context Protocol is an open standard that lets AI assistants (Claude Code, Claude Desktop, Cursor, Windsurf, Cline, and others) discover and call external tools through a uniform interface. fastCRW ships a built-in MCP server (`crw-mcp`) that exposes 8 tools: `crw_scrape`, `crw_crawl`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_parse_file`, `crw_search`, and `crw_check_crawl_status`. In embedded mode the MCP binary runs the scraping engine inline — no separate server needed. In proxy mode it forwards calls to a remote CRW server (the hosted cloud or your own self-hosted instance). See [MCP Server](/docs/mcp) for setup and [MCP Client Setup](/docs/mcp-clients) for host-specific config snippets.
+Model Context Protocol is an open standard that lets AI assistants (Claude Code, Claude Desktop, Cursor, Windsurf, Cline, and others) discover and call external tools through a uniform interface. fastCRW ships a built-in MCP server (`crw-mcp`) that exposes 9 tools: `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_cancel_extract`, `crw_search`, and `crw_parse_file`. In embedded mode the MCP binary runs the scraping engine inline — no separate server needed. In proxy mode it forwards calls to a remote CRW server (the hosted cloud or your own self-hosted instance). See [MCP Server](/docs/mcp) for setup and [MCP Client Setup](/docs/mcp-clients) for host-specific config snippets.
 
 ---
 

--- a/docs/docs/mcp.md
+++ b/docs/docs/mcp.md
@@ -158,7 +158,7 @@ This yields a ~4.2 MB binary (vs ~17 MB for the default embedded build) because 
 | `crw_search` | Search the web → titles, URLs, descriptions | `POST /v1/search` | Always in proxy mode; embedded only when a search backend is configured |
 | `crw_parse_file` | Parse a local PDF (base64) → markdown | `POST /firecrawl/v2/parse` (multipart) | All modes |
 
-> **Output bounding:** Tool results are bounded by default to keep agent context small. Content fields (markdown/html/etc.) are truncated to ~15 000 chars; `crw_map` returns at most 100 URLs. Truncated responses include `truncated: true` and `totalDiscovered` markers. Pass `maxLength: 0` (scrape / check_status / parse_file) or `limit: 0` (map) to opt out.
+> **Output bounding:** Tool results are bounded by default to keep agent context small. Content fields (markdown/html/etc.) are truncated to ~15 000 chars — including page content inlined into `crw_search` results via `scrapeOptions` — and `crw_map` returns at most 100 URLs. Truncated responses include `truncated: true` and `totalDiscovered` markers. Pass `maxLength: 0` (scrape / check_status / parse_file) or `limit: 0` (map) to opt out. `crw_search` does not *advertise* `maxLength`, so an agent will not discover it, but bounding is applied per-tool from the call's own arguments — a hand-written client may still pass `maxLength: 0` on a search to opt out, or a smaller value to tighten it.
 
 ## Browser Automation (`crw-browse`)
 
@@ -358,7 +358,9 @@ In embedded mode, the scraping engine runs in-process with zero overhead. In pro
 
 Protocol version: `2025-06-18`
 
-The `crw_search` tool declares an `outputSchema` and therefore returns its result both as the usual text content block and as a spec-compliant `structuredContent` object (MCP 2025-06-18) shaped like `{ success, data: { results: [...] } }` — strict clients can validate it directly, while lenient clients keep reading the text block unchanged.
+Every tool call returns its result as a text content block, and tools with a structured result also return it as a spec-compliant `structuredContent` object (MCP 2025-06-18). The two are always the same value, so lenient clients can keep reading the text block unchanged.
+
+An `outputSchema` is advertised by the two surfaces that produce the body themselves — **embedded stdio** and the engine's own **HTTP `/mcp`** — because there the shape is guaranteed. The **stdio proxy** (`crw-mcp --api-url …`) advertises none: `--api-url` can point at a self-hosted engine (which nests the results as `data.results`) or at the hosted API (which puts them directly in `data`), and under MCP 2025-06-18 a declared schema is a promise the server MUST keep — on a mismatch, a strict client rejects the entire call. `structuredContent` is still emitted in proxy mode; there is simply no advertised schema to validate it against. See [response shapes](/response-shapes) for both bodies.
 
 ## Operational Notes
 

--- a/docs/docs/migrate-from-firecrawl.md
+++ b/docs/docs/migrate-from-firecrawl.md
@@ -335,7 +335,8 @@ curl -s -X POST https://api.fastcrw.com/v1/search \
   | python3 -m json.tool | head -30
 ```
 
-Expected: `"data": {"results": [...]}` with search results.
+Expected: `"data": [...]` with search results. (Against a self-hosted engine the same
+call returns `"data": {"results": [...]}` — see [Response shapes](/response-shapes).)
 
 **5. SDK round-trip (Python)**
 

--- a/docs/docs/recipe-mcp-5min.md
+++ b/docs/docs/recipe-mcp-5min.md
@@ -4,7 +4,7 @@ This recipe walks from zero to a working Claude Code agent that can search the w
 
 **Time to complete:** ~5 minutes  
 **Prerequisites:** Node.js 18+, Claude Code installed  
-**Result:** Claude Code gains `crw_search`, `crw_scrape`, `crw_crawl`, `crw_map`, `crw_check_crawl_status`, `crw_extract`, `crw_check_extract_status`, and `crw_parse_file`
+**Result:** Claude Code gains `crw_search`, `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_cancel_extract`, and `crw_parse_file`
 
 ---
 
@@ -20,9 +20,9 @@ claude mcp add crw -- npx -y crw-mcp
 
 Claude Code writes this into your project `.claude/mcp.json` automatically. You are done. Start a new Claude Code session and the tools are available.
 
-> **What you get:** `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_parse_file`. `crw_search` requires a SearXNG backend — use cloud mode to get it instantly.
+> **What you get:** `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_cancel_extract`, `crw_parse_file`. `crw_search` requires a SearXNG backend — use cloud mode to get it instantly.
 
-### Option B: Cloud mode (all 8 tools, including `crw_search`)
+### Option B: Cloud mode (all 9 tools, including `crw_search`)
 
 Get a free API key at [fastcrw.com](https://fastcrw.com) — 500 one-time lifetime credits, no monthly reset.
 
@@ -33,7 +33,7 @@ claude mcp add crw \
   -- npx -y crw-mcp
 ```
 
-This registers the same `crw-mcp` binary in proxy mode. Tool calls are forwarded to `api.fastcrw.com`. All 8 tools are advertised, including `crw_search`.
+This registers the same `crw-mcp` binary in proxy mode. Tool calls are forwarded to `api.fastcrw.com`. All 9 tools are advertised, including `crw_search`.
 
 **Verify it works:**
 
@@ -122,6 +122,8 @@ Claude recognizes it needs live data and calls the search tool first.
 
 Claude now has 5 live search results with titles, URLs, and descriptions. It picks the most informative result to read in full.
 
+> **Response shape note:** the envelope above is the self-hosted engine's — it nests the results as `data.results`. In cloud mode (`CRW_API_URL=https://api.fastcrw.com`) the hosted REST contract puts them **directly in `data`**, i.e. `{"success":true,"data":[{…}]}`. Read `data.results` when present and fall back to `data`. Because the two differ, `crw-mcp` advertises an `outputSchema` for its tools in embedded mode only; in proxy mode it still returns `structuredContent`, just without a schema to validate against. (The engine's own HTTP `/mcp` advertises them too — it produces the body itself.)
+
 ---
 
 ### Turn 2: Claude calls `crw_scrape`
@@ -187,17 +189,18 @@ Claude now has 5 live search results with titles, URLs, and descriptions. It pic
 
 ## Tool reference (MCP)
 
-All 8 tools registered by `crw-mcp`:
+All 9 tools registered by `crw-mcp`:
 
 | Tool | Required params | Returns |
 |------|-----------------|---------|
-| `crw_search` | `query` | `{ success, data: { results: [{title, url, description, position}] } }` |
+| `crw_search` | `query` | `{ success, data: [{title, url, description, position}] }` (cloud); `{ success, data: { results: [...] } }` (self-hosted engine) |
 | `crw_scrape` | `url` | `{ success, data: { markdown, metadata: { sourceURL, title, statusCode, renderedWith } } }` (cloud); `{ markdown, metadata: {...} }` (embedded) |
 | `crw_crawl` | `url` | `{ success, id }` — async job ID |
 | `crw_check_crawl_status` | `id` | `{ status, data: [...], total, completed }` |
 | `crw_map` | `url` | `{ links: ["url1", ...] }` |
 | `crw_extract` | `urls` | `{ success, id }` — async job ID |
 | `crw_check_extract_status` | `id` | `{ status, results: [{url, status, data, error, llmUsage}] }` |
+| `crw_cancel_extract` | `id` | `{ success, id, status, results, creditsUsed, tokensUsed }` |
 | `crw_parse_file` | `contentBase64` | `{ success, data: { markdown } }` |
 
 **Key points:**

--- a/docs/docs/response-shapes.md
+++ b/docs/docs/response-shapes.md
@@ -87,24 +87,46 @@ Use this page when you want the common CRW envelopes in one place. The endpoint 
 
 ## Search
 
-`data` is a wrapper around the actual results. When you do not use any LLM feature, the wrapper still holds the results in `data.results` and the other fields stay empty/null.
+**Two hosts, two shapes — read `data.results` when present, otherwise `data`.** A self-hosted engine wraps the results, as shown below. The hosted API at `api.fastcrw.com` puts the results **directly in `data`** and hoists `answer`, `citations`, `llmUsage` and `warnings` to the top level, so adding `answer: true` never changes `data`'s shape.
+
+`answer`, `citations`, `llmUsage` and `warnings` are **omitted entirely** when they have nothing to report — they are not emitted as `null` or `[]`. A plain self-hosted search is usually just `{"success": true, "data": {"results": [...]}}`. Test with `"answer" in data`, never by truthiness of a key you assume exists.
+
+Two of them appear without any LLM feature being used: `data.warnings` is populated when a search leg degrades, and a top-level `warning` (singular, on the envelope) appears when `scrapeOptions` enrichment fails. Both are routine partial-success signals, not errors — do not assert on the exact key set.
+
+The self-hosted wrapper, with every optional field populated:
 
 ```json
 {
   "success": true,
   "data": {
     "results": <flat array OR grouped object — see below>,
-    "answer": "string or null",
+    "answer": "Synthesized answer over the top results.",
     "citations": [
       { "url": "https://...", "title": "...", "position": 0 }
     ],
-    "llmUsage": { "inputTokens": 3420, "outputTokens": 96, "totalTokens": 3516, "estimatedCostUsd": 0.0008, "model": "gpt-4o-mini", "provider": "openai" },
-    "warnings": []
+    "llmUsage": { "inputTokens": 3420, "outputTokens": 96, "totalTokens": 3516, "estimatedCostUsd": 0.0008, "model": "...", "provider": "..." },
+    "warnings": ["answer synthesis unavailable"]
   }
 }
 ```
 
-`results` shape:
+The hosted equivalent of the same response — same fields, one level higher:
+
+```json
+{
+  "success": true,
+  "data": <flat array OR grouped object — same two shapes as below>,
+  "answer": "Synthesized answer over the top results.",
+  "citations": [
+    { "url": "https://...", "title": "...", "position": 0 }
+  ],
+  "llmUsage": { "inputTokens": 3420, "outputTokens": 96, "totalTokens": 3516 },
+  "warnings": ["answer synthesis unavailable"],
+  "_meta": { "...": "request accounting; present on the LLM path" }
+}
+```
+
+`results` shape (identical on both hosts — only its position differs):
 
 - flat array when `sources` is not set
 - grouped object when `sources` is set

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -75,10 +75,16 @@ resp = requests.post(
 #     json={"query": "web scraping tools", "limit": 5},
 # )
 
+# The results sit directly in `data` on the hosted API; a self-hosted engine
+# nests them one level deeper as `data.results`. Read `results` when present,
+# fall back to `data` — works on both hosts.
+data = resp.json()["data"]
+results = data["results"] if isinstance(data, dict) and "results" in data else data
+
 # Each result row has: title, url, snippet, description, position, score.
 # `snippet` is the LLM-ready summary line (Firecrawl-compatible name);
 # `description` is the same value, kept as an alias.
-for item in resp.json()["data"]:
+for item in results:
     print(item["title"], item["url"], item["snippet"])
 ```
 ::tab{title="Node.js"}
@@ -90,7 +96,10 @@ const resp = await fetch("http://localhost:3000/v1/search", {
 });
 
 const body = await resp.json();
-console.log(body.data);
+// Hosted puts the results directly in `data`; a self-hosted engine nests them
+// as `data.results`. Read `results` when present, fall back to `data`.
+const { data } = body;
+console.log(data?.results ?? data);
 ```
 ::tab{title="cURL"}
 ```bash
@@ -127,9 +136,20 @@ curl -X POST https://api.fastcrw.com/v1/search \
 
 `snippet` is the LLM-ready summary line — name kept identical to Firecrawl
 so existing pipelines work unchanged. `description` is the same value
-under the SearXNG-native name. Pick whichever; both are emitted.
+under the search-backend-native name. Pick whichever; both are emitted.
 
 That is the flat response shape used when `sources` is not set.
+
+:::note
+**Where the results live depends on the host.** The shape of a result row is
+identical everywhere, but its position is not. The hosted API
+(`api.fastcrw.com`) returns the results **as `data` itself**, exactly as shown
+above, and puts `answer`, `citations`, `llmUsage` and `warnings` at the top
+level. A self-hosted engine wraps them one level deeper as `data.results`, with
+those four fields as siblings inside `data`. Portable clients should read
+`data.results` when it is present and fall back to `data`. Full side-by-side in
+[Response shapes](/response-shapes).
+:::
 
 ## Parameters
 
@@ -253,7 +273,9 @@ Each scraped result that produced markdown gets a `result.summary` field. Per-re
 }
 ```
 
-The response wrapper carries:
+A self-hosted engine carries these inside `data`; the hosted API puts `answer`,
+`citations`, `llmUsage` and `warnings` at the top level, next to the results. Fields
+with nothing to report are omitted, not emitted as `null` or `[]`. Self-hosted:
 
 ```json
 {
@@ -265,7 +287,7 @@ The response wrapper carries:
       { "url": "https://...", "title": "...", "position": 0 }
     ],
     "llmUsage": { "inputTokens": 3420, "outputTokens": 96, "totalTokens": 3516, "estimatedCostUsd": 0.0008, "model": "gpt-4o-mini", "provider": "openai" },
-    "warnings": []
+    "warnings": ["answer synthesis unavailable"]
   }
 }
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -307,8 +307,13 @@ Flat response (no sources param):
     }
   }
 
-Grouped response (when sources:["web","news"] set): data.results is a keyed object
+Grouped response (when sources:["web","news"] set): the results are a keyed object
   {"web": [...], "news": [...]}
+
+Two hosts, two positions for the SAME results. A self-hosted engine nests them as
+data.results, alongside answer/citations/llmUsage/warnings. The hosted API at
+api.fastcrw.com puts them directly in data and hoists those four to the top level.
+Portable read: use data.results when present, otherwise data.
 
 ────────────────────────────────────────────────────────────────────────────────
 ### 4.5  POST /firecrawl/v2/parse
@@ -701,7 +706,13 @@ Credit-aware crawl in Python (copy-paste-runnable, stdlib + requests):
   Example:
     resp = requests.post(f"{BASE}/v1/search",
         headers=H, json={"query": "fastCRW web scraping", "limit": 5})
-    for item in resp.json()["data"]["results"]:
+    data = resp.json()["data"]
+    # hosted API returns the results directly in data; a self-hosted engine
+    # nests them one level deeper as data.results. Read results when present,
+    # fall back to data. (With sources set, both forms hold a keyed object
+    # instead of a list — iterate the per-source arrays inside it.)
+    results = data["results"] if isinstance(data, dict) and "results" in data else data
+    for item in results:
         page = requests.post(f"{BASE}/v1/scrape",
             headers=H, json={"url": item["url"], "formats": ["markdown"]})
         print(page.json()["data"]["markdown"][:500])

--- a/docs/openapi-3.0.json
+++ b/docs/openapi-3.0.json
@@ -637,9 +637,92 @@
             "type": "boolean"
           },
           "data": {
+            "description": "Search results. On the hosted API (https://api.fastcrw.com) the results ARE the value of `data`. A self-hosted engine wraps them one level deeper as `data.results`, and carries `answer`/`citations`/`llmUsage`/`warnings` inside `data` instead of at the top level. Clients that must work against both should read `data.results` when present and fall back to `data`.",
+            "anyOf": [
+              {
+                "title": "Flat results",
+                "description": "Returned when `sources` is not set.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SearchResult"
+                }
+              },
+              {
+                "title": "Grouped results",
+                "description": "Returned when `sources` is set.",
+                "type": "object",
+                "properties": {
+                  "web": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "news": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "Self-hosted wrapper",
+                "description": "The self-hosted engine nests the flat or grouped results under `results`.",
+                "type": "object",
+                "required": [
+                  "results"
+                ],
+                "properties": {
+                  "results": {},
+                  "answer": {
+                    "type": "string"
+                  },
+                  "citations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "llmUsage": {
+                    "type": "object"
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "answer": {
+            "type": "string",
+            "description": "Hosted API only — synthesized answer over the top results, present when `answer: true` was set. A self-hosted engine returns this inside `data`."
+          },
+          "citations": {
             "type": "array",
+            "description": "Hosted API only — sources for `answer`, in citation order. A self-hosted engine returns this inside `data`.",
             "items": {
-              "$ref": "#/components/schemas/SearchResult"
+              "type": "object"
+            }
+          },
+          "llmUsage": {
+            "type": "object",
+            "description": "Hosted API only — token usage for the answer synthesis. A self-hosted engine returns this inside `data`."
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Hosted API only — soft-failure notices (e.g. an answer leg that was rate-limited). A self-hosted engine returns this inside `data`.",
+            "items": {
+              "type": "string"
             }
           }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1009,9 +1009,92 @@
             "type": "boolean"
           },
           "data": {
+            "description": "Search results. On the hosted API (https://api.fastcrw.com) the results ARE the value of `data`. A self-hosted engine wraps them one level deeper as `data.results`, and carries `answer`/`citations`/`llmUsage`/`warnings` inside `data` instead of at the top level. Clients that must work against both should read `data.results` when present and fall back to `data`.",
+            "anyOf": [
+              {
+                "title": "Flat results",
+                "description": "Returned when `sources` is not set.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SearchResult"
+                }
+              },
+              {
+                "title": "Grouped results",
+                "description": "Returned when `sources` is set.",
+                "type": "object",
+                "properties": {
+                  "web": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "news": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SearchResult"
+                    }
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                }
+              },
+              {
+                "title": "Self-hosted wrapper",
+                "description": "The self-hosted engine nests the flat or grouped results under `results`.",
+                "type": "object",
+                "required": [
+                  "results"
+                ],
+                "properties": {
+                  "results": {},
+                  "answer": {
+                    "type": "string"
+                  },
+                  "citations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "llmUsage": {
+                    "type": "object"
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "answer": {
+            "type": "string",
+            "description": "Hosted API only — synthesized answer over the top results, present when `answer: true` was set. A self-hosted engine returns this inside `data`."
+          },
+          "citations": {
             "type": "array",
+            "description": "Hosted API only — sources for `answer`, in citation order. A self-hosted engine returns this inside `data`.",
             "items": {
-              "$ref": "#/components/schemas/SearchResult"
+              "type": "object"
+            }
+          },
+          "llmUsage": {
+            "type": "object",
+            "description": "Hosted API only — token usage for the answer synthesis. A self-hosted engine returns this inside `data`."
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Hosted API only — soft-failure notices (e.g. an answer leg that was rate-limited). A self-hosted engine returns this inside `data`.",
+            "items": {
+              "type": "string"
             }
           }
         }

--- a/mcp/crw-mcp/skills/SKILL.md
+++ b/mcp/crw-mcp/skills/SKILL.md
@@ -37,7 +37,7 @@ npx crw-mcp@latest init      # skill only
 
 ## MCP Tools
 
-> **Output bounds:** By default, content is truncated to ~15 000 chars (`crw_scrape`, `crw_check_crawl_status`, `crw_parse_file`) and `crw_map` returns ≤ 100 URLs. Truncated results carry a `truncated: true` marker (`crw_map` also adds `totalDiscovered`). Pass `maxLength: 0` or `limit: 0` to opt out of bounding.
+> **Output bounds:** By default, content is truncated to ~15 000 chars (`crw_scrape`, `crw_check_crawl_status`, `crw_parse_file`, and any page content inlined into `crw_search` results via `scrapeOptions`) and `crw_map` returns ≤ 100 URLs. Truncated results carry a `truncated: true` marker (`crw_map` also adds `totalDiscovered`). Pass `maxLength: 0` or `limit: 0` to opt out of bounding. `crw_search` does not advertise `maxLength`, so an agent will not discover it, but a hand-written client may still pass it.
 
 ### crw_scrape
 

--- a/skills/crw-dynamic-search/SKILL.md
+++ b/skills/crw-dynamic-search/SKILL.md
@@ -129,6 +129,11 @@ For most filtering tasks you want `markdown` (the main content) and
 
 ### MCP `crw_search` output (when using MCP, not CLI)
 
+The results sit in one of two places depending on which backend served the call:
+directly in `data` on the hosted API (`api.fastcrw.com`), or nested as
+`data.results` on a self-hosted engine. Read `data.results` when present and fall
+back to `data`. The nested form:
+
 ```json
 {
   "success": true,


### PR DESCRIPTION
`crw_search` declared an `outputSchema` shaped like the ENGINE's `/v1/search`
(`{success, data:{results}}`). The stdio proxy returns the REMOTE's body verbatim, and
the hosted API's public REST contract puts the results directly in `data`. Under MCP
2025-06-18 a declared schema is a promise the server MUST keep, so the official client
SDKs reject the whole call:

```
MCP error -32602: Structured content does not match the tool's output schema: data/data must be object
```

Reproduced against `api.fastcrw.com` before the fix, and verified gone after.

The same class of bug was already live on a second tool. `crw_extract` advertises the
engine's async accept envelope (`additionalProperties:false`, requires
`{success,id,status,urls}`) while the managed proxy resolves the job synchronously and
returns `{success, results:[...]}` — of the four required fields only `success` is present,
and `results` is rejected outright. Unreported, no workaround anywhere, no test coverage.
That is why the fix is not per-tool.

## Changes

**`tool_definitions` strips every `outputSchema` in proxy mode.** The function already
took `proxy_mode` and discarded it with `let _ = proxy_mode;` — that discard was the bug's
home. In proxy mode `--api-url` may front a self-hosted engine or the hosted API, so no
shape can be promised. Embedded stdio and the engine's own HTTP `/mcp` keep their schemas
untouched: there the body is ours and its shape is locked by tests. Stripping is
spec-legal (`outputSchema` is optional) and costs callers nothing — `structuredContent` is
still emitted, it just carries no advertised schema to validate against. The managed
connector reached the same rule independently (`crw-saas` `managedSearchTool`).

Applied to every tool rather than a name list: a per-tool audit is exactly how
`crw_extract` stayed broken after `crw_search` was already known to be.

**`bound_search_results` now bounds both shapes.** It only ever reached `data.results`, so
on the hosted shape the default 15 KB bound silently no-opped and a `crw_search` with
`scrapeOptions` shipped whole pages into the agent's context. It now reads `results` when
present and falls back to `data`, matching its two sibling helpers `scrape_target_mut` and
`bound_map_links`, which were already dual-shape. `strip_mcp_only_args` also learned to
strip `crw_search`'s `maxLength`, which was being forwarded to the REST body as junk.

**`crw mcp` gained the missing `crw_cancel_extract` proxy arm.** It was advertised in
`tools/list` and answered `unknown tool` — a copy-paste omission against the standalone
`crw-mcp` binary, which has always had it.

**Four tests**, each verified to fail under the mutation it guards: the proxy list carries
no schema; the proxy still emits `structuredContent` without one (the counter-intuitive
half a later "consistency" refactor would silently delete); both managed bodies fail the
engine schemas at the specific instance paths; and the managed search shapes get bounded.

**Docs.** `components.schemas.SearchResponse` documented only the hosted `data: array` while
being `include_str!`'d into the engine that returns `data:{results}` — the engine shipped a
spec that misdescribed the engine, and no CI check could catch it (`check-openapi.sh`
diffs the served spec against the committed one, so both were wrong together). It is now a
three-branch union across all four spec files, with the hosted top-level `answer` /
`citations` / `llmUsage` / `warnings` documented for the first time. The prose pages that
published one shape as universal were corrected, including two copy-pasteable snippets
that raised `TypeError`/`KeyError` against the host they were shown next to.

## Behaviour change worth calling out

Proxy-mode `crw_search` + `scrapeOptions` results over 15,000 chars per field are now
truncated with a `truncated: true` marker. They were not before — that was the bug. The
engine path has always behaved this way and the managed `/mcp` already truncates the same
shape, so this makes the third surface consistent rather than adding a new limit.
`crw_search` still does not advertise `maxLength` (adding it pushes `tools/list` past the
ceiling guarded by `tools_list_token_budget`), but a hand-written client may pass it.

## Delivery

This does not reach prod on merge. Only `proxy_mode` is affected, and the prod engine
serves `proxy_mode = false`. Proxy mode lives in the `crw-mcp` npm package, so users get
it at the next release + npm publish. Interim path for the reporter:
`https://fastcrw.com/mcp/<API_KEY>`, which already drops the `crw_search` schema and works
today.

## Known follow-ups, deliberately not in this PR

- `crw-saas`: the managed `/mcp` re-fetches the ENGINE's `tools/list` (`proxy_mode=false`),
  so this PR cannot reach it. It still needs the same schema drop applied to `crw_extract`,
  and `crw_cancel_extract` added to `MANAGED_TOOL_DENYLIST` (advertised there but
  undispatchable). Verified: landing this PR alone leaves the managed endpoint bit-for-bit
  as it is today, so there is no window where anything gets worse.
- The new `crw_cancel_extract` arm is correct against a self-hosted engine. The hosted API
  has no `/v1/extract/{id}` route, so on the default remote the tool now returns a 404 from
  the remote instead of `unknown tool`. Better, not fixed.
- Realigning the engine's REST `/v1/search` `data` back to a flat array so self-host and
  cloud finally agree. `SearchResponseData` is structurally forced — `SearchData` is
  `#[serde(untagged)]`, so `answer`/`citations`/`llmUsage`/`warnings` cannot be its
  siblings — and flattening means restructuring the shared `ApiResponse<T>` plus a breaking
  REST change for every self-hoster since 2026-05-12. Separate decision.
- Two blog posts still teach `data.results` as universal; they are mirrored into crw-saas,
  so fixing only the opencore copy would create fresh drift.
- The committed static HTML mirrors under `docs/*/index.html` carry the old wording until
  the post-merge regen workflow runs.

ref #391
