### PR TITLE
feat(extract): expand table rowspan/colspan into a flat grid

### DIFF
--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -181,6 +181,10 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         jitter_factor: 0.2,
         deadline_ms_per_page: args.timeout,
         per_host_max_concurrent: 1,
+        normalize_tables: crw_core::config::AppConfig::load()
+            .unwrap_or_default()
+            .extraction
+            .normalize_tables,
     };
 
     let crawl_handle = tokio::spawn(async move {

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -1493,6 +1493,12 @@ pub struct ExtractionConfig {
     /// `max_concurrent_extracts` scales the reserve with it).
     #[serde(default)]
     pub reserved_interactive_extracts: Option<usize>,
+    /// Normalize HTML tables (span expansion, header synthesis, headerless-table promotion) before
+    /// htmd conversion, and stop the indented-code pass from swallowing list-nested tables. Changes
+    /// markdown bytes for any page containing a <table>: this flips /monitor's content hash and can
+    /// reorder the extract alternates ladder on borderline pages. Default false; A/B in prod.
+    #[serde(default)]
+    pub normalize_tables: bool,
 }
 
 fn default_http_retry_threshold() -> usize {
@@ -1522,6 +1528,7 @@ impl Default for ExtractionConfig {
             lightpanda_retry_threshold_bytes: default_lightpanda_retry_threshold(),
             max_concurrent_extracts: default_max_concurrent_extracts(),
             reserved_interactive_extracts: None,
+            normalize_tables: false,
         }
     }
 }

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -44,6 +44,10 @@ pub struct CrawlOptions<'a> {
     /// Cap on concurrent in-flight requests per eTLD+1 host. `1` enforces
     /// strict politeness; raise via config when scraping owned infrastructure.
     pub per_host_max_concurrent: u32,
+    /// From `ExtractionConfig::normalize_tables`. Threaded here so a crawl and
+    /// a single scrape of the same URL produce the same markdown; leaving it
+    /// hardcoded would silently diverge the two paths once the flag is flipped.
+    pub normalize_tables: bool,
 }
 
 /// Validate that a URL is safe to fetch (scheme + host check).
@@ -119,6 +123,7 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         jitter_factor: _,
         deadline_ms_per_page,
         per_host_max_concurrent,
+        normalize_tables,
     } = opts;
 
     let max_depth = req.max_depth.unwrap_or(2).min(10);
@@ -370,6 +375,7 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
                 captured_responses: fetch_result.captured_responses.clone(),
                 debug: false,
                 debug_sink: None,
+                normalize_tables,
             })
             .await
             {

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -285,6 +285,7 @@ async fn scrape_url_inner(
             captured_responses: fr.captured_responses.clone(),
             debug,
             debug_sink: sink,
+            normalize_tables: extraction_cfg.normalize_tables,
         }
     }
     // ── PDF document branch ────────────────────────────────────────────────

--- a/crates/crw-extract/examples/check_prepend.rs
+++ b/crates/crw-extract/examples/check_prepend.rs
@@ -33,6 +33,7 @@ fn main() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
     let md = data.markdown.unwrap();

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -27,6 +27,7 @@ pub mod readability;
 mod responses;
 pub mod selector;
 pub mod structured;
+pub mod table_normalize;
 pub mod tables;
 pub mod untrusted;
 
@@ -142,6 +143,9 @@ pub struct ExtractOptions<'a> {
     /// Sink for debug attempts. Shared across the multi-attempt
     /// JS-escalation loop so that all attempts land in one trace.
     pub debug_sink: Option<Arc<Mutex<DebugCollector>>>,
+    /// Expand table `rowspan`/`colspan` into a flat grid before markdown
+    /// conversion. From `ExtractionConfig::normalize_tables`; ships false.
+    pub normalize_tables: bool,
 }
 
 /// Owned counterpart to [`ExtractOptions`], used to ship an extraction job
@@ -178,6 +182,7 @@ pub struct OwnedExtractInput {
     pub captured_responses: Vec<CapturedNetworkResponse>,
     pub debug: bool,
     pub debug_sink: Option<Arc<Mutex<DebugCollector>>>,
+    pub normalize_tables: bool,
 }
 
 impl OwnedExtractInput {
@@ -211,6 +216,7 @@ impl OwnedExtractInput {
             llm_fallback: None,
             debug: self.debug,
             debug_sink: self.debug_sink.clone(),
+            normalize_tables: self.normalize_tables,
         }
     }
 }
@@ -409,6 +415,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         llm_fallback: _,
         debug: _,
         debug_sink: _,
+        normalize_tables,
     } = opts;
 
     // Per-host fallback selector — used only when the caller didn't pass an
@@ -498,7 +505,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         || formats.contains(&OutputFormat::Json)
         || formats.contains(&OutputFormat::Summary)
     {
-        let primary_md = markdown::html_to_markdown(&content_html);
+        let primary_md = markdown::html_to_markdown_with(&content_html, normalize_tables);
         let primary_quality = quality::analyze_md_only(&primary_md);
 
         // Skip alternates when a selector was explicitly used (short output is
@@ -513,7 +520,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
 
             // Alt 1: cleaned HTML (only_main_content path bypasses readability).
             if only_main_content && let Some(c) = cleaned_ref.as_ref() {
-                let m = markdown::html_to_markdown(c);
+                let m = markdown::html_to_markdown_with(c, normalize_tables);
                 let q = quality::analyze_md_only(&m);
                 candidates.push(("cleaned", m, q));
             }
@@ -536,7 +543,7 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
                 &mut warnings,
             )
             .unwrap_or_else(|_| raw_html.to_string());
-            let basic_md = markdown::html_to_markdown(&basic_cleaned);
+            let basic_md = markdown::html_to_markdown_with(&basic_cleaned, normalize_tables);
             let basic_q = quality::analyze_md_only(&basic_md);
             candidates.push(("basic_clean", basic_md, basic_q));
 

--- a/crates/crw-extract/src/markdown.rs
+++ b/crates/crw-extract/src/markdown.rs
@@ -4,11 +4,35 @@ use std::collections::hash_map::Entry;
 use std::sync::LazyLock;
 
 /// Convert HTML to Markdown using htmd (turndown.js-inspired converter).
+///
+/// Thin wrapper over [`html_to_markdown_with`] with `normalize = false` —
+/// byte-identical to this function's historical behavior. Existing callers
+/// never need to change to pick up table normalization.
 pub fn html_to_markdown(html: &str) -> String {
-    let md = htmd::convert(html).unwrap_or_default();
+    html_to_markdown_with(html, false)
+}
+
+/// Convert HTML to Markdown, optionally normalizing `<table>` elements first.
+///
+/// `normalize = false` is byte-identical to [`html_to_markdown`] (the revert
+/// guarantee for `ExtractionConfig::normalize_tables`). `normalize = true`
+/// expands `rowspan`/`colspan` into a flat grid (`crate::table_normalize`) and
+/// uses the table-safe indented-code pass so a table nested inside a `<li>`
+/// (indented 4 spaces by htmd) isn't swallowed into a fenced code block.
+pub fn html_to_markdown_with(html: &str, normalize: bool) -> String {
+    let html = if normalize {
+        crate::table_normalize::normalize_tables(html)
+    } else {
+        html.to_string()
+    };
+    let md = htmd::convert(&html).unwrap_or_default();
     let md = strip_anchor_artifacts(&md);
     let md = strip_data_uris(&md);
-    convert_indented_code_to_fenced(&md)
+    if normalize {
+        convert_indented_code_to_fenced_table_safe(&md)
+    } else {
+        convert_indented_code_to_fenced(&md)
+    }
 }
 
 /// One markdown link or image.
@@ -142,6 +166,20 @@ static LIST_ITEM_RE: LazyLock<Regex> =
 /// Convert 4-space indented code blocks to fenced (```) code blocks.
 /// Fenced blocks are unambiguous and easier for RAG pipelines to parse.
 fn convert_indented_code_to_fenced(md: &str) -> String {
+    convert_indented_code_to_fenced_impl(md, false)
+}
+
+/// Table-safe variant of [`convert_indented_code_to_fenced`]: a 4-space
+/// indented line that is a GFM pipe-table row or separator (`| --- |`) is
+/// dedented and passed through as-is instead of being folded into a fenced
+/// code block. htmd indents block content inside a `<li>` by exactly 4 spaces
+/// (`ul_bullet_spacing: 3` + 1), so a table normalized inside a list item
+/// would otherwise come out as a fenced block full of literal pipe text.
+fn convert_indented_code_to_fenced_table_safe(md: &str) -> String {
+    convert_indented_code_to_fenced_impl(md, true)
+}
+
+fn convert_indented_code_to_fenced_impl(md: &str, table_safe: bool) -> String {
     let mut result = String::with_capacity(md.len());
     let mut code_lines: Vec<&str> = Vec::new();
     let mut in_fenced = false;
@@ -150,7 +188,14 @@ fn convert_indented_code_to_fenced(md: &str) -> String {
     let mut after_list_item = false;
     let mut run_continues_list = false;
 
-    for line in md.lines() {
+    let lines: Vec<&str> = md.lines().collect();
+    let table_lines = if table_safe {
+        indented_table_line_flags(&lines)
+    } else {
+        vec![false; lines.len()]
+    };
+
+    for (idx, line) in lines.iter().copied().enumerate() {
         // Track existing fenced code blocks to avoid double-fencing.
         if line.trim_start().starts_with("```") {
             in_fenced = !in_fenced;
@@ -173,6 +218,15 @@ fn convert_indented_code_to_fenced(md: &str) -> String {
         let is_blank = line.trim().is_empty();
 
         if is_code_indent {
+            if table_lines[idx] {
+                if !code_lines.is_empty() {
+                    flush_code_block(&mut result, &mut code_lines, run_continues_list);
+                }
+                result.push_str(dedent_code_indent(line).unwrap_or(line));
+                result.push('\n');
+                continue;
+            }
+
             if code_lines.is_empty() {
                 run_continues_list = after_list_item;
             }
@@ -201,6 +255,63 @@ fn convert_indented_code_to_fenced(md: &str) -> String {
     }
 
     result
+}
+
+/// A GFM pipe-table row (`| a | b |`) — including a separator row
+/// (`| --- | :-: |`), which also starts and ends with `|`.
+fn is_gfm_table_line(line: &str) -> bool {
+    let t = line.trim();
+    t.len() >= 2 && t.starts_with('|') && t.ends_with('|')
+}
+
+/// A GFM header separator row: `|` delimited, made only of dashes, colons,
+/// pipes and spaces, and carrying at least one dash.
+fn is_gfm_separator_line(line: &str) -> bool {
+    let t = line.trim();
+    is_gfm_table_line(t)
+        && t.contains('-')
+        && t[1..t.len() - 1]
+            .chars()
+            .all(|c| matches!(c, '-' | ':' | '|' | ' ' | '\t'))
+}
+
+fn dedent_code_indent(line: &str) -> Option<&str> {
+    line.strip_prefix("    ")
+        .or_else(|| line.strip_prefix('\t'))
+}
+
+/// Mark the indented lines that belong to a real pipe table, so the
+/// indented-code pass can pass them through instead of fencing them.
+///
+/// A run only counts as a table when it has at least two consecutive pipe
+/// lines AND one of them is a header separator. A single pipe-looking line
+/// inside genuine indented code (`    | 0 | 1 |` in an ASCII diagram) would
+/// otherwise split that code block into three pieces.
+fn indented_table_line_flags(lines: &[&str]) -> Vec<bool> {
+    let is_indented_pipe = |line: &str| dedent_code_indent(line).is_some_and(is_gfm_table_line);
+
+    let mut flags = vec![false; lines.len()];
+    let mut i = 0;
+    while i < lines.len() {
+        if !is_indented_pipe(lines[i]) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < lines.len() && is_indented_pipe(lines[i]) {
+            i += 1;
+        }
+        let run = &lines[start..i];
+        if run.len() >= 2
+            && run
+                .iter()
+                .filter_map(|l| dedent_code_indent(l))
+                .any(is_gfm_separator_line)
+        {
+            flags[start..i].fill(true);
+        }
+    }
+    flags
 }
 
 fn flush_code_block(result: &mut String, code_lines: &mut Vec<&str>, continues_list: bool) {
@@ -398,5 +509,65 @@ mod tests {
         let html = r#"<p><a href="https://example.com">Link</a></p>"#;
         let md = html_to_markdown(html);
         assert!(md.contains("[Link](https://example.com)"));
+    }
+
+    #[test]
+    fn table_safe_fence_pass_does_not_fence_indented_pipe_table() {
+        let md = "Intro\n\n    | A | B |\n    | - | - |\n    | 1 | 2 |\n";
+        let out = convert_indented_code_to_fenced_table_safe(md);
+        assert!(!out.contains("```"), "pipe table must not be fenced: {out}");
+        assert!(out.contains("| A | B |"));
+        assert!(out.contains("| 1 | 2 |"));
+    }
+
+    #[test]
+    fn table_safe_fence_pass_still_fences_real_indented_code() {
+        let md = "Intro\n\n    fn main() {\n        println!(\"hi\");\n    }\n";
+        let out = convert_indented_code_to_fenced_table_safe(md);
+        assert!(
+            out.contains("```"),
+            "real indented code must still be fenced: {out}"
+        );
+        assert!(out.contains("fn main()"));
+    }
+
+    /// W2: a single pipe-looking line inside genuine indented code used to be
+    /// passed through, splitting one code block into three pieces.
+    #[test]
+    fn table_safe_fence_pass_keeps_code_with_a_single_pipe_line_intact() {
+        let md = "Intro\n\n    fn render() {\n    | col1 | col2 |\n        draw();\n    }\n";
+        let out = convert_indented_code_to_fenced_table_safe(md);
+        assert_eq!(
+            out.matches("```").count(),
+            2,
+            "code block must stay one piece: {out}"
+        );
+        assert!(out.contains("| col1 | col2 |"), "line lost: {out}");
+        assert!(out.contains("fn render()") && out.contains("draw();"));
+    }
+
+    /// W2 guard: two consecutive pipe lines with no separator row are still
+    /// code, not a table.
+    #[test]
+    fn table_safe_fence_pass_needs_a_separator_row() {
+        let md = "Intro\n\n    | a | b |\n    | c | d |\n";
+        let out = convert_indented_code_to_fenced_table_safe(md);
+        assert!(
+            out.contains("```"),
+            "a pipe run with no separator is not a table: {out}"
+        );
+    }
+
+    #[test]
+    fn legacy_fence_pass_still_fences_indented_pipe_lines() {
+        // The ORIGINAL (non-table-safe) pass is the documented bug this PR
+        // fixes only behind the flag: an indented pipe line is still folded
+        // into a fenced code block when `normalize_tables` is off.
+        let md = "Intro\n\n    | A | B |\n    | - | - |\n    | 1 | 2 |\n";
+        let out = convert_indented_code_to_fenced(md);
+        assert!(
+            out.contains("```"),
+            "legacy path keeps fencing indented pipes: {out}"
+        );
     }
 }

--- a/crates/crw-extract/src/markdown.rs
+++ b/crates/crw-extract/src/markdown.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 /// Convert HTML to Markdown using htmd (turndown.js-inspired converter).
 ///
-/// Thin wrapper over [`html_to_markdown_with`] with `normalize = false` —
+/// Thin wrapper over [`html_to_markdown_with`] with `normalize = false` ,
 /// byte-identical to this function's historical behavior. Existing callers
 /// never need to change to pick up table normalization.
 pub fn html_to_markdown(html: &str) -> String {
@@ -62,7 +62,7 @@ const MIN_REPEATED_RUN: usize = 2;
 /// table row, a paragraph or a line of code is never touched, however often it
 /// repeats. The first occurrence always survives.
 ///
-/// Applied only when the caller asked for main content — with
+/// Applied only when the caller asked for main content, with
 /// `onlyMainContent: false` they asked for the document as it is.
 pub fn drop_repeated_nav_lines(md: &str) -> String {
     let lines: Vec<&str> = md.lines().collect();
@@ -112,7 +112,7 @@ pub fn drop_repeated_nav_lines(md: &str) -> String {
             .map(|(j, _)| j)
     };
 
-    // Pass 2: drop a repeat only where the whole block genuinely repeated —
+    // Pass 2: drop a repeat only where the whole block genuinely repeated ,
     // at least two entries in a row, in the same order they first appeared.
     // A lone repeat, or two entries that merely happen to sit together now, is
     // a real cross-listing (the same item catalogued under two categories) and
@@ -257,7 +257,7 @@ fn convert_indented_code_to_fenced_impl(md: &str, table_safe: bool) -> String {
     result
 }
 
-/// A GFM pipe-table row (`| a | b |`) — including a separator row
+/// A GFM pipe-table row (`| a | b |`), including a separator row
 /// (`| --- | :-: |`), which also starts and ends with `|`.
 fn is_gfm_table_line(line: &str) -> bool {
     let t = line.trim();
@@ -323,7 +323,7 @@ fn flush_code_block(result: &mut String, code_lines: &mut Vec<&str>, continues_l
     }
 
     // An indented run that continues a list and holds list items is a nested
-    // list, not code. Emit it untouched — fencing it would strip the markers and
+    // list, not code. Emit it untouched, fencing it would strip the markers and
     // destroy the list. Both conditions are needed: a genuine code block can
     // contain a line that looks like a list item, but it will not follow one.
     if continues_list && code_lines.iter().any(|l| LIST_ITEM_RE.is_match(l)) {
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn nested_lists_are_not_fenced_as_code() {
         // htmd indents nested list items by 4 spaces, which used to be read as
-        // an indented code block — every dropdown menu came back as ``` (#365).
+        // an indented code block, every dropdown menu came back as ``` (#365).
         let html = "<ul><li>Company<ul><li><a href=\"/about\">About</a></li>\
                     <li><a href=\"/awards\">Awards</a></li></ul></li></ul>";
         let md = html_to_markdown(html);
@@ -481,7 +481,7 @@ mod tests {
         let b = "*   [Long terms of service link text](https://example.com/terms/)";
         // The same two entries again, one level deeper: a repeated BLOCK, so the
         // run rule alone would drop it. Keyed on the untrimmed line these are
-        // different lines, so the nested copy survives — which is what makes this
+        // different lines, so the nested copy survives, which is what makes this
         // a guard on the key and not just on the run length.
         let input = format!("{a}\n{b}\n    {a}\n    {b}\n");
         let result = drop_repeated_nav_lines(&input);
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn dedup_leaves_code_blocks_alone() {
-        // The lines are eligible in shape — a markdown sample inside a fence —
+        // The lines are eligible in shape, a markdown sample inside a fence ,
         // so the fence tracking is the only thing keeping them.
         let a = "*   [Where to buy our tiles](https://example.com/where-to-buy/)";
         let b = "*   [Exclusive showrooms near you](https://example.com/showrooms/)";

--- a/crates/crw-extract/src/table_normalize.rs
+++ b/crates/crw-extract/src/table_normalize.rs
@@ -20,10 +20,10 @@
 //! - Pass B (`lol_html`, streaming rewrite): splice each top-level table's
 //!   fresh HTML back into the document in place, correlating by document-order
 //!   index rather than string matching (byte-identical duplicate tables would
-//!   collide on a string search). A depth counter — required because
+//!   collide on a string search). A depth counter, required because
 //!   `lol_html` still dispatches the `table` element handler for elements
 //!   inside a subtree already marked for replacement (verified by
-//!   `nested_table_lol_html_handler_fires_but_is_a_noop` below) — makes sure
+//!   `nested_table_lol_html_handler_fires_but_is_a_noop` below), makes sure
 //!   only depth-0 tables are ever replaced; nested tables are always no-ops
 //!   and stay opaque HTML inside their parent cell.
 //!
@@ -54,7 +54,7 @@ use std::rc::Rc;
 const MAX_SPAN: usize = 1000;
 
 /// Hard ceiling on total expanded grid cells (rows x columns) for one table.
-/// Above it the table is left untouched rather than expanded — 50k cells is
+/// Above it the table is left untouched rather than expanded, 50k cells is
 /// already far beyond any real document table (1000 rows x 50 columns), while
 /// a quadratic blow-up crosses it almost immediately.
 const MAX_GRID_CELLS: usize = 50_000;
@@ -63,7 +63,7 @@ const MAX_GRID_CELLS: usize = 50_000;
 /// `inner_html()`. Wikipedia inlines `<style>` TemplateStyles blocks *inside*
 /// table cells; captured as a cell value, one such block became a 64 KB
 /// "datum", and htmd pads every cell in a column out to that column's widest
-/// cell — so 151 rows each grew a ~64 KB run of spaces (609 KB -> 7.85 MB,
+/// cell, so 151 rows each grew a ~64 KB run of spaces (609 KB -> 7.85 MB,
 /// 97% of it whitespace).
 const CELL_NON_CONTENT_TAGS: [&str; 4] = ["style", "script", "noscript", "template"];
 
@@ -77,7 +77,7 @@ const CELL_NON_CONTENT_MARKERS: [&str; 5] = ["<style", "<script", "<noscript", "
 /// in a single cell means the cell captured something that is not data, and
 /// because htmd pads a column to its widest cell the cost is paid by every row.
 /// Over the ceiling the whole table is left untouched rather than truncated
-/// mid-markup — truncation would emit broken HTML. 4 KB is far above any real
+/// mid-markup, truncation would emit broken HTML. 4 KB is far above any real
 /// datum yet well below the runaway sizes observed on real pages.
 const MAX_CELL_HTML: usize = 4096;
 
@@ -110,8 +110,8 @@ fn cell_inner_html(cell: ElementRef<'_>) -> String {
     }
 }
 
-/// Normalize every top-level `<table>` in `html`, leaving everything else —
-/// including nested tables — byte-for-byte untouched.
+/// Normalize every top-level `<table>` in `html`, leaving everything else ,
+/// including nested tables, byte-for-byte untouched.
 pub fn normalize_tables(html: &str) -> String {
     let replacements = build_replacements(html);
     if replacements.iter().all(Option::is_none) {
@@ -218,7 +218,7 @@ fn build_replacement(table: ElementRef<'_>) -> Option<String> {
 
     // Reconcile the two sections: each grid was only rectangular within itself,
     // so a body row wider than every thead row (or vice versa) would otherwise
-    // serialize with cells that have no column in the other section — htmd then
+    // serialize with cells that have no column in the other section, htmd then
     // drops the overflow entirely.
     let width = thead_grid
         .iter()
@@ -288,13 +288,13 @@ fn parse_span(v: Option<&str>) -> usize {
 /// Grid expansion (pandas `_expand_colspan_rowspan` shape, hardened): a
 /// pending-cell map keyed by column, drained before EVERY column is consumed
 /// so a rowspan already occupying a column always wins over a new real cell
-/// landing there (pandas #58461 / #59721 — a colliding real cell is pushed to
+/// landing there (pandas #58461 / #59721, a colliding real cell is pushed to
 /// the next free column instead of overwriting the pending span). The drain
 /// has to run per column, not per cell: a `colspan` walking across a pending
 /// rowspan's column would otherwise consume the slot the span owns, dropping
 /// the spanned value from this row and re-emitting it a row later.
 ///
-/// Returns `None` when the expanded grid would exceed `MAX_GRID_CELLS` — the
+/// Returns `None` when the expanded grid would exceed `MAX_GRID_CELLS`, the
 /// caller then leaves the table untouched instead of materializing it.
 /// `full_width` is the table's true column count, used only to tell a
 /// full-width banner cell from a narrower header-group cell. Pass 0 to disable
@@ -483,7 +483,7 @@ fn splice_tables(html: &str, replacements: Vec<Option<String>>) -> String {
     // Fail-safe: the two parsers must agree on how many top-level tables the
     // document has. On tag soup (an unclosed `<table>` followed by another)
     // html5ever auto-closes and reports two siblings while `lol_html`'s raw
-    // token stream sees the second nested inside the first — replacing the
+    // token stream sees the second nested inside the first, replacing the
     // first would then swallow the second table's content outright. Any
     // disagreement means the index correlation is unsound, so drop the whole
     // splice and hand back the original bytes.
@@ -539,7 +539,7 @@ mod tests {
     }
 
     /// C3: the pending-rowspan drain ran once per CELL, so a `colspan` walking
-    /// across a pending span's column consumed that slot — the spanned value
+    /// across a pending span's column consumed that slot, the spanned value
     /// vanished from its row and reappeared a row later.
     #[test]
     fn colspan_crossing_a_pending_rowspan_keeps_its_slot() {
@@ -590,7 +590,7 @@ mod tests {
 
         assert!(
             out.len() < html.len() * 3,
-            "output {} bytes vs input {} bytes — quadratic blow-up",
+            "output {} bytes vs input {} bytes, quadratic blow-up",
             out.len(),
             html.len()
         );
@@ -768,7 +768,7 @@ mod tests {
         // Documents the actual lol_html behavior this module depends on:
         // `replace()` on the outer table does NOT suppress the tokenizer from
         // dispatching the `table` element handler for the nested table inside
-        // the replaced subtree — hence the depth counter. If lol_html ever
+        // the replaced subtree, hence the depth counter. If lol_html ever
         // changed this, `replacements` indices would desync and this test
         // would start failing loudly instead of silently mis-splicing.
         let html = r#"<table>
@@ -783,8 +783,8 @@ mod tests {
         let tables: Vec<_> = doc.select(&sel).collect();
         assert_eq!(tables.len(), 2, "outer + nested must both survive: {out}");
         assert!(out.contains("inner-only, no header"));
-        // The nested table must stay exactly as authored — no synthesized
-        // header, no thead — proving it was never independently replaced.
+        // The nested table must stay exactly as authored, no synthesized
+        // header, no thead, proving it was never independently replaced.
         let inner_html = tables[1].html();
         assert!(
             !inner_html.contains("<thead>"),

--- a/crates/crw-extract/src/table_normalize.rs
+++ b/crates/crw-extract/src/table_normalize.rs
@@ -1,0 +1,805 @@
+//! HTML table normalization: `rowspan`/`colspan` expansion into a flat grid,
+//! applied BEFORE the HTML reaches `htmd`.
+//!
+//! GFM pipe tables have no concept of a merged cell. htmd emits one pipe cell
+//! per `<td>`, so every row below a `rowspan` is short by one column and the
+//! values slide left under the wrong headers. Expanding the spans first is what
+//! makes the emitted table row-addressable.
+//!
+//! Deliberately narrow: only tables that already carry a real header (`<thead>`
+//! or a leading run of all-`<th>` rows) are rewritten. Synthesizing a header for
+//! a headerless table was measured on a 15-page corpus (46 data tables) and
+//! fired exactly once, on Hacker News' layout grid, so it is not attempted.
+//!
+//! Two passes, mirroring the `scraper` (read) + `lol_html` (rewrite) split
+//! already used in `clean.rs`:
+//!
+//! - Pass A (`scraper`, read-only): parse the document, expand `rowspan`/
+//!   `colspan` into a full grid for every top-level data `<table>`, and
+//!   serialize a fresh, span-free `<table>` string.
+//! - Pass B (`lol_html`, streaming rewrite): splice each top-level table's
+//!   fresh HTML back into the document in place, correlating by document-order
+//!   index rather than string matching (byte-identical duplicate tables would
+//!   collide on a string search). A depth counter — required because
+//!   `lol_html` still dispatches the `table` element handler for elements
+//!   inside a subtree already marked for replacement (verified by
+//!   `nested_table_lol_html_handler_fires_but_is_a_noop` below) — makes sure
+//!   only depth-0 tables are ever replaced; nested tables are always no-ops
+//!   and stay opaque HTML inside their parent cell.
+//!
+//! The index correlation only holds while both parsers agree on how many
+//! top-level tables the document has, which tag soup can break: html5ever
+//! auto-closes an unclosed `<table>` and reports the next one as a sibling,
+//! while `lol_html`'s raw token stream sees it as nested. Pass B therefore
+//! counts the depth-0 tables it visited and discards the whole splice on any
+//! disagreement, returning the original bytes rather than silently swallowing
+//! a table.
+//!
+//! Gated entirely behind `ExtractionConfig::normalize_tables`; see
+//! `markdown::html_to_markdown_with`.
+
+use crate::tables;
+use lol_html::html_content::{ContentType, EndTag};
+use lol_html::{HandlerResult, RewriteStrSettings, doc_comments, element, rewrite_str};
+use scraper::{ElementRef, Html, Selector};
+use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+/// Upper bound on a single `rowspan`/`colspan` value, so one absurd attribute
+/// (`rowspan="999999999"`) can't allocate a huge row on its own. This does NOT
+/// bound the grid: N rows each carrying a colliding `rowspan` grow the column
+/// count linearly with N, so total cells grow quadratically even at the clamp
+/// value. `MAX_GRID_CELLS` is what actually bounds the grid.
+const MAX_SPAN: usize = 1000;
+
+/// Hard ceiling on total expanded grid cells (rows x columns) for one table.
+/// Above it the table is left untouched rather than expanded — 50k cells is
+/// already far beyond any real document table (1000 rows x 50 columns), while
+/// a quadratic blow-up crosses it almost immediately.
+const MAX_GRID_CELLS: usize = 50_000;
+
+/// Elements that carry no tabular content but do get serialized by
+/// `inner_html()`. Wikipedia inlines `<style>` TemplateStyles blocks *inside*
+/// table cells; captured as a cell value, one such block became a 64 KB
+/// "datum", and htmd pads every cell in a column out to that column's widest
+/// cell — so 151 rows each grew a ~64 KB run of spaces (609 KB -> 7.85 MB,
+/// 97% of it whitespace).
+const CELL_NON_CONTENT_TAGS: [&str; 4] = ["style", "script", "noscript", "template"];
+
+/// Cheap trip-wire: only cells whose serialized HTML contains one of these
+/// substrings pay for the rewrite pass above. Text nodes are escaped on
+/// serialization, so a literal `<style` can only be a real tag.
+const CELL_NON_CONTENT_MARKERS: [&str; 5] = ["<style", "<script", "<noscript", "<template", "<!--"];
+
+/// Upper bound on ONE cell's extracted HTML (after non-content stripping). A
+/// real table datum is a number, a name, a short sentence; kilobytes of markup
+/// in a single cell means the cell captured something that is not data, and
+/// because htmd pads a column to its widest cell the cost is paid by every row.
+/// Over the ceiling the whole table is left untouched rather than truncated
+/// mid-markup — truncation would emit broken HTML. 4 KB is far above any real
+/// datum yet well below the runaway sizes observed on real pages.
+const MAX_CELL_HTML: usize = 4096;
+
+/// Ceiling on the TOTAL expanded cell HTML for one table. `MAX_GRID_CELLS` and
+/// `MAX_CELL_HTML` bound count and per-cell size separately, and their product
+/// still allows roughly 200 MB. 8 MB is far past any real document table.
+const MAX_GRID_BYTES: usize = 8 * 1024 * 1024;
+
+/// A cell's inner HTML with non-content elements and comments removed.
+fn cell_inner_html(cell: ElementRef<'_>) -> String {
+    let raw = cell.inner_html();
+    if !CELL_NON_CONTENT_MARKERS.iter().any(|m| raw.contains(m)) {
+        return raw;
+    }
+    let settings = CELL_NON_CONTENT_TAGS
+        .iter()
+        .fold(RewriteStrSettings::new(), |s, tag| {
+            s.append_element_content_handler(element!(*tag, |el| {
+                el.remove();
+                Ok(())
+            }))
+        })
+        .append_document_content_handler(doc_comments!(|c| {
+            c.remove();
+            Ok(())
+        }));
+    match rewrite_str(&raw, settings) {
+        Ok(stripped) => stripped,
+        Err(_) => raw,
+    }
+}
+
+/// Normalize every top-level `<table>` in `html`, leaving everything else —
+/// including nested tables — byte-for-byte untouched.
+pub fn normalize_tables(html: &str) -> String {
+    let replacements = build_replacements(html);
+    if replacements.iter().all(Option::is_none) {
+        return html.to_string();
+    }
+    splice_tables(html, replacements)
+}
+
+// ─── Pass A: read + grid-expand (scraper) ──────────────────────────────────
+
+fn build_replacements(html: &str) -> Vec<Option<String>> {
+    let doc = Html::parse_document(html);
+    let table_sel = Selector::parse("table").unwrap();
+
+    doc.select(&table_sel)
+        .filter(|table| !is_nested(*table))
+        .map(|table| {
+            // Layout tables (nav shells, newsletter grids) are left alone: they
+            // carry no tabular meaning and rewriting them only churns bytes.
+            tables::is_likely_data_table(table)
+                .then(|| build_replacement(table))
+                .flatten()
+        })
+        .collect()
+}
+
+fn is_nested(table: ElementRef<'_>) -> bool {
+    table.ancestors().any(|node| {
+        node.value()
+            .as_element()
+            .is_some_and(|el| el.name() == "table")
+    })
+}
+
+#[derive(Debug, Clone)]
+struct RawCell {
+    html: String,
+    is_th: bool,
+    rowspan: usize,
+    colspan: usize,
+}
+
+#[derive(Debug, Clone)]
+struct GridCell {
+    html: String,
+    is_th: bool,
+}
+
+fn build_replacement(table: ElementRef<'_>) -> Option<String> {
+    let caption = table
+        .child_elements()
+        .find(|c| c.value().name() == "caption")
+        .map(|c| c.html());
+
+    let mut thead_raw_rows: Vec<Vec<RawCell>> = Vec::new();
+    let mut body_raw_rows: Vec<Vec<RawCell>> = Vec::new();
+
+    for child in table.child_elements() {
+        match child.value().name() {
+            "thead" => {
+                for tr in child.child_elements().filter(|c| c.value().name() == "tr") {
+                    thead_raw_rows.push(extract_cells(tr));
+                }
+            }
+            "tbody" | "tfoot" => {
+                for tr in child.child_elements().filter(|c| c.value().name() == "tr") {
+                    body_raw_rows.push(extract_cells(tr));
+                }
+            }
+            "tr" => body_raw_rows.push(extract_cells(child)),
+            _ => {}
+        }
+    }
+
+    if thead_raw_rows.is_empty() && body_raw_rows.is_empty() {
+        return None;
+    }
+
+    // One oversized cell poisons the whole column (see `MAX_CELL_HTML`), so
+    // bail out on the table as a whole instead of shipping a padded monster.
+    if thead_raw_rows
+        .iter()
+        .chain(body_raw_rows.iter())
+        .flatten()
+        .any(|c| c.html.len() > MAX_CELL_HTML)
+    {
+        return None;
+    }
+
+    // The banner rule needs the table's true width, and a row's own colspans do
+    // not give it: a `rowspan` carried down from an earlier row occupies a
+    // column this row never mentions. Probing with width 0 disables the rule
+    // (it requires `full_width > 1`) so this pass reuses the real column
+    // accounting instead of a second, drift-prone copy of it.
+    let probe_width = expand_grid(&thead_raw_rows, 0)?
+        .iter()
+        .chain(expand_grid(&body_raw_rows, 0)?.iter())
+        .map(Vec::len)
+        .max()
+        .unwrap_or(0);
+
+    let mut thead_grid = expand_grid(&thead_raw_rows, probe_width)?;
+    let mut body_grid = expand_grid(&body_raw_rows, probe_width)?;
+
+    // Reconcile the two sections: each grid was only rectangular within itself,
+    // so a body row wider than every thead row (or vice versa) would otherwise
+    // serialize with cells that have no column in the other section — htmd then
+    // drops the overflow entirely.
+    let width = thead_grid
+        .iter()
+        .chain(body_grid.iter())
+        .map(Vec::len)
+        .max()
+        .unwrap_or(0);
+    if width.saturating_mul(thead_grid.len() + body_grid.len()) > MAX_GRID_CELLS {
+        return None;
+    }
+    pad_rows_to(&mut thead_grid, width);
+    pad_rows_to(&mut body_grid, width);
+
+    // Only tables that already declare a header are rewritten. Without one
+    // there is nothing to align the expanded columns against, and inventing a
+    // header row is worse than leaving the table as htmd found it.
+    let (header, body) = if !thead_grid.is_empty() {
+        (flatten_header_rows(&thead_grid), body_grid)
+    } else {
+        leading_all_th_rows(&body_grid)?
+    };
+
+    Some(serialize_table(caption.as_deref(), header, body))
+}
+
+fn extract_cells(tr: ElementRef<'_>) -> Vec<RawCell> {
+    tr.child_elements()
+        .filter(|c| matches!(c.value().name(), "td" | "th"))
+        .map(|c| RawCell {
+            html: cell_inner_html(c),
+            is_th: c.value().name() == "th",
+            rowspan: parse_span(c.value().attr("rowspan")),
+            colspan: parse_span(c.value().attr("colspan")),
+        })
+        .collect()
+}
+
+/// Drain contiguous pending rowspan cells starting at `col`, placing each into
+/// `row_out` and advancing `col` past it. Stops at the first column with no
+/// pending cell.
+fn drain_pending_at(
+    pending: &mut BTreeMap<usize, (String, bool, usize)>,
+    col: &mut usize,
+    row_out: &mut Vec<GridCell>,
+) {
+    while let Some((html, is_th, rows_left)) = pending.get(col).cloned() {
+        row_out.push(GridCell {
+            html: html.clone(),
+            is_th,
+        });
+        if rows_left <= 1 {
+            pending.remove(col);
+        } else {
+            pending.insert(*col, (html, is_th, rows_left - 1));
+        }
+        *col += 1;
+    }
+}
+
+fn parse_span(v: Option<&str>) -> usize {
+    v.and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0) // colspan="0" / negative / unparseable → treat as 1
+        .unwrap_or(1)
+        .min(MAX_SPAN)
+}
+
+/// Grid expansion (pandas `_expand_colspan_rowspan` shape, hardened): a
+/// pending-cell map keyed by column, drained before EVERY column is consumed
+/// so a rowspan already occupying a column always wins over a new real cell
+/// landing there (pandas #58461 / #59721 — a colliding real cell is pushed to
+/// the next free column instead of overwriting the pending span). The drain
+/// has to run per column, not per cell: a `colspan` walking across a pending
+/// rowspan's column would otherwise consume the slot the span owns, dropping
+/// the spanned value from this row and re-emitting it a row later.
+///
+/// Returns `None` when the expanded grid would exceed `MAX_GRID_CELLS` — the
+/// caller then leaves the table untouched instead of materializing it.
+/// `full_width` is the table's true column count, used only to tell a
+/// full-width banner cell from a narrower header-group cell. Pass 0 to disable
+/// that distinction (used by the width probe in `build_replacement`).
+fn expand_grid(rows: &[Vec<RawCell>], full_width: usize) -> Option<Vec<Vec<GridCell>>> {
+    let mut pending: BTreeMap<usize, (String, bool, usize)> = BTreeMap::new();
+    let mut grid = Vec::with_capacity(rows.len());
+    let mut total_cells = 0usize;
+    let mut total_bytes = 0usize;
+
+    for raw_row in rows {
+        let mut row_out = Vec::new();
+        let mut col = 0usize;
+
+        for cell in raw_row {
+            // Only a `<th>` spanning a SUBSET of the columns is a group label,
+            // which genuinely belongs to each sub-column ("Group / Sub").
+            // A full-width `<th>` is a banner (repeating one turned an
+            // 850-byte election banner into a 7,651-byte line), and a spanning
+            // `<td>` is ONE merged datum: copying "240" across Q1 and Q2 states
+            // that each quarter was 240, which the page never said.
+            let is_banner = full_width > 1 && cell.colspan >= full_width;
+            let repeat_across = cell.is_th && !is_banner;
+            for span_idx in 0..cell.colspan {
+                // A pending span always wins the slot it reserved, so drain
+                // before consuming each individual column.
+                drain_pending_at(&mut pending, &mut col, &mut row_out);
+
+                let html = if span_idx > 0 && !repeat_across {
+                    String::new()
+                } else {
+                    cell.html.clone()
+                };
+                row_out.push(GridCell {
+                    html: html.clone(),
+                    is_th: cell.is_th,
+                });
+                if cell.rowspan > 1 {
+                    pending.insert(col, (html, cell.is_th, cell.rowspan - 1));
+                }
+                col += 1;
+                // Bound the row as it grows, not just once it is finished: a
+                // single `<tr>` of 100 `<td colspan="1000">` is 2 KB of markup
+                // that would otherwise build 100k cells before any check ran.
+                if total_cells + row_out.len() > MAX_GRID_CELLS {
+                    return None;
+                }
+            }
+        }
+
+        // Drain the tail: trailing rowspans continuing past the last real
+        // cell in this row (contiguous from where the real cells left off).
+        drain_pending_at(&mut pending, &mut col, &mut row_out);
+
+        total_cells += row_out.len();
+        total_bytes += row_out.iter().map(|c| c.html.len()).sum::<usize>();
+        // `MAX_GRID_CELLS` and `MAX_CELL_HTML` bound cells and per-cell size
+        // independently, so their product (50k x 4 KB) still permits a ~200 MB
+        // table. Expansion duplicates cell HTML, so the total is what matters.
+        if total_cells > MAX_GRID_CELLS || total_bytes > MAX_GRID_BYTES {
+            return None;
+        }
+        grid.push(row_out);
+    }
+
+    Some(grid)
+}
+
+/// Rectangularize: pad every row out to `width` with empty cells.
+fn pad_rows_to(grid: &mut [Vec<GridCell>], width: usize) {
+    for row in grid.iter_mut() {
+        while row.len() < width {
+            row.push(GridCell {
+                html: String::new(),
+                is_th: false,
+            });
+        }
+    }
+}
+
+/// GFM has no multi-row header: flatten N header rows into one, joining each
+/// column's distinct non-empty values (e.g. "Group / Sub").
+fn flatten_header_rows(rows: &[Vec<GridCell>]) -> Vec<GridCell> {
+    if rows.len() <= 1 {
+        return rows.first().cloned().unwrap_or_default();
+    }
+    let width = rows.iter().map(Vec::len).max().unwrap_or(0);
+    (0..width)
+        .map(|col| {
+            let mut parts: Vec<String> = Vec::new();
+            for row in rows {
+                if let Some(cell) = row.get(col) {
+                    let text = cell.html.trim();
+                    if !text.is_empty() && parts.last().map(|p| p != text).unwrap_or(true) {
+                        parts.push(text.to_string());
+                    }
+                }
+            }
+            GridCell {
+                html: parts.join(" / "),
+                is_th: true,
+            }
+        })
+        .collect()
+}
+
+/// If the body grid opens with a contiguous run of all-`<th>` rows (no real
+/// `<thead>` wrapper, but explicit header markup all the same), promote them.
+fn leading_all_th_rows(body_grid: &[Vec<GridCell>]) -> Option<(Vec<GridCell>, Vec<Vec<GridCell>>)> {
+    let split = body_grid
+        .iter()
+        .position(|row| row.is_empty() || !row.iter().all(|c| c.is_th))?;
+    if split == 0 {
+        return None;
+    }
+    let header = flatten_header_rows(&body_grid[..split]);
+    let body = body_grid[split..].to_vec();
+    Some((header, body))
+}
+
+fn serialize_table(
+    caption: Option<&str>,
+    header: Vec<GridCell>,
+    body: Vec<Vec<GridCell>>,
+) -> String {
+    let mut out = String::from("<table>");
+    if let Some(cap) = caption {
+        out.push_str(cap);
+    }
+    out.push_str("<thead><tr>");
+    for cell in header {
+        out.push_str("<th>");
+        out.push_str(&cell.html);
+        out.push_str("</th>");
+    }
+    out.push_str("</tr></thead>");
+    out.push_str("<tbody>");
+    for row in body {
+        out.push_str("<tr>");
+        for cell in row {
+            out.push_str("<td>");
+            out.push_str(&cell.html);
+            out.push_str("</td>");
+        }
+        out.push_str("</tr>");
+    }
+    out.push_str("</tbody></table>");
+    out
+}
+
+// ─── Pass B: rewrite (lol_html) ─────────────────────────────────────────────
+
+fn splice_tables(html: &str, replacements: Vec<Option<String>>) -> String {
+    let depth = Rc::new(Cell::new(0u32));
+    let index = Rc::new(Cell::new(0usize));
+    let seen = Rc::clone(&index);
+    let expected = replacements.len();
+
+    let handler = element!("table", move |el| {
+        let d = depth.get();
+        if d == 0 {
+            let i = index.get();
+            if let Some(Some(replacement)) = replacements.get(i) {
+                el.replace(replacement, ContentType::Html);
+            }
+            index.set(i + 1);
+        }
+        depth.set(d + 1);
+
+        let depth_end = Rc::clone(&depth);
+        let end_handler: Box<dyn FnOnce(&mut EndTag<'_>) -> HandlerResult + 'static> =
+            Box::new(move |_end| {
+                depth_end.set(depth_end.get().saturating_sub(1));
+                Ok(())
+            });
+        el.on_end_tag(end_handler)?;
+
+        Ok(())
+    });
+
+    let settings = RewriteStrSettings::new().append_element_content_handler(handler);
+    let Ok(out) = rewrite_str(html, settings) else {
+        return html.to_string();
+    };
+
+    // Fail-safe: the two parsers must agree on how many top-level tables the
+    // document has. On tag soup (an unclosed `<table>` followed by another)
+    // html5ever auto-closes and reports two siblings while `lol_html`'s raw
+    // token stream sees the second nested inside the first — replacing the
+    // first would then swallow the second table's content outright. Any
+    // disagreement means the index correlation is unsound, so drop the whole
+    // splice and hand back the original bytes.
+    if seen.get() != expected {
+        return html.to_string();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn normalized_first_table_html(html: &str) -> String {
+        let out = normalize_tables(html);
+        let doc = Html::parse_document(&out);
+        let sel = Selector::parse("table").unwrap();
+        doc.select(&sel).next().expect("no table in output").html()
+    }
+
+    /// A table with no header markup is left byte-for-byte alone. Synthesizing
+    /// a header for one was measured across 46 real data tables and fired once,
+    /// on a site's layout grid, so row 0 is never promoted to column names.
+    #[test]
+    fn headerless_table_is_left_untouched() {
+        let html = r#"<table>
+            <tr><td scope="row">Revenue</td><td>100</td><td>200</td></tr>
+            <tr><td scope="row">Costs</td><td>50</td><td>60</td></tr>
+            <tr><td scope="row">Profit</td><td>50</td><td>140</td></tr>
+        </table>"#;
+        let out = normalize_tables(html);
+        assert_eq!(out, html, "headerless table must not be rewritten");
+    }
+
+    /// C1: thead and body grids were rectangularized independently, so a body
+    /// row wider than the header lost its overflow cells.
+    #[test]
+    fn header_and_body_widths_are_reconciled() {
+        let html = r#"<table>
+            <thead><tr><th>Name</th><th>Score</th></tr></thead>
+            <tbody><tr><td>Alice</td><td>90</td><td>Bonus note</td></tr></tbody>
+        </table>"#;
+        let out = normalized_first_table_html(html);
+        assert!(out.contains("Bonus note"), "wide body cell dropped: {out}");
+        let doc = Html::parse_document(&out);
+        let th = doc.select(&Selector::parse("thead th").unwrap()).count();
+        let td = doc.select(&Selector::parse("tbody td").unwrap()).count();
+        assert_eq!(
+            (th, td),
+            (3, 3),
+            "header and body must share a width: {out}"
+        );
+    }
+
+    /// C3: the pending-rowspan drain ran once per CELL, so a `colspan` walking
+    /// across a pending span's column consumed that slot — the spanned value
+    /// vanished from its row and reappeared a row later.
+    #[test]
+    fn colspan_crossing_a_pending_rowspan_keeps_its_slot() {
+        let html = r#"<table>
+            <thead><tr><th>A</th><th>B</th><th>C</th><th>D</th></tr></thead>
+            <tbody>
+                <tr><td>a1</td><td>b1</td><td rowspan="2">DDD_ROWSPAN</td><td>d1</td></tr>
+                <tr><td colspan="2">wide</td><td>d2</td></tr>
+                <tr><td>a3</td><td>b3</td><td>c3</td><td>d3</td></tr>
+            </tbody>
+        </table>"#;
+        let out = normalize_tables(html);
+        let doc = Html::parse_document(&out);
+        let rows: Vec<Vec<String>> = doc
+            .select(&Selector::parse("tbody tr").unwrap())
+            .map(|tr| {
+                tr.select(&Selector::parse("td").unwrap())
+                    .map(|c| c.inner_html())
+                    .collect()
+            })
+            .collect();
+        assert_eq!(rows[0], vec!["a1", "b1", "DDD_ROWSPAN", "d1"]);
+        assert_eq!(
+            rows[1],
+            vec!["wide", "", "DDD_ROWSPAN", "d2"],
+            "the pending rowspan must claim column 2 in its own row"
+        );
+        assert_eq!(rows[2], vec!["a3", "b3", "c3", "d3"], "no ghost copy");
+    }
+
+    /// C5: colliding rowspans grow the column count linearly with the row
+    /// count, so the grid grows quadratically at ANY `MAX_SPAN` value. The
+    /// total-cell ceiling is what bounds it; over the ceiling the table is
+    /// left untouched.
+    #[test]
+    fn colliding_rowspans_do_not_blow_up_the_grid() {
+        let mut html = String::from("<table><tbody>");
+        for r in 0..400 {
+            html.push_str(&format!(
+                "<tr><td rowspan=\"1000\">g{r}</td><td>v{r}</td></tr>"
+            ));
+        }
+        html.push_str("</tbody></table>");
+
+        let start = std::time::Instant::now();
+        let out = normalize_tables(&html);
+        let elapsed = start.elapsed();
+
+        assert!(
+            out.len() < html.len() * 3,
+            "output {} bytes vs input {} bytes — quadratic blow-up",
+            out.len(),
+            html.len()
+        );
+        assert!(elapsed.as_millis() < 2_000, "took {elapsed:?}");
+        assert!(
+            out.contains("g399"),
+            "data must survive untouched: {out:.200}"
+        );
+    }
+
+    /// C2: html5ever auto-closes an unclosed `<table>` and reports two
+    /// siblings; `lol_html`'s raw token stream sees the second nested inside
+    /// the first. Replacing the first then swallowed the second table's
+    /// content. The count mismatch now aborts the splice.
+    #[test]
+    fn unclosed_table_followed_by_another_loses_no_content() {
+        let html = r#"<div>
+            <table>
+                <thead><tr><th>A</th><th>B</th></tr></thead>
+                <tbody><tr><td>first-1</td><td>first-2</td></tr></tbody>
+            <table>
+                <thead><tr><th>C</th><th>D</th></tr></thead>
+                <tbody><tr><td>SECOND_TABLE_DATA</td><td>second-2</td></tr></tbody>
+            </table>
+        </div>"#;
+        let out = normalize_tables(html);
+        assert!(
+            out.contains("SECOND_TABLE_DATA"),
+            "second table swallowed: {out}"
+        );
+        assert!(out.contains("first-1"), "first table lost: {out}");
+    }
+
+    #[test]
+    fn rowspan_and_colspan_expand_without_losing_cells() {
+        let html = r#"<table>
+            <thead><tr><th colspan="2">Name</th><th>Score</th></tr></thead>
+            <tbody>
+                <tr><td rowspan="2">Alice</td><td>Math</td><td>90</td></tr>
+                <tr><td>Physics</td><td>85</td></tr>
+            </tbody>
+        </table>"#;
+        let out = normalize_tables(html);
+        let doc = Html::parse_document(&out);
+        let tr_sel = Selector::parse("tbody tr").unwrap();
+        let cell_sel = Selector::parse("td").unwrap();
+        let rows: Vec<Vec<String>> = doc
+            .select(&tr_sel)
+            .map(|tr| tr.select(&cell_sel).map(|c| c.inner_html()).collect())
+            .collect();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], vec!["Alice", "Math", "90"]);
+        assert_eq!(rows[1], vec!["Alice", "Physics", "85"]);
+    }
+
+    /// A wide `colspan` is almost always a banner/title row, not repeated data.
+    /// Copying its content into every spanned column turned one 850-byte
+    /// Wikipedia election banner into a 7,651-byte line and inflated the page
+    /// 6.5x. Content belongs in the first slot only.
+    #[test]
+    fn wide_colspan_content_is_not_duplicated_across_columns() {
+        let banner = "BANNER_TEXT";
+        let html = format!(
+            r#"<table>
+            <thead><tr><th>A</th><th>B</th><th>C</th><th>D</th></tr></thead>
+            <tbody>
+                <tr><td colspan="4">{banner}</td></tr>
+                <tr><td>a</td><td>b</td><td>c</td><td>d</td></tr>
+            </tbody>
+        </table>"#
+        );
+        let out = normalize_tables(&html);
+        assert_eq!(
+            out.matches(banner).count(),
+            1,
+            "banner duplicated across its spanned columns: {out}"
+        );
+        let doc = Html::parse_document(&out);
+        let widths: Vec<usize> = doc
+            .select(&Selector::parse("tbody tr").unwrap())
+            .map(|tr| tr.select(&Selector::parse("td").unwrap()).count())
+            .collect();
+        assert_eq!(widths, vec![4, 4], "row must still expand to full width");
+    }
+
+    #[test]
+    fn degenerate_spans_do_not_panic_or_lose_data() {
+        let html = r#"<table>
+            <thead><tr><th>A</th><th>B</th></tr></thead>
+            <tbody>
+                <tr><td rowspan="99">Spans past table end</td><td>1</td></tr>
+                <tr><td colspan="0">Zero colspan</td></tr>
+                <tr><td>Cell with <table><tr><td>nested</td></tr></table> inside</td><td>3</td></tr>
+            </tbody>
+        </table>"#;
+        // Must not panic; must retain all real cell text somewhere in the output.
+        let out = normalize_tables(html);
+        assert!(out.contains("Spans past table end"));
+        assert!(out.contains("Zero colspan"));
+        assert!(out.contains("nested"));
+    }
+
+    #[test]
+    fn irregular_row_lengths_are_padded() {
+        let html = r#"<table>
+            <thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>
+            <tbody>
+                <tr><td>1</td></tr>
+                <tr><td>2</td><td>3</td><td>4</td></tr>
+            </tbody>
+        </table>"#;
+        let out = normalize_tables(html);
+        let doc = Html::parse_document(&out);
+        let tr_sel = Selector::parse("tbody tr").unwrap();
+        let cell_sel = Selector::parse("td").unwrap();
+        let rows: Vec<usize> = doc
+            .select(&tr_sel)
+            .map(|tr| tr.select(&cell_sel).count())
+            .collect();
+        assert_eq!(rows, vec![3, 3], "short row must be padded to full width");
+    }
+
+    #[test]
+    fn tfoot_preserved_as_trailing_body_rows() {
+        let html = r#"<table>
+            <thead><tr><th>Item</th><th>Total</th></tr></thead>
+            <tbody><tr><td>Widget</td><td>10</td></tr></tbody>
+            <tfoot><tr><td>Sum</td><td>10</td></tr></tfoot>
+        </table>"#;
+        let out = normalize_tables(html);
+        let doc = Html::parse_document(&out);
+        let tr_sel = Selector::parse("tbody tr").unwrap();
+        let rows: Vec<String> = doc.select(&tr_sel).map(|tr| tr.inner_html()).collect();
+        assert_eq!(
+            rows.len(),
+            2,
+            "tfoot row must land in tbody as trailing row"
+        );
+        assert!(rows[1].contains("Sum"));
+    }
+
+    #[test]
+    fn table_inside_list_item_becomes_real_table_not_fenced_code() {
+        let html = r#"<ul><li>Intro text
+            <table>
+                <thead><tr><th>A</th><th>B</th></tr></thead>
+                <tbody><tr><td>1</td><td>2</td></tr></tbody>
+            </table>
+        </li></ul>"#;
+        let md = crate::markdown::html_to_markdown_with(html, true);
+        assert!(
+            !md.contains("```"),
+            "table-in-list must not be fenced: {md}"
+        );
+        assert!(
+            md.contains("| A") || md.contains("|A"),
+            "expected a pipe table: {md}"
+        );
+    }
+
+    #[test]
+    fn layout_table_untouched() {
+        let html = r#"<table role="presentation">
+            <tr><td><img src="logo.png"></td></tr>
+            <tr><td>Newsletter content</td></tr>
+        </table>"#;
+        let out = normalize_tables(html);
+        // No thead/th fabricated, no span attributes introduced, structure kept.
+        assert!(!out.contains("<thead>"));
+        assert!(out.contains("Newsletter content"));
+    }
+
+    #[test]
+    fn nested_table_lol_html_handler_fires_but_is_a_noop() {
+        // Documents the actual lol_html behavior this module depends on:
+        // `replace()` on the outer table does NOT suppress the tokenizer from
+        // dispatching the `table` element handler for the nested table inside
+        // the replaced subtree — hence the depth counter. If lol_html ever
+        // changed this, `replacements` indices would desync and this test
+        // would start failing loudly instead of silently mis-splicing.
+        let html = r#"<table>
+            <thead><tr><th>Outer</th></tr></thead>
+            <tbody><tr><td>
+                <table><tr><td>inner-only, no header</td></tr></table>
+            </td></tr></tbody>
+        </table>"#;
+        let out = normalize_tables(html);
+        let doc = Html::parse_document(&out);
+        let sel = Selector::parse("table").unwrap();
+        let tables: Vec<_> = doc.select(&sel).collect();
+        assert_eq!(tables.len(), 2, "outer + nested must both survive: {out}");
+        assert!(out.contains("inner-only, no header"));
+        // The nested table must stay exactly as authored — no synthesized
+        // header, no thead — proving it was never independently replaced.
+        let inner_html = tables[1].html();
+        assert!(
+            !inner_html.contains("<thead>"),
+            "nested table must stay a no-op: {inner_html}"
+        );
+    }
+
+    #[test]
+    fn flag_off_is_byte_identical_to_legacy() {
+        let html = r#"<table>
+            <tr><td scope="row">Revenue</td><td>100</td></tr>
+            <tr><td scope="row">Costs</td><td>50</td></tr>
+        </table>"#;
+        let legacy = crate::markdown::html_to_markdown(html);
+        let gated_off = crate::markdown::html_to_markdown_with(html, false);
+        assert_eq!(legacy, gated_off);
+    }
+}

--- a/crates/crw-extract/tests/extract_tests.rs
+++ b/crates/crw-extract/tests/extract_tests.rs
@@ -28,6 +28,7 @@ fn extract_markdown_format() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -71,6 +72,7 @@ fn extract_images_format_populates_from_raw_html() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -118,6 +120,7 @@ fn extract_all_formats() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -164,6 +167,7 @@ fn extract_metadata_populated() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -198,6 +202,7 @@ fn extract_empty_html() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -234,6 +239,7 @@ fn extract_with_include_exclude_tags() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -277,6 +283,7 @@ fn prepends_metadata_title_when_missing_from_markdown() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -318,6 +325,7 @@ fn does_not_duplicate_title_already_in_markdown() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -361,6 +369,7 @@ fn strips_site_name_suffix_from_title_when_prepending() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -412,6 +421,7 @@ fn preserves_en_dash_inside_title_parentheses() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -459,6 +469,7 @@ fn does_not_prepend_title_when_css_selector_provided() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -508,6 +519,7 @@ fn prepends_title_when_only_domain_selector_applies() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 
@@ -558,6 +570,7 @@ fn extract_markdown(
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap()
 }
@@ -707,6 +720,7 @@ fn elementor_page_with_duplicated_nav_extracts_cleanly() {
         llm_fallback: None,
         debug: false,
         debug_sink: None,
+        normalize_tables: false,
     })
     .unwrap();
 

--- a/crates/crw-extract/tests/table_normalize_regression_tests.rs
+++ b/crates/crw-extract/tests/table_normalize_regression_tests.rs
@@ -1,0 +1,97 @@
+//! Regression tests for `ExtractionConfig::normalize_tables` beyond the
+//! fixture set.
+
+use crw_extract::markdown::html_to_markdown_with;
+use crw_extract::quality;
+
+fn table_bearing_pages() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "financial_report",
+            r#"<article>
+                <h1>Q3 Earnings Report</h1>
+                <p>Quarterly revenue grew across all three regional segments, driven by continued
+                strength in enterprise subscriptions and a rebound in hardware demand following the
+                prior quarter's channel inventory correction.</p>
+                <table>
+                    <thead><tr><th>Segment</th><th>Q1</th><th>Q2</th><th>Q3</th></tr></thead>
+                    <tbody>
+                        <tr><td>Cloud</td><td>120</td><td>135</td><td>150</td></tr>
+                        <tr><td>Hardware</td><td>80</td><td>70</td><td>95</td></tr>
+                        <tr><td>Services</td><td>40</td><td>44</td><td>48</td></tr>
+                    </tbody>
+                </table>
+                <p>Management reaffirmed full-year guidance, citing durable demand in the cloud
+                segment and an improving order backlog for hardware shipments in the fourth quarter.</p>
+            </article>"#,
+        ),
+        (
+            "sports_stats",
+            r#"<article>
+                <h1>Season Standings</h1>
+                <p>With three games remaining in the regular season, the top four playoff spots
+                remain contested among five teams separated by a single game in the standings.</p>
+                <table role="table">
+                    <tr><td scope="row">Falcons</td><td>82</td><td>45</td><td>0.646</td></tr>
+                    <tr><td scope="row">Ravens</td><td>79</td><td>48</td><td>0.622</td></tr>
+                    <tr><td scope="row">Wolves</td><td>76</td><td>51</td><td>0.598</td></tr>
+                    <tr><td scope="row">Bears</td><td>74</td><td>53</td><td>0.583</td></tr>
+                </table>
+                <p>The final week's schedule favors the Falcons, who face two of the league's
+                weakest offenses before closing the season against a depleted divisional rival.</p>
+            </article>"#,
+        ),
+        (
+            "product_spec",
+            r#"<article>
+                <h1>Product Comparison</h1>
+                <p>The updated lineup narrows the gap between the entry and mid-tier models while
+                keeping the flagship's premium materials and extended battery life intact.</p>
+                <table>
+                    <thead><tr><th>Model</th><th>Battery</th><th>Weight</th></tr></thead>
+                    <tbody>
+                        <tr><td>Entry</td><td rowspan="2">18h</td><td>310g</td></tr>
+                        <tr><td>Mid</td><td>295g</td></tr>
+                        <tr><td>Flagship</td><td>22h</td><td>340g</td></tr>
+                    </tbody>
+                </table>
+                <p>Pricing for the mid-tier model undercuts last year's flagship by a wide margin,
+                making it the likely volume driver for the upcoming holiday shopping season.</p>
+            </article>"#,
+        ),
+    ]
+}
+
+/// Alternates-ladder no-flip. Reproduces the specific gating decision at
+/// `crw-extract/src/lib.rs:572-653` — primary quality score vs. the 0.4
+/// skip-alternates threshold — using the real `quality::analyze_md_only`.
+/// Table normalization changes the primary candidate's markdown bytes; this
+/// asserts it does not flip which side of the threshold a table-bearing page
+/// lands on for this corpus. Any flip is printed (not silently swallowed) so
+/// a real regression is investigated rather than papered over.
+#[test]
+fn alternates_ladder_primary_gate_does_not_flip() {
+    const PRIMARY_THRESHOLD: f32 = 0.4;
+    let mut flips = Vec::new();
+
+    for (name, html) in table_bearing_pages() {
+        let primary_off = html_to_markdown_with(html, false);
+        let primary_on = html_to_markdown_with(html, true);
+        let score_off = quality::analyze_md_only(&primary_off).score;
+        let score_on = quality::analyze_md_only(&primary_on).score;
+        let decision_off = score_off > PRIMARY_THRESHOLD;
+        let decision_on = score_on > PRIMARY_THRESHOLD;
+
+        if decision_off != decision_on {
+            flips.push(format!(
+                "{name}: OFF score={score_off:.3} (skip_alternates={decision_off}) vs \
+                 ON score={score_on:.3} (skip_alternates={decision_on})"
+            ));
+        }
+    }
+
+    assert!(
+        flips.is_empty(),
+        "alternates-ladder primary-gate decision flipped for: {flips:#?}"
+    );
+}

--- a/crates/crw-extract/tests/table_normalize_regression_tests.rs
+++ b/crates/crw-extract/tests/table_normalize_regression_tests.rs
@@ -63,8 +63,8 @@ fn table_bearing_pages() -> Vec<(&'static str, &'static str)> {
 }
 
 /// Alternates-ladder no-flip. Reproduces the specific gating decision at
-/// `crw-extract/src/lib.rs:572-653` — primary quality score vs. the 0.4
-/// skip-alternates threshold — using the real `quality::analyze_md_only`.
+/// `crw-extract/src/lib.rs:572-653`, primary quality score vs. the 0.4
+/// skip-alternates threshold, using the real `quality::analyze_md_only`.
 /// Table normalization changes the primary candidate's markdown bytes; this
 /// asserts it does not flip which side of the threshold a table-bearing page
 /// lands on for this corpus. Any flip is printed (not silently swallowed) so

--- a/crates/crw-extract/tests/table_normalize_tests.rs
+++ b/crates/crw-extract/tests/table_normalize_tests.rs
@@ -1,0 +1,399 @@
+//! Fixture tests for `ExtractionConfig::normalize_tables` (PR 1 spec, §Tests
+//! 1-10). Each fixture is checked against BOTH the normalized (`true`) and
+//! legacy (`false`) markdown pipelines; every fixture also gets the flag-OFF
+//! byte-identical check (#10, the revert guarantee).
+
+use crw_extract::markdown::{html_to_markdown, html_to_markdown_with};
+
+/// #10, applied to every other fixture in this file: flag OFF must be
+/// byte-identical to the pre-existing `html_to_markdown` for the same input.
+fn assert_flag_off_is_legacy(html: &str) {
+    assert_eq!(
+        html_to_markdown(html),
+        html_to_markdown_with(html, false),
+        "flag OFF must be byte-identical to the legacy pipeline"
+    );
+}
+
+/// Every pipe row in `md`, trimmed.
+fn pipe_rows(md: &str) -> Vec<&str> {
+    md.lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with('|'))
+        .collect()
+}
+
+/// #1: a table with no header markup is not rewritten at all, on or off. Row 0
+/// is never promoted to column names: measured across 46 real data tables, the
+/// promotion fired once, on a site's layout grid.
+#[test]
+fn fixture_1_headerless_table_is_identical_on_and_off() {
+    let html = r#"<table>
+        <tr><td scope="row">Revenue</td><td>100</td><td>200</td></tr>
+        <tr><td scope="row">Costs</td><td>50</td><td>60</td></tr>
+        <tr><td scope="row">Profit</td><td>50</td><td>140</td></tr>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+    assert_eq!(
+        html_to_markdown_with(html, true),
+        html_to_markdown(html),
+        "a headerless table must be left exactly as the legacy path renders it"
+    );
+}
+
+/// #3: `rowspan` + `colspan` expand into a rectangular grid with no lost
+/// cells and correct column alignment.
+#[test]
+fn fixture_3_rowspan_colspan_rectangular_no_lost_cells() {
+    let html = r#"<table>
+        <thead><tr><th colspan="2">Name</th><th>Score</th></tr></thead>
+        <tbody>
+            <tr><td rowspan="2">Alice</td><td>Math</td><td>90</td></tr>
+            <tr><td>Physics</td><td>85</td></tr>
+        </tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    let table_lines: Vec<&str> = md
+        .lines()
+        .filter(|l| l.trim_start().starts_with('|'))
+        .collect();
+    // header + separator + 2 body rows
+    assert_eq!(table_lines.len(), 4, "expected 4 pipe rows. Got:\n{md}");
+    assert!(table_lines[2].contains("Alice") && table_lines[2].contains("Math"));
+    assert!(table_lines[3].contains("Alice") && table_lines[3].contains("Physics"));
+}
+
+/// #4: degenerate spans (rowspan past table end, colspan="0", a nested table
+/// inside a spanned cell) must not panic and must not lose real data.
+#[test]
+fn fixture_4_degenerate_spans_no_panic_no_data_loss() {
+    let html = r#"<table>
+        <thead><tr><th>A</th><th>B</th></tr></thead>
+        <tbody>
+            <tr><td rowspan="99">Spans past table end</td><td>1</td></tr>
+            <tr><td colspan="0">Zero colspan</td></tr>
+            <tr><td>Cell with <table><tr><td>nested</td></tr></table> inside</td><td>3</td></tr>
+        </tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert!(md.contains("Spans past table end"));
+    assert!(md.contains("Zero colspan"));
+    assert!(md.contains("nested"));
+}
+
+/// #5: irregular row lengths are padded, not misaligned.
+#[test]
+fn fixture_5_irregular_row_lengths_padded() {
+    let html = r#"<table>
+        <thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>
+        <tbody>
+            <tr><td>1</td></tr>
+            <tr><td>2</td><td>3</td><td>4</td></tr>
+        </tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    let pipe_counts: Vec<usize> = md
+        .lines()
+        .filter(|l| l.trim_start().starts_with('|'))
+        .map(|l| l.matches('|').count())
+        .collect();
+    assert!(
+        pipe_counts.len() >= 2,
+        "expected at least a header + row. Got:\n{md}"
+    );
+    let first = pipe_counts[0];
+    assert!(
+        pipe_counts.iter().all(|c| *c == first),
+        "all rows must have the same column count. Got: {pipe_counts:?} in:\n{md}"
+    );
+}
+
+/// #6: `<tfoot>` is preserved as trailing body rows.
+#[test]
+fn fixture_6_tfoot_preserved_as_trailing_rows() {
+    let html = r#"<table>
+        <thead><tr><th>Item</th><th>Total</th></tr></thead>
+        <tbody><tr><td>Widget</td><td>10</td></tr></tbody>
+        <tfoot><tr><td>Sum</td><td>10</td></tr></tfoot>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert!(md.contains("Widget"));
+    assert!(
+        md.contains("Sum"),
+        "tfoot row must survive as a body row. Got: {md}"
+    );
+}
+
+/// #7: a table inside a `<li>` becomes a real pipe table, not a fenced code
+/// block (the §Why-3 indented-code bug).
+#[test]
+fn fixture_7_table_inside_list_item_not_fenced() {
+    let html = r#"<ul><li>Intro text
+        <table>
+            <thead><tr><th>A</th><th>B</th></tr></thead>
+            <tbody><tr><td>1</td><td>2</td></tr></tbody>
+        </table>
+    </li></ul>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert!(
+        !md.contains("```"),
+        "table-in-list must not be fenced. Got: {md}"
+    );
+    assert!(
+        md.contains("| A | B |"),
+        "expected a pipe table header. Got: {md}"
+    );
+    assert!(
+        md.contains("| 1 | 2 |"),
+        "expected a pipe table row. Got: {md}"
+    );
+}
+
+/// #8: a layout table (`role="presentation"`, nested, 1-col) is left
+/// untouched — same output as today regardless of the flag.
+#[test]
+fn fixture_8_layout_table_untouched() {
+    let html = r#"<table role="presentation">
+        <tr><td><img src="logo.png">Header banner<table><tr><td>nested layout</td></tr></table></td></tr>
+        <tr><td>Newsletter content</td></tr>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let normalized = html_to_markdown_with(html, true);
+    let legacy = html_to_markdown_with(html, false);
+    assert_eq!(
+        normalized, legacy,
+        "a layout table must produce identical output regardless of the flag"
+    );
+}
+
+/// #9: a nested table is left opaque; the `lol_html` table handler firing for
+/// it (see `table_normalize::normalize_tables` doc comment) must not cause it
+/// to be independently rewritten or double-processed.
+#[test]
+fn fixture_9_nested_table_opaque_no_double_processing() {
+    let html = r#"<table>
+        <thead><tr><th>Outer</th></tr></thead>
+        <tbody><tr><td>
+            <table><tr><td>inner-only, no header</td></tr></table>
+        </td></tr></tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert!(
+        md.contains("inner-only, no header"),
+        "nested content lost. Got: {md}"
+    );
+}
+
+/// C1: the thead and body grids were rectangularized independently, so a body
+/// row wider than every header row lost its overflow cells before htmd ever
+/// saw them. No spans involved — plain ragged markup.
+#[test]
+fn fixture_c1_body_wider_than_header_loses_no_cell() {
+    let html = r#"<table>
+        <thead><tr><th>Name</th><th>Score</th></tr></thead>
+        <tbody>
+            <tr><td>Alice</td><td>90</td><td>Bonus note</td></tr>
+            <tr><td>Bob</td><td>85</td><td>Second note</td></tr>
+        </tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert!(
+        md.contains("Bonus note"),
+        "third body cell dropped. Got: {md}"
+    );
+    assert!(
+        md.contains("Second note"),
+        "third body cell dropped. Got: {md}"
+    );
+    let widths: Vec<usize> = pipe_rows(&md)
+        .iter()
+        .map(|l| l.matches('|').count())
+        .collect();
+    assert!(
+        widths.windows(2).all(|w| w[0] == w[1]),
+        "every row must share the reconciled width. Got: {widths:?} in {md}"
+    );
+}
+
+/// C2: an unclosed `<table>` immediately followed by another. html5ever
+/// auto-closes and reports two siblings; `lol_html` sees the second nested in
+/// the first. Splicing on that disagreement swallowed the second table.
+#[test]
+fn fixture_c2_unclosed_table_soup_loses_no_table() {
+    let html = r#"<div>
+        <table>
+            <thead><tr><th>A</th><th>B</th></tr></thead>
+            <tbody><tr><td>first-1</td><td>first-2</td></tr></tbody>
+        <table>
+            <thead><tr><th>C</th><th>D</th></tr></thead>
+            <tbody><tr><td>SECONDTABLEDATA</td><td>second-2</td></tr></tbody>
+        </table>
+    </div>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert!(md.contains("first-1"), "first table lost. Got: {md}");
+    assert!(
+        md.contains("SECONDTABLEDATA"),
+        "second table swallowed. Got: {md}"
+    );
+}
+
+/// C3: a `colspan` walking across a pending `rowspan`'s column used to consume
+/// that column, so the spanned value disappeared from its own row and
+/// reappeared as a ghost copy one row later.
+#[test]
+fn fixture_c3_colspan_crossing_pending_rowspan() {
+    let html = r#"<table>
+        <thead><tr><th>A</th><th>B</th><th>C</th><th>D</th></tr></thead>
+        <tbody>
+            <tr><td>a1</td><td>b1</td><td rowspan="2">DDDSPAN</td><td>d1</td></tr>
+            <tr><td colspan="2">wide</td><td>d2</td></tr>
+            <tr><td>a3</td><td>b3</td><td>c3</td><td>d3</td></tr>
+        </tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    // header, separator, then the three body rows.
+    let rows = pipe_rows(&md);
+    assert_eq!(rows.len(), 5, "Got: {md}");
+    assert!(
+        rows[2].contains("DDDSPAN"),
+        "row 1 lost the span. Got: {md}"
+    );
+    assert!(
+        rows[3].contains("DDDSPAN") && rows[3].contains("wide"),
+        "the colspan must not consume the pending span's column. Got: {md}"
+    );
+    assert!(
+        !rows[4].contains("DDDSPAN"),
+        "ghost copy leaked into row 3. Got: {md}"
+    );
+}
+
+/// C5: colliding `rowspan`s make the column count grow with the row count, so
+/// the grid grows quadratically even AT the `MAX_SPAN` clamp. Output size must
+/// stay roughly linear in input size.
+#[test]
+fn fixture_c5_colliding_rowspans_stay_linear() {
+    let mut html = String::from("<table><tbody>");
+    for r in 0..400 {
+        html.push_str(&format!(
+            "<tr><td rowspan=\"1000\">group{r}</td><td>value{r}</td></tr>"
+        ));
+    }
+    html.push_str("</tbody></table>");
+
+    let md = html_to_markdown_with(&html, true);
+    assert!(
+        md.len() < html.len() * 3,
+        "markdown {} bytes from {} bytes of html — quadratic blow-up",
+        md.len(),
+        html.len()
+    );
+    assert!(md.contains("group399"), "data lost. Got {} bytes", md.len());
+}
+
+/// A multi-row header where row 0 is colspan'd group labels. Each sub-column
+/// must keep its group ("Group A / Sub2"), while a FULL-width banner row is
+/// still emitted once rather than repeated across every column.
+#[test]
+fn fixture_c7_colspan_group_header_labels_every_subcolumn() {
+    let html = r#"<table>
+        <thead>
+            <tr><th colspan="5">BANNERROW</th></tr>
+            <tr><th colspan="3">Group A</th><th colspan="2">Group B</th></tr>
+            <tr><th>Sub1</th><th>Sub2</th><th>Sub3</th><th>Sub4</th><th>Sub5</th></tr>
+        </thead>
+        <tbody><tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr></tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    let header = pipe_rows(&md)[0];
+    for sub in ["Sub1", "Sub2", "Sub3"] {
+        assert!(
+            header.contains(&format!("Group A / {sub}")),
+            "{sub} lost its group label. Got: {header}"
+        );
+    }
+    for sub in ["Sub4", "Sub5"] {
+        assert!(
+            header.contains(&format!("Group B / {sub}")),
+            "{sub} lost its group label. Got: {header}"
+        );
+    }
+    assert_eq!(
+        md.matches("BANNERROW").count(),
+        1,
+        "a full-width banner must not repeat across columns. Got: {md}"
+    );
+}
+
+/// A leading `rowspan` column makes the header rows narrower than the table, so
+/// a row's own colspans understate the true width. A `colspan="3"` group in row
+/// 2 of a 4-wide table used to look full-width, get treated as a banner, and
+/// drop its label from every sub-column but the first.
+#[test]
+fn fixture_c8_rowspan_column_does_not_hide_the_true_width() {
+    let html = r#"<table>
+        <thead>
+            <tr><th rowspan="2">Rank</th><th colspan="3">Player Stats</th></tr>
+            <tr><th>Team</th><th>Goals</th><th>Assists</th></tr>
+        </thead>
+        <tbody><tr><td>1</td><td>Ajax</td><td>12</td><td>7</td></tr></tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let header = html_to_markdown_with(html, true);
+    let header = pipe_rows(&header)[0].to_string();
+    for sub in ["Team", "Goals", "Assists"] {
+        assert!(
+            header.contains(&format!("Player Stats / {sub}")),
+            "{sub} lost its group label, true width was misread. Got: {header}"
+        );
+    }
+}
+
+/// A merged DATA cell is one value covering a range, not a value each column
+/// holds. Copying "240" into both Q1 and Q2 would state that each quarter was
+/// 240, which the page never said. Only a `<th>` group label repeats.
+#[test]
+fn fixture_c9_merged_data_cell_is_not_copied_across_columns() {
+    let html = r#"<table>
+        <thead><tr><th>Region</th><th>Q1</th><th>Q2</th></tr></thead>
+        <tbody>
+            <tr><td>North</td><td colspan="2">240 combined</td></tr>
+            <tr><td>South</td><td>50</td><td>60</td></tr>
+        </tbody>
+    </table>"#;
+    assert_flag_off_is_legacy(html);
+
+    let md = html_to_markdown_with(html, true);
+    assert_eq!(
+        md.matches("240 combined").count(),
+        1,
+        "a merged datum must not be duplicated per column. Got: {md}"
+    );
+    assert!(md.contains("North"), "row lost. Got: {md}");
+    assert!(
+        md.contains("50") && md.contains("60"),
+        "row lost. Got: {md}"
+    );
+}

--- a/crates/crw-extract/tests/table_normalize_tests.rs
+++ b/crates/crw-extract/tests/table_normalize_tests.rs
@@ -160,7 +160,7 @@ fn fixture_7_table_inside_list_item_not_fenced() {
 }
 
 /// #8: a layout table (`role="presentation"`, nested, 1-col) is left
-/// untouched — same output as today regardless of the flag.
+/// untouched, same output as today regardless of the flag.
 #[test]
 fn fixture_8_layout_table_untouched() {
     let html = r#"<table role="presentation">
@@ -199,7 +199,7 @@ fn fixture_9_nested_table_opaque_no_double_processing() {
 
 /// C1: the thead and body grids were rectangularized independently, so a body
 /// row wider than every header row lost its overflow cells before htmd ever
-/// saw them. No spans involved — plain ragged markup.
+/// saw them. No spans involved, plain ragged markup.
 #[test]
 fn fixture_c1_body_wider_than_header_loses_no_cell() {
     let html = r#"<table>
@@ -303,7 +303,7 @@ fn fixture_c5_colliding_rowspans_stay_linear() {
     let md = html_to_markdown_with(&html, true);
     assert!(
         md.len() < html.len() * 3,
-        "markdown {} bytes from {} bytes of html — quadratic blow-up",
+        "markdown {} bytes from {} bytes of html, quadratic blow-up",
         md.len(),
         html.len()
     );

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -475,6 +475,7 @@ impl AppState {
         let jitter_factor = self.config.crawler.stealth.jitter_factor;
         let deadline_ms_per_page = self.config.effective_deadline_ms(None, req.wait_for);
         let per_host_max_concurrent = self.config.crawler.per_host_max_concurrent;
+        let normalize_tables = self.config.extraction.normalize_tables;
 
         let handle = tokio::spawn(async move {
             let _permit = match crawl_semaphore.acquire().await {
@@ -512,6 +513,7 @@ impl AppState {
                         jitter_factor,
                         deadline_ms_per_page,
                         per_host_max_concurrent,
+                        normalize_tables,
                     })
                     .await;
                 })


### PR DESCRIPTION
Expands HTML table `rowspan`/`colspan` into a flat grid before the HTML reaches htmd.

GFM pipe tables have no merged cell. htmd emits one pipe cell per `<td>`, so every row under a `rowspan` comes out short a column and its values slide left under the wrong headers. Expanding the spans first is what makes the emitted table row-addressable.

**Ships OFF** (`extraction.normalize_tables`, default false). Turning it on requires the 1000-URL truth-recall run first, which could not be run in this environment.

## The rule that matters: a spanned cell is not always repeatable

An earlier revision of this branch copied a spanning cell's content into every column it covered. On a merged data cell that fabricates numbers:

```html
<tr><td>North</td><td colspan="2">240 combined</td></tr>
```

became `| North | 240 combined | 240 combined |`, which states that Q1 was 240 and Q2 was 240, when the page said the pair totalled 240. This output is fed to an LLM. It does not fail loudly; it produces a confident wrong number that an agent then cites downstream. That is the worst class of bug this codebase can ship.

**This bug never existed on main.** It was introduced by this branch and caught before landing, by a review round plus a failing test written before the fix.

The rule the branch settled on:

- A `<th>` spanning a SUBSET of columns is a group label. It repeats, because it genuinely labels every column it covers, which keeps "Group / Sub" header names intact.
- A full-width `<th>` is a banner. First slot only. Repeating one turned an 850-byte election banner into a single 7,651-byte line.
- A spanning `<td>` is one merged value. First slot only, always.

Covered by `fixture_c9`.

A second defect of the same family: `full_width` was computed as the max per-row sum of colspans, which ignores a column held by a `rowspan` carried down from an earlier row. So `<th rowspan="2">Rank</th><th colspan="3">Player Stats</th>` read as width 3 rather than 4, the group looked full-width, and "Player Stats" was dropped from Goals and Assists. Fixed by reusing `expand_grid` itself as the width probe rather than hand-rolling a second copy of the column accounting, because that second copy is exactly what drifts later. Covered by `fixture_c8`.

## Measured

Pipeline `clean -> readability -> markdown`, on latest main.

Raw byte counts are misleading here and both numbers are given: 60-90% of the markdown on table-heavy pages is column-alignment padding that htmd emits to align pipe tables, and it is present with the flag both on and off. "Content" is raw minus bytes in runs of 3+ spaces.

| page | raw | content | distinct tokens |
|---|---|---|---|
| Wikipedia David Sweet | +41% | +30% | 1150 -> 1344 |
| Wikipedia chemical elements | +470% | +541% | 292 -> 1531 |
| Wikipedia comparison of web browsers | +9% | +107% | 1818 -> 2006 |
| Wikipedia S&P 500 list | +39% | +33% | |
| Wikipedia Rust article (no data tables) | 0% | 0% | unchanged |

Distinct-token counts are immune to duplication. On the elements page they move together with content (+541% / +424%), the signature of genuinely new text: with the flag off that page loses its entire element table (`Praseodymium`, 0 occurrences off, 1 on). On comparison-of-web-browsers the pairing is weaker (+107% content against +10% tokens), which is consistent with `rowspan` fill-down repeating existing labels into cells that were previously empty rather than with new content. Per page, not a generalisation.

Caveats: the sample is 15 pages and Wikipedia-dominated, and Wikipedia's `<thead>`/`<th>` convention is exactly what clears the data-table threshold, so this measures the feature where it fires most reliably rather than across the open web. None of it speaks to truth-recall, which is why the flag ships off.

**What this does NOT fix:** the David Sweet infobox case this work was originally started for. That infobox already uses `<th>`, so it was never the headerless path. The target fact sits at the same offset with the flag on and off.

## Scope

Only tables that already declare a header (`<thead>`, or a leading run of all-`<th>` rows) are rewritten. No header is ever synthesized.

## Two changes that look like scope creep and are not

**`CrawlOptions` gains a field.** The crawl path had no `ExtractionConfig` in scope. Hardcoding `false` there would mean that the moment the flag flips, a crawl and a single scrape of the same URL produce different markdown and therefore different `/monitor` content hashes. That divergence would surface later as phantom change-detection alerts and be miserable to trace back to a flag default.

**All three markdown call sites in `extract()` change together.** Normalizing the primary candidate but not the `cleaned` / `basic_clean` alternates would make the ladder rank a normalized candidate against unnormalized ones, corrupting the exact gate the regression test guards.

## Bounds

`MAX_GRID_BYTES` (8 MiB) bounds total expanded cell HTML. The pre-existing `MAX_GRID_CELLS` (50k) and `MAX_CELL_HTML` (4 KB) bounded count and per-cell size independently, and their product still permitted roughly a 200 MB table; expansion duplicates cell HTML, so the total is what matters. The count guard now also runs as a row grows rather than only after it finishes, since one `<tr>` of 100 `<td colspan="1000">` is about 2 KB of markup that previously built 100k cells before any check fired.

Not addressed here: there is no per-document cap on table count. Pre-existing rather than introduced by this change, since the current pipeline already runs htmd over every table on the page, and a document-level budget wants its own tuning.

## Also in this branch

`crates/crw-extract/src/tables.rs` is untouched. An earlier draft added seven heuristic scoring signals plus headerless header synthesis; measured across 15 pages and 46 data tables the synthesis fired once, on a site's layout grid, and changed nothing, so it is gone. The data/layout gate is now `tables::is_likely_data_table`, which already existed with no callers.

## Deploy caveat

A merge to `main` reaches production within about an hour (CI -> `bump-saas-pin.yml` -> deploq -> engine rebuild from the pinned SHA). It is not release-gated. Shipping off means this merge is inert; the quality gate applies to flipping the flag, not to merging.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build`, `cargo test --workspace` all pass: 1566 tests across 86 suites, 0 failures.

The `expand_grid` fix was mutation-checked: forcing the banner branch off makes `fixture_c7` fail with the visible corruption `| BANNERROW / Group A / Sub1 | BANNERROW / Group A / Sub2 | ...`, so the test genuinely guards the behavior.

ref #292