### PR TITLE
perf(renderer): cut chrome challenge retries from 3 to 1

### DIFF
--- a/config.docker.toml
+++ b/config.docker.toml
@@ -56,6 +56,31 @@ chrome_intercept_resources = true
 # partial-DOM snapshot is returned with truncated=true.
 chrome_nav_budget_ms = 12000
 
+# Post-navigate challenge retry loop, cut from the default 3 to 1.
+#
+# A/B measured 2026-06-21 (plans/PHASE-RESULTS-2026-06-21.md, same binary, same
+# config, this knob alone): scrape-success 90% -> 90%, truth-recall 67.57% ->
+# 67.57%, median markdown 7816 -> 8218, and p90 23857 -> 20314 (-15%, -3543ms).
+# `quality_gate.py` verdict: PASS, 0 new failures, 0 content drops.
+#
+# The render-phase breakdown attributes 28% of render time to this loop (mean
+# 1028ms, p90 7209ms), and the pages that burn the full 3x3s never clear anyway,
+# so one retry loses nothing and keeps the fast-clearing CF challenges. Neither
+# Firecrawl (defaultWait=0, no retry loop) nor Spider runs a blind challenge
+# retry; we were the only one.
+#
+# The 2026-06-21 run recommended this for prod and it was never applied, so prod
+# ran the default 3 until now. Not set to 0 (Firecrawl-style) deliberately: 1
+# still clears a challenge that resolves on the first re-check.
+#
+# This knob is shared by both the `chrome` and `chrome_proxy` renderer tiers
+# (crw-renderer/src/lib.rs). The A/B above only exercised `chrome`; no
+# [renderer.chrome_proxy] tier is configured in this file, so retries=1 has no
+# effect on residential-egress recovery today. Re-validate before enabling
+# chrome_proxy: a challenge over a fresh residential IP may need more than one
+# re-check to clear.
+chrome_challenge_max_retries = 1
+
 # Phase 4 §B5: bounded browser-context pool. Validated 2026-05-11
 # (PROGRESS.md gap-closure): cookie/storage isolation T1 PASS, B2 sanity
 # ratio < 2× (T2), RSS soak chrome 1.08× over 500 reqs (T3), TOML flip


### PR DESCRIPTION
## Summary

- Sets `chrome_challenge_max_retries = 1` in `config.docker.toml` (default
  is 3, `crates/crw-renderer/src/cdp.rs`). Governs the post-navigate
  Cloudflare-challenge poll loop on both the `chrome` and `chrome_proxy`
  renderer tiers (`crates/crw-renderer/src/lib.rs`).
- Reapplies a measured-but-never-shipped tuning value: an A/B on
  2026-06-21 (`plans/PHASE-RESULTS-2026-06-21.md`, N=100, same
  binary/config, this knob alone) found cutting retries 3 -> 1 is
  quality neutral with a real p90 win: scrape-success 90% -> 90%,
  truth-recall 67.57% -> 67.57% (both identical), median markdown
  length 7816 -> 8218 (slightly higher), p90 23857ms -> 20314ms (-15%,
  -3543ms). `quality_gate.py` verdict: PASS, 0 new failures, 0 content
  drops. It was recommended for prod at the time and never applied.
- Change is scoped to `config.docker.toml` only, matching the existing
  pattern for sibling perf knobs (`chrome_nav_budget_ms` is also
  docker-only, absent from `config.default.toml`). Did not touch
  `config.default.toml` (self-host default) since the A/B only covered
  the docker/prod path.

## Open questions for follow-up (not changed here)

- `config.stealth.toml` sets `chrome_nav_budget_ms` but not
  `chrome_challenge_max_retries`. Left it alone since the 2026-06-21
  measurement didn't cover that profile; flagging in case it should be
  aligned.
- `crates/crw-core/src/config.rs:213-214` has a doc comment on
  `CLOAK_ARM_FLOOR_MS` (added by the newer cloak CF-recovery-arm
  feature) noting "the 24s margin assumes chrome_challenge_max_retries
  stays OFF (prod default)". Traced the actual gate
  (`deadline.remaining() >= floor + reserve`, `crates/crw-renderer/src/lib.rs:1456`):
  it depends on real wall-clock time the ladder burns, which is lower
  with fewer retries, so cutting retries 3 -> 1 makes this floor
  strictly easier to clear, not harder. The risk that comment warns
  about only applies to raising the knob above the default, not
  lowering it. Also, `cloak_recover_on_cf` defaults to `false` and
  isn't set anywhere in `config.docker.toml`, so this interaction isn't
  live via this config file today regardless. Not editing that comment
  here since it's outside the scope of this docker-config change; noting
  it so the two aren't independently "corrected" out of sync later.
- A dedicated `bench/recovery.py` / 170-URL gold set referenced in
  earlier discussion of this work is not present in this worktree (only
  a stale, gitignored `bench/__pycache__/recovery.cpython-314.pyc`
  remnant survives). Not recreating it; the existing
  `plans/PHASE-RESULTS-2026-06-21.md` A/B is the evidence for this PR.

## Deploy caveat

opencore `main` is not release-gated: a merge reaches production within
about an hour (CI -> `bump-saas-pin.yml` -> deploq -> engine rebuild
from the pinned SHA). The benchmark gate above needs to hold before
merge, since merge effectively means prod.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo build`
- [x] `cargo test --workspace` (1567 passed, 23 ignored)