### PR TITLE
fix(renderer): attribute nav-budget log to the real renderer tier

### DIFF
--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -2658,10 +2658,16 @@ impl CdpRenderer {
                 Ok(Ok(html)) => (html, false),
                 Ok(Err(err)) => return Err(err),
                 Err(_) => {
+                    // Name the tier that actually ran out, for the same reason
+                    // `budget_truncated_warning()` does: this struct drives every
+                    // CDP-speaking renderer, so a hardcoded "chrome" blamed Chrome
+                    // for LightPanda's much smaller budget and sent anyone reading
+                    // the logs to the wrong tier.
                     tracing::info!(
                         url,
+                        renderer = %self.name,
                         budget_ms = nav_budget.as_millis() as u64,
-                        "chrome nav budget hit; attempting partial snapshot"
+                        "nav budget hit; attempting partial snapshot"
                     );
                     let _ = conn
                         .send_recv(


### PR DESCRIPTION
## Summary
- The nav-budget-hit log line in `CdpRenderer::fetch_with_js` hardcoded `"chrome"` in its message regardless of which CDP renderer tier actually timed out (chrome, lightpanda, playwright, chrome_proxy all share this struct).
- LightPanda's own much smaller nav budget was being misattributed to Chrome in that log line, which is the one operators read first when diagnosing slow scrapes. Observed ~364 occurrences/24h in production.
- Adds a `renderer = %self.name` field and drops the hardcoded word from the message text, mirroring the same `self.name`-based pattern already used by `budget_truncated_warning()`.
- Pure log-attribution fix: no control flow, timing, or metric changes. Grepped the file and its neighbours for other hardcoded per-renderer "chrome" strings; found none beyond the two static Prometheus metric identifiers (`chrome_navigate_seconds`, `chrome_budget_truncated_total`), which are out of scope (renaming those is a metric-schema/dashboard-breaking change, not a log-string fix).

## Deploy note
A merge to opencore `main` reaches production within about an hour via the existing CI -> pin-bump -> deploq pipeline; it is not release-gated.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo build`
- [x] `cargo test --workspace` (1567 passed, 23 ignored, 0 failed)
- No new test added: pure log-string change with zero new logic branches. The existing `budget_truncated_warning_names_the_tier_that_ran_out` test already proves `self.name` differs correctly between chrome/lightpanda instances via the same real construction path this fix reads from.