### PR TITLE
fix(renderer): classify a blackholed origin with a hung proxy rescue as unreachable

### DIFF
--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -488,6 +488,10 @@ impl PageFetcher for HttpFetcher {
         };
         let mut use_proxy = proxy_first;
         let mut direct_rescue_used = false;
+        // Set when the DIRECT egress got NOTHING back from the origin: a connect-phase
+        // timeout, i.e. the blackholed SYN. See where it is set for why the shape is
+        // narrowed that far and why the 422 below depends on it.
+        let mut direct_connect_failed = false;
         // Set when the proxy is armed MID-LOOP (by a 429 or a header-announced
         // challenge) rather than by the latch. Such an attempt needs the same
         // direct-rescue guarantee the latched path gets, or a hung proxy turns a
@@ -601,6 +605,35 @@ impl PageFetcher for HttpFetcher {
                     direct_rescue_used = true;
                 }
                 Err(_) => {
+                    // The origin blackholed our direct SYNs and the proxy rescue then
+                    // failed to overturn that, so the original finding stands: nothing
+                    // answered for this URL. The verdict rests on the direct blackhole,
+                    // never on the proxy hang alone.
+                    //
+                    // Without this the class surfaced as `Timeout` -> 504, which pages
+                    // the 5xx watchdog as OUR outage, tells the caller to raise a
+                    // `timeout` for a host with no listening socket, and bills them. The
+                    // 422 path already refunds; it was simply unreachable once the proxy
+                    // retry was armed in front of it. `Ok(Err(_))` below still keeps a
+                    // fast-refusing proxy at 502 (`proxy_connect_failure_is_not_blamed_
+                    // on_the_caller`), so a dead pool cannot land here either.
+                    if direct_connect_failed {
+                        // Logged at this specific classification (rather than relying on the
+                        // generic 422 count) so a spike here is greppable on its own: this is
+                        // the one 422 shape that used to be a paging 504, so if it is ever OUR
+                        // fault (e.g. host-level starvation delaying both egresses' timers
+                        // alike) rather than a genuinely dead target, this line is how an
+                        // operator tells the two apart instead of the alert going quiet.
+                        tracing::warn!(
+                            url,
+                            "direct connect-timeout and proxy rescue both failed; \
+                             reporting target_unreachable (was: timeout)"
+                        );
+                        return Err(CrwError::TargetUnreachable(format!(
+                            "Could not reach {url}: no response from the origin over \
+                             either egress"
+                        )));
+                    }
                     return Err(CrwError::Timeout(remaining.as_millis() as u64));
                 }
                 Ok(Ok(r))
@@ -765,6 +798,22 @@ impl PageFetcher for HttpFetcher {
                         "direct egress could not reach {url} ({e}); retrying via proxy (egress_blocked)"
                     );
                     use_proxy = true;
+                    // Deliberately narrower than this arm's own guard. Only a
+                    // connect-phase TIMEOUT counts: we sent SYNs straight at the origin
+                    // and got zero packets back, which is a first-hand observation of
+                    // the ORIGIN, not an inference about the hop after it. A refused or
+                    // reset connection is excluded even though it also lands here,
+                    // because an RST proves a live TCP stack answered.
+                    //
+                    // That distinction is what makes the 422 below safe. A congested
+                    // (rather than down) proxy pool HANGS exactly like a proxy waiting
+                    // on a dead origin, so the hang on its own proves nothing; if the
+                    // verdict rested on it, our own pool degrading would be laundered
+                    // into a flood of caller-blaming refunds and the 5xx watchdog would
+                    // go quiet during a real outage. Requiring the direct blackhole
+                    // first means proxy congestion alone can never reach 422: a healthy
+                    // origin answers the direct attempt and the proxy is never armed.
+                    direct_connect_failed = e.is_connect() && e.is_timeout();
                 }
                 // Retry once on the same egress. Read-phase timeouts qualify (the origin
                 // connected and is slow — a retry may help). Connection-level failures
@@ -1415,6 +1464,114 @@ mod tests {
         assert!(
             matches!(err, CrwError::HttpError(_)),
             "a proxy-side failure must not be reported as TargetUnreachable (422); got {err:?}"
+        );
+    }
+
+    /// The counterpart to `proxy_connect_failure_is_not_blamed_on_the_caller`: when the
+    /// origin blackholes our direct SYNs AND the proxy then HANGS instead of refusing,
+    /// the origin is the root cause and the caller must get a 422, not a 504.
+    ///
+    /// The two tests together pin the discriminator: a proxy that is DOWN refuses fast
+    /// and stays a 502 (our fault), while a hanging proxy only ever confirms a verdict
+    /// the DIRECT attempt already reached on its own. Without this, a DNS-resolvable
+    /// host with no listening socket pages the 5xx watchdog, tells the caller to raise
+    /// a `timeout` that cannot help, and is billed rather than refunded.
+    #[tokio::test]
+    async fn direct_blackhole_then_hanging_proxy_is_target_unreachable() {
+        // proxy: accepts the connection but never answers, the hang shape.
+        let p = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let paddr = p.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = p.accept().await {
+                held.push(sock); // hold it open, write nothing
+            }
+        });
+        let fetcher = HttpFetcher {
+            // Short connect timeout so the direct blackhole resolves well inside the
+            // deadline and still leaves MIN_TIER_BUDGET to arm the proxy.
+            client: reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_millis(300))
+                .build()
+                .unwrap(),
+            relaxed_client: None,
+            has_static_proxy: false,
+            ratelimit_proxy_client: Some(
+                build_client(
+                    "ua",
+                    Some(&format!("http://{paddr}")),
+                    std::time::Duration::from_secs(5),
+                    false,
+                )
+                .unwrap(),
+            ),
+            inject_stealth_headers: false,
+        };
+        // origin: 192.0.2.1 is RFC 5737 TEST-NET-1, never routed, so the SYN is
+        // blackholed and the direct attempt is a connect-phase timeout. Same address
+        // `connection_failure_catches_connect_timeout` relies on.
+        let err = fetcher
+            .fetch(
+                "http://192.0.2.1/",
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(2_000),
+            )
+            .await
+            .expect_err("origin blackholes and the proxy never answers");
+        assert!(
+            matches!(err, CrwError::TargetUnreachable(_)),
+            "a blackholing origin behind a reachable-but-hanging proxy must surface as \
+             TargetUnreachable (422), not a 504; got {err:?}"
+        );
+    }
+
+    /// The revenue guard: an origin that REFUSES our direct connection is alive at the
+    /// TCP layer, so a later proxy hang must NOT be read as a dead target. Only a
+    /// direct blackhole earns the refunded 422; anything else stays a billed 504, which
+    /// also keeps a congested proxy pool visible to the 5xx watchdog instead of
+    /// laundering it into caller-blaming refunds.
+    #[tokio::test]
+    async fn direct_refusal_then_hanging_proxy_stays_a_timeout() {
+        let o = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let oaddr = o.local_addr().unwrap();
+        drop(o); // closed port: refuses with an RST rather than blackholing
+        let p = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let paddr = p.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = p.accept().await {
+                held.push(sock);
+            }
+        });
+        let fetcher = HttpFetcher {
+            client: reqwest::Client::new(),
+            relaxed_client: None,
+            has_static_proxy: false,
+            ratelimit_proxy_client: Some(
+                build_client(
+                    "ua",
+                    Some(&format!("http://{paddr}")),
+                    std::time::Duration::from_secs(5),
+                    false,
+                )
+                .unwrap(),
+            ),
+            inject_stealth_headers: false,
+        };
+        let err = fetcher
+            .fetch(
+                &format!("http://{oaddr}/"),
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(2_000),
+            )
+            .await
+            .expect_err("origin refuses and the proxy never answers");
+        assert!(
+            matches!(err, CrwError::Timeout(_)),
+            "a live-but-refusing origin must stay a billed 504, not become a refunded \
+             422; got {err:?}"
         );
     }
 

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -475,10 +475,6 @@ enum HedgeOutcome {
 /// when both fail. Getting it wrong in the permissive direction (treating our fault as
 /// the origin's) would blame the caller for our outage, so the match is deliberately
 /// narrow.
-///
-/// `Timeout` is NOT included: a JS-tier timeout is just as likely to be a local CDP
-/// websocket/command timeout as a slow origin, and it already maps to 504 on its own,
-/// which is the honest answer either way.
 fn is_origin_navigation_failure(e: &CrwError) -> bool {
     match e {
         CrwError::TargetUnreachable(_) => true,
@@ -489,6 +485,22 @@ fn is_origin_navigation_failure(e: &CrwError) -> bool {
             let m = msg.to_ascii_lowercase();
             m.contains("navigation failed") || m.contains("net::err_")
         }
+        // A JS-tier timeout does not refute the HTTP tier's positive finding. Both
+        // callers only consult this when the HTTP error was already
+        // `TargetUnreachable`, i.e. two independent egresses failed to connect; a
+        // browser that then also gets no answer is absence of evidence, not evidence
+        // against. A host that blackholes SYNs hangs every tier, so chrome/lightpanda
+        // report a plain timeout and never a `net::ERR_*`, which is why the arm above
+        // alone never fired for this class. Safe because the pairing is required: an
+        // `http=Timeout` (slow origin) or `HttpError` (our proxy) is not
+        // `TargetUnreachable`, so a CDP-pool outage of ours can never be laundered
+        // into a caller-blaming 422 on its own. It also does not matter if THIS
+        // `js` timeout happens to be our own CDP connect (e.g. `cdp_conn.rs`'s
+        // websocket handshake) rather than a hung navigation: the 422 verdict
+        // rests on the HTTP tier's independent, already-verified
+        // `TargetUnreachable` finding, not on why the browser failed. The JS
+        // failure only ever needs to not contradict that finding.
+        CrwError::Timeout(_) => true,
         _ => false,
     }
 }
@@ -3715,6 +3727,7 @@ mod tests {
         Ok(String),
         OkStatus(u16, String),
         Err(String),
+        Timeout,
     }
 
     #[async_trait::async_trait]
@@ -3730,6 +3743,7 @@ mod tests {
                 MockBehavior::Ok(html) => (200u16, html.clone()),
                 MockBehavior::OkStatus(s, html) => (*s, html.clone()),
                 MockBehavior::Err(msg) => return Err(CrwError::RendererError(msg.clone())),
+                MockBehavior::Timeout => return Err(CrwError::Timeout(1)),
             };
             Ok(FetchResult {
                 url: url.to_string(),
@@ -3953,37 +3967,39 @@ mod tests {
         );
     }
 
+    /// An HTTP tier that cannot reach the origin at all, for the two attribution tests
+    /// below.
+    struct Unreachable;
+    #[async_trait::async_trait]
+    impl PageFetcher for Unreachable {
+        async fn fetch(
+            &self,
+            url: &str,
+            _h: &HashMap<String, String>,
+            _w: Option<u64>,
+            _d: crw_core::Deadline,
+        ) -> CrwResult<FetchResult> {
+            Err(CrwError::TargetUnreachable(format!(
+                "Could not reach {url}"
+            )))
+        }
+        fn name(&self) -> &str {
+            "http"
+        }
+        fn supports_js(&self) -> bool {
+            false
+        }
+        async fn is_available(&self) -> bool {
+            true
+        }
+    }
+
     /// When the HTTP tier could not reach the origin at all, that error must win over
     /// the JS tier's generic RendererError. `TargetUnreachable` maps to 422 (the caller
     /// gave us a dead target); `RendererError` falls through to a 500 and reads as "our
     /// server broke". Production emitted 11 such 500s that should have been 422s.
     #[tokio::test]
     async fn unreachable_origin_beats_js_renderer_error() {
-        struct Unreachable;
-        #[async_trait::async_trait]
-        impl PageFetcher for Unreachable {
-            async fn fetch(
-                &self,
-                url: &str,
-                _h: &HashMap<String, String>,
-                _w: Option<u64>,
-                _d: crw_core::Deadline,
-            ) -> CrwResult<FetchResult> {
-                Err(CrwError::TargetUnreachable(format!(
-                    "Could not reach {url}"
-                )))
-            }
-            fn name(&self) -> &str {
-                "http"
-            }
-            fn supports_js(&self) -> bool {
-                false
-            }
-            async fn is_available(&self) -> bool {
-                true
-            }
-        }
-
         let js = Arc::new(MockFetcher {
             name: "chrome",
             behavior: MockBehavior::Err("Navigation failed: net::ERR_SSL".to_string()),
@@ -4008,6 +4024,40 @@ mod tests {
             matches!(err, CrwError::TargetUnreachable(_)),
             "an unreachable origin must surface as TargetUnreachable (422), not the JS \
              tier's RendererError (500); got {err:?}"
+        );
+    }
+
+    /// The same rule when the JS tier TIMES OUT instead of reporting a navigation
+    /// error. A host that blackholes SYNs hangs the browser rather than producing a
+    /// `net::ERR_*`, so this is the shape the class actually takes in production: it
+    /// surfaced as a 504 that paged the 5xx watchdog, told the caller to raise a
+    /// `timeout` no host would ever answer, and billed them for it.
+    #[tokio::test]
+    async fn unreachable_origin_beats_js_timeout() {
+        let js = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Timeout,
+        });
+        let mut r = make_renderer_with_mocks(vec![js]);
+        r.http = Arc::new(Unreachable);
+        r.render_js_default = None; // auto branch
+
+        let err = r
+            .fetch(
+                "https://dead.example",
+                &HashMap::new(),
+                None, // render_js: auto
+                None, // wait_for_ms
+                None, // requested_renderer
+                tdl(),
+            )
+            .await
+            .expect_err("both tiers fail");
+
+        assert!(
+            matches!(err, CrwError::TargetUnreachable(_)),
+            "a dead origin that hangs the browser must surface as TargetUnreachable \
+             (422, refunded), not Timeout (504, billed); got {err:?}"
         );
     }
 


### PR DESCRIPTION
## What changed

- `HttpFetcher::fetch` (http_only.rs): when a direct GET's TCP connect times out (SYN blackholed, not refused/reset), the fallback proxy is armed as before. If that proxy attempt then also fails to answer, the request now returns `TargetUnreachable` (422) instead of `Timeout` (504), but only for that specific connect-phase-timeout shape. A refused or reset direct connection (a live TCP stack answered) is unaffected and still surfaces as `Timeout`.
- `is_origin_navigation_failure` (lib.rs), used by the auto-JS escalation path: a JS-tier (chrome/lightpanda) `Timeout` no longer overrides an HTTP-tier `TargetUnreachable` verdict. A blackholed origin hangs a browser navigation the same way it hangs the HTTP client (no distinguishing `net::ERR_*` is ever produced), and this arm only ever fires when the HTTP tier has already independently reached `TargetUnreachable`.
- Added a `tracing::warn!` on the new 422 path specifically, so this reclassified class stays greppable even though it no longer feeds the raw 5xx count.
- Three new tests: blackhole-then-hung-proxy resolves to `TargetUnreachable`; refusal-then-hung-proxy stays a `Timeout` (the guard against misclassifying a live-but-failing target); HTTP `TargetUnreachable` + JS `Timeout` resolves to `TargetUnreachable` in the auto-render path.

## Why

Before this change, a dead origin (DNS resolves, nothing answers) surfaced as a 504 once the proxy rescue was armed in front of it: it paged the 5xx on-call watchdog as our own outage, and told the caller to raise a `timeout` that could never help a target with no listening socket.

`TargetUnreachable` (422) is the existing signal for "the caller's target is dead," and is on the SaaS's refund path today (`src/lib/api-handler.ts`: any upstream status `>= 400` is refunded via `safeRefund()`, so both 422 and 504 were already refunded, this change fixes the classification and the alerting noise, not billing correctness). This is not a recall regression: the request fails in both cases (both egresses genuinely got nothing back), so no upstream caller (crawl/map/batch) retries differently on `Timeout` vs `TargetUnreachable`, verified no such branching exists anywhere in the workspace.

Known, pre-existing tradeoff worth flagging explicitly rather than silently shipping: the `is_connect() && is_timeout()` heuristic this relies on (already used elsewhere in this file before this change) can, in principle, also fire under severe host-level resource starvation rather than a genuinely dead target, and `HTTP_CONNECT_TIMEOUT` (2.5s) covers TLS handshake time, not just SYN RTT. Neither is new to this diff, but this diff is what makes that ambiguity billing/alerting-visible for the proxy-armed case, which is why the new path gets its own dedicated log line rather than folding silently into the general `TargetUnreachable` count.

## Deploy

opencore `main` is not release-gated: a merge reaches production within about an hour (CI on `main` -> `bump-saas-pin.yml` -> deploq -> `crw-api` rebuilt from the pinned SHA). No further release step is required for this to take effect.

## Gates

- `cargo fmt --check`: pass
- `cargo clippy --workspace -- -D warnings`: pass, no issues
- `cargo build`: pass
- `cargo test --workspace`: 1450 passed, 19 ignored, 0 failed