### PR TITLE
perf(crawl): stop rendering JSON bodies that score low on quality

### DIFF
--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -401,8 +401,13 @@ async fn scrape_url_inner(
         // the document has no DOM to escalate into.
         && fetch_result.content_type.as_deref() != Some("application/pdf");
 
-        let escalate_for_quality =
-            !md_is_byte_thin && md_is_low_quality && fetch_result.html.len() > 5000;
+        let escalate_for_quality = escalate_for_quality(
+            md_is_byte_thin,
+            md_is_low_quality,
+            fetch_result.status_code,
+            &fetch_result.html,
+            fetch_result.content_type.as_deref(),
+        );
         // A request whose JS ladder already failed comes back as an HTTP body
         // carrying the `js_escalation_failed:` warning. It looks exactly like a
         // low-tier result, so without this check we would re-run the whole
@@ -1251,6 +1256,51 @@ fn classify_block(
     })
 }
 
+/// Should a substantive-but-low-scoring body buy a browser render?
+///
+/// The content-type term matters because the HTTP tier decodes every non-PDF
+/// body as HTML regardless of its declared type, so a healthy JSON API response
+/// scores as low-quality (no sentences, few word-like tokens) and used to buy a
+/// full render that was then discarded: prod measured 114 of 135 quality
+/// escalations ending in "keeping HTTP", ~2.5-3s each. Unlike the byte-thin
+/// trigger this one fires on a body we already hold in full, so for a
+/// non-html-ish type there is nothing left for a browser (or a different
+/// egress) to reveal. The byte-thin path stays content-type-agnostic on
+/// purpose: a near-empty response may be a deny stub that a retry from another
+/// fingerprint recovers.
+///
+/// Two things still earn a render under a data content type, so both get the
+/// last word before we suppress. Both are short-circuited away on the html
+/// path, which keeps its current cost exactly.
+fn escalate_for_quality(
+    md_is_byte_thin: bool,
+    md_is_low_quality: bool,
+    status: u16,
+    html: &str,
+    content_type: Option<&str>,
+) -> bool {
+    if md_is_byte_thin || !md_is_low_quality || html.len() <= 5000 {
+        return false;
+    }
+    // Only JSON is gated, and only because it is the one type we measured: 114
+    // of 135 quality escalations in 24h of production ended in "keeping HTTP",
+    // all of them JSON API bodies. Every other content type keeps escalating
+    // exactly as before, so no content sniffing has to be correct for recall to
+    // hold. Widening this needs its own measurement.
+    let is_json = content_type
+        .and_then(|ct| ct.split(';').next())
+        .map(|ct| ct.trim().eq_ignore_ascii_case("application/json"))
+        .unwrap_or(false);
+    if !is_json {
+        return true;
+    }
+    // A vendor wall can be served under a data content type, and that one a
+    // retry from another fingerprint can clear.
+    crw_extract::antibot::classify(Some(status), html)
+        .signal
+        .is_blocked()
+}
+
 fn formats_include_json(formats: &[OutputFormat]) -> bool {
     formats.contains(&OutputFormat::Json)
 }
@@ -1286,6 +1336,40 @@ mod tests {
     use super::*;
 
     const THRESH: usize = 100;
+
+    #[test]
+    fn quality_escalation_skips_json_only() {
+        // Prod: 114 of 135 quality escalations ended in "keeping HTTP" because
+        // a healthy JSON body scores low-quality (no sentences, few word-like
+        // tokens) and bought a browser render that was then discarded.
+        let json = r#"{"id":1,"body":"comment text"},"#.repeat(200); // > 5000 bytes
+        let q = |ct, html: &str| escalate_for_quality(false, true, 200, html, ct);
+        assert!(!q(Some("application/json"), &json));
+        // Production sends the charset suffix, so the media type is what counts.
+        assert!(!q(Some("application/json; charset=utf-8"), &json));
+        assert!(!q(Some("APPLICATION/JSON"), &json));
+        // Everything else is left exactly as it behaves on main. Only JSON was
+        // measured, and gating a type we never measured would trade recall for
+        // a saving we cannot show. `text/plain` and `application/octet-stream`
+        // in particular can carry a mislabeled SPA shell that a browser sniffs
+        // and hydrates, so they must keep escalating.
+        assert!(q(Some("text/html"), &json));
+        assert!(q(None, &json));
+        assert!(q(Some("text/plain"), &json));
+        assert!(q(Some("application/octet-stream"), &json));
+        // A vendor wall served as JSON is the one JSON case still worth a retry:
+        // another fingerprint can clear it.
+        let walled = format!("{json}\"url\":\"https://captcha-delivery.com/x\"");
+        assert!(q(Some("application/json"), &walled));
+        // A byte-thin body never reaches this trigger, whatever the type.
+        assert!(!escalate_for_quality(
+            true,
+            true,
+            200,
+            &json,
+            Some("text/html")
+        ));
+    }
 
     #[test]
     fn classify_block_challenge_on_cf_200() {


### PR DESCRIPTION
## What this fixes

A healthy JSON API response scores low on the markdown quality heuristic
(`crw_extract::quality::is_low_quality` is `score < 0.4 && words < 200`) because
JSON has no sentences and few word-like tokens. So `escalate_for_quality` fired,
spent a browser render, and then discarded the result in favour of the HTTP body
it already had.

## Production evidence

From `crw-saas-crw-api-1` logs over 24h, 2026-08-04:

| Signal | Count |
|---|---|
| `escalate_for_quality=true` dispatched | 135 |
| ...that ended in `keeping HTTP` | **114 (84%)** |

The discarded-render path is visible in one request:

```
13:23:45 empty markdown after fetch, escalating to JS renderer
         url=api.github.com/repos/.../issues/78193 status=200 html_len=5198
         md_bytes=5358 quality_score_before=Some(0.09563188) escalate_for_quality=true
13:23:48 chrome nav budget hit; attempting partial snapshot budget_ms=2500
13:23:48 JS retry returned worse-quality markdown (0.09563188 -> 0.09563188), keeping HTTP
```

GitHub returned a healthy 200 with 5358 bytes of good markdown. Chrome was
launched, 2.5s of nav budget burned, result discarded. That request took 3494ms
where the HTTP tier alone answers in about 480ms.

## The change

One file. The quality escalation is gated on `application/json` only, matching on
the media type before any `;` so the `application/json; charset=utf-8` that
production actually sends is covered.

Every other content type keeps escalating exactly as it does on main. That is
deliberate: `text/plain` and `application/octet-stream` can carry a mislabeled
SPA shell that a browser sniffs and hydrates, and only JSON was measured. Gating
a type with no measurement behind it would trade recall for a saving that cannot
be shown.

A vendor wall served under a JSON content type still escalates, via
`crw_extract::antibot::classify`, since another fingerprint can clear that one.

## Why not broader

Earlier iterations used a content-type allowlist plus an HTML content sniff plus
`crw_renderer::detector::warrants_browser_retry`. Review found a real defect in
each:

- `detector.rs` is the weak block detector (phrase list plus 8 vendors). Behind
  `||`, a false negative there suppresses a rescuable page, which costs recall.
- `warrants_browser_retry` does plain substring scanning with no JSON-string
  awareness, so a JSON body merely quoting `<script src=` in a field
  (WordPress `content.rendered`, GitHub comment bodies) re-triggered the waste
  this change exists to remove.
- The HTML sniff was an incomplete mirror of Chromium's mimesniff table.

All three were removed rather than patched. Under the JSON-only gate those cases
do not need handling, because the code that could get them wrong no longer runs.

## Recall

The 114 measured cases are zero-recall-change by construction: the escalation
result was already being discarded. Nothing that escalates on main stops
escalating here unless the response is `application/json` and the antibot
classifier does not flag it.

## Test

`quality_escalation_skips_json_only` covers the charset and uppercase media-type
forms, confirms `text/html`, absent, `text/plain` and `application/octet-stream`
all still escalate, confirms a JSON vendor wall still escalates, and confirms a
byte-thin body never reaches this trigger.

## Gates

```
cargo fmt --check                        pass
cargo clippy --workspace -- -D warnings  pass, no issues
cargo test --workspace                   1567 passed, 24 ignored
```

## Not fixed here

The customer-visible 16 to 20s latencies in the same traffic come from a
different path: an origin rate-limit 403 (api.github.com allows 60
unauthenticated requests per hour per IP, and the box shares one egress IP)
escalates through lightpanda and chrome, returns the rate-limit message as a
successful 200, and charges a credit. A browser leaving from the same IP gets the
same 403, so that escalation cannot succeed. That remains open.

## Deploy caveat

opencore `main` reaches production within about an hour of merge via
`bump-saas-pin.yml` and deploq. It is not release-gated. So the scrape-success
gate has to clear BEFORE merge, not after.