### PR TITLE
chore: point every Discord link at the current invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ licenses are available — **hello@fastcrw.com**.
 [Benchmarks](https://fastcrw.com/benchmarks) ·
 [Pricing](https://fastcrw.com/pricing) ·
 [Changelog](CHANGELOG.md) ·
-[Discord](https://discord.gg/kkFh2SC8) ·
+[Discord](https://discord.gg/KNQBfFVc9J) ·
 [X](https://x.com/fast_crw)
 
 ## Star History

--- a/docs/agent-onboarding/index.html
+++ b/docs/agent-onboarding/index.html
@@ -601,7 +601,7 @@ elif resp.status_code == 429:
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -467,7 +467,7 @@ Client → GET /v1/crawl/{id}
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/authentication/index.html
+++ b/docs/authentication/index.html
@@ -400,7 +400,7 @@ api_keys = [&quot;crw_live_key-1234&quot;, &quot;crw_live_key-5678&quot;]</code>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/capabilities/index.html
+++ b/docs/capabilities/index.html
@@ -692,7 +692,7 @@ else:
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -1214,7 +1214,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/choose-endpoint/index.html
+++ b/docs/choose-endpoint/index.html
@@ -518,7 +518,7 @@ curl https://api.fastcrw.com/v1/crawl/{id} \
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/compatibility/index.html
+++ b/docs/compatibility/index.html
@@ -424,7 +424,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/configuration/index.html
+++ b/docs/configuration/index.html
@@ -647,7 +647,7 @@ CRW_CONFIG=config.stealth crw-server</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/crates/index.html
+++ b/docs/crates/index.html
@@ -411,7 +411,7 @@ crw https://example.com -o page.md</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/crawling/index.html
+++ b/docs/crawling/index.html
@@ -573,7 +573,7 @@ console.log((await status.json()).status);</code></pre></div><div class="code-ta
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/credit-costs/index.html
+++ b/docs/credit-costs/index.html
@@ -467,7 +467,7 @@ LLM-backed extraction (<code>json</code>/<code>summary</code> formats) is <stron
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/crw-browse/index.html
+++ b/docs/crw-browse/index.html
@@ -694,7 +694,7 @@ crw-browse \
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/docker/index.html
+++ b/docs/docker/index.html
@@ -586,7 +586,7 @@ itself.</p>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/error-codes/index.html
+++ b/docs/error-codes/index.html
@@ -523,7 +523,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/extract/index.html
+++ b/docs/extract/index.html
@@ -587,7 +587,7 @@ managed and self-hosted parity.</p>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -364,7 +364,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/index.html
+++ b/docs/index.html
@@ -331,7 +331,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -425,7 +425,7 @@ curl http://localhost:3000/health</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/integrations/index.html
+++ b/docs/integrations/index.html
@@ -682,7 +682,7 @@ console.log(data.markdown);</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/introduction/index.html
+++ b/docs/introduction/index.html
@@ -495,7 +495,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/js-rendering/index.html
+++ b/docs/js-rendering/index.html
@@ -647,7 +647,7 @@ is skipped rather than failing every request.</p>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -525,7 +525,7 @@ console.log(body.data.links);</code></pre></div><div class="code-tab-panel" data
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/mcp-clients/index.html
+++ b/docs/mcp-clients/index.html
@@ -750,7 +750,7 @@ CRW_API_KEY = &quot;YOUR_API_KEY&quot;</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -954,7 +954,7 @@ codex mcp add crw -- npx crw-mcp</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/migrate-from-firecrawl/index.html
+++ b/docs/migrate-from-firecrawl/index.html
@@ -664,7 +664,7 @@ print(&quot;All checks passed — safe to promote to production.&quot;)</code></
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/monitoring/index.html
+++ b/docs/monitoring/index.html
@@ -962,7 +962,7 @@ Authorization: Bearer $CRW_API_KEY</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/output-formats/index.html
+++ b/docs/output-formats/index.html
@@ -826,7 +826,7 @@ appends <code>/responses</code>; a complete endpoint URL is also accepted unchan
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/pdf-parsing/index.html
+++ b/docs/pdf-parsing/index.html
@@ -797,7 +797,7 @@ sandbox              = false      # isolate each parse in a child process</code>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -356,7 +356,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/proxies/index.html
+++ b/docs/proxies/index.html
@@ -474,7 +474,7 @@ WITH_CHROME=1 ./scripts/verify-proxy-rotation.sh   # also exercises the JS path<
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/quick-start/index.html
+++ b/docs/quick-start/index.html
@@ -434,7 +434,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/rate-limits/index.html
+++ b/docs/rate-limits/index.html
@@ -449,7 +449,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-batch/index.html
+++ b/docs/recipe-batch/index.html
@@ -687,7 +687,7 @@ data[]        — Document objects for this page
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-js-spa/index.html
+++ b/docs/recipe-js-spa/index.html
@@ -618,7 +618,7 @@ Only pin a browser renderer when HTTP-only clearly fails. Plain HTTP fetches tak
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-mcp-5min/index.html
+++ b/docs/recipe-mcp-5min/index.html
@@ -493,7 +493,7 @@ All 9 tools registered by `crw-mcp`:
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-monitoring/index.html
+++ b/docs/recipe-monitoring/index.html
@@ -707,7 +707,7 @@ Diff: https://fastcrw.com/dashboard (monitor → latest check)</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-pdf/index.html
+++ b/docs/recipe-pdf/index.html
@@ -730,7 +730,7 @@ automatically — you do not change your call.</p>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-product-catalog/index.html
+++ b/docs/recipe-product-catalog/index.html
@@ -787,7 +787,7 @@ re-runs. Pages that have not changed come back with <code>changeTracking.status:
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/recipe-rag/index.html
+++ b/docs/recipe-rag/index.html
@@ -742,7 +742,7 @@ before re-embedding — avoids re-embedding unchanged content.</li>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/research-api/index.html
+++ b/docs/research-api/index.html
@@ -432,7 +432,7 @@ the roadmap.</li>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/response-shapes/index.html
+++ b/docs/response-shapes/index.html
@@ -464,7 +464,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/rest-api/index.html
+++ b/docs/rest-api/index.html
@@ -450,7 +450,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/scraping/index.html
+++ b/docs/scraping/index.html
@@ -684,7 +684,7 @@ console.log(body.data.markdown);</code></pre></div><div class="code-tab-panel" d
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/sdk-examples/index.html
+++ b/docs/sdk-examples/index.html
@@ -549,7 +549,7 @@ console.log(data);</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/sdk-reference/index.html
+++ b/docs/sdk-reference/index.html
@@ -912,7 +912,7 @@ a message that explains why and how to switch mode.</p>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -820,7 +820,7 @@ with nothing to report are omitted, not emitted as <code>null</code> or <code>[]
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/self-hosting-hardening/index.html
+++ b/docs/self-hosting-hardening/index.html
@@ -509,7 +509,7 @@ model    = &quot;gpt-4o-mini&quot;</code></pre>
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/self-hosting/index.html
+++ b/docs/self-hosting/index.html
@@ -444,7 +444,7 @@ that need it. Full details: <a href="/js-rendering">JS rendering → Camoufox</a
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/site.config.js
+++ b/docs/site.config.js
@@ -156,7 +156,7 @@ export default {
       { title: "Community", links: [
         { label: "GitHub", href: "https://github.com/us/crw", external: true },
         { label: "Issues", href: "https://github.com/us/crw/issues", external: true },
-        { label: "Discord", href: "https://discord.gg/VNxv2DuBB", external: true },
+        { label: "Discord", href: "https://discord.gg/KNQBfFVc9J", external: true },
       ]},
       { title: "Legal", links: [
         { label: "License (AGPL-3.0)", href: "https://github.com/us/crw/blob/main/LICENSE", external: true },
@@ -164,7 +164,7 @@ export default {
     ],
     socials: [
       { icon: "github", href: "https://github.com/us/crw" },
-      { icon: "discord", href: "https://discord.gg/VNxv2DuBB" },
+      { icon: "discord", href: "https://discord.gg/KNQBfFVc9J" },
     ],
   },
 };

--- a/docs/troubleshooting/index.html
+++ b/docs/troubleshooting/index.html
@@ -723,7 +723,7 @@ if data[&quot;balance&quot;] &lt; 100:
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">

--- a/docs/v2-api/index.html
+++ b/docs/v2-api/index.html
@@ -1434,7 +1434,7 @@ const result = await crw.extract({
           <div class="footer-col-links">
             <a href="https://github.com/us/crw" target="_blank" rel="noopener">GitHub</a>
             <a href="https://github.com/us/crw/issues" target="_blank" rel="noopener">Issues</a>
-            <a href="https://discord.gg/VNxv2DuBB" target="_blank" rel="noopener">Discord</a>
+            <a href="https://discord.gg/KNQBfFVc9J" target="_blank" rel="noopener">Discord</a>
           </div>
         </div>
         <div class="footer-col">


### PR DESCRIPTION
Four different Discord invite codes were live across the tree. This
consolidates the ones that are ours onto the current invite,
`discord.gg/KNQBfFVc9J`, verified against the Discord API as an active
invite to the fastCRW guild before the rollout.

## What changed

- `README.md` carried `kkFh2SC8`, a code used nowhere else.
- The docs site carried `VNxv2DuBB` across 51 pages.
- `docs/index.html` is included deliberately. It is the template
  `scripts/build-docs-pages.mjs` generates every other docs page from, so
  updating only the generated pages would restore the old link on the next
  regeneration.

52 files, one code in, three codes out.

## Deliberately not changed

`crw-saas/marketing/x-posts/kit/assets/demo-outputs/search-llama.json`
holds two more invite codes (`sH3SSRp2`, `jvDVwtfq`). Those belong to
third-party communities quoted inside scraped demo output, not to us.
Rewriting them would falsify a captured page.

## Verification

`scripts/docs-guards.sh` passes. No occurrence of any old code remains in
`README.md` or `docs/`.

The crw-saas side (footer and the onboarding reward task) ships separately.