### PR TITLE
fix(extract): drop single-render nav menus under onlyMainContent

### DIFF
--- a/crates/crw-extract/examples/offline_corpus.rs
+++ b/crates/crw-extract/examples/offline_corpus.rs
@@ -1,0 +1,88 @@
+//! Run the real extraction path over a frozen corpus of raw HTML, offline.
+//!
+//! Lets an extractor change be scored against the benchmark set without
+//! refetching a thousand URLs for every iteration.
+//!
+//! in:  jsonl `{"url": ..., "raw_html": ...}`
+//! out: jsonl `{"url": ..., "markdown": ..., "chars": n, "micros": n}`
+//! usage: cargo run --release --example offline_corpus -- <in.jsonl> <out.jsonl>
+
+use crw_core::types::OutputFormat;
+use crw_extract::ExtractOptions;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let rd = BufReader::new(File::open(&args[1]).expect("open input"));
+    let mut wr = BufWriter::new(File::create(&args[2]).expect("create output"));
+    let formats = [OutputFormat::Markdown];
+
+    let (mut n, mut empty) = (0usize, 0usize);
+    let t0 = Instant::now();
+
+    for line in rd.lines() {
+        let line = line.expect("read line");
+        let v: serde_json::Value = serde_json::from_str(&line).expect("parse row");
+        let url = v["url"].as_str().unwrap_or("");
+        let html = v["raw_html"].as_str().unwrap_or("");
+        n += 1;
+
+        let t = Instant::now();
+        let md = if html.is_empty() {
+            String::new()
+        } else {
+            crw_extract::extract(ExtractOptions {
+                raw_html: html,
+                source_url: url,
+                status_code: 200,
+                rendered_with: Some("http".into()),
+                elapsed_ms: 0,
+                render_decision: None,
+                credit_cost: 0,
+                warnings: Vec::new(),
+                formats: &formats,
+                only_main_content: true,
+                include_tags: &[],
+                exclude_tags: &[],
+                css_selector: None,
+                xpath: None,
+                chunk_strategy: None,
+                query: None,
+                filter_mode: None,
+                top_k: None,
+                domain_selectors: None,
+                captured_responses: &[],
+                llm_fallback: None,
+                debug: false,
+                debug_sink: None,
+                normalize_tables: false,
+            })
+            .ok()
+            .and_then(|d| d.markdown)
+            .unwrap_or_default()
+        };
+        let micros = t.elapsed().as_micros();
+        if md.trim().is_empty() {
+            empty += 1;
+        }
+
+        writeln!(
+            wr,
+            "{}",
+            serde_json::json!({
+                "url": url,
+                "markdown": md,
+                "chars": md.len(),
+                "micros": micros,
+            })
+        )
+        .expect("write row");
+    }
+
+    eprintln!(
+        "rows {n} | empty {empty} | {:.1}s",
+        t0.elapsed().as_secs_f64()
+    );
+}

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -622,7 +622,24 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // document as it is.
     let md = md.map(|m| {
         if only_main_content {
-            markdown::drop_repeated_nav_lines(&m)
+            let m = markdown::drop_repeated_nav_lines(&m);
+            // `drop_repeated_nav_lines` only catches a menu that a responsive
+            // template rendered more than once. A menu rendered once survives
+            // it, and the class-name rules in `clean` miss it whenever the site
+            // does not name the container (`nav`, `sidebar`, …). What is left
+            // is a run of short lines that are nothing but a link, which is the
+            // same shape in every language. Drop those too, unless too little
+            // text would survive — then the links are the page.
+            //
+            // Never when the caller narrowed the page themselves: asking for
+            // `includeTags: ["nav"]` and getting the nav removed would be
+            // absurd, and a `css_selector` means they already said what they
+            // want.
+            if user_selected || !include_tags.is_empty() {
+                m
+            } else {
+                quality::strip_nav_lines(&m).unwrap_or(m)
+            }
         } else {
             m
         }

--- a/crates/crw-extract/src/quality.rs
+++ b/crates/crw-extract/src/quality.rs
@@ -14,7 +14,109 @@ pub struct Quality {
     pub avg_line_len: f32,
     pub link_or_image_ratio: f32,
     pub boilerplate_ratio: f32,
+    /// Share of the text that sits in bare navigation entries: short lines that
+    /// are almost entirely one link. Language-independent, unlike
+    /// [`BOILERPLATE_TOKENS`].
+    ///
+    /// Measured in words, not lines. A docs page carries a long sidebar of
+    /// one-word links beside a real article; by line count the nav dominates and
+    /// the page looks like pure chrome, by word count it is the minority it
+    /// actually is.
+    pub chrome_ratio: f32,
     pub score: f32,
+}
+
+/// Weight of the nav-line penalty in the composite score.
+///
+/// Zero on purpose. Penalising nav here demotes the one candidate that carried
+/// the article body on docs and help-centre pages, where a long sidebar sits
+/// beside real prose, and the ladder then falls through to a thin candidate
+/// that lost the body (measured: 63 real phrases dropped across 25 pages).
+/// Nav is removed from the winner instead, by [`strip_nav_lines`], which keeps
+/// the body and drops the menu. The field is still computed because that
+/// removal and its content floor are both driven by it.
+const CHROME_WEIGHT: f32 = 0.0;
+
+/// Longest visible line still treated as a possible nav entry. Menu labels are
+/// short; a link-heavy line longer than this is usually a real sentence that
+/// happens to cite sources.
+const CHROME_MAX_VISIBLE: usize = 80;
+
+/// Most words a nav entry carries. This is what separates a menu label from a
+/// linked headline, and it is the whole reason the rule is safe to apply: an
+/// author page, a blog index and a docs index are all lists of links whose text
+/// is a real title, and those titles run long. "Dow Jones Newswires" is three
+/// words; "Introducing HoneyBee: How We Automate Honeypot Deployment for Threat
+/// Research" is ten. Without this bound the rule ate 119 real phrases across 58
+/// pages of the frozen set. Counted with [`label_tokens`] so a spaceless script
+/// is measured in characters rather than reported as a single word.
+const CHROME_MAX_WORDS: usize = 4;
+
+/// A nav entry looks the same in every language: a short line, usually a list
+/// item, that is almost entirely one link. `[Barron's](https://barrons.com)`
+/// and `[Ana Sayfa](/)` are the same shape, and neither is caught by the
+/// English phrase list below, which scores 0 on 68% of the article corpus.
+///
+/// Reads the line once, tracking how many visible characters sit inside link
+/// text versus outside it.
+fn is_link_chrome(line: &str) -> bool {
+    let mut s = line.trim();
+    // Strip one markdown list marker: "* ", "- ", "+ ", "1. ".
+    if let Some(rest) = s
+        .strip_prefix('*')
+        .or_else(|| s.strip_prefix('-'))
+        .or_else(|| s.strip_prefix('+'))
+    {
+        if rest.starts_with(char::is_whitespace) {
+            s = rest.trim_start();
+        }
+    } else {
+        let digits = s.chars().take_while(char::is_ascii_digit).count();
+        if digits > 0 && s[digits..].starts_with(". ") {
+            s = s[digits + 2..].trim_start();
+        }
+    }
+
+    // Walk the line once, collecting what a reader would see. URLs are not
+    // visible text: counting them made `[会社概要](/company)` look like a
+    // five-word line.
+    //
+    // The obvious optimisation, counting tokens inline to skip this buffer, was
+    // tried and measured slower (21.8s vs 20.2s over the 948-page set), so the
+    // straightforward version stays.
+    let (mut in_link, mut outside, mut links) = (0usize, 0usize, 0usize);
+    let mut visible_text = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'[' {
+            // `[text](url)` — keep `text`, skip `(url)` entirely.
+            if let Some(close) = s[i..].find("](") {
+                let text = &s[i + 1..i + close];
+                if let Some(paren) = s[i + close + 2..].find(')') {
+                    in_link += text.chars().filter(|c| !c.is_whitespace()).count();
+                    visible_text.push_str(text);
+                    visible_text.push(' ');
+                    links += 1;
+                    i += close + 2 + paren + 1;
+                    continue;
+                }
+            }
+        }
+        let ch = s[i..].chars().next().unwrap_or(' ');
+        if !ch.is_whitespace() {
+            outside += 1;
+        }
+        visible_text.push(ch);
+        i += ch.len_utf8();
+    }
+
+    let visible = in_link + outside;
+    links > 0
+        && visible > 0
+        && visible <= CHROME_MAX_VISIBLE
+        && in_link * 5 >= visible * 4
+        && label_tokens(&visible_text) <= CHROME_MAX_WORDS
 }
 
 const BOILERPLATE_TOKENS: &[&str] = &[
@@ -49,6 +151,138 @@ const BOILERPLATE_TOKENS: &[&str] = &[
 /// to [`analyze`] with `dom = None`.
 pub fn analyze_md_only(markdown: &str) -> Quality {
     analyze(markdown, None)
+}
+
+/// How many words must survive the strip for it to be worth doing.
+///
+/// This is the guard that keeps a gallery, a docs index or a product listing
+/// intact: there the links ARE the content, and removing them leaves nothing.
+/// It deliberately does NOT look at the share of the text that is nav. A
+/// paywalled news page is mostly menu by volume and still has an article under
+/// it, and a share-based floor protected exactly those worst cases.
+const CHROME_MIN_BODY_WORDS: usize = 60;
+
+/// A menu arrives as a block. One link line on its own is far more likely to be
+/// content: a byline of linked author names, a contact address, a single
+/// reference. Requiring a run keeps those.
+const CHROME_MIN_RUN: usize = 4;
+
+/// Drop bare navigation lines from finished markdown.
+///
+/// Three guards keep this from eating content: enough text has to survive
+/// ([`CHROME_MIN_BODY_WORDS`]), the lines have to arrive as a block
+/// ([`CHROME_MIN_RUN`]), and each has to be short enough to be a label rather
+/// than a headline ([`CHROME_MAX_WORDS`]).
+///
+/// Returns `None` when nothing was removed, letting callers avoid a copy.
+pub fn strip_nav_lines(markdown: &str) -> Option<String> {
+    // Classify and count in one pass. Calling `analyze` here instead cost
+    // ~3.5ms per page on the frozen set, nearly all of it building the
+    // unique-word set, which this does not need.
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut chrome = vec![false; lines.len()];
+    let (mut body_words, mut chrome_words) = (0usize, 0usize);
+    for (i, line) in lines.iter().enumerate() {
+        let w = count_words(line);
+        if is_link_chrome(line) {
+            chrome[i] = true;
+            chrome_words += w;
+        } else {
+            body_words += w;
+        }
+    }
+    if chrome_words == 0 || body_words < CHROME_MIN_BODY_WORDS {
+        return None;
+    }
+
+    // Keep only the nav lines that sit in a run.
+    let mut drop = vec![false; lines.len()];
+    let mut i = 0;
+    while i < lines.len() {
+        if !chrome[i] {
+            i += 1;
+            continue;
+        }
+        // A menu block is often split by blank lines, one group per submenu.
+        // Blanks continue the run without counting toward its length; any real
+        // line ends it.
+        let (mut j, mut last, mut count) = (i, i, 0usize);
+        while j < lines.len() {
+            if chrome[j] {
+                count += 1;
+                last = j;
+            } else if !lines[j].trim().is_empty() {
+                break;
+            }
+            j += 1;
+        }
+        if count >= CHROME_MIN_RUN {
+            drop[i..=last].fill(true);
+        }
+        i = j.max(i + 1);
+    }
+    if !drop.iter().any(|d| *d) {
+        return None;
+    }
+
+    let mut out = String::with_capacity(markdown.len());
+    let mut blank_run = 0usize;
+    for (idx, line) in lines.iter().enumerate() {
+        if drop[idx] {
+            continue;
+        }
+        if line.trim().is_empty() {
+            blank_run += 1;
+            if blank_run > 1 {
+                continue;
+            }
+        } else {
+            blank_run = 0;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    Some(out.trim_end().to_string())
+}
+
+/// Same tokenization the composite score uses, applied to one line.
+fn count_words(line: &str) -> usize {
+    line.split_ascii_whitespace()
+        .filter(|raw| {
+            raw.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '\'')
+                .count()
+                >= 2
+        })
+        .count()
+}
+
+/// Scripts that do not put spaces between words. Counting whitespace tokens in
+/// Japanese returns 1 for a whole sentence, which made a Japanese table of
+/// contents look like a four-word menu label.
+fn is_spaceless_script(c: char) -> bool {
+    matches!(c,
+        '\u{3040}'..='\u{30FF}'   // hiragana + katakana
+        | '\u{3400}'..='\u{4DBF}' // CJK ext A
+        | '\u{4E00}'..='\u{9FFF}' // CJK unified
+        | '\u{F900}'..='\u{FAFF}' // CJK compatibility
+        | '\u{AC00}'..='\u{D7AF}' // hangul syllables
+        | '\u{0E00}'..='\u{0E7F}' // thai
+    )
+}
+
+/// Length of a candidate menu label, in units comparable across scripts: a
+/// whitespace-separated word, or a single character of a spaceless script.
+fn label_tokens(s: &str) -> usize {
+    let spaceless = s.chars().filter(|c| is_spaceless_script(*c)).count();
+    let spaced = s
+        .split_ascii_whitespace()
+        .filter(|w| {
+            w.chars()
+                .any(|c| c.is_alphanumeric() && !is_spaceless_script(c))
+        })
+        .count();
+    spaceless + spaced
 }
 
 pub fn analyze(markdown: &str, dom: Option<&DomFeatures>) -> Quality {
@@ -97,6 +331,17 @@ pub fn analyze(markdown: &str, dom: Option<&DomFeatures>) -> Quality {
         boilerplate_lines as f32 / lines.len() as f32
     };
 
+    let chrome_words: usize = lines
+        .iter()
+        .filter(|l| is_link_chrome(l))
+        .map(|l| count_words(l))
+        .sum();
+    let chrome_ratio = if words == 0 {
+        0.0
+    } else {
+        (chrome_words as f32 / words as f32).min(1.0)
+    };
+
     let unique_ratio = unique_words as f32 / words.max(1) as f32;
     // Weight recalibration (v6 plan, mirrors crawl4ai composite):
     // OLD: + 0.5 * (1 - link_or_image_ratio)
@@ -113,6 +358,7 @@ pub fn analyze(markdown: &str, dom: Option<&DomFeatures>) -> Quality {
     let mut score = (words.min(800) as f32 / 800.0) + dom_density_bonus
         - 0.2 * link_penalty
         - 1.0 * boilerplate_ratio
+        - CHROME_WEIGHT * chrome_ratio
         - 0.3 * (1.0 - unique_ratio);
     score = score.clamp(-1.0, 2.0);
 
@@ -123,6 +369,7 @@ pub fn analyze(markdown: &str, dom: Option<&DomFeatures>) -> Quality {
         avg_line_len,
         link_or_image_ratio,
         boilerplate_ratio,
+        chrome_ratio,
         score,
     }
 }
@@ -134,6 +381,64 @@ pub fn is_low_quality(q: &Quality) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nav_run_goes_article_stays() {
+        let body: String = (0..12)
+            .map(|i| format!("Paragraph {i} carries several words of ordinary prose text.\n\n"))
+            .collect();
+        let md = format!(
+            "# Headline\n\n\
+             *   [Barron's](https://www.barrons.com)\n\
+             *   [BigCharts](http://bigcharts.marketwatch.com)\n\
+             *   [Factiva](https://global.factiva.com/login)\n\
+             *   [Financial News](https://www.fnlondon.com/)\n\n\
+             {body}"
+        );
+        let out = strip_nav_lines(&md).expect("a four-link menu is a run");
+        assert!(!out.contains("BigCharts"), "menu survived:\n{out}");
+        assert!(out.contains("Paragraph 0"), "body was eaten:\n{out}");
+        assert!(out.contains("# Headline"));
+    }
+
+    #[test]
+    fn linked_headlines_and_lone_links_survive() {
+        // An author page: every line is a link, but each is a real title. Also
+        // covers the run rule, since two of these sit together.
+        let md = "# Author\n\n\
+             *   [Introducing HoneyBee: How We Automate Honeypot Deployment for Research](/a)\n\
+             *   [Turning attacker insights into stronger cloud security protections](/b)\n\
+             *   [What the latest cloud threat data says about identity attacks](/c)\n\n"
+            .to_string()
+            + &(0..12)
+                .map(|i| format!("Paragraph {i} carries several words of ordinary prose text.\n\n"))
+                .collect::<String>();
+        assert!(
+            strip_nav_lines(&md).is_none_or(|o| o.contains("HoneyBee")),
+            "linked headlines must not read as a menu"
+        );
+    }
+
+    #[test]
+    fn spaceless_script_is_not_a_menu_label() {
+        // Counted as whitespace words this Japanese heading is one "word" and
+        // looks like a menu entry; counted per character it plainly is not.
+        assert!(!is_link_chrome(
+            "*   [1.1 ライブコマースを始める企業がなぜ増えているのか](/x)"
+        ));
+        assert!(is_link_chrome("*   [会社概要](/company)"));
+    }
+
+    #[test]
+    fn a_listing_page_keeps_its_links() {
+        let md: String = (0..30)
+            .map(|i| format!("*   [Photo {i}](/p/{i})\n"))
+            .collect();
+        assert!(
+            strip_nav_lines(&md).is_none(),
+            "with no body left, the links are the page"
+        );
+    }
 
     fn high_quality_markdown() -> String {
         // Diverse-vocabulary article so unique_ratio doesn't sink the


### PR DESCRIPTION
## What

`drop_repeated_nav_lines` only removes a menu that a responsive template rendered more than once, and the class/id rules in `clean` only fire when a site names the container (`nav`, `sidebar`, …). A menu rendered once inside an unnamed wrapper reaches the markdown untouched, and on paywalled news templates it is the bulk of the output.

This removes what is left by shape rather than by name. A run of short lines carrying nothing but a link looks the same in every language, whereas the existing `BOILERPLATE_TOKENS` list is English-only and inert on most of the web.

## How

New `quality::strip_nav_lines`, applied after the candidate is chosen, so scoring and therefore which candidate wins is unaffected. Three guards keep it off real content:

- **run of at least 4 lines** — a menu arrives as a block, so a linked byline, a contact address or a lone reference survives
- **at most 4 label tokens per line** — a linked headline is not a menu entry. Spaceless scripts are counted per character; counted as whitespace words a Japanese heading is one "word" and reads as a label
- **at least 60 words must survive** — on a gallery, a docs index or a product listing the links *are* the content, so those pages are left alone

Skipped entirely when the caller passed `css_selector` or `includeTags`: they already narrowed the page, and removing a nav they explicitly asked for would be wrong.

`chrome_ratio` is added to `Quality` and computed in words rather than lines: a docs page carries a long sidebar of one-word links beside a real article, so by line count the nav dominates and the page looks like pure chrome. It carries weight 0.0 in the composite score on purpose — penalising nav there demoted the one candidate holding the article body and the ladder fell through to a thinner one.

## Notes

- Behaviour changes only for `onlyMainContent: true` without an explicit selector, which is the default scrape path.
- Adds `examples/offline_corpus.rs`, which runs the extraction path over a frozen corpus of raw HTML so this class of change can be scored offline instead of refetching.
- No API, schema or config surface change.