### PR TITLE
feat(renderer): make the interactive render reserve configurable

### DIFF
--- a/config.docker.toml
+++ b/config.docker.toml
@@ -103,6 +103,13 @@ ws_url = "ws://chrome:9222/"
 # exceed the old 2g under load). Drop to 6 if RAM headroom tightens.
 [renderer.chrome_pool]
 size = 8
+# Interactive render reserve (B lane). Of the 8-slot pool, guarantee 3 slots for
+# interactive single /scrape so one tenant's batch/crawl of slow sites can't
+# squeeze other tenants' interactive scrapes below 3 (batch keeps 8-3=5). Was an
+# effective 2 (pool/4); raised after the 2026-07-30 cross-tenant timeout leak.
+# Fast revert without redeploy: CRW_RENDERER__CHROME_POOL__RESERVED_INTERACTIVE_RENDERS=2
+# (env overrides this file; merely unsetting it falls back to 3, not the old 2).
+reserved_interactive_renders = 3
 
 # /v1/search points at the bundled SearXNG sidecar. On the reference
 # docker-compose stack the sidecar is reachable as `searxng:8080` over the

--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -918,6 +918,15 @@ pub struct ChromePoolConfig {
     /// in-flight chrome requests per pool.
     #[serde(default)]
     pub size: Option<usize>,
+    /// Interactive render-slot reserve (the B lane), the 4th sibling of
+    /// `reserved_interactive_{parses,extracts,llm}`. `None` → `pool/4` (the
+    /// historical `render_reserve` default), so batch keeps `size - reserve`
+    /// render slots and interactive is guaranteed `reserve`. Bounds one tenant's
+    /// batch/crawl from squeezing other tenants' interactive scrapes below
+    /// `reserve` Chrome slots. Resolved via `resolve_interactive_reserve` and
+    /// clamped by `BatchGate::new` (never zeroes batch).
+    #[serde(default)]
+    pub reserved_interactive_renders: Option<usize>,
     /// Recycle policy: v1 always recreates the context after each release.
     /// Reserved for a future "reuse N navigations then recreate" mode.
     #[serde(default = "default_recycle_after_navs")]
@@ -937,6 +946,7 @@ impl Default for ChromePoolConfig {
     fn default() -> Self {
         Self {
             size: None,
+            reserved_interactive_renders: None,
             recycle_after_navs: default_recycle_after_navs(),
             idle_timeout_secs: default_idle_timeout_secs(),
             health_check_secs: default_health_check_secs(),

--- a/crates/crw-core/src/reserved_sem.rs
+++ b/crates/crw-core/src/reserved_sem.rs
@@ -255,6 +255,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn configured_reserve_three_guarantees_three_interactive_pool_slots() {
+        // The prod shape: chrome_pool size=8, reserved_interactive_renders=3
+        // resolves to reserve=3 → batch gate = total-reserved = 5, so at least
+        // 3 downstream pool slots stay reachable by interactive even when batch
+        // pins its whole lane. Guards the config resolver + gate arithmetic the
+        // pool gate (cdp.rs with_pool) relies on.
+        use crate::config::resolve_interactive_reserve;
+        assert_eq!(
+            resolve_interactive_reserve(None, 8),
+            2,
+            "None preserves old pool/4"
+        );
+        assert_eq!(resolve_interactive_reserve(Some(3), 8), 3);
+
+        let pool = std::sync::Arc::new(Semaphore::new(8)); // mock downstream chrome pool
+        let gate = BatchGate::new(8, resolve_interactive_reserve(Some(3), 8), "render"); // gate=5
+
+        // 5 batch holders each take a gate permit AND a pool slot.
+        let mut batch = Vec::new();
+        for _ in 0..5 {
+            let g = gate
+                .enter(ScrapeClass::Batch)
+                .await
+                .expect("batch gate permit");
+            let p = Semaphore::acquire_owned(pool.clone()).await.unwrap();
+            batch.push((g, p));
+        }
+        assert_eq!(gate.available(), 0, "batch gate exhausted at 5 holders");
+
+        // Exactly 3 interactive acquire the reserved pool slots (skip the gate).
+        let mut inter = Vec::new();
+        for _ in 0..3 {
+            assert!(gate.enter(ScrapeClass::Interactive).await.is_none());
+            inter.push(Semaphore::acquire_owned(pool.clone()).await.unwrap());
+        }
+        assert_eq!(
+            pool.available_permits(),
+            0,
+            "pool full: 5 batch + 3 interactive = 8"
+        );
+
+        // A 4th interactive blocks (pool full) and a 6th batch blocks (gate empty).
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                Semaphore::acquire_owned(pool.clone())
+            )
+            .await
+            .is_err(),
+            "4th interactive must block on a full pool"
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), gate.enter(ScrapeClass::Batch))
+                .await
+                .is_err(),
+            "6th batch must block on an exhausted gate"
+        );
+        drop(batch);
+        drop(inter);
+    }
+
+    #[tokio::test]
     async fn task_local_class_drives_lane_end_to_end() {
         // Proves the full mechanism the real lanes use: REQUEST_CLASS scope →
         // current_scrape_class() → correct lane. total=2, reserve 1 => batch_gate=1.

--- a/crates/crw-renderer/src/browser_pool.rs
+++ b/crates/crw-renderer/src/browser_pool.rs
@@ -206,6 +206,10 @@ pub type ConnFactory<C> =
 #[derive(Clone, Debug)]
 pub struct PoolCfg {
     pub size: usize,
+    /// Interactive render reserve override (`None` → `pool/4`). Carried from
+    /// `[renderer.chrome_pool].reserved_interactive_renders`; resolved into the
+    /// pool `BatchGate` at construction.
+    pub reserved_interactive_renders: Option<usize>,
     pub recycle_after_navs: u32,
     pub idle_timeout: Duration,
     pub health_check_after: Duration,
@@ -219,6 +223,7 @@ impl Default for PoolCfg {
     fn default() -> Self {
         Self {
             size: 4,
+            reserved_interactive_renders: None,
             recycle_after_navs: 1,
             idle_timeout: Duration::from_secs(300),
             health_check_after: Duration::from_secs(60),
@@ -993,6 +998,7 @@ mod tests {
     fn small_pool_cfg() -> PoolCfg {
         PoolCfg {
             size: 2,
+            reserved_interactive_renders: None,
             recycle_after_navs: 1,
             idle_timeout: Duration::from_secs(300),
             health_check_after: Duration::from_secs(60),

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -493,9 +493,13 @@ impl CdpRenderer {
             blocklist: Blocklist::defaults(),
             host_intercept_disable: Vec::new(),
             conn_semaphore: Arc::new(Semaphore::new(pool_size)),
+            // Conn/no-context-pool path (per-request-proxy, self-host). Keeps the
+            // default reserve; the configurable override lives only on the pool
+            // gate (the path with the 12-30s render hold). `pool_size` here may be
+            // the small default (4), so an absolute override must NOT reach it.
             conn_batch_gate: crw_core::BatchGate::new(
                 pool_size,
-                crate::render_reserve(pool_size),
+                crw_core::config::resolve_interactive_reserve(None, pool_size),
                 "render",
             ),
             pool: None,
@@ -582,7 +586,10 @@ impl CdpRenderer {
             .set(cfg.size as i64);
         self.pool_batch_gate = Some(crw_core::BatchGate::new(
             cfg.size,
-            crate::render_reserve(cfg.size),
+            crw_core::config::resolve_interactive_reserve(
+                cfg.reserved_interactive_renders,
+                cfg.size,
+            ),
             "render",
         ));
         self.pool = Some(crate::browser_pool::BrowserContextPool::new(cfg, factory));
@@ -3172,6 +3179,33 @@ mod tests {
         let lp = CdpRenderer::new("lightpanda", "ws://x/", 1000, 1);
         assert_eq!(chrome.budget_truncated_warning(), "chrome_budget_truncated");
         assert_eq!(lp.budget_truncated_warning(), "lightpanda_budget_truncated");
+    }
+
+    #[test]
+    fn pool_gate_reflects_configured_reserved_interactive_renders() {
+        // Guards the FULL config→PoolCfg→with_pool threading, not just the
+        // resolver arithmetic: a configured reserve must actually reach the pool
+        // gate. If the `cdp.rs` resolve call regressed to `None`, the first
+        // assert (expecting 2) would read 6 and fail.
+        use crate::browser_pool::PoolCfg;
+        // Some(6) on a size-8 pool → batch gate = 8 - 6 = 2.
+        let r = CdpRenderer::new("chrome", "ws://x/", 1000, 8).with_pool(PoolCfg {
+            size: 8,
+            reserved_interactive_renders: Some(6),
+            ..Default::default()
+        });
+        assert_eq!(
+            r.pool_batch_gate.as_ref().unwrap().available(),
+            2,
+            "pool gate must use the configured reserve (8-6=2), not the default"
+        );
+        // None → pool/4 = 2 → batch gate = 8 - 2 = 6 (default preserved).
+        let r2 = CdpRenderer::new("chrome", "ws://x/", 1000, 8).with_pool(PoolCfg {
+            size: 8,
+            reserved_interactive_renders: None,
+            ..Default::default()
+        });
+        assert_eq!(r2.pool_batch_gate.as_ref().unwrap().available(), 6);
     }
 
     #[test]

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -110,19 +110,6 @@ tokio::task_local! {
     pub static REQUEST_SCREENSHOT: Option<ScreenshotReq>;
 }
 
-/// Interactive render-slot reserve for a Chrome pool of `pool_size` (the B
-/// reserved lane). About a quarter of the pool, floored at 1 whenever there are
-/// ≥2 slots so even small (2–3 slot) self-hosted pools keep interactive render
-/// isolation; only a 1-slot pool disables it (a reserve there would starve
-/// batch). Always kept below `pool_size` so the batch gate stays ≥1.
-pub fn render_reserve(pool_size: usize) -> usize {
-    if pool_size <= 1 {
-        0
-    } else {
-        (pool_size / 4).max(1).min(pool_size - 1)
-    }
-}
-
 /// Attach the browser-context pool to a CDP tier, when enabled and supported.
 ///
 /// Every pooled tier gets its own pool, sized from the shared
@@ -155,6 +142,7 @@ fn maybe_with_pool(
             tracing::info!(tier, pool_size = size, "browser-context pool enabled");
             renderer.with_pool(browser_pool::PoolCfg {
                 size,
+                reserved_interactive_renders: pcfg.reserved_interactive_renders,
                 recycle_after_navs: pcfg.recycle_after_navs,
                 idle_timeout: std::time::Duration::from_secs(pcfg.idle_timeout_secs),
                 health_check_after: std::time::Duration::from_secs(pcfg.health_check_secs),

--- a/crates/crw-renderer/tests/browser_pool_real_chrome.rs
+++ b/crates/crw-renderer/tests/browser_pool_real_chrome.rs
@@ -89,6 +89,7 @@ fn build_pool(ws_url: String, size: usize) -> Arc<BrowserContextPool<CdpConnecti
     BrowserContextPool::new(
         PoolCfg {
             size,
+            reserved_interactive_renders: None,
             recycle_after_navs: 1,
             idle_timeout: Duration::from_secs(300),
             health_check_after: Duration::from_secs(60),


### PR DESCRIPTION
## What

Makes the Chrome render pool's interactive reserve configurable, so one tenant's
batch/crawl of many slow sites cannot squeeze other tenants' interactive scrapes
below a guaranteed floor of render slots.

- Add `reserved_interactive_renders: Option<usize>` to `ChromePoolConfig`, the
  fourth sibling of `reserved_interactive_{parses,extracts,llm}`, resolved via the
  existing `resolve_interactive_reserve` helper.
- `None` preserves the current `pool/4` default (byte-identical behaviour;
  self-host unchanged). `config.docker.toml` sets `3`: on the size-8 prod pool the
  batch gate goes 6 → 5 and interactive is guaranteed 3 slots (was an effective 2).
- Remove `render_reserve`; both gate sites route through the shared resolver. Only
  the pool gate takes the override, so the smaller conn/LightPanda gates keep the
  default.

## Why

On 2026-07-30/31 one tenant batch-crawling slow sites drove other tenants'
interactive scrape timeouts up (peak ~6.2%) because the shared 8-slot chrome pool
only reserved 2 slots for interactive. Raising the reserve bounds that blast radius.

## Rollback

Env-revertible with no redeploy:
`CRW_RENDERER__CHROME_POOL__RESERVED_INTERACTIVE_RENDERS=2` (env overrides the
baked config). Unsetting alone falls back to the file value `3`, so set `2` to revert.

## Verification

- fmt + `clippy --workspace --all-targets -D warnings` + `test --workspace` green.
- New unit test asserts the size-8/reserve-3 gate arithmetic (5 batch hold the
  lane, 3 interactive slots remain, 4th interactive and 6th batch block).
- New cdp test asserts the config→PoolCfg→pool-gate threading (a configured reserve
  reaches the pool gate, not just the resolver).
- Batch is the yielding class; total pool size is unchanged (concurrency is only
  reallocated). Confirm no batch-recall regression on the next heavy batch workload
  via `crw_reserved_lane_wait_seconds{lane="render",class}` before/after.

Merging reaches prod within ~1h via the pinned-engine rebuild.