### PR TITLE
fix(extract): retry an LLM request that never reached the provider

### DIFF
--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -76,6 +76,28 @@ pub(crate) fn shared_client() -> &'static reqwest::Client {
     })
 }
 
+/// Was the request never delivered?
+///
+/// A connect failure is the one transport error it is safe to repeat on a POST:
+/// no connection was established, so the provider cannot have seen the body.
+/// A timeout is deliberately excluded — there the request may well have been
+/// processed, and repeating it would double-charge the call.
+///
+/// Worth handling because a dropped keep-alive connection, an idle-timeout on a
+/// load balancer, or a provider closing a pooled socket all surface here, and
+/// failing the whole extraction on the first refused socket is a poor trade for
+/// a call that already tolerates a 30s wait.
+pub(crate) fn is_undelivered(err: &reqwest::Error) -> bool {
+    err.is_connect()
+}
+
+/// Backoff before repeating attempt `attempt` (1-based): ~0.5s, then ~1s, each
+/// with up to ~1s of jitter.
+pub(crate) fn retry_backoff(attempt: u32) -> Duration {
+    let base_ms = 500u64 * (1u64 << (attempt - 1));
+    Duration::from_millis(base_ms + rand::rng().random_range(0..1000))
+}
+
 fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
         return s;
@@ -467,34 +489,41 @@ async fn call_openai(
         body["reasoning_effort"] = serde_json::json!(effort);
     }
     // Fixed self-limiting retry on transient server throttling (HTTP 429/503)
-    // only. The shared client carries a 30s per-attempt timeout and the
-    // caller's request deadline is not threaded in here, so the budget stays
-    // small and fixed (a few short jittered sleeps). 429/503 are fast server
-    // rejects, so the worst case stays well under the request deadline. All
-    // other non-2xx responses (and transport/timeout errors) keep the original
-    // single-POST contract: hard-error on the first response.
+    // and on a request that was never delivered (see [`is_undelivered`]). The
+    // shared client carries a 30s per-attempt timeout and the caller's request
+    // deadline is not threaded in here, so the budget stays small and fixed (a
+    // few short jittered sleeps). 429/503 are fast server rejects and a refused
+    // connection is faster still, so the worst case stays well under the
+    // request deadline. Every other non-2xx response, and every transport error
+    // that could have reached the provider (a timeout above all), keeps the
+    // original single-POST contract: hard-error on the first response.
     const MAX_ATTEMPTS: u32 = 3;
     let mut attempt: u32 = 0;
     let (status, text) = loop {
         attempt += 1;
-        let resp = client
+        let sent = client
             .post(url)
             .bearer_auth(api_key)
             .header("content-type", "application/json")
             .json(&body)
             .send()
-            .await
-            .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
+            .await;
+
+        let resp = match sent {
+            Ok(resp) => resp,
+            Err(e) if is_undelivered(&e) && attempt < MAX_ATTEMPTS => {
+                tokio::time::sleep(retry_backoff(attempt)).await;
+                continue;
+            }
+            Err(e) => return Err(CrwError::Internal(format!("LLM request failed: {e}"))),
+        };
 
         let status = resp.status();
         let is_retryable = status == reqwest::StatusCode::TOO_MANY_REQUESTS
             || status == reqwest::StatusCode::SERVICE_UNAVAILABLE;
         if is_retryable && attempt < MAX_ATTEMPTS {
-            // Exponential backoff with jitter: ~0.5s, ~1s base + up to ~1s
-            // jitter. Drop the response body unread — the status is enough.
-            let base_ms = 500u64 * (1u64 << (attempt - 1));
-            let jitter_ms = rand::rng().random_range(0..1000);
-            tokio::time::sleep(Duration::from_millis(base_ms + jitter_ms)).await;
+            // Drop the response body unread — the status is enough.
+            tokio::time::sleep(retry_backoff(attempt)).await;
             continue;
         }
 

--- a/crates/crw-extract/src/responses.rs
+++ b/crates/crw-extract/src/responses.rs
@@ -51,15 +51,36 @@ async fn post(
     timeout: Duration,
 ) -> CrwResult<serde_json::Value> {
     let url = responses_url(llm.base_url.as_deref());
-    let resp = shared_client()
-        .post(&url)
-        .timeout(timeout)
-        .bearer_auth(&llm.api_key)
-        .header("content-type", "application/json")
-        .json(body)
-        .send()
-        .await
-        .map_err(|e| CrwError::ExtractionError(format!("Responses API request failed: {e}")))?;
+
+    // Repeat only a request that never reached the provider, on the same terms
+    // as the Chat Completions path: a refused connection carries no risk of a
+    // duplicate generation, a timeout does. Without this a single dropped
+    // socket, which a pooled keep-alive connection makes routine, failed the
+    // whole extraction.
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut attempt: u32 = 0;
+    let resp = loop {
+        attempt += 1;
+        match shared_client()
+            .post(&url)
+            .timeout(timeout)
+            .bearer_auth(&llm.api_key)
+            .header("content-type", "application/json")
+            .json(body)
+            .send()
+            .await
+        {
+            Ok(resp) => break resp,
+            Err(e) if crate::llm::is_undelivered(&e) && attempt < MAX_ATTEMPTS => {
+                tokio::time::sleep(crate::llm::retry_backoff(attempt)).await;
+            }
+            Err(e) => {
+                return Err(CrwError::ExtractionError(format!(
+                    "Responses API request failed: {e}"
+                )));
+            }
+        }
+    };
 
     let status = resp.status();
     let text = resp.text().await.map_err(|e| {

--- a/crates/crw-extract/tests/transport_retry_tests.rs
+++ b/crates/crw-extract/tests/transport_retry_tests.rs
@@ -1,0 +1,88 @@
+//! A request that never reached the provider is repeated; one that may have
+//! been processed is not.
+
+use crw_core::config::LlmConfig;
+use crw_extract::llm::chat;
+use serde_json::json;
+use std::time::{Duration, Instant};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn responses_llm(base_url: String) -> LlmConfig {
+    LlmConfig {
+        provider: "openai-responses".into(),
+        api_key: "test-key".into(),
+        model: "test-model".into(),
+        base_url: Some(base_url),
+        max_tokens: 512,
+        ..Default::default()
+    }
+}
+
+/// A port nothing is listening on yet. Reserving and releasing a real socket is
+/// the only way to name a port the OS agrees is free.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("reserve a port")
+        .local_addr()
+        .expect("port of the reserved socket")
+        .port()
+}
+
+#[tokio::test]
+async fn a_refused_connection_is_retried_and_then_succeeds() {
+    let port = free_port();
+    let llm = responses_llm(format!("http://127.0.0.1:{port}/v1"));
+
+    // Nothing is listening, so the first attempt is refused. The server appears
+    // while the call is backing off, well inside the ~0.5s first sleep.
+    let call = tokio::spawn(async move { chat(&llm, "instructions", "input").await });
+
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).expect("bind the same port");
+    let server = MockServer::builder().listener(listener).start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp_test",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "served on the retry" }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = call.await.expect("task joins").expect("retry recovers");
+    assert_eq!(result.content, "served on the retry");
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        1,
+        "the refused attempt never reached the server, so exactly one request lands"
+    );
+}
+
+#[tokio::test]
+async fn a_dead_endpoint_still_gives_up() {
+    let port = free_port();
+    let llm = responses_llm(format!("http://127.0.0.1:{port}/v1"));
+
+    let started = Instant::now();
+    let err = chat(&llm, "instructions", "input")
+        .await
+        .expect_err("nothing ever listens, so the call fails");
+    let elapsed = started.elapsed();
+
+    assert!(
+        err.to_string().contains("request failed"),
+        "unexpected error: {err}"
+    );
+    // Two backoffs (~0.5s and ~1s, before jitter) separate the three attempts,
+    // so giving up immediately would mean the retry never ran.
+    assert!(
+        elapsed >= Duration::from_millis(1400),
+        "gave up after {elapsed:?}, so the attempts were not spaced by the backoff"
+    );
+}


### PR DESCRIPTION
## What

A refused or dropped connection failed the whole extraction. The Responses transport sent a single POST with no retry at all; the Chat Completions path retried only HTTP 429/503 and treated every transport error as terminal.

## Why this one error and not the others

A **connect** failure is the only transport error that is safe to repeat on a POST: no connection was established, so the provider cannot have seen the body and a second attempt cannot produce a duplicate generation, or a duplicate charge. A **timeout** is excluded for exactly the opposite reason, and that contract is unchanged.

In production this is the shape a closed keep-alive connection takes: a provider or an idle load balancer drops a pooled socket, the next call picks it up, and today the extraction dies on it.

It is also what makes the Responses wire tests fail intermittently on CI. Three of the last twenty-five runs on `main` failed this way, all with `error sending request` against their own local mock server, on `07f4b96`, `01b1fc4` and `c5bd7e6`.

## Evidence

The new tests reproduce the CI failure exactly. Without the fix:

```
ExtractionError("Responses API request failed: error sending request for url (http://127.0.0.1:64930/v1/responses)")
```

which is character-for-character the shape seen on CI. With the fix both pass, and they were run 40 times without a flake.

Note the three earlier hypotheses this replaced, each disproven with a throwaway reproduction before landing anything: a stale pooled connection to a re-bound port, a client outliving the runtime that created it, and the two combined. All three are handled correctly by the client already.

## How

One shared rule (`is_undelivered`) and one shared backoff (`retry_backoff`) used by both call sites, so the two paths cannot drift apart again. Budget is unchanged at three attempts with the existing jittered backoff, and a refused connection returns faster than the 429/503 case it reuses, so the worst case still sits well inside the request deadline.

## Notes

- No API, schema or config surface change.
- `a_refused_connection_is_retried_and_then_succeeds` also asserts the server receives exactly one request, so the retry cannot be silently double-sending.