### PR TITLE
feat(search): per-request query-expand override and deadline-bounded scout

### DIFF
--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -1653,6 +1653,11 @@ pub struct SearchRequest {
     /// recall (e.g. 1 vs 3) at a fixed answer temperature.
     #[serde(default, alias = "query_expand_variants")]
     pub query_expand_variants: Option<usize>,
+    /// Per-request override for `[search].query_expand` — turns multi-query
+    /// expansion on/off for this request. None uses the server config. Used by
+    /// the eval harness to A/B expansion against prod without a global flip.
+    #[serde(default, alias = "query_expand")]
+    pub query_expand: Option<bool>,
     /// Per-request override for `[search].multi_round` — the adaptive
     /// evidence-scout round that fires when the round-1 answer abstains. None
     /// uses the server config. The eval harness sets this to A/B the lever.

--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -226,8 +226,15 @@ pub async fn scout_followups(
          evidence, quoted, plus the specific thing asked (the predicate, the date, \
          the number). ALWAYS keep any place name, city, region, or country from \
          the question VERBATIM in every query — a location is never optional. \
-         (3) Try a different angle than the original phrasing — an exact-phrase \
-         query, an authoritative source guess, or the canonical entity. (4) Do NOT \
+         (3) If the question uses an ordinal or positional reference (\"16th \
+         edition\", \"Nth annual\", \"3rd president\", \"the Nth winner\") and the \
+         evidence EXPLICITLY ties that reference to a concrete year, name, or \
+         entity, use that concrete value in a query. Resolve ONLY from what the \
+         evidence supports, never guess. Do NOT resolve open-ended temporal \
+         references (\"current\", \"latest\", \"most recent\"), and never alter a \
+         place name. \
+         (4) Try a different angle than the original phrasing — an exact-phrase \
+         query, an authoritative source guess, or the canonical entity. (5) Do NOT \
          repeat the user's original wording. Output ONLY the queries, ONE per \
          line: no quotes around the whole line, no numbering, no labels. Output at \
          most {n} line(s)."

--- a/crates/crw-search/src/params.rs
+++ b/crates/crw-search/src/params.rs
@@ -172,6 +172,7 @@ mod tests {
             answer_temperature: None,
             query_expand_variants: None,
             multi_round: None,
+            query_expand: None,
             answer_list_format: None,
             max_content_chars: None,
         }

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -314,13 +314,18 @@ pub async fn search_inner(
         .query_expand_variants
         .unwrap_or(state.config.search.query_expand_variants)
         .clamp(1, MAX_QUERY_EXPAND_VARIANTS);
+    // Per-request override for query expansion (eval A/B harness), same shape as
+    // the multi_round override; None uses the server config. Lets the benchmark
+    // A/B expansion against prod via a request param without a global config flip
+    // (so real customers are not switched onto the path during a measurement).
+    let want_expand = req.query_expand.unwrap_or(state.config.search.query_expand);
     // Phase C1: when expansion + scrapeOptions are both in play, overlap the
     // scrape of the original-query results with the expansion (LLM rewrite +
     // variant fetches) instead of doing them serially. The final pool is the
     // identical union, so the reranked source set is unchanged — only the
     // ~5-10s expansion overhead is hidden behind the original scrape.
     let c1_overlap = state.config.search.pipeline_overlap
-        && state.config.search.query_expand
+        && want_expand
         && llm_path
         && req.scrape_options.is_some()
         && effective_llm.is_some();
@@ -352,7 +357,7 @@ pub async fn search_inner(
         let mut merged = orig;
         union_pools(&mut merged, variant_pools);
         merged
-    } else if state.config.search.query_expand
+    } else if want_expand
         && llm_path
         && let Some(llm) = effective_llm
     {
@@ -684,9 +689,23 @@ pub async fn search_inner(
                                 .await;
                                 let mut grew = false;
                                 for sq in scout_qs {
+                                    // Bound every scout op by the request deadline.
+                                    // `multi_budget_ok` only gates ENTRY; once inside,
+                                    // a slow SearXNG fetch or a hung scrape could run
+                                    // far past the caller's budget (a scout scrape was
+                                    // observed hanging ~6 min → 502). Out of budget:
+                                    // stop and keep round-1.
+                                    if req_deadline.remaining().is_zero() {
+                                        break;
+                                    }
                                     let mut sp = params.clone();
                                     sp.q = sq;
-                                    if let Ok(resp2) = client.fetch(&sp).await {
+                                    if let Ok(Ok(resp2)) = tokio::time::timeout(
+                                        req_deadline.remaining(),
+                                        client.fetch(&sp),
+                                    )
+                                    .await
+                                    {
                                         let extra = transform_flat_reranked(
                                             &resp2,
                                             &req.query,
@@ -705,13 +724,21 @@ pub async fn search_inner(
                                             continue;
                                         }
                                         let mut sd = SearchData::Flat(fresh);
-                                        let _ = enrich_with_scrape(&mut sd, opts, state).await;
+                                        let _ = tokio::time::timeout(
+                                            req_deadline.remaining(),
+                                            enrich_with_scrape(&mut sd, opts, state),
+                                        )
+                                        .await;
                                         if let SearchData::Flat(rows) = sd {
                                             grew |= merge_scraped(&mut data, rows);
                                         }
                                     }
                                 }
+                                // Skip the round-2 re-synthesis if the scout work
+                                // already consumed the deadline, so the extra LLM
+                                // call can't run (and bill) past the caller's budget.
                                 if grew
+                                    && !req_deadline.remaining().is_zero()
                                     && let Ok((ans2, cites2, usage2, mut warns2)) =
                                         synthesize_answer(
                                             &req,
@@ -1642,6 +1669,7 @@ mod tests {
             answer_temperature: None,
             query_expand_variants: None,
             multi_round: None,
+            query_expand: None,
             answer_list_format: None,
             max_content_chars: None,
         }


### PR DESCRIPTION
Search-answer recall groundwork, measured against a frozen SimpleQA set.

## What changed
- **Per-request `queryExpand` override** (`crw-core` request field + wiring in `search_inner`), mirroring the existing `multiRound` / `queryExpandVariants` overrides. Lets multi-query expansion be A/B measured via a request param without flipping a global config flag, so a measurement run never switches real customers onto the path.
- **Evidence-anchored ordinal resolution in `scout_followups`**: the abstention-retry query generator now resolves static ordinal/positional references from the round-1 evidence excerpt (e.g. "16th edition" -> the year shown, "3rd president" -> the named person) only when the evidence explicitly ties the reference to a concrete value. It never guesses, and it deliberately does not touch open-ended temporal references (current/latest) or place names.
- **Deadline-bounded scout**: the multi-round scout's SearXNG fetch, scrape enrichment, and round-2 re-synthesis are each bounded by the request deadline. Previously the budget was only checked on entry, so a slow or hung scout scrape could run far past the caller's budget (observed: a scout scrape hanging minutes -> 502). Resource cleanup on the cancelled scrape is already handled by the existing pool-guard drop path.

## Behavior / compatibility
- Default behavior is unchanged: `query_expand` and `multi_round` remain config-gated and off by default; the new request field defaults to `None` (uses server config).
- The scout deadline bound only tightens an existing path; on timeout it keeps the round-1 answer.

## Tests
- `cargo test --workspace`: 1589 passed, 0 failed.
- fmt + clippy (`--workspace -D warnings`) clean.