### PR TITLE
test(extract): keep responses mock servers alive for the test binary

### DIFF
--- a/crates/crw-extract/tests/responses_tests.rs
+++ b/crates/crw-extract/tests/responses_tests.rs
@@ -8,6 +8,19 @@ use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+/// Start a mock server that outlives the test.
+///
+/// wiremock frees the server's ephemeral port when the `MockServer` is dropped,
+/// and this crate's LLM client is a process-wide pooled `reqwest::Client`. On
+/// Linux a later `MockServer::start()` can be handed that same port while the
+/// pool still holds an idle connection to it with nothing behind it any more,
+/// and reqwest does not retry a POST that fails on a reused connection, so the
+/// call surfaces as a transport error instead of reaching the mock. Never
+/// releasing a port makes that rebind impossible.
+async fn start_mock_server() -> &'static MockServer {
+    Box::leak(Box::new(MockServer::start().await))
+}
+
 fn responses_llm(base_url: String) -> LlmConfig {
     LlmConfig {
         provider: "openai-responses".into(),
@@ -21,7 +34,7 @@ fn responses_llm(base_url: String) -> LlmConfig {
 
 #[tokio::test]
 async fn text_call_uses_responses_wire_shape_and_parses_usage() {
-    let server = MockServer::start().await;
+    let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path("/v1/responses"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -39,7 +52,7 @@ async fn text_call_uses_responses_wire_shape_and_parses_usage() {
                 "input_tokens_details": { "cached_tokens": 8 }
             }
         })))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let mut llm = responses_llm(format!("{}/v1", server.uri()));
@@ -69,7 +82,7 @@ async fn text_call_uses_responses_wire_shape_and_parses_usage() {
 
 #[tokio::test]
 async fn structured_call_forces_flat_function_tool_and_parses_arguments() {
-    let server = MockServer::start().await;
+    let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path("/v1/responses"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -85,7 +98,7 @@ async fn structured_call_forces_flat_function_tool_and_parses_arguments() {
             }],
             "usage": { "input_tokens": 100, "output_tokens": 12, "total_tokens": 112 }
         })))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let llm = responses_llm(format!("{}/v1/", server.uri()));
@@ -118,7 +131,7 @@ async fn structured_call_forces_flat_function_tool_and_parses_arguments() {
 
 #[tokio::test]
 async fn structured_call_still_validates_function_arguments_locally() {
-    let server = MockServer::start().await;
+    let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path("/v1/responses"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -128,7 +141,7 @@ async fn structured_call_still_validates_function_arguments_locally() {
                 "arguments": "{\"count\":\"not-an-integer\"}"
             }]
         })))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let llm = responses_llm(format!("{}/v1", server.uri()));
@@ -147,14 +160,14 @@ async fn structured_call_still_validates_function_arguments_locally() {
 async fn text_call_returning(
     payload: serde_json::Value,
 ) -> (
-    MockServer,
+    &'static MockServer,
     Result<crw_extract::llm::LlmCallResult, crw_core::error::CrwError>,
 ) {
-    let server = MockServer::start().await;
+    let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path("/v1/responses"))
         .respond_with(ResponseTemplate::new(200).set_body_json(payload))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let llm = responses_llm(format!("{}/v1", server.uri()));
@@ -289,13 +302,13 @@ async fn refusal_only_response_errors_instead_of_returning_an_empty_answer() {
 async fn http_error_body_is_never_echoed_to_the_caller() {
     // A gateway that mirrors the request back in its error body would otherwise
     // hand the bearer key or the prompt to the API caller.
-    let server = MockServer::start().await;
+    let server = start_mock_server().await;
     Mock::given(method("POST"))
         .and(path("/v1/responses"))
         .respond_with(ResponseTemplate::new(400).set_body_string(
             "{\"error\":{\"message\":\"echoed Authorization: Bearer SENTINEL-LEAK-TOKEN\"}}",
         ))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let llm = responses_llm(format!("{}/v1", server.uri()));


### PR DESCRIPTION
`crates/crw-extract/tests/responses_tests.rs` has been failing CI intermittently
since it was added. It took down 3 of the last 8 `ci.yml` runs on `main`, and it
failed the `v0.30.0` release pipeline twice in a row, which skipped all eleven
publish jobs and left a tagged release with no artifacts on any channel.

**Root cause**

wiremock frees a server's ephemeral port when the `MockServer` is dropped, and
crw-extract's LLM transports go through process-wide pooled `reqwest::Client`s
(`llm.rs` and `structured.rs` each hold one in a `OnceLock`). On Linux a later
`MockServer::start()` can be handed a port the pool still holds an idle
connection to, with nothing behind it any more. reqwest does not retry a POST
that fails on a reused connection, so the call surfaced as

```
ExtractionError("Responses API request failed: error sending request for url (http://127.0.0.1:45139/v1/responses)")
```

instead of reaching the mock. It never reproduced on macOS because macOS refuses
the rebind (`Address already in use`) where Linux allows it.

**Fix**

Leak the mock servers, so a port is never released and the rebind cannot happen.

**Measurements**

All on a Linux runner, running the suite binary 300 times per column:

| | failures |
|---|---|
| `responses_tests` before | 6 / 300 |
| `responses_tests` after | 0 / 300 |
| runs that bound the same port twice, after | 0 / 300 |

Instrumenting the port each server binds showed that in the failing runs the
port named in the error had been bound twice in that process, which is what
identified the mechanism rather than inferring it.

`structured_tests`, `judge_tests` and `reasoning_effort_tests` share the pattern
but measured 0 / 300 each, so they are left alone.

**Not addressed here**

`responses.rs::post` has no retry, so the same reused-connection failure can
reach a user when a provider closes an idle keep-alive connection. That is a
separate change.
