### PR TITLE
fix(extract): retry an LLM POST that died before reaching the provider

### DIFF
--- a/crates/crw-extract/src/llm.rs
+++ b/crates/crw-extract/src/llm.rs
@@ -76,6 +76,57 @@ pub(crate) fn shared_client() -> &'static reqwest::Client {
     })
 }
 
+/// hyper's wording for a pooled keep-alive connection the peer had already
+/// closed. Matched on the message because hyper is not a direct dependency of
+/// this crate; `crates/crw-extract/tests/transport_retry.rs` drives the real
+/// failure end to end, so a hyper rewording fails a test rather than silently
+/// disabling the retry below.
+const DEAD_POOLED_CONNECTION: &str = "connection closed before message completed";
+
+/// Send a provider POST, retrying once when the connection died before the
+/// provider could have seen the request.
+///
+/// Every LLM call here rides a process-wide pooled client, and a provider (or
+/// any middlebox between us) may close an idle keep-alive connection whenever
+/// it likes. We only find out on the next send, so an otherwise good request
+/// fails having never reached the provider. Retrying that costs one extra
+/// round trip and turns a spurious user-visible extraction failure into a
+/// success.
+pub(crate) async fn send_provider_post(
+    req: reqwest::RequestBuilder,
+) -> reqwest::Result<reqwest::Response> {
+    let retry = req.try_clone();
+    let err = match req.send().await {
+        Ok(resp) => return Ok(resp),
+        Err(e) => e,
+    };
+    match retry {
+        Some(retry) if request_never_reached_provider(&err) => retry.send().await,
+        _ => Err(err),
+    }
+}
+
+/// True only when the request provably never got to the provider, so replaying
+/// it cannot duplicate work that was already billed.
+fn request_never_reached_provider(err: &reqwest::Error) -> bool {
+    // A timeout is deliberately not retried: the provider may have received the
+    // request and be working on it, and these calls cost money.
+    if err.is_timeout() {
+        return false;
+    }
+    if err.is_connect() {
+        return true;
+    }
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = source {
+        if e.to_string().contains(DEAD_POOLED_CONNECTION) {
+            return true;
+        }
+        source = e.source();
+    }
+    false
+}
+
 fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
         return s;
@@ -385,15 +436,16 @@ async fn call_anthropic(
     if let Some(t) = temperature {
         body["temperature"] = serde_json::json!(t);
     }
-    let resp = client
-        .post(url)
-        .header("x-api-key", api_key)
-        .header("anthropic-version", ANTHROPIC_VERSION)
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
+    let resp = send_provider_post(
+        client
+            .post(url)
+            .header("x-api-key", api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body),
+    )
+    .await
+    .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
 
     let status = resp.status();
     let text = resp
@@ -484,14 +536,15 @@ async fn call_openai(
     let mut attempt: u32 = 0;
     let (status, text) = loop {
         attempt += 1;
-        let resp = client
-            .post(url)
-            .bearer_auth(api_key)
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
+        let resp = send_provider_post(
+            client
+                .post(url)
+                .bearer_auth(api_key)
+                .header("content-type", "application/json")
+                .json(&body),
+        )
+        .await
+        .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
 
         let status = resp.status();
         let is_retryable = status == reqwest::StatusCode::TOO_MANY_REQUESTS
@@ -561,14 +614,15 @@ async fn call_azure(
         body["temperature"] = serde_json::json!(t);
         body["seed"] = serde_json::json!(42);
     }
-    let resp = client
-        .post(&url)
-        .header("api-key", api_key)
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
+    let resp = send_provider_post(
+        client
+            .post(&url)
+            .header("api-key", api_key)
+            .header("content-type", "application/json")
+            .json(&body),
+    )
+    .await
+    .map_err(|e| CrwError::Internal(format!("LLM request failed: {e}")))?;
 
     let status = resp.status();
     let text = resp

--- a/crates/crw-extract/src/responses.rs
+++ b/crates/crw-extract/src/responses.rs
@@ -51,15 +51,16 @@ async fn post(
     timeout: Duration,
 ) -> CrwResult<serde_json::Value> {
     let url = responses_url(llm.base_url.as_deref());
-    let resp = shared_client()
-        .post(&url)
-        .timeout(timeout)
-        .bearer_auth(&llm.api_key)
-        .header("content-type", "application/json")
-        .json(body)
-        .send()
-        .await
-        .map_err(|e| CrwError::ExtractionError(format!("Responses API request failed: {e}")))?;
+    let resp = crate::llm::send_provider_post(
+        shared_client()
+            .post(&url)
+            .timeout(timeout)
+            .bearer_auth(&llm.api_key)
+            .header("content-type", "application/json")
+            .json(body),
+    )
+    .await
+    .map_err(|e| CrwError::ExtractionError(format!("Responses API request failed: {e}")))?;
 
     let status = resp.status();
     let text = resp.text().await.map_err(|e| {

--- a/crates/crw-extract/src/structured.rs
+++ b/crates/crw-extract/src/structured.rs
@@ -408,16 +408,17 @@ pub(crate) async fn call_anthropic(
     };
 
     let client = shared_client();
-    let resp = client
-        .post(&url)
-        .timeout(timeout)
-        .header("x-api-key", &llm.api_key)
-        .header("anthropic-version", "2023-06-01")
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| CrwError::ExtractionError(format!("Anthropic API request failed: {e}")))?;
+    let resp = crate::llm::send_provider_post(
+        client
+            .post(&url)
+            .timeout(timeout)
+            .header("x-api-key", &llm.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&body),
+    )
+    .await
+    .map_err(|e| CrwError::ExtractionError(format!("Anthropic API request failed: {e}")))?;
 
     let status = resp.status();
     let text = resp.text().await.map_err(|e| {
@@ -659,15 +660,16 @@ pub(crate) async fn call_openai(
     };
 
     let client = shared_client();
-    let resp = client
-        .post(&url)
-        .timeout(timeout)
-        .header("Authorization", format!("Bearer {}", llm.api_key))
-        .header("content-type", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| CrwError::ExtractionError(format!("OpenAI API request failed: {e}")))?;
+    let resp = crate::llm::send_provider_post(
+        client
+            .post(&url)
+            .timeout(timeout)
+            .header("Authorization", format!("Bearer {}", llm.api_key))
+            .header("content-type", "application/json")
+            .json(&body),
+    )
+    .await
+    .map_err(|e| CrwError::ExtractionError(format!("OpenAI API request failed: {e}")))?;
 
     let status = resp.status();
     let text = resp

--- a/crates/crw-extract/tests/transport_retry.rs
+++ b/crates/crw-extract/tests/transport_retry.rs
@@ -1,0 +1,101 @@
+//! A provider that drops a pooled connection must not fail the caller.
+//!
+//! Every LLM call rides a process-wide pooled `reqwest::Client`, so a provider
+//! closing an idle keep-alive connection surfaces as a transport error on the
+//! next send even though the request never left us. These tests drive that
+//! exact failure over a real socket, which is also what pins the error match in
+//! `llm::send_provider_post` to hyper's actual wording.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crw_core::config::LlmConfig;
+use crw_extract::llm::chat;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const OK_BODY: &str = r#"{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}]}"#;
+
+/// Serve `OK_BODY`, but drop the first `dead_first` connections the moment they
+/// are accepted. Returns the base URL and the accepted-connection counter.
+async fn provider_dropping_first(dead_first: usize) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let seen = Arc::new(AtomicUsize::new(0));
+    let counter = seen.clone();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
+            if n <= dead_first {
+                // Close without answering: what a peer that already dropped the
+                // pooled connection looks like from our side.
+                drop(sock);
+                continue;
+            }
+            let mut buf = [0u8; 8192];
+            let _ = sock.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                OK_BODY.len(),
+                OK_BODY
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.flush().await;
+        }
+    });
+
+    (format!("http://{addr}/v1"), seen)
+}
+
+fn llm(base_url: String) -> LlmConfig {
+    LlmConfig {
+        provider: "openai-responses".into(),
+        api_key: "test-key".into(),
+        model: "test-model".into(),
+        base_url: Some(base_url),
+        max_tokens: 64,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn a_dead_connection_is_retried_and_the_call_succeeds() {
+    let (base_url, seen) = provider_dropping_first(1).await;
+
+    let result = chat(&llm(base_url), "sys", "user")
+        .await
+        .expect("the retry rescues a connection that died before delivery");
+
+    assert_eq!(result.content, "hello");
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        2,
+        "one failed connection plus one retry"
+    );
+}
+
+#[tokio::test]
+async fn the_retry_happens_at_most_once() {
+    // A provider that is genuinely down must surface as an error rather than
+    // being hammered: these calls are billed, so the retry budget is exactly
+    // one extra attempt.
+    let (base_url, seen) = provider_dropping_first(usize::MAX).await;
+
+    let err = chat(&llm(base_url), "sys", "user")
+        .await
+        .expect_err("a provider that never answers still fails");
+
+    assert!(
+        err.to_string().contains("Responses API request failed"),
+        "the transport error is surfaced: {err}"
+    );
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        2,
+        "the original send plus exactly one retry"
+    );
+}


### PR DESCRIPTION
Every LLM provider call rides a process-wide pooled `reqwest::Client`, and a
provider (or any middlebox) may close an idle keep-alive connection whenever it
likes. We only find out on the next send, so a perfectly good request failed
with `error sending request for url (...)` having never left us, and reached the
caller as a failed extraction.

The existing retry in `llm::dispatch` covered HTTP 429/503 only, and its comment
made the gap explicit: transport and timeout errors kept "the original
single-POST contract: hard-error on the first response."

This is the same mechanism that made `responses_tests.rs` flaky in CI (us/crw#417),
just reached from the production side instead of a test.

**What changed**

All six provider POSTs (Anthropic, OpenAI chat completions, Azure, Responses,
and the two structured-output paths) now go through `llm::send_provider_post`,
which retries exactly once and only when the request provably never reached the
provider:

- a connector failure (`reqwest::Error::is_connect`), or
- hyper reporting `connection closed before message completed` anywhere in the
  error source chain.

Timeouts are deliberately excluded: the provider may already be working on a
call, and replaying it would bill the user twice for one answer. The retry
budget is exactly one extra attempt, so a provider that is genuinely down still
fails fast.

**Why the message is matched as a string**

`is_connect()` is false for this failure and there is no `io::Error` anywhere in
the chain (measured, not assumed), so the only reliable marker is hyper's own
wording. hyper is not a direct dependency of `crw-extract` and adding one just
to classify an error is not worth it, so the string is matched and pinned by a
test that drives the real failure over a socket. A hyper rewording fails that
test rather than silently disabling the retry.

**Verification**

`crates/crw-extract/tests/transport_retry.rs` stands up a TCP listener that
drops connections on accept:

- `a_dead_connection_is_retried_and_the_call_succeeds` -- first connection
  dropped, call succeeds, exactly 2 connections observed.
- `the_retry_happens_at_most_once` -- every connection dropped, the error is
  surfaced, exactly 2 connections observed.

Negative control: with the retry disabled both tests fail; with it, both pass.
