### PR TITLE
fix: stop selling refused pages as successful scrapes

### DIFF
--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -162,11 +162,17 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         status: CrawlStatus::InProgress,
         total: 0,
         completed: 0,
+        blocked: 0,
         data: vec![],
         error: None,
     });
 
     // Spawn the crawl task
+    // One config load for both extraction knobs the crawl has to match the
+    // single-scrape path on.
+    let crawl_extraction_cfg = crw_core::config::AppConfig::load()
+        .unwrap_or_default()
+        .extraction;
     let crawl_opts = CrawlOptions {
         id,
         req: crawl_req,
@@ -181,10 +187,8 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         jitter_factor: 0.2,
         deadline_ms_per_page: args.timeout,
         per_host_max_concurrent: 1,
-        normalize_tables: crw_core::config::AppConfig::load()
-            .unwrap_or_default()
-            .extraction
-            .normalize_tables,
+        http_retry_threshold_bytes: crawl_extraction_cfg.http_retry_threshold_bytes,
+        normalize_tables: crawl_extraction_cfg.normalize_tables,
     };
 
     let crawl_handle = tokio::spawn(async move {

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -743,9 +743,12 @@ pub struct ScrapeData {
     /// once in `single.rs` (`FetchResult.screenshot` stays raw base64).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screenshot: Option<String>,
-    /// Anti-bot verdict stamped once at the scrape choke (`single::scrape_url`).
-    /// `Some` means the page is a block/challenge shell — v1/v2 turn this into
-    /// `success:false`. `None` (skipped when serializing) = not blocked.
+    /// Why this document has no body: an anti-bot verdict stamped at the scrape
+    /// choke (`single::scrape_url`), or — on the crawl and batch paths, which
+    /// return documents rather than one envelope — `HTTP_ERROR_VENDOR` for an
+    /// origin error page. `Some` means the caller did not get the page they
+    /// asked for, so v1/v2 turn it into `success:false` and nobody bills it.
+    /// `None` (skipped when serializing) = a real page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block: Option<BlockOutcome>,
     /// The renderer snapshotted a partial DOM because the navigation budget
@@ -757,7 +760,74 @@ pub struct ScrapeData {
     pub truncated: bool,
 }
 
+/// Above this many bytes of body, a `>= 400` response is treated as the real page
+/// rather than the origin's error page.
+///
+/// Measured, not guessed. Across one prod day (43 responses graded `success` while
+/// carrying `metadata.statusCode >= 400`) the largest error page — a CentOS Apache
+/// test page — rendered to 2,356 bytes of markdown, and the next-largest 4xx body
+/// was 3,340. So the bar sits in that gap. Above it live real pages served under an
+/// error status, which the renderer deliberately keeps (`crw_renderer` accept gate,
+/// and `crw_crawl::single`: "the status is a soft signal, not a content gate"):
+/// stackoverflow.com under 403 renders 39,499 chars, a YouTube watch page under 401
+/// renders 12,256, a Medium article under 403 renders 10,826.
+///
+/// Deliberately conservative. It leaves large branded 404s (GitHub's is 3,340)
+/// passing as successes; raising it is a recall decision that needs its own
+/// benchmark run, not a nudge.
+const ERROR_PAGE_MAX_TEXT: usize = 2_500;
+
 impl ScrapeData {
+    /// Size of the body the caller actually asked for, in bytes.
+    ///
+    /// Text formats first: the previous gate took `.max()` across all four body
+    /// fields, so an error page's raw HTML — always large — kept the gate from
+    /// ever firing whenever `formats` included `html` or `rawHtml`.
+    ///
+    /// But measuring only text would be worse than the bug it fixes. A request
+    /// for `formats:["rawHtml"]` populates neither text field, so a text-only
+    /// measurement reads 0 and fails **every** `>= 400` response, including the
+    /// large real pages that soft-block statuses are known to carry. So when the
+    /// caller asked for no text at all, fall back to the markup we do hold. It
+    /// discriminates less well (an error page's HTML is bulkier than its text),
+    /// which is the right direction to be wrong in.
+    /// `None` when the document holds no body at all — `formats:["screenshot"]`,
+    /// `["links"]` and a summary-only request all populate none of these fields,
+    /// and "nothing to measure" must not be read as "measured nothing".
+    /// A present-but-empty field is a real measurement of 0: the caller asked for
+    /// that format and the page yielded none of it.
+    fn rendered_text_len(&self) -> Option<usize> {
+        let text = [self.markdown.as_deref(), self.plain_text.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(str::len)
+            .max();
+        text.or_else(|| {
+            [self.html.as_deref(), self.raw_html.as_deref()]
+                .into_iter()
+                .flatten()
+                .map(str::len)
+                .max()
+        })
+    }
+
+    /// `Some(message)` when the origin answered `>= 400` and what we are holding is
+    /// its error page rather than the page that was asked for.
+    ///
+    /// One helper for every surface: v1, v2, crawl and batch all have to agree, or
+    /// the same URL is refunded on one endpoint and billed on another.
+    pub fn http_error(&self) -> Option<String> {
+        let status = self.metadata.status_code;
+        if status < 400 || self.rendered_text_len()? >= ERROR_PAGE_MAX_TEXT {
+            return None;
+        }
+        Some(
+            self.warning
+                .clone()
+                .unwrap_or_else(|| format!("Target returned HTTP {status}")),
+        )
+    }
+
     /// Clear the page-content fields (markdown, HTML, text, links, and any
     /// LLM-derived outputs), keeping `metadata`, `block`, warnings, and the
     /// screenshot. Used on the block-response path so a detected anti-bot
@@ -793,6 +863,12 @@ pub struct BlockOutcome {
 /// keeps inside `AntibotSignal` because `is_blocked()` drives renderer escalation.
 /// See `message()` for why the customer-facing wording splits here.
 pub const STRUCTURAL_FAILURE_VENDOR: &str = "structural_failure";
+
+/// `BlockOutcome::vendor` for "the origin answered with an error status and this
+/// is its error page". Not an anti-bot verdict, but the same consequence for the
+/// caller and for billing, and the crawl/batch surfaces have nowhere else to say
+/// it: they return an array of documents, not an envelope with an error code.
+pub const HTTP_ERROR_VENDOR: &str = "http_error";
 
 impl BlockOutcome {
     /// Standard anti-bot block error string shared by the v1 and v2 handlers so
@@ -973,6 +1049,115 @@ pub fn resolve_pinned_renderer(req: Option<RequestedRenderer>) -> Option<&'stati
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fully populated document, so each test can vary just the field it is about.
+    fn blocked_fixture() -> ScrapeData {
+        ScrapeData {
+            markdown: Some("Just a moment... Humans only".into()),
+            source_hash: Some("sha256:abc".into()),
+            html: Some("<html>challenge</html>".into()),
+            raw_html: Some("<html>challenge</html>".into()),
+            plain_text: Some("challenge text".into()),
+            links: Some(vec!["https://help.example.com".into()]),
+            images: Some(vec![ScrapedImage {
+                url: "https://help.example.com/logo.png".into(),
+                alt: Some("logo".into()),
+            }]),
+            json: Some(serde_json::json!({"junk": true})),
+            summary: Some("a summary of junk".into()),
+            llm_usage: None,
+            chunks: None,
+            warning: Some("blocked".into()),
+            warnings: vec!["blocked".into()],
+            render_decision: None,
+            credit_cost: 0,
+            basis: None,
+            basis_warnings: Vec::new(),
+            llm_input_hash: None,
+            metadata: PageMetadata {
+                title: None,
+                description: None,
+                og_title: None,
+                og_description: None,
+                og_image: None,
+                canonical_url: None,
+                source_url: "https://www.glassdoor.com/Reviews/x.htm".into(),
+                language: None,
+                status_code: 200,
+                rendered_with: None,
+                elapsed_ms: 0,
+                page_count: None,
+                source_filename: None,
+                extra: Default::default(),
+            },
+            debug_extraction: None,
+            content_type: Some("text/html".into()),
+            change_tracking: None,
+            screenshot: Some("data:image/png;base64,AA".into()),
+            block: Some(BlockOutcome {
+                vendor: "cloudflare".into(),
+                reason: "cloudflare challenge interstitial".into(),
+            }),
+            truncated: false,
+        }
+    }
+
+    fn page(status: u16, markdown_len: usize) -> ScrapeData {
+        let mut d = blocked_fixture();
+        d.metadata.status_code = status;
+        d.markdown = Some("x".repeat(markdown_len));
+        d.plain_text = None;
+        d.html = None;
+        d.raw_html = None;
+        d.warning = None;
+        d
+    }
+
+    #[test]
+    fn http_error_fires_on_an_error_page_and_spares_a_real_one() {
+        // americastire.com: 403 with 650 bytes of CloudFront prose, billed as a
+        // success in prod for months because the old bar was 200 bytes.
+        assert!(page(403, 650).http_error().is_some());
+        // stackoverflow.com/questions/tagged/rust answers 403 and serves the real
+        // page (39,499 chars). The renderer keeps it on purpose; so must this.
+        assert!(page(403, 39_499).http_error().is_none());
+        // A thin page that the origin says is fine stays a success.
+        assert!(page(200, 2).http_error().is_none());
+    }
+
+    #[test]
+    fn http_error_is_silent_when_there_is_no_body_to_judge() {
+        // `formats:["screenshot"]` / `["links"]` populate none of the four body
+        // fields. Nothing to measure is not a measurement of nothing.
+        let mut d = page(403, 0);
+        d.markdown = None;
+        d.plain_text = None;
+        d.html = None;
+        d.raw_html = None;
+        assert!(d.http_error().is_none());
+    }
+
+    #[test]
+    fn http_error_measures_markup_when_no_text_was_requested() {
+        // `formats:["rawHtml"]` populates neither text field. Measuring text only
+        // would read 0 and fail every >= 400 response, including the large real
+        // pages that soft-block statuses are known to carry.
+        let mut d = page(403, 0);
+        d.markdown = None;
+        d.raw_html = Some("<html>".repeat(2_000));
+        assert!(d.http_error().is_none());
+        d.raw_html = Some("<html>403</html>".into());
+        assert!(d.http_error().is_some());
+    }
+
+    #[test]
+    fn http_error_ignores_raw_html_length() {
+        // The old gate took `.max()` across markdown/text/html/rawHtml, so asking
+        // for `rawHtml` made the bar unreachable and the gate never fired.
+        let mut d = page(404, 250);
+        d.raw_html = Some("<html>".repeat(10_000));
+        assert!(d.http_error().is_some());
+    }
 
     #[test]
     fn clear_body_drops_content_keeps_metadata_and_block() {
@@ -1356,6 +1541,13 @@ pub struct CrawlState {
     pub status: CrawlStatus,
     pub total: u32,
     pub completed: u32,
+    /// How many of `completed` came back a block or an origin error page rather
+    /// than the requested page. Counted here because a caller billing per page
+    /// reads this envelope, not the paginated `data` array — and a walled page
+    /// must not be charged. Additive: `#[serde(default)]` keeps an older client
+    /// and an older engine interoperable in both directions.
+    #[serde(default)]
+    pub blocked: u32,
     pub data: Vec<ScrapeData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -48,6 +48,11 @@ pub struct CrawlOptions<'a> {
     /// a single scrape of the same URL produce the same markdown; leaving it
     /// hardcoded would silently diverge the two paths once the flag is flipped.
     pub normalize_tables: bool,
+    /// From `ExtractionConfig::http_retry_threshold_bytes`. Same reason as
+    /// `normalize_tables`: `classify_block` takes it, and a crawl that judged
+    /// blocks differently from a single scrape of the same URL would bill the
+    /// customer for a wall on one surface and refund it on the other.
+    pub http_retry_threshold_bytes: usize,
 }
 
 /// Validate that a URL is safe to fetch (scheme + host check).
@@ -63,6 +68,7 @@ fn send_failed(id: Uuid, state_tx: &tokio::sync::watch::Sender<CrawlState>, erro
         status: CrawlStatus::Failed,
         total: 0,
         completed: 0,
+        blocked: 0,
         data: vec![],
         error: Some(error),
     });
@@ -124,6 +130,7 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         deadline_ms_per_page,
         per_host_max_concurrent,
         normalize_tables,
+        http_retry_threshold_bytes,
     } = opts;
 
     let max_depth = req.max_depth.unwrap_or(2).min(10);
@@ -232,6 +239,10 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
     let mut visited: HashSet<String> = HashSet::new();
     let mut queue: VecDeque<(String, u32)> = VecDeque::new();
     let mut results: Vec<ScrapeData> = Vec::new();
+    // How many completed pages came back a wall or an origin error page. The
+    // caller bills off `completed`, so it needs this to bill `completed - blocked`
+    // without walking the paginated array.
+    let mut blocked: u32 = 0;
 
     queue.push_back((req.url.clone(), 0));
     visited.insert(normalize_url(&req.url));
@@ -393,7 +404,55 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         // POST /v1/change-tracking/diff, not inline here.
         data.content_type = fetch_result.content_type.clone();
 
+        // Same verdict a single scrape gets. Without this a crawl shipped the
+        // Cloudflare wall as the page's markdown, `success: true`, billed — the
+        // classifier was simply never called on this path.
+        //
+        // With one exception: `structural_failure` is not applied here. It means
+        // "we got a 200 and produced nothing", and `single::scrape_url` only
+        // reaches that verdict after a JS escalation has already failed to
+        // recover the page. A crawl does one fetch and no escalation, so the same
+        // verdict here would fail JS-hydrated pages that `/v1/scrape` recovers —
+        // the cross-surface divergence this change exists to remove, inverted.
+        data.block = crate::single::classify_block(
+            fetch_result.status_code,
+            fetch_result.content_type.as_deref(),
+            &fetch_result.html,
+            data.markdown.as_deref(),
+            fetch_result.screenshot.is_some(),
+            http_retry_threshold_bytes,
+        )
+        .filter(|b| b.vendor != crw_core::types::STRUCTURAL_FAILURE_VENDOR);
+        // An origin error page is not the page that was asked for either. One
+        // helper, so `/v1/scrape` and a crawl of the same URL agree. It is
+        // stamped onto `block` because a crawl returns documents, not an
+        // envelope with an error code — and the caller's billing filters on
+        // exactly this field.
+        let is_wall = data.block.is_some();
+        if !is_wall && let Some(reason) = data.http_error() {
+            data.block = Some(crw_core::types::BlockOutcome {
+                vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
+                reason,
+            });
+        }
+        if data.block.is_some() {
+            // Only a wall loses its body, matching `/v1/scrape`: there the
+            // challenge shell is dropped and the origin's error page is kept for
+            // the caller to read. Either way the page is marked and not billed.
+            if is_wall {
+                data.clear_body();
+            }
+            blocked += 1;
+        }
+
+        // Never send a refused page to the model. A wall dodges this by accident
+        // (`clear_body()` nulled the markdown); an origin error page keeps its
+        // body on purpose, so without the check a crawl with a `jsonSchema` over
+        // a 404-heavy site makes one real provider call per error page — pages
+        // that are then counted `blocked` and not billed, so we pay and nobody
+        // is charged.
         if let (Some(schema), Some(llm)) = (&req.json_schema, llm_config)
+            && data.block.is_none()
             && let Some(md) = &data.markdown
         {
             match crw_extract::structured::extract_structured_with_usage(
@@ -427,6 +486,7 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
             status: CrawlStatus::InProgress,
             total: visited.len() as u32,
             completed: results.len() as u32,
+            blocked,
             data: vec![],
             error: None,
         });
@@ -438,6 +498,7 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         status: CrawlStatus::Completed,
         total: visited.len() as u32,
         completed: results.len() as u32,
+        blocked,
         data: results,
         error: None,
     });

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -519,6 +519,16 @@ async fn scrape_url_inner(
                             // requested) lives on `js_fetch`, not the original low-tier
                             // `fetch_result`. Carry it over so it isn't dropped.
                             fetch_result.screenshot = js_fetch.screenshot.take();
+                            // Same for the body: `classify_block` below reads
+                            // `fetch_result.html`, and leaving the DISCARDED tier's
+                            // shell there means a challenge we just solved still
+                            // carries `_cf_chl_opt` into CF_STRONG_MARKERS — which
+                            // runs ahead of the markdown guard and would clear the
+                            // page this escalation just recovered.
+                            // `content_type` is deliberately NOT swapped: every
+                            // browser tier hardcodes it to `None`, and it is read
+                            // later for `data.content_type`.
+                            fetch_result.html = std::mem::take(&mut js_fetch.html);
                             // Replace the original "Target returned 4xx" with the JS
                             // fetch's warning (which is None for a clean 2xx render),
                             // so a successful escalation doesn't leak the original
@@ -609,7 +619,13 @@ async fn scrape_url_inner(
         ));
     }
 
-    if formats_include_json(&req.formats) {
+    // Never send a wall or an origin error page to the model. The verdict is
+    // already stamped above and every surface turns it into a failure, so any LLM
+    // work below is billed to us by the provider and to nobody by us — an extract
+    // job over a walled domain used to make one real call per URL and report zero
+    // tokens.
+    let unusable = data.block.is_some() || data.http_error().is_some();
+    if formats_include_json(&req.formats) && !unusable {
         // A schema OR a prompt is enough to run structured extraction.
         if effective_schema.is_none() && effective_prompt.is_none() {
             return Err(crw_core::error::CrwError::InvalidRequest(
@@ -680,7 +696,8 @@ async fn scrape_url_inner(
         }
     }
 
-    if formats_include_summary(&req.formats) {
+    // Same reason as the json branch above: neither is summarizable content.
+    if formats_include_summary(&req.formats) && !unusable {
         let Some(llm) = effective_llm else {
             return Err(crw_core::error::CrwError::ExtractionError(
                 "Summary format requires an LLM config. Either set [extraction.llm] in server config, or pass 'llmApiKey' in the request body.".into()
@@ -1135,7 +1152,7 @@ fn detect_block_interstitial(html: &str) -> Option<String> {
 /// 3. Reuse the trusted `crw_extract::antibot::classify` detector.
 /// 4. A captured screenshot may suppress ONLY the generic near-empty
 ///    StructuralFailure heuristic — never a positive vendor block.
-fn classify_block(
+pub(crate) fn classify_block(
     status: u16,
     content_type: Option<&str>,
     html: &str,
@@ -1144,6 +1161,14 @@ fn classify_block(
     threshold: usize,
 ) -> Option<BlockOutcome> {
     if content_type.map(|c| c.contains("pdf")).unwrap_or(false) {
+        return None;
+    }
+    // Our own egress failing proxy auth is not the target blocking us. Narrow to
+    // exactly that: a 407 with no body. Everything else with an empty body stays
+    // classifiable, because a near-empty 403/503 is the canonical CloudFront and
+    // Akamai deny signature and a near-empty 429 is the canonical rate limit —
+    // those feed `blockVendor`, which feeds the routing registry.
+    if status == 407 && html.is_empty() {
         return None;
     }
     // Modern Cloudflare Turnstile / managed challenge is frequently served with
@@ -1248,6 +1273,19 @@ fn classify_block(
         return None;
     }
     if screenshot_present && r.signal == crw_extract::antibot::AntibotSignal::StructuralFailure {
+        return None;
+    }
+    // A non-HTML body is CONTENT, so the HTML SHAPE heuristics do not apply to it:
+    // the HTTP tier decodes every non-PDF response as HTML, so a 68-byte
+    // requirements.txt has no `<body>` and came back `structural_failure` /
+    // `anti_bot` — measured live on raw.githubusercontent.com. Only the structural
+    // verdict is suppressed; the vendor arms above stay live, because a wall IS
+    // sometimes served under a data content type (DataDome answers XHR-shaped
+    // requests with an `application/json` captcha stub, and `escalate_for_quality`
+    // below runs `classify` on JSON bodies for the same reason).
+    if r.signal == crw_extract::antibot::AntibotSignal::StructuralFailure
+        && !crw_renderer::is_html_like_content_type(content_type)
+    {
         return None;
     }
     Some(BlockOutcome {
@@ -1647,6 +1685,64 @@ mod tests {
     fn classify_block_pdf_skipped() {
         // PDF branch has empty html — must not false-flag as StructuralFailure.
         assert!(classify_block(200, Some("application/pdf"), "", None, false, THRESH).is_none());
+    }
+
+    #[test]
+    fn classify_block_skips_non_html_payloads() {
+        // A 68-byte requirements.txt from raw.githubusercontent.com came back
+        // `success:false` / `anti_bot` in prod: "Near-empty content (68 bytes)
+        // with HTTP 200". It is a complete, valid file.
+        let txt = "fastapi>=0.110.0\nuvicorn>=0.29.0\npydantic>=2.6\npython-multipart\n";
+        assert!(classify_block(200, Some("text/plain"), txt, Some(txt), false, THRESH).is_none());
+        for ct in [
+            "text/csv",
+            "application/json",
+            "text/markdown",
+            "application/javascript",
+            "text/css",
+        ] {
+            assert!(
+                classify_block(200, Some(ct), "x", None, false, THRESH).is_none(),
+                "{ct} was classified as a block"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_block_still_sees_a_vendor_wall_under_a_data_content_type() {
+        // Only the HTML SHAPE heuristics are suppressed for non-HTML bodies.
+        // DataDome answers XHR-shaped requests with an application/json captcha
+        // stub, and that is still a block.
+        let json = r#"{"url":"https://geo.captcha-delivery.com/captcha/?initialCid=x"}"#;
+        assert!(classify_block(200, Some("application/json"), json, None, false, THRESH).is_some());
+    }
+
+    #[test]
+    fn classify_block_still_sees_walls_without_a_content_type() {
+        // The guard must not blind the classifier: a wall is html or type-less.
+        let html = "<html><body>You've been blocked by network security. \
+                    Please log in to your Reddit account.</body></html>";
+        assert!(classify_block(200, None, html, None, false, THRESH).is_some());
+    }
+
+    #[test]
+    fn classify_block_407_is_our_proxy_not_a_target_block() {
+        // 215 records in 14 days of prod were our own DataImpulse egress failing
+        // auth, stamped `structural_failure` and poisoning the routing registry.
+        assert!(classify_block(407, Some("text/html"), "", None, false, THRESH).is_none());
+        // Everything else with an empty body stays classifiable: a near-empty
+        // 403/503 is the canonical CloudFront/Akamai deny signature.
+        assert!(classify_block(403, Some("text/html"), "", None, false, THRESH).is_some());
+    }
+
+    #[test]
+    fn classify_block_modern_cf_marker_beats_the_markdown_guard() {
+        // Why the accepted JS escalation must replace `fetch_result.html`: with
+        // the discarded tier's shell still in place, a challenge we SOLVED is
+        // stamped `cloudflare` here and `clear_body()` throws the recovery away.
+        let html = r#"<html><body><script>window._cf_chl_opt={}</script></body></html>"#;
+        let md = "x".repeat(500);
+        assert!(classify_block(200, Some("text/html"), html, Some(&md), false, THRESH).is_some());
     }
 
     fn sample_fetch(status_code: u16, html: &str) -> FetchResult {

--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -1684,6 +1684,7 @@ async fn wait_for_page_ready(
 ) -> CrwResult<u16> {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut main_document_status: Option<u16> = None;
+    let mut main_frame: Option<String> = None;
 
     loop {
         match tokio::time::timeout_at(deadline, events.recv()).await {
@@ -1705,7 +1706,24 @@ async fn wait_for_page_ready(
                             .get("type")
                             .and_then(|v| v.as_str())
                             .is_some_and(|v| v == "Document");
-                        if is_document {
+                        // An iframe is a Document too. Without the frame check a
+                        // 404 ad/widget frame inside a healthy page stamps the
+                        // page 404 — harmless while nothing read the status, but
+                        // `ScrapeData::http_error` now fails the page on it.
+                        // First Document response wins the main frame; later ones
+                        // on that frame are redirects, and last-wins is right.
+                        let frame_id = ev.params.get("frameId").and_then(|v| v.as_str());
+                        // Adopt only a frame we can actually name. Adopting a
+                        // `None` would leave the slot unfilled and let the NEXT
+                        // Document response — an iframe — claim it.
+                        if is_document && main_frame.is_none() && frame_id.is_some() {
+                            main_frame = frame_id.map(str::to_string);
+                        }
+                        // Until a main frame is known, keep the old behaviour of
+                        // taking any Document status rather than reporting none.
+                        if is_document
+                            && (main_frame.is_none() || frame_id == main_frame.as_deref())
+                        {
                             main_document_status = ev
                                 .params
                                 .get("response")

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -390,7 +390,11 @@ fn has_recovery_tier(
         || http_fallback_proxy_ready
 }
 
-/// May a browser render plausibly reveal more than this response body did?
+/// Is this response an HTML document, or an unknown type we must assume is one?
+///
+/// Two callers, one question. A browser render can only add to an HTML document,
+/// and the HTML structural heuristics in `antibot::classify` are only meaningful
+/// on one (`crw_crawl::single::classify_block`).
 ///
 /// The HTTP tier decodes every non-PDF response as HTML regardless of its
 /// declared type, so an empty `application/json` / `text/plain` / `image/*` /
@@ -399,7 +403,7 @@ fn has_recovery_tier(
 /// nothing but latency. Absent or unrecognised types stay eligible: a server
 /// that omits `Content-Type` on a bot-wall shell is exactly the case worth
 /// escalating.
-fn content_type_allows_js_escalation(content_type: Option<&str>) -> bool {
+pub fn is_html_like_content_type(content_type: Option<&str>) -> bool {
     match content_type {
         None => true,
         Some(ct) => {
@@ -471,7 +475,17 @@ fn is_origin_navigation_failure(e: &CrwError) -> bool {
         // carry different messages and keep their own error.
         CrwError::RendererError(msg) => {
             let m = msg.to_ascii_lowercase();
-            m.contains("navigation failed") || m.contains("net::err_")
+            m.contains("navigation failed")
+                || m.contains("net::err_")
+                // "we could not confirm where this origin points" — the CDP
+                // destination re-check collapses NXDOMAIN and a resolver
+                // brown-out into one `Unresolved`. Same reasoning as the
+                // `Timeout` arm below: absence of evidence, not evidence
+                // against the HTTP tier's independent finding. Without this a
+                // dead host exits as 500 `renderer_error` ("the page could not
+                // be rendered") instead of 422 `target_unreachable`, which was
+                // 10,107 requests over 14 days in prod.
+                || m.contains("outbound destination check unavailable")
         }
         // A JS-tier timeout does not refute the HTTP tier's positive finding. Both
         // callers only consult this when the HTTP error was already
@@ -1833,7 +1847,7 @@ impl FallbackRenderer {
                 let is_empty_2xx = is_2xx
                     && !is_hard_pinned
                     && !matches!(result.status_code, 204..=206)
-                    && content_type_allows_js_escalation(result.content_type.as_deref())
+                    && is_html_like_content_type(result.content_type.as_deref())
                     && result.html.trim().is_empty();
 
                 if !self.js_renderers.is_empty()
@@ -3576,10 +3590,7 @@ mod tests {
             Some("text/html"),
             Some("application/xhtml+xml"),
         ] {
-            assert!(
-                content_type_allows_js_escalation(ct),
-                "{ct:?} should stay eligible"
-            );
+            assert!(is_html_like_content_type(ct), "{ct:?} should stay eligible");
         }
         for ct in [
             "application/json",
@@ -3589,7 +3600,7 @@ mod tests {
             "text/csv",
         ] {
             assert!(
-                !content_type_allows_js_escalation(Some(ct)),
+                !is_html_like_content_type(Some(ct)),
                 "{ct} cannot be improved by a browser"
             );
         }

--- a/crates/crw-server/src/routes/scrape.rs
+++ b/crates/crw-server/src/routes/scrape.rs
@@ -84,42 +84,39 @@ pub async fn scrape(
     )
     .await?;
 
-    // Return success:false when target HTTP status >= 400 and body is minimal.
-    // Check all text-producing formats so rawHtml-only requests aren't falsely flagged.
-    let status_code = data.metadata.status_code;
-    if status_code >= 400 {
-        let body_len = [
-            data.markdown.as_deref(),
-            data.plain_text.as_deref(),
-            data.html.as_deref(),
-            data.raw_html.as_deref(),
-        ]
-        .iter()
-        .filter_map(|opt| opt.map(|t| t.len()))
-        .max()
-        .unwrap_or(0);
-
-        if body_len < 200 {
-            let error_msg = data
-                .warning
-                .clone()
-                .unwrap_or_else(|| format!("Target returned HTTP {status_code}"));
-            return Ok(Json(ApiResponse {
-                success: false,
-                data: Some(data),
-                error: Some(error_msg),
-                error_code: Some("http_error".into()),
-                warning: None,
-            }));
-        }
+    // The origin answered with an error status and what came back is its error
+    // page, so this is `success:false` however the caller framed the request.
+    // `ScrapeData::http_error` owns both halves of that judgement (see its
+    // measured text bar) and is shared with v2, crawl and batch — the same URL
+    // must not be refunded on one surface and billed on another.
+    //
+    // The body stays in the envelope: the caller can still read the error page
+    // and `metadata.statusCode`. Only a genuine wall gets `clear_body()` below.
+    if let Some(error_msg) = data.http_error() {
+        return Ok(Json(ApiResponse {
+            success: false,
+            data: Some(data),
+            error: Some(error_msg),
+            error_code: Some("http_error".into()),
+            warning: None,
+        }));
     }
 
     // Anti-bot block: the verdict is now classified ONCE at the scrape choke
     // (`single::classify_block`) and stamped onto `data.block`, so v1/v2/crawl
-    // share one decision. `error_code` stays "anti_bot" (identical to the prior
-    // md_empty path) so credit-refund logic is unchanged.
+    // share one decision.
     if let Some(b) = data.block.clone() {
         let error_msg = b.message();
+        // A structural failure is not a wall: it is "we fetched the page fine and
+        // there was nothing usable in it". The customer-facing message has split
+        // these since `BlockOutcome::message()`; the machine-readable code now
+        // does too, so a client can branch without matching English. Refunds are
+        // unaffected — the SaaS keys on `success:false`, not on this code.
+        let error_code = if b.vendor == crw_core::types::STRUCTURAL_FAILURE_VENDOR {
+            "no_usable_content"
+        } else {
+            "anti_bot"
+        };
         // Drop the interstitial/challenge shell so the caller gets a clean block
         // instead of the "Just a moment / Humans only" wall as markdown. Runs
         // after the http_error gate above, which reads the content lengths.
@@ -129,7 +126,7 @@ pub async fn scrape(
             success: false,
             data: Some(data),
             error: Some(error_msg),
-            error_code: Some("anti_bot".into()),
+            error_code: Some(error_code.into()),
             warning: None,
         }));
     }

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -134,6 +134,11 @@ pub struct V2CrawlStatus {
     pub status: &'static str,
     pub total: u32,
     pub completed: u32,
+    /// How many of `completed` came back a block or an origin error page.
+    /// Additive to the Firecrawl envelope (their SDKs ignore unknown keys) and
+    /// load-bearing: the SaaS bills off `completed`, and without this the
+    /// blocked-page billing fix would be inert on every `/v2` status surface.
+    pub blocked: u32,
     pub credits_used: u32,
     pub expires_at: String,
     /// Pagination cursor; `null` once the job is `completed` and no further
@@ -213,9 +218,16 @@ pub fn build_crawl_status(
         None
     };
 
+    // A blocked page is not billed, so it must not be counted here either.
+    // Note this is a lower bound rather than the exact charge on the batch path:
+    // `completed` also advances for a URL whose scrape returned `Err` and pushed
+    // no document, and the SaaS bills `completed - blocked`. Pre-existing; fixing
+    // it means changing what `completed` counts, which the job-completion gate
+    // depends on.
     let credits_used: u32 = state
         .data
         .iter()
+        .filter(|d| d.block.is_none())
         .map(|d| if d.credit_cost == 0 { 1 } else { d.credit_cost })
         .sum();
 
@@ -224,6 +236,7 @@ pub fn build_crawl_status(
         status: status_str(state.status),
         total: state.total.max(total_docs as u32),
         completed: state.completed,
+        blocked: state.blocked,
         credits_used,
         expires_at: expires_at_rfc3339(created_at, job_ttl_secs),
         next,
@@ -349,6 +362,7 @@ mod tests {
             status,
             total,
             completed,
+            blocked: 0,
             data: (0..n)
                 .map(|i| fake_doc(&format!("https://x/{i}")))
                 .collect(),

--- a/crates/crw-server/src/routes/v2/scrape.rs
+++ b/crates/crw-server/src/routes/v2/scrape.rs
@@ -263,26 +263,7 @@ pub async fn scrape(
     // is a plain HTTP error, not an anti-bot block. It must short-circuit before
     // the block check so classify()'s StructuralFailure can't mislabel it, and
     // so both API surfaces label the identical page the same way.
-    let status_code = data.metadata.status_code;
-    let http_error = if status_code >= 400 {
-        let body_len = [
-            data.markdown.as_deref(),
-            data.plain_text.as_deref(),
-            data.html.as_deref(),
-            data.raw_html.as_deref(),
-        ]
-        .iter()
-        .filter_map(|opt| opt.map(|t| t.len()))
-        .max()
-        .unwrap_or(0);
-        (body_len < 200).then(|| {
-            data.warning
-                .clone()
-                .unwrap_or_else(|| format!("Target returned HTTP {status_code}"))
-        })
-    } else {
-        None
-    };
+    let http_error = data.http_error();
     // Anti-bot verdict from the choke: a blocked page is `success:false` with an
     // error string, matching v1's behaviour. Read before `to_v2_document`
     // consumes `data`.

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -445,6 +445,7 @@ impl AppState {
             status: CrawlStatus::InProgress,
             total: 0,
             completed: 0,
+            blocked: 0,
             data: vec![],
             error: None,
         };
@@ -476,6 +477,7 @@ impl AppState {
         let deadline_ms_per_page = self.config.effective_deadline_ms(None, req.wait_for);
         let per_host_max_concurrent = self.config.crawler.per_host_max_concurrent;
         let normalize_tables = self.config.extraction.normalize_tables;
+        let http_retry_threshold_bytes = self.config.extraction.http_retry_threshold_bytes;
 
         let handle = tokio::spawn(async move {
             let _permit = match crawl_semaphore.acquire().await {
@@ -487,6 +489,7 @@ impl AppState {
                         status: CrawlStatus::Failed,
                         total: 0,
                         completed: 0,
+                        blocked: 0,
                         data: vec![],
                         error: Some("Server is overloaded, try again later".into()),
                     });
@@ -514,6 +517,7 @@ impl AppState {
                         deadline_ms_per_page,
                         per_host_max_concurrent,
                         normalize_tables,
+                        http_retry_threshold_bytes,
                     })
                     .await;
                 })
@@ -549,6 +553,7 @@ impl AppState {
             status: CrawlStatus::InProgress,
             total,
             completed: 0,
+            blocked: 0,
             data: vec![],
             error: None,
         });
@@ -588,6 +593,7 @@ impl AppState {
                         status: CrawlStatus::Failed,
                         total,
                         completed: 0,
+                        blocked: 0,
                         data: vec![],
                         error: Some("Server is overloaded, try again later".into()),
                     });
@@ -602,6 +608,7 @@ impl AppState {
                     status: CrawlStatus::Completed,
                     total: 0,
                     completed: 0,
+                    blocked: 0,
                     data: vec![],
                     error: None,
                 });
@@ -669,7 +676,31 @@ impl AppState {
                                 // copying on large batches). A failed scrape still
                                 // advances `completed`.
                                 tx.send_modify(|st| {
-                                    if let Some(d) = scraped {
+                                    if let Some(mut d) = scraped {
+                                        // `scrape_url` stamps the verdict but this
+                                        // path used to push it through untouched,
+                                        // so a wall shipped as an ordinary batch
+                                        // document (and `/v2`'s adapter drops
+                                        // `block`, hiding it completely). Clear the
+                                        // shell and count it, exactly as the single
+                                        // scrape route does.
+                                        let is_wall = d.block.is_some();
+                                        if !is_wall && let Some(reason) = d.http_error() {
+                                            d.block = Some(crw_core::types::BlockOutcome {
+                                                vendor: crw_core::types::HTTP_ERROR_VENDOR
+                                                    .to_string(),
+                                                reason,
+                                            });
+                                        }
+                                        if d.block.is_some() {
+                                            // Same split as `/v1/scrape` and the crawl
+                                            // loop: a wall loses its shell, an origin
+                                            // error page stays readable.
+                                            if is_wall {
+                                                d.clear_body();
+                                            }
+                                            st.blocked += 1;
+                                        }
                                         st.data.push(d);
                                     }
                                     st.completed += 1;
@@ -818,6 +849,32 @@ impl AppState {
                         )
                         .await
                         {
+                            // A wall or an origin error page is not a completed
+                            // extraction: it used to be marked Completed, charged,
+                            // and to have burned the LLM call on the wall's text.
+                            Ok(d) if d.block.is_some() || d.http_error().is_some() => {
+                                let msg = d
+                                    .block
+                                    .as_ref()
+                                    .map(|b| b.message())
+                                    .or_else(|| d.http_error())
+                                    .unwrap_or_else(|| "Blocked".into());
+                                (
+                                    UrlResult {
+                                        url: entry.url,
+                                        status: ExtractStatus::Failed,
+                                        data: None,
+                                        error: Some(msg),
+                                        llm_usage: None,
+                                        basis: None,
+                                        basis_warnings: Vec::new(),
+                                        llm_input_hash: None,
+                                    },
+                                    None,
+                                    0,
+                                    0,
+                                )
+                            }
                             Ok(d) => {
                                 let merged_fields = match &d.json {
                                     Some(serde_json::Value::Object(obj)) => Some(obj.clone()),

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -14,7 +14,7 @@ Before diving into individual patterns:
 
 1. Check `success` in the response body — `false` means a hard failure.
 2. Check `error_code` (snake_case string) for the machine-readable cause.
-3. Check `data.warnings[]` when `success: true` — soft issues like truncation, unsupported formats, and renderer fallbacks surface there. Anti-bot blocks are **not** in `data.warnings[]`; they always return `success: false` + `error_code: "anti_bot"` (see pattern 2).
+3. Check `data.warnings[]` when `success: true` — soft issues like truncation, unsupported formats, and renderer fallbacks surface there. Anti-bot blocks are **not** in `data.warnings[]`; they always return `success: false` + `error_code: "anti_bot"` (see pattern 2). A page the origin answered with a `>= 400` status returns `success: false` + `error_code: "http_error"`, with the error page still in `data`.
 4. Check `metadata.statusCode` — this is the **target site's** HTTP status, not fastCRW's.
 5. Check the fastCRW HTTP status separately — `401`/`422`/`429` all mean different things.
 
@@ -65,9 +65,9 @@ print(result["markdown"][:300])
 
 **Cause:** The target site fingerprints the request as non-browser traffic. Common triggers: missing `User-Agent`, no `Sec-Fetch-*` headers, a datacenter IP, or a detectable headless browser.
 
-> **Not a block: `"No usable content could be extracted (...)"`.** The same
-> `error_code: "anti_bot"` also covers the case where we fetched the page fine
-> but it held nothing usable — a handful of visible characters, no content
+> **Not a block: `"No usable content could be extracted (...)"`.** That case has
+> its own code, `error_code: "no_usable_content"` — we fetched the page fine but
+> it held nothing usable: a handful of visible characters, no content
 > elements. That is usually a broken TLS certificate serving an error stub, a
 > parked domain, or a JS shell that never hydrated. The staged anti-bot fixes
 > below will not help it. Check the URL in a browser first; if it renders a real
@@ -411,7 +411,8 @@ if data["balance"] < 100:
 | `invalid_url` | — | Reserved — not emitted in practice; invalid URLs are returned as `invalid_request` (HTTP 400) by all server routes |
 | `target_unreachable` | 422 | DNS failure, connection refused, host down |
 | `extraction_error` | 422 | LLM extraction failed or CSS/XPath selector invalid |
-| `http_error` | 502 | Network-level error reaching the target |
+| `http_error` | 502, or 200 with `success: false` | The origin answered with a `>= 400` status and what came back is its error page. The body is kept in `data` so you can read the error page and `metadata.statusCode`. A large page served under an error status is still returned as a success — some sites answer 403/404 while serving the real content |
+| `no_usable_content` | 200 with `success: false` | The fetch worked, the page held nothing extractable (parked domain, un-hydrated JS shell, error stub). Not an anti-bot block |
 | `timeout` | 504 | Engine or upstream search timed out |
 | `rate_limited` | 429 | RPM rate limit (engine-level) |
 | `search_disabled` | 503 | `/v1/search` called with no search backend configured |
@@ -420,4 +421,4 @@ if data["balance"] < 100:
 | `renderer_error` | 500 | CDP browser internal error |
 | `internal_error` | 500 | Unexpected engine failure |
 
-Source: `crw-core/src/error.rs` (`error_code()` method), `crw-server/src/error.rs` (HTTP status mapping), and `crw-server/src/routes/scrape.rs` (anti-bot detection + `anti_bot` code).
+Source: `crw-core/src/error.rs` (`error_code()` method), `crw-server/src/error.rs` (HTTP status mapping), and `crw-server/src/routes/scrape.rs` (the `http_error` / `no_usable_content` / `anti_bot` split).


### PR DESCRIPTION
Found by auditing 14 days of production logs (94,803 scrape records, 118,076 request rows, one full day of engine traces). Every finding below was reproduced live against prod before anything was changed, and again against a local build after.

## What was broken

**We returned bot walls and origin error pages as `success: true` and billed for them.** 761 requests over 14 days, across at least 6 paying accounts. Live examples at the time of the audit:

| URL | what the customer got | charged |
|---|---|---|
| `medium.com` | Cloudflare "Sorry, you have been blocked", 790 chars | 1 credit |
| `americastire.com` | CloudFront 403 country-block page, 650 chars | 1 credit |
| `docs.fastcrw.com/billing` | GitHub's "Unicorn!" 503 page, 327 chars | 1 credit |

The `>= 400` gate existed but only fired below 200 bytes, and it measured the largest of markdown/text/html/rawHtml — so an error page always cleared it, and asking for `rawHtml` made it unreachable outright. A further 470 requests were graded success with a completely empty body.

**The mirror image was also true:** a valid 68-byte `requirements.txt` came back `errorCode: "anti_bot"` with no content, because the HTTP tier decodes every non-PDF response as HTML and the file has no `<body>`. Our own docs site and `raw.githubusercontent.com` were among the top hosts hitting it.

**Crawl, batch, extract and monitor never applied the verdict at all.** A crawl of a walled site reported one completed page whose content was the block wall. The crw-saas#544 refund only ever touched the single-scrape handler, so "no billing on failure" was false everywhere else.

**A dead origin exited as three different errors** depending on which tier noticed first — 422, 500 `renderer_error` or 504. 10,107 of them were the 500.

**A transient DNS failure was served as a permanent HTTP 400** telling the caller to fix a URL that was fine.

## The threshold, and why it is not zero

A body-blind rule was the obvious fix and it is wrong. Measured on the same traffic: `stackoverflow.com/questions/tagged/rust` answers **403 with 39,499 chars of the real page**, a YouTube watch page answers 401 with 12,256, a Medium article answers 403 with 10,826. The renderer keeps those on purpose (`crw-crawl/src/single.rs`: *"the status is a soft signal, not a content gate"*), and both SDKs raise on `success:false` and discard `data`, so failing them would be a real recall regression.

The bar is 2,500 bytes because that is where the measured gap is: the largest observed error page rendered to 2,356 bytes, the next-largest 4xx body was 3,340. It is deliberately conservative and leaves large branded 404s (GitHub's is 3,340) passing. Raising it is a recall decision that needs its own benchmark.

## Benchmark impact — read before merging

On the frozen 1,000-URL run (`bench/server-runs/results-fixed-20260429T220032Z.jsonl`), 54 of the 853 successes carry `metadata.statusCode >= 400`. All 54 markdown samples were read: every one is an error or wall page, zero real content. Under the 2,500 bar **40 flip to failure and 14 stay**, so scrape-success on that artifact moves **853/1000 → 813/1000**.

That is the number going down because the old one counted walls, not because anything got worse. Truth-recall does not move: the error envelope keeps `data`, and `diagnose_3way.py` scores recall off `data.markdown` regardless of `success`. A full re-run is the pre-merge gate.

## Verified

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (1,601 passed). Against a locally built engine, real sites:

- `medium.com`, `americastire.com` → `success:false` + `errorCode:"http_error"`, body retained
- `raw.githubusercontent.com/.../requirements-server.txt` → `success:true`, 69 chars of file content
- `aave.com/docs/...` (404, 2,974 chars) → still `success:true`
- same page as `formats:["rawHtml"]` (255,904 bytes, no text format) → still `success:true`
- same page as `formats:["links"]` (no body at all) → still `success:true`
- crawl of `encuentra24.com` → `completed:2, blocked:1`, the walled page marked and cleared

## Notes for review

- `/v2` compat **semantics** change (shape does not): a Firecrawl-compat caller who received `success:true` + markdown for a small 403 now receives `success:false` + markdown, and the SaaS refunds it.
- A structural failure now reports `no_usable_content` instead of `anti_bot`. Nothing branches on `anti_bot`; refunds key on `success:false`.
- The "structured extraction requires a jsonSchema or a prompt" 400 is now skipped for a blocked URL, which answers `200 + success:false` instead.
- Deliberately **not** in this PR: clamping the JS ladder after a connect-level failure (22,741 timeouts over 14 days spend a full 30s on hosts that are dead at 2.5s, ~6.5% of the Chrome pool). It is the one change that can move recall, so it waits for its own benchmarked PR.
- The companion crw-saas PR stops billing blocked crawl/batch/monitor pages and reads the new `blocked` counter. It tolerates an engine without the field, so the two can merge independently, engine first.