### PR TITLE
feat(search): carry a paid-rescue entitlement to the search backend

### DIFF
--- a/crates/crw-cli/src/commands/search.rs
+++ b/crates/crw-cli/src/commands/search.rs
@@ -111,6 +111,8 @@ pub async fn run(args: SearchArgs) {
         engines: None,
         pageno: None,
         safesearch: args.safesearch,
+        // Self-host/CLI never spends on a metered backend tier.
+        paid_rescue: false,
     };
 
     let response = match client.fetch(&params).await {

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -1869,6 +1869,17 @@ pub struct SearchRequest {
     /// caps the answer-synthesis path, not the per-result summary path.
     #[serde(default, alias = "max_content_chars")]
     pub max_content_chars: Option<usize>,
+    /// Entitlement to the search backend's PAID rescue tier when the free legs
+    /// return nothing. NOT part of the public request body: `serde(skip)` means
+    /// a caller cannot set it by sending the field, and we never serialize it
+    /// onward. It is populated server-side from a trusted header
+    /// (`X-Crw-Paid-Rescue`) that only crw-saas may send, because only crw-saas
+    /// can see the plan and role that decide whether the request may spend.
+    ///
+    /// Defaults to false, so a self-host deployment, the CLI, MCP and every
+    /// internally-constructed request behave exactly as before.
+    #[serde(skip)]
+    pub paid_rescue: bool,
 }
 
 /// A single search result (web or news). Mirrors `SearchResult` in

--- a/crates/crw-search/src/client.rs
+++ b/crates/crw-search/src/client.rs
@@ -24,6 +24,15 @@ const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 /// with multi-megabyte error pages.
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
 
+/// Signals to the search backend that this request may use a metered rescue
+/// tier if the free legs come back empty. Sent ONLY when
+/// [`SearxngParams::paid_rescue`] is set, which only crw-saas can cause.
+///
+/// Positive opt-in on purpose. The inverse design — "spend unless told not to"
+/// — cannot fail closed: a caller that forgets the header, or a self-host
+/// pointing at a backend that honours it, would silently start spending.
+pub const PAID_RESCUE_HEADER: &str = "X-Crw-Paid-Rescue";
+
 async fn read_capped(response: reqwest::Response, cap: usize) -> Result<Vec<u8>, SearchError> {
     if let Some(declared) = response.content_length()
         && declared as usize > cap
@@ -201,22 +210,26 @@ impl SearxngClient {
             }
         }
 
-        let response = self
-            .http
-            .get(url)
-            .timeout(self.timeout)
-            .send()
-            .await
-            .map_err(|e: reqwest::Error| {
-                if e.is_timeout() {
-                    SearchError::Timeout
-                } else {
-                    // `without_url()` strips reqwest's embedded request URL from
-                    // the Display string — that URL can carry credentials/tokens
-                    // (issue #90). The route layer re-attaches a sanitized origin.
-                    SearchError::Transport(e.without_url().to_string())
-                }
-            })?;
+        // A HEADER, not a query parameter: the entitlement belongs to the
+        // caller, not to the query, so it must not widen the search surface nor
+        // enter the backend's cache key (two callers asking the same thing must
+        // still share one cached answer). Absent header = today's exact request,
+        // byte for byte, which is what keeps self-host and every non-SaaS caller
+        // unchanged.
+        let mut req = self.http.get(url).timeout(self.timeout);
+        if params.paid_rescue {
+            req = req.header(PAID_RESCUE_HEADER, "1");
+        }
+        let response = req.send().await.map_err(|e: reqwest::Error| {
+            if e.is_timeout() {
+                SearchError::Timeout
+            } else {
+                // `without_url()` strips reqwest's embedded request URL from
+                // the Display string — that URL can carry credentials/tokens
+                // (issue #90). The route layer re-attaches a sanitized origin.
+                SearchError::Transport(e.without_url().to_string())
+            }
+        })?;
 
         let status = response.status();
         if !status.is_success() {

--- a/crates/crw-search/src/lib.rs
+++ b/crates/crw-search/src/lib.rs
@@ -19,7 +19,7 @@ pub mod structured;
 pub mod transform;
 pub mod wikidata;
 
-pub use client::{SearchError, SearxngClient, SearxngResponse, SearxngResult};
+pub use client::{PAID_RESCUE_HEADER, SearchError, SearxngClient, SearxngResponse, SearxngResult};
 pub use params::{SearxngParams, clean_query, map_to_searxng_params};
 pub use rerank::{rerank, rerank_relevance};
 pub use structured::{StructuredFact, structured_facts};

--- a/crates/crw-search/src/params.rs
+++ b/crates/crw-search/src/params.rs
@@ -21,6 +21,16 @@ pub struct SearxngParams {
     pub engines: Option<String>,
     pub pageno: Option<u32>,
     pub safesearch: Option<u8>,
+    /// Does this request carry an entitlement to a PAID rescue tier in the
+    /// backend, if the free tiers come back empty?
+    ///
+    /// Deliberately not a query parameter: it is a property of the caller's
+    /// account, not of the query, so it travels as a header
+    /// (`X-Crw-Paid-Rescue`) and never widens the search surface or the
+    /// backend's cache key. Only crw-saas can set it — it decides from the
+    /// plan/role it alone can see — and it defaults to false everywhere else,
+    /// so self-hosters, the CLI, MCP and the research legs never spend.
+    pub paid_rescue: bool,
 }
 
 /// Map the public [`SearchRequest`] to SearXNG query parameters.
@@ -138,6 +148,7 @@ pub fn map_to_searxng_params(req: &SearchRequest, config: &SearchConfig) -> Sear
         engines,
         pageno: None,
         safesearch: None,
+        paid_rescue: req.paid_rescue,
     }
 }
 
@@ -175,7 +186,28 @@ mod tests {
             query_expand: None,
             answer_list_format: None,
             max_content_chars: None,
+            paid_rescue: false,
         }
+    }
+
+    #[test]
+    fn paid_rescue_travels_from_request_to_params() {
+        // The entitlement has to survive the mapper, or the header never gets
+        // sent and the backend silently keeps returning nothing.
+        let mut r = req("rust async");
+        assert!(!map_to_searxng_params(&r, &cfg()).paid_rescue);
+        r.paid_rescue = true;
+        assert!(map_to_searxng_params(&r, &cfg()).paid_rescue);
+    }
+
+    #[test]
+    fn paid_rescue_cannot_be_set_from_the_request_body() {
+        // `serde(skip)`: a caller sending the field must NOT be able to grant
+        // itself a metered tier. This is the whole reason the flag is not a
+        // normal request field.
+        let r: SearchRequest =
+            serde_json::from_str(r#"{"query":"x","paidRescue":true,"paid_rescue":true}"#).unwrap();
+        assert!(!r.paid_rescue);
     }
 
     #[test]

--- a/crates/crw-search/tests/paid_rescue_header_tests.rs
+++ b/crates/crw-search/tests/paid_rescue_header_tests.rs
@@ -1,0 +1,111 @@
+//! The `X-Crw-Paid-Rescue` header is what lets the search backend spend money
+//! on a metered rescue tier. It must appear ONLY when the request carries the
+//! entitlement, because the backend gate is a positive opt-in: a header that
+//! leaks onto ordinary traffic bills for searches nobody authorised, and a
+//! header that goes missing silently turns the rescue off with no error.
+//!
+//! Asserted against a real HTTP server rather than the request builder, so a
+//! refactor that drops the header (or moves it to a query param, which would
+//! also corrupt the backend's cache key) fails here.
+
+use crw_search::{PAID_RESCUE_HEADER, SearxngClient, SearxngParams};
+use std::sync::Arc;
+use std::time::Duration;
+use wiremock::matchers::{header_exists, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn body() -> serde_json::Value {
+    serde_json::json!({"query": "q", "results": [], "unresponsive_engines": []})
+}
+
+fn params(paid_rescue: bool) -> SearxngParams {
+    SearxngParams {
+        q: "rust async".into(),
+        paid_rescue,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn header_is_sent_when_the_request_is_entitled() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .and(header_exists(PAID_RESCUE_HEADER))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = SearxngClient::new(
+        Arc::new(reqwest::Client::new()),
+        server.uri(),
+        Duration::from_secs(5),
+    );
+    client
+        .fetch(&params(true))
+        .await
+        .expect("fetch should succeed");
+    // `expect(1)` is verified on drop.
+}
+
+#[tokio::test]
+async fn header_is_absent_by_default() {
+    // The default path must be byte-identical to before this feature existed —
+    // that is what keeps self-host, the CLI, MCP and the research legs off a
+    // metered tier.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = SearxngClient::new(
+        Arc::new(reqwest::Client::new()),
+        server.uri(),
+        Duration::from_secs(5),
+    );
+    client
+        .fetch(&params(false))
+        .await
+        .expect("fetch should succeed");
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0].headers.get(PAID_RESCUE_HEADER).is_none(),
+        "an unentitled request must not carry the paid-rescue header"
+    );
+}
+
+#[tokio::test]
+async fn entitlement_never_becomes_a_query_parameter() {
+    // If it ever leaked into the query string it would split the backend cache
+    // per caller class and stop two identical searches from sharing one answer.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .and(query_param("q", "rust async"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body()))
+        .mount(&server)
+        .await;
+
+    let client = SearxngClient::new(
+        Arc::new(reqwest::Client::new()),
+        server.uri(),
+        Duration::from_secs(5),
+    );
+    client
+        .fetch(&params(true))
+        .await
+        .expect("fetch should succeed");
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let url = requests[0].url.as_str();
+    assert!(
+        !url.contains("paid_rescue") && !url.to_lowercase().contains("paid-rescue"),
+        "entitlement must travel as a header only, got url: {url}"
+    );
+}

--- a/crates/crw-server/src/routes/research.rs
+++ b/crates/crw-server/src/routes/research.rs
@@ -72,6 +72,12 @@ async fn searxng_papers(
         engines,
         pageno: None,
         safesearch: None,
+        // Never on the research legs. They already fan out across arxiv,
+        // crossref, OpenAlex and Semantic Scholar, so a thin web pool here is
+        // not a dead end — and this leg REPLACES the pool it merges (every row
+        // is filtered through `PaperHit::from_searxng`), so a general-web
+        // rescue could shrink a scholarly result set while spending money.
+        paid_rescue: false,
     };
     let Ok(resp) = client.fetch(&params).await else {
         return Vec::new();
@@ -279,6 +285,8 @@ pub async fn github(
         engines: join_nonempty(&state.config.search.github_engines),
         pageno: None,
         safesearch: None,
+        // Curated-engine leg; a paid general-web tier cannot honour it.
+        paid_rescue: false,
     };
     let resp = client
         .fetch(&params)

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use axum::extract::State;
 use axum::extract::rejection::JsonRejection;
+use axum::http::HeaderMap;
 use crw_core::Deadline;
 use crw_core::config::LlmConfig;
 use crw_core::error::CrwError;
@@ -257,9 +258,23 @@ fn is_valid_lang(lang: &str) -> bool {
 /// (minus the credit / quota wrapper, which lives in the SaaS layer).
 pub async fn search(
     State(state): State<AppState>,
+    headers: HeaderMap,
     body: Result<Json<SearchRequest>, JsonRejection>,
 ) -> Result<Json<SearchResponse>, AppError> {
-    let Json(req) = body.map_err(AppError::from)?;
+    let Json(mut req) = body.map_err(AppError::from)?;
+    // Read the entitlement from the header, never from the body: `paid_rescue`
+    // is `serde(skip)`, so a caller cannot grant it to itself by sending the
+    // field. Only crw-saas sets this header, and only after checking the plan
+    // and role it alone can see.
+    //
+    // Deliberately NOT wired into `/v2/search` (routes/v2), which is an
+    // unconditional proxy open to every plan including FREE, nor into the MCP
+    // dispatcher or the research legs — all of those reach `search_inner`
+    // directly and so keep `paid_rescue: false`.
+    req.paid_rescue = headers
+        .get(crw_search::PAID_RESCUE_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.trim() == "1");
     let resp = search_inner(&state, req).await?;
     Ok(Json(resp))
 }
@@ -1672,6 +1687,7 @@ mod tests {
             query_expand: None,
             answer_list_format: None,
             max_content_chars: None,
+            paid_rescue: false,
         }
     }
 


### PR DESCRIPTION
Groundwork only. **Nothing sets the header yet**, so a request without it produces the same bytes on the wire as before this PR.

## Why

The engine is the one search path with nothing below it. `answer:true` requests go straight here (crw-saas dispatches them to `crwFetch("/v1/search")`), `SearxngClient::fetch` makes a single call, and `resolve_backend_url()` returns one URL. When that comes back empty, the answer is synthesized from an empty pool and the caller still pays the base search credit.

The fix is a metered rescue tier in the search backend — but spending money needs a decision, and only crw-saas can make it, because only crw-saas sees the plan and the role. So this PR carries the decision instead of letting the backend guess.

## What

- `SearchRequest.paid_rescue`, `#[serde(skip)]` — a caller **cannot** grant itself a metered tier by sending the field.
- The `/v1/search` handler populates it from `X-Crw-Paid-Rescue`, a header only crw-saas can set (`crwFetch`'s server-only header option; caller headers are not forwarded).
- `SearxngClient` sends it as a **header, never a query parameter**: the entitlement belongs to the caller, not the query, so it must not widen the search surface nor split the backend's cache key (two identical searches must still share one cached answer).
- Everything else keeps the `false` default *by construction*, not by remembering to pass it: `/v2/search` (an unconditional proxy open to every plan including FREE), the MCP dispatcher, the CLI and both research legs all reach the search path without that handler.

Research is excluded deliberately. Those legs already fan out across arxiv / crossref / OpenAlex / Semantic Scholar, and the plain leg **replaces** the pool it merges (every row is filtered through `PaperHit::from_searxng`), so a general-web rescue could *shrink* a scholarly result set while spending money.

## Positive opt-in, on purpose

The inverse design — "spend unless told not to" — cannot fail closed. A caller that forgets a header, or a self-host pointed at a backend that honours one, would silently start spending. This way a missing header costs nothing and breaks nothing.

## Tests

`crates/crw-search/tests/paid_rescue_header_tests.rs` asserts against a real HTTP server, not the request builder:

- header present exactly when the request is entitled
- header absent by default (the byte-identical path)
- entitlement never leaks into the query string (which would corrupt the backend cache key)

Plus two in `params.rs`: the flag survives the mapper, and `serde(skip)` really does reject `{"paidRescue":true}` from a request body.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings` and the full `cargo test --workspace` are clean.

## Follow-up

The crw-saas side (which sets the header after a plan/role check, and the orchestrator tier that acts on it) lands separately and must merge **after** this.