### PR TITLE
fix(renderer): search for </body> after <body>, not from the start

### DIFF
--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -3429,9 +3429,20 @@ impl FallbackRenderer {
 /// where a renderer returned HTML but failed to execute JavaScript.
 fn html_body_text_len(html: &str) -> usize {
     // Extract body content if present, otherwise use entire HTML.
+    //
+    // The closing tag is searched from `start`, not from 0. Searching the whole
+    // document finds the FIRST `</body>` anywhere, which on a page that mentions
+    // the literal string before its real body — a script writing markup, an
+    // escaped snippet in a docs page, plain malformed HTML — lands BEFORE the
+    // opening tag. `&html[start..end]` then panics with
+    // "byte range starts at 198294 but ends at 197897" and kills the request.
+    // Seen in production 2026-08-11, 9 times in 30 minutes.
     let body = if let Some(start) = html.find("<body") {
         let start = html[start..].find('>').map(|i| start + i + 1).unwrap_or(0);
-        let end = html.find("</body>").unwrap_or(html.len());
+        let end = html[start..]
+            .find("</body>")
+            .map(|i| start + i)
+            .unwrap_or(html.len());
         &html[start..end]
     } else {
         html
@@ -3473,6 +3484,39 @@ mod tests {
     /// Generous deadline used by tests that don't care about budget enforcement.
     fn tdl() -> crw_core::Deadline {
         crw_core::Deadline::now_plus(Duration::from_secs(60))
+    }
+
+    #[test]
+    fn body_text_len_survives_a_closing_tag_before_the_opening_one() {
+        // A page that prints the literal "</body>" before its real body — a script
+        // writing markup, an escaped snippet in documentation, or plain malformed
+        // HTML. Searching the whole document for the closing tag found this one,
+        // producing end < start and panicking on the slice. Production hit it 9
+        // times in 30 minutes on 2026-08-11.
+        let html = concat!(
+            "<html><head><script>var tpl = \"</body>\";</script></head>",
+            "<body><p>real content here</p></body></html>"
+        );
+        assert!(html.find("</body>").unwrap() < html.find("<body").unwrap());
+        assert!(html_body_text_len(html) > 0);
+    }
+
+    #[test]
+    fn body_text_len_measures_only_the_body() {
+        let html = "<html><head><title>ignored</title></head><body>hello there</body></html>";
+        // "hello there" collapses to 11 visible characters; the head must not count.
+        assert_eq!(html_body_text_len(html), 11);
+    }
+
+    #[test]
+    fn body_text_len_handles_a_missing_closing_tag() {
+        let html = "<html><body><p>unclosed document";
+        assert!(html_body_text_len(html) > 0);
+    }
+
+    #[test]
+    fn body_text_len_handles_no_body_at_all() {
+        assert!(html_body_text_len("<html><p>fragment</p></html>") > 0);
     }
 
     fn base_cfg(mode: RendererMode) -> RendererConfig {


### PR DESCRIPTION
`html_body_text_len` found the opening `<body` tag, then searched the **whole document** for the closing one. When a page contains the literal string `</body>` before its real body — a script writing markup, an escaped snippet in docs, plain malformed HTML — the closing index lands before the opening one and `&html[start..end]` panics.

```
thread 'tokio-rt-worker' panicked at crates/crw-renderer/src/lib.rs:3435:14:
byte range starts at 198294 but ends at 197897
```

The panic unwinds the tokio task, not the process, so the container stays `healthy` and `/health` keeps returning 200 while the request being served dies. That is why it went unnoticed: every liveness signal is green.

Observed on production 2026-08-11: **9 panics in 30 minutes**, container `restarts=0`, health green throughout.

## Fix

Search for the closing tag from `start` rather than from 0. Besides removing the panic this is the semantically correct read — the closing tag that delimits a body is the one that follows its opening tag.

## Tests

Four cases in `crates/crw-renderer/src/lib.rs`:

- a closing tag appearing before the opening one (the regression)
- body-only measurement, so the head is still excluded
- a document with no closing tag
- a fragment with no body at all

The first one fails on the unpatched function with the same message class seen in production (`byte range starts at 62 but ends at 31`), so it reproduces the bug rather than merely asserting the new behaviour.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **1610 passed, 0 failed**, 24 ignored, 88 test binaries

## Merge note

A merge here reaches production within the hour via the `opencore.pin` bump, so the panic stops as soon as the engine image is rebuilt. The change is confined to one pure function with no callers' behaviour altered on well-formed input: for any document where `</body>` follows `<body>`, the computed slice is byte-identical to before.
