### PR TITLE
docs(skills): document the REST path for agents without MCP

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,15 @@
 
 set -e
 
+# The checks below build and test the whole workspace. Nothing they cover can
+# be affected by a commit that touches no Rust sources, so skip them entirely
+# for docs-only and script-only commits.
+STAGED_RUST=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs' '*.toml' 'Cargo.lock' || true)
+if [ -z "$STAGED_RUST" ]; then
+    echo "⏭️  No Rust files staged, skipping cargo checks."
+    exit 0
+fi
+
 echo "🔍 cargo fmt --check..."
 cargo fmt --all -- --check
 

--- a/skills/crw/SKILL.md
+++ b/skills/crw/SKILL.md
@@ -34,8 +34,13 @@ step.
 crw --version          # binary on PATH?  (brew install us/crw/crw)
 ```
 
-- **No binary?** Use the MCP tools instead (`crw_scrape`, `crw_search`, …) — see
-  `crw-self-host` for setup, or run zero-install with `npx crw-mcp`.
+- **No binary?** If your harness has MCP, use the MCP tools (`crw_scrape`,
+  `crw_search`, …) — see `crw-self-host` for setup, or run zero-install with
+  `npx crw-mcp`.
+- **No binary and no MCP?** Use REST with `curl`. Every verb below has a REST
+  equivalent and needs nothing installed. Set `CRW_API_URL`, then call
+  `POST $CRW_API_URL/v1/{scrape,crawl,map,search}`. Each verb skill shows the
+  exact request.
 - **Auth:** self-hosted needs none. Managed/cloud needs `CRW_API_KEY=crw_live_…`
   and `CRW_API_URL=https://api.fastcrw.com` (free tier: 500 one-time lifetime
   credits, never resets).


### PR DESCRIPTION
Two small changes, unrelated to engine behaviour.

**`skills/crw/SKILL.md`** — the prerequisites section sent readers without the
binary to the MCP tools. On a harness with no MCP support that dead-ends, since
the skill then names tools the agent does not have. Adds the REST path, which
needs nothing installed.

Every verb skill already documents CLI, MCP and REST, so this was the only gap.
Verified by parsing all 13 `skills/*/SKILL.md` files through a third-party
agent's skill parser: all 13 load clean before and after.

**`.githooks/pre-commit`** — the hook ran `cargo fmt`, `clippy`, `build` and
`test --workspace` on every commit, including docs-only ones. That is several GB
of build artifacts for a change the checks cannot cover, and it filled the disk
on a markdown commit. `scripts/pre-commit` already carries a staged-file filter;
this mirrors it.

Guard verified in both directions:
- markdown-only commit: `No Rust files staged, skipping cargo checks`
- with a `.rs` staged: the filter matches, so cargo still runs