### PR TITLE
feat(search): snippet-first lazy-scrape answer path (gated, default off)

### DIFF
--- a/crates/crw-core/src/config.rs
+++ b/crates/crw-core/src/config.rs
@@ -361,6 +361,17 @@ pub struct SearchConfig {
     /// first pool" — the dominant remaining miss. Defaults to `false` (gated).
     #[serde(default)]
     pub multi_round: bool,
+    /// Snippet-first answer path (lazy scrape). When on, the answer is first
+    /// synthesized from the FREE SearXNG snippets (title/description) + any
+    /// structured sources, WITHOUT scraping. Only if that answer abstains does
+    /// the original result set get scraped and the answer re-synthesized once.
+    /// Most factoid queries answer from the snippet, so this skips the expensive
+    /// scrape (chrome RAM + the p90 latency tail) on the majority of traffic.
+    /// Recall-safe + monotone: a still-abstaining post-scrape answer keeps the
+    /// snippet answer; abstention always escalates to the full scrape. Defaults
+    /// to `false` (gated).
+    #[serde(default)]
+    pub snippet_first: bool,
     /// Passage-level relevance gate for the LLM answer path: split each scraped
     /// source into passages and feed the answer LLM only the query-relevant
     /// ones (DeepSeek-scored, no new ML deps). Subtractive — removes noise, never
@@ -500,6 +511,7 @@ impl Default for SearchConfig {
             query_expand_variants: default_query_expand_variants(),
             pipeline_overlap: false,
             multi_round: false,
+            snippet_first: false,
             passage_select: false,
             answer_bm25_select: false,
             page2_fallback: false,

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -1855,6 +1855,11 @@ pub struct SearchRequest {
     /// uses the server config. The eval harness sets this to A/B the lever.
     #[serde(default, alias = "multi_round")]
     pub multi_round: Option<bool>,
+    /// Per-request override for `[search].snippet_first` — answer from free SERP
+    /// snippets first and scrape only if that abstains. None uses server config.
+    /// Used by the eval harness to A/B the lazy-scrape path against prod.
+    #[serde(default, alias = "snippet_first")]
+    pub snippet_first: Option<bool>,
     /// Per-request override for `[search].answer_list_format` — when the query
     /// has list intent ("best/top X in Y", "recommend …"), render the answer as
     /// a ranked list of named options instead of prose. None uses the server

--- a/crates/crw-search/src/params.rs
+++ b/crates/crw-search/src/params.rs
@@ -184,6 +184,7 @@ mod tests {
             query_expand_variants: None,
             multi_round: None,
             query_expand: None,
+            snippet_first: None,
             answer_list_format: None,
             max_content_chars: None,
             paid_rescue: false,

--- a/crates/crw-server/src/routes/search.rs
+++ b/crates/crw-server/src/routes/search.rs
@@ -524,9 +524,26 @@ pub async fn search_inner(
     if response.is_degraded() && !structured_rescue {
         warnings.push(DEGRADED_MESSAGE.into());
     }
-    if let Some(opts) = req.scrape_options.as_ref() {
+    // Snippet-first (lazy scrape): on the answer path, defer the scrape and try to
+    // answer from the free SERP snippets + structured sources first; only scrape
+    // if that answer abstains (below, after synthesis). Most factoid queries answer
+    // from the snippet, so this skips the expensive scrape on the majority.
+    // snippet_first REQUIRES snippet_fallback: the round-1 lazy synth builds its
+    // sources from snippets, and with scrape skipped a non-fallback synth would
+    // return Err (empty markdown pool) and never reach the escalation, silently
+    // yielding no answer. Gate on it so enabling snippet_first alone is a safe
+    // no-op (normal eager scrape) rather than a recall regression.
+    let want_snippet_first = req.answer.unwrap_or(false)
+        && req
+            .snippet_first
+            .unwrap_or(state.config.search.snippet_first)
+        && state.config.search.snippet_fallback;
+    let mut scraped = false;
+    if let Some(opts) = req.scrape_options.as_ref()
+        && !want_snippet_first
+    {
         match enrich_with_scrape(&mut data, opts, state).await {
-            Ok(()) => {}
+            Ok(()) => scraped = true,
             Err(msg) => {
                 tracing::warn!(error = %msg, "scrape enrichment failed");
                 warning = Some(msg);
@@ -667,6 +684,55 @@ pub async fn search_inner(
                                     &mut agg_truncated,
                                     u,
                                 );
+                            }
+                            // Snippet-first escalation: the snippet-only answer
+                            // abstained, so NOW scrape the original results and
+                            // re-synthesize once. Monotone: a still-abstaining
+                            // re-synth keeps the snippet answer. Bounded by the
+                            // request deadline like the scout's scrape.
+                            if want_snippet_first
+                                && !scraped
+                                && is_abstention(&ans)
+                                && let Some(opts) = req.scrape_options.as_ref()
+                            {
+                                let _ = tokio::time::timeout(
+                                    req_deadline.remaining(),
+                                    enrich_with_scrape(&mut data, opts, state),
+                                )
+                                .await;
+                                if let Ok((ans2, cites2, usage2, mut warns2)) = synthesize_answer(
+                                    &req,
+                                    &data,
+                                    &leg_cfg,
+                                    state.config.search.passage_select,
+                                    state.config.search.answer_bm25_select,
+                                    state.config.search.answer_calibrated,
+                                    state.config.search.snippet_fallback,
+                                    state.config.search.answer_guarded,
+                                    &structured_sources,
+                                    list_format,
+                                )
+                                .await
+                                {
+                                    if let Some(ref u) = usage2 {
+                                        merge_usage(
+                                            &mut agg_input_tokens,
+                                            &mut agg_output_tokens,
+                                            &mut agg_cache_hit,
+                                            &mut agg_cache_miss,
+                                            &mut agg_calls,
+                                            &mut agg_provider,
+                                            &mut agg_model,
+                                            &mut agg_truncated,
+                                            u,
+                                        );
+                                    }
+                                    if !is_abstention(&ans2) {
+                                        ans = ans2;
+                                        cites = cites2;
+                                        warnings.append(&mut warns2);
+                                    }
+                                }
                             }
                             // Adaptive multi-round (gated): if round-1 ABSTAINED,
                             // the evidence-scout issues targeted follow-ups; we
@@ -1685,6 +1751,7 @@ mod tests {
             query_expand_variants: None,
             multi_round: None,
             query_expand: None,
+            snippet_first: None,
             answer_list_format: None,
             max_content_chars: None,
             paid_rescue: false,


### PR DESCRIPTION
Adds an opt-in **snippet-first** mode to `/v1/search answer:true`: answer from the free SERP snippets + structured sources first, and only scrape the original results (and re-synthesize once) if that answer abstains.

## Why
Scrape is the dominant real cost and the p90-latency tail of the answer path; snippets come free with the search. Offline simulation on a 250q SimpleQA set: **~85.6% accuracy at ~81% fewer scrapes** vs ~88% at 100% scrapes (a ~2.4pt trade for skipping the scrape on the majority). Gated + default-off, so no behavior change until enabled and bench-gated.

## What
- Config `snippet_first` (default `false`) + per-request `snippetFirst` override, mirroring the `multiRound` / `queryExpand` override shape.
- **Gated on `snippet_fallback`**: the round-1 lazy synth builds sources from snippets, so without `snippet_fallback` it would return an empty-pool `Err` and never reach the escalation. The gate makes enabling `snippet_first` alone a safe no-op (normal eager scrape) instead of a recall regression.
- The escalation scrape is deadline-bounded; its re-synth is monotone (a still-abstaining answer keeps the snippet answer). Cancelled-scrape cleanup uses the existing pool-guard drop path.

## Status / caveat
- Default off → zero prod impact until enabled.
- The 85.6%/81% numbers are an offline simulation ceiling; the real engine number needs a prod bench-gate (per-request `snippetFirst` A/B on the frozen SimpleQA/FRAMES sets) **before** flipping any default. Do NOT enable as default without that.
- Pairs with a small crw-saas change to accept the `snippetFirst` request param.