### PR TITLE
fix(scrape): stop selling parking pages, and report dead origins honestly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "proptest",
  "publicsuffix",
  "rand 0.10.2",
+ "regex",
  "reqwest",
  "scraper",
  "serde_json",

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -870,6 +870,13 @@ pub const STRUCTURAL_FAILURE_VENDOR: &str = "structural_failure";
 /// it: they return an array of documents, not an envelope with an error code.
 pub const HTTP_ERROR_VENDOR: &str = "http_error";
 
+/// `BlockOutcome::vendor` for a registrar parking page, a domain-marketplace listing
+/// or a default web-server vhost. Like `HTTP_ERROR_VENDOR` it is not an anti-bot
+/// verdict but carries the same consequence: nothing the caller asked for was
+/// delivered. Kept distinct from `STRUCTURAL_FAILURE_VENDOR` because these pages are
+/// not thin or broken — they render perfectly well, they are just not the site.
+pub const PARKED_DOMAIN_VENDOR: &str = "parked_domain";
+
 impl BlockOutcome {
     /// Standard anti-bot block error string shared by the v1 and v2 handlers so
     /// the two API surfaces label the same block identically.
@@ -886,7 +893,11 @@ impl BlockOutcome {
     /// still escalate to the next renderer tier, which is what `is_blocked()`
     /// drives.
     pub fn message(&self) -> String {
-        if self.vendor == STRUCTURAL_FAILURE_VENDOR {
+        // `parked_domain` rides the same wording for the same reason: telling a
+        // customer their target was "blocked by anti-bot" when the domain is simply
+        // for sale is what sends them off to buy proxies for a site that does not
+        // exist.
+        if self.vendor == STRUCTURAL_FAILURE_VENDOR || self.vendor == PARKED_DOMAIN_VENDOR {
             format!("No usable content could be extracted ({})", self.reason)
         } else {
             format!("Blocked by anti-bot ({}): {}", self.vendor, self.reason)

--- a/crates/crw-crawl/Cargo.toml
+++ b/crates/crw-crawl/Cargo.toml
@@ -13,6 +13,7 @@ description = "Async BFS web crawler with rate limiting and robots.txt support f
 crw-core = { workspace = true }
 crw-diff = { workspace = true }
 crw-renderer = { workspace = true }
+regex = { workspace = true }
 crw-extract = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -421,6 +421,8 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
             data.markdown.as_deref(),
             fetch_result.screenshot.is_some(),
             http_retry_threshold_bytes,
+            &fetch_result.url,
+            fetch_result.final_url.as_deref(),
         )
         .filter(|b| b.vendor != crw_core::types::STRUCTURAL_FAILURE_VENDOR);
         // An origin error page is not the page that was asked for either. One

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -8,6 +8,8 @@ use crw_core::types::{
 use crw_renderer::FallbackRenderer;
 use crw_renderer::http_only::HttpFetcher;
 use crw_renderer::traits::PageFetcher;
+use regex::Regex;
+use std::sync::LazyLock;
 use std::sync::{Arc, Mutex};
 
 /// Resolve the effective proxy for a request, honoring precedence
@@ -571,6 +573,8 @@ async fn scrape_url_inner(
         data.markdown.as_deref(),
         fetch_result.screenshot.is_some(),
         extraction_cfg.http_retry_threshold_bytes,
+        &fetch_result.url,
+        fetch_result.final_url.as_deref(),
     );
     // Surface redirect mismatch as warning. Helps detect cases like
     // northernair.ca/history.htm silently 302'ing to the homepage — extraction
@@ -1140,6 +1144,117 @@ fn detect_block_interstitial(html: &str) -> Option<String> {
     }
 }
 
+/// The one signal this arm trusts: **the page names its own host and declares itself a
+/// placeholder**. Capture group 1 is the domain token, and the caller must match it
+/// against the host actually scraped.
+///
+/// That comparison is the entire guarantee, and it is why every earlier shape was
+/// removed. Unanchored template literals ("the nginx web server is successfully
+/// installed", "apache2 ubuntu default page", "this domain has been registered") fire on
+/// the most-scraped technical content there is: every nginx install tutorial quotes the
+/// default vhost verbatim to confirm the install worked, every "Apache2 Ubuntu Default
+/// Page still showing" StackOverflow thread repeats it in the title, and UDRP decisions
+/// say "this domain has been registered and is being used in bad faith". A token match
+/// alone is just as bad: "Insurance.com is for sale" is a real domain-industry headline,
+/// and `[a-z]{2,12}` happily accepts `checkout.html`, `main.py` or `config.yaml`, so a
+/// task board reading "- checkout.html ready for development" would fail too.
+///
+/// Requiring the token to BE the scraped host kills all of it at once: an article talks
+/// about someone else's domain, a parking page talks about the one you asked for.
+///
+/// Measured over 20,012 real prod scrape successes (2026-08-09..12): 294 matches, and in
+/// every single one the token equalled the scraped host — the host check costs nothing
+/// and removes the whole false-positive surface. It also correctly rejected two pages
+/// that named a DIFFERENT domain. Dropping the four unanchored literals costs 15
+/// records (0.075%), which against rejecting a real tutorial is not a close trade.
+static DOMAIN_PLACEHOLDER: LazyLock<Regex> = LazyLock::new(|| {
+    // The left guard is a CONSUMED character class, not `\b` and not a lookbehind:
+    // the `regex` crate has no lookaround, and `\b` matches straight after a dot, so
+    // `\b(...)` on "shop.example.com is for sale" captured only "example.com" — which
+    // would then equal the scraped host and fail a real page. It also truncated
+    // "example.co.uk" to "co.uk" (missing genuine parked pages) and could not match a
+    // single-letter label like "x.com" at all. Capturing whole dotted labels fixes all
+    // three at once and changed nothing on the 20,012-doc corpus (294 before, 294 after).
+    Regex::new(
+        r"(?:^|[^a-z0-9.\-])([a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*\.[a-z]{2,24})\s{0,24}(?:[-–—]\s{0,24}|::\s{0,24}this domain\s{0,24})?(?:is for sale|ready for development|is parked free)\b",
+    )
+    .expect("static parked-domain pattern")
+});
+
+/// Upper bound on a placeholder page's own body. See `looks_like_parked_domain`.
+const PARKED_MAX_BODY_BYTES: usize = 16 * 1024;
+
+/// Host of `url`, lowercased with a leading `www.` stripped, for comparing against a
+/// domain token rendered in the page body.
+fn normalized_host(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    Some(host.strip_prefix("www.").unwrap_or(&host).to_string())
+}
+
+/// Registrar parking, domain-marketplace and holding pages: the page is served at the
+/// domain and its whole content is "this domain is available", so nothing the caller
+/// asked for was delivered.
+///
+/// Matches MARKDOWN, not HTML, for two load-bearing reasons: `classify_block` already
+/// receives the markdown so no extraction is needed, and `detector.rs`'s HTML text
+/// extractor emits no separator at tag boundaries, so `<h1>host</h1><h2>is for
+/// sale</h2>` would collapse to `hostis for sale` and silently break the pattern.
+///
+/// Both the requested and the post-redirect host count, so a domain that 302s to its
+/// registrar still matches on the name the caller asked for.
+///
+/// ponytail: "under construction" and "coming soon" are deliberately NOT here. Those are
+/// pages the origin published on purpose — `eliteteam.ch` renders its own WordPress
+/// under-construction plugin — so they are truthful scrapes and stay billable. That is
+/// 68% of the flagged population, so this does not take the class to zero by design.
+fn looks_like_parked_domain(markdown: &str, requested_url: &str, final_url: Option<&str>) -> bool {
+    /// Byte-bounded prefix that never splits a UTF-8 char (`&s[..n]` panics off a
+    /// char boundary, and scraped markdown is routinely non-ASCII).
+    fn head(s: &str, max: usize) -> &str {
+        if s.len() <= max {
+            return s;
+        }
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+
+    // A placeholder page IS the whole document. Bounding the body stops a LIVE site
+    // that merely carries a "<our domain> is for sale" banner from having every page of
+    // a crawl failed and its body destroyed (`crawl.rs` clears the body on a block).
+    // The largest real placeholder measured over the 20,012-doc corpus is 9,459 bytes,
+    // so 16 KB costs nothing against all 294 matches and closes the banner class.
+    if markdown.len() > PARKED_MAX_BODY_BYTES {
+        return false;
+    }
+
+    let hosts: Vec<String> = [Some(requested_url), final_url]
+        .into_iter()
+        .flatten()
+        .filter_map(normalized_host)
+        .collect();
+    if hosts.is_empty() {
+        return false;
+    }
+
+    // ponytail: bound the scan rather than the verdict. A parking notice is always at
+    // the top (largest observed placeholder body is ~13 KB); this only stops a
+    // multi-hundred-KB article from being lowercased on the scrape hot path.
+    let low = head(markdown, 40_960).to_lowercase();
+
+    // `captures_iter`, not `captures`: a page may name another domain before its own.
+    DOMAIN_PLACEHOLDER.captures_iter(&low).any(|c| {
+        c.get(1).is_some_and(|m| {
+            let token = m.as_str();
+            let token = token.strip_prefix("www.").unwrap_or(token);
+            hosts.iter().any(|h| h == token)
+        })
+    })
+}
+
 /// Classify whether a fetched page is an anti-bot block/challenge shell. Runs
 /// ONCE at the scrape choke so every consumer (v1/v2/crawl/batch) inherits one
 /// verdict. Returns `None` for real content; `Some(BlockOutcome)` for a block.
@@ -1152,6 +1267,7 @@ fn detect_block_interstitial(html: &str) -> Option<String> {
 /// 3. Reuse the trusted `crw_extract::antibot::classify` detector.
 /// 4. A captured screenshot may suppress ONLY the generic near-empty
 ///    StructuralFailure heuristic — never a positive vendor block.
+#[allow(clippy::too_many_arguments)] // independent page signals; a struct adds noise
 pub(crate) fn classify_block(
     status: u16,
     content_type: Option<&str>,
@@ -1159,6 +1275,8 @@ pub(crate) fn classify_block(
     markdown: Option<&str>,
     screenshot_present: bool,
     threshold: usize,
+    requested_url: &str,
+    final_url: Option<&str>,
 ) -> Option<BlockOutcome> {
     if content_type.map(|c| c.contains("pdf")).unwrap_or(false) {
         return None;
@@ -1263,6 +1381,20 @@ pub(crate) fn classify_block(
         return Some(BlockOutcome {
             vendor: "vercel".to_string(),
             reason: "Vercel security checkpoint".to_string(),
+        });
+    }
+    // Fifth instance of the same trap as the four strong-marker arms above, and the
+    // one prod actually pays for. A registrar parking / marketplace / default-server
+    // page is HTTP 200, so `ScrapeData::http_error()` clears it, and it renders 300 to
+    // 9,000 chars of clean prose, so the `>= threshold` guard below clears it too and
+    // `antibot::classify` is never even called. Measured over 20,007 prod scrape
+    // successes (2026-08-09..12): 304 of them, every one billed as content.
+    if let Some(md) = markdown
+        && looks_like_parked_domain(md, requested_url, final_url)
+    {
+        return Some(BlockOutcome {
+            vendor: crw_core::types::PARKED_DOMAIN_VENDOR.to_string(),
+            reason: "parked domain / placeholder page".to_string(),
         });
     }
     if markdown.map(|m| m.trim().len()).unwrap_or(0) >= threshold {
@@ -1409,14 +1541,307 @@ mod tests {
         ));
     }
 
+    /// Every body below is a VERBATIM prefix of a real prod scrape from
+    /// 2026-08-09..12 that was billed as content. They render fine and carry
+    /// substantial markdown, so they sail past both the HTTP-status gate and the
+    /// `>= threshold` guard — which is why they needed their own arm.
+    #[test]
+    fn classify_block_parked_domain_templates() {
+        // (requested url, markdown) — the host must be the one the page names.
+        let cases: [(&str, &str); 4] = [
+            (
+                "https://ft-access.com/",
+                "ft-access.com\n\nis parked free, courtesy of GoDaddy.com.\n\n\
+                 [Get This Domain](https://www.godaddy.com/domainsearch/find?key=parkweb)",
+            ),
+            (
+                "https://arym.com/",
+                "# Arym.com is for sale\n\nWe value your privacy\n\nWe use cookies to \
+                 enhance your browsing experience and serve personalised ads.",
+            ),
+            (
+                // eWeb holding page: no "for sale" wording at all.
+                "https://sterki.com/",
+                "# Sterki.com -\n        Ready for Development\n\n[Contact Us for Details]\
+                 (https://ewebdevelopment.com/quotes/inquire/sterki.com)\n\n# Sterki.com\n\n\
+                 ## Ready For Development\n\nIf you're interested in this domain, contact us.",
+            ),
+            (
+                // `www.` on the request must still match the bare name in the body.
+                "https://www.conditorei.com/",
+                "conditorei.com :: this domain is for sale\n\nInquire now for pricing \
+                 and availability through our brokerage partner.",
+            ),
+        ];
+        for (url, md) in cases {
+            let b = classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(md),
+                false,
+                THRESH,
+                url,
+                None,
+            )
+            .unwrap_or_else(|| panic!("{url} must be flagged"));
+            assert_eq!(b.vendor, crw_core::types::PARKED_DOMAIN_VENDOR, "{url}");
+            // Wording matters as much as the verdict: telling the caller a domain that
+            // is for sale was "blocked by anti-bot" is what sends them to buy proxies.
+            assert!(
+                b.message().starts_with("No usable content"),
+                "{url} must not be worded as an anti-bot block, got {:?}",
+                b.message()
+            );
+        }
+    }
+
+    /// THE guarantee. The identical body is a parking page when served AT that domain
+    /// and ordinary editorial content when served anywhere else, and the host
+    /// comparison is the only thing that tells them apart.
+    ///
+    /// `Insurance.com is for sale` is a real domain-industry headline; without this
+    /// check every article covering a domain sale, and every broker's inventory page,
+    /// becomes a failed scrape.
+    #[test]
+    fn classify_block_parked_arm_requires_the_page_to_name_its_own_host() {
+        let body = "# Insurance.com is for sale\n\nThe record-setting domain returns to \
+                    the market more than a decade after it changed hands.";
+        let call = |url: &str| {
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(body),
+                false,
+                THRESH,
+                url,
+                None,
+            )
+        };
+        assert!(
+            call("https://insurance.com/").is_some(),
+            "served at the domain it names, this is a parking page"
+        );
+        assert!(
+            call("https://domainnamewire.com/2026/08/12/insurance-com/").is_none(),
+            "the same text on a news site is editorial content, not a parking page"
+        );
+    }
+
+    /// A post-redirect host counts too. Discriminating on purpose: the REQUESTED host
+    /// deliberately does not appear in the body, so this passes only if `final_url` is
+    /// really consulted, and the body clears `THRESH` so a `Some` cannot come from the
+    /// structural arm instead.
+    #[test]
+    fn classify_block_parked_arm_accepts_either_requested_or_final_host() {
+        let md = "# Parked-Target.com is for sale\n\nThis premium name is available \
+                  immediately. Submit an offer through our brokerage and we will respond \
+                  within one business day with pricing and transfer details.";
+        assert!(md.len() > THRESH, "fixture must clear the threshold guard");
+        let call = |requested: &str, final_url: Option<&str>| {
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html><body><p>a real enough shell</p></body></html>",
+                Some(md),
+                false,
+                THRESH,
+                requested,
+                final_url,
+            )
+        };
+        assert!(
+            call(
+                "https://links.example.org/out?to=parked-target",
+                Some("https://parked-target.com/"),
+            )
+            .is_some(),
+            "the post-redirect host names the page and must count"
+        );
+        // Same body, same requested URL, no redirect recorded: nothing names the page.
+        assert!(
+            call("https://links.example.org/out?to=parked-target", None).is_none(),
+            "without the final host there is no anchor, so the arm must decline"
+        );
+    }
+
+    /// The token must be a host, not any dotted word. `[a-z]{2,12}` after a dot also
+    /// accepts file extensions, so a task board line like
+    /// `- checkout.html ready for development` matched before the host check existed.
+    #[test]
+    fn classify_block_parked_arm_ignores_dotted_non_hosts() {
+        let md = "# Sprint 12 board\n\n- checkout.html ready for development\n\
+                  - main.py ready for development\n- config.yaml is for sale (internal joke)";
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(md),
+                false,
+                THRESH,
+                "https://tasks.internal.example/board",
+                None,
+            )
+            .is_none(),
+            "dotted filenames are not the scraped host"
+        );
+    }
+
+    /// The capture must be the WHOLE dotted name. `\b` matches straight after a dot, so
+    /// the first version of this pattern read `shop.example.com is for sale` as
+    /// `example.com` — which then equalled a scrape of example.com and failed a real
+    /// page. It also truncated `example.co.uk` to `co.uk`, missing genuine parked
+    /// pages, and could not match a single-letter label at all.
+    #[test]
+    fn classify_block_parked_arm_captures_whole_domain_tokens() {
+        let call = |md: &str, url: &str| {
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(md),
+                false,
+                THRESH,
+                url,
+                None,
+            )
+        };
+        // A subdomain named in the body is NOT the host that was scraped. The body is
+        // kept comfortably above `THRESH` so a `None` here proves the parked arm
+        // declined, rather than the structural arm firing on a thin page.
+        let announcement = "# Our shop is moving\n\nshop.example.com is for sale, and the \
+             main site stays exactly where it is. Existing orders, accounts and support \
+             tickets are unaffected by the change; only the storefront hostname retires.";
+        assert!(
+            call(announcement, "https://example.com/").is_none(),
+            "a subdomain mentioned in prose must not satisfy the host anchor"
+        );
+        // ...but scraping that subdomain directly does match it.
+        assert!(
+            call("shop.example.com is for sale", "https://shop.example.com/").is_some(),
+            "the page names exactly the host it was served at"
+        );
+        // Multi-label TLDs must survive whole.
+        assert!(
+            call("example.co.uk is for sale", "https://example.co.uk/").is_some(),
+            "a .co.uk parked page must be caught, not truncated to co.uk"
+        );
+        // Single-character label.
+        assert!(
+            call("x.com is for sale", "https://x.com/").is_some(),
+            "a one-letter label is still a host"
+        );
+        // A leading www. in the body still matches the bare scraped host.
+        assert!(
+            call("www.arym.com is for sale", "https://arym.com/").is_some(),
+            "www. is stripped on both sides before comparing"
+        );
+    }
+
+    /// The deliberate scope limit, pinned so nobody "improves" it later. An
+    /// under-construction page is a state the origin published on purpose — this body
+    /// is `cset-ag.com`, a real WordPress site in maintenance serving its own logo —
+    /// so it is a truthful scrape and stays billable. 68% of the flagged population
+    /// looks like this, which is why the fix does not take the class to zero.
+    #[test]
+    fn classify_block_leaves_a_real_under_construction_page_alone() {
+        let md = "![logo](https://www.cset-ag.com/wp-content/uploads/2025/09/cset-wit.png)\n\n\
+                  ## Under construction for new update\n\n### Clear Sustainable Energy Trading\n\n\
+                  © CSET Group 2025";
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(md),
+                false,
+                THRESH,
+                "https://www.cset-ag.com/",
+                None,
+            )
+            .is_none(),
+            "an origin's own under-construction page is real content"
+        );
+    }
+
+    /// The four unanchored template literals that used to live here are gone, and this
+    /// pins why: every nginx install tutorial quotes the default vhost verbatim to
+    /// confirm the install worked, and it is exactly the kind of page a RAG pipeline
+    /// scrapes. Same shape for the Apache default page and for UDRP decisions saying
+    /// "this domain has been registered and is being used in bad faith".
+    #[test]
+    fn classify_block_leaves_technical_docs_quoting_default_pages_alone() {
+        let tutorial = "# How to install nginx on Ubuntu\n\nAfter `apt install nginx`, \
+             open the server in a browser. You should see the default landing page: \
+             \"Welcome to nginx! If you see this page, the nginx web server is \
+             successfully installed and working. Further configuration is required.\" \
+             If instead you get the Apache2 Ubuntu Default Page, another service is \
+             bound to port 80.\n\nNote that this domain has been registered for the \
+             lab and resolves locally.\n"
+            .repeat(3);
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(&tutorial),
+                false,
+                THRESH,
+                "https://www.digitalocean.com/community/tutorials/install-nginx",
+                None,
+            )
+            .is_none(),
+            "a tutorial quoting default landing pages is real content"
+        );
+    }
+
+    /// Non-ASCII markdown is routine and `&s[..n]` panics off a char boundary. The
+    /// 3-byte repeat unit puts byte 40_960 mid-character (40_960 % 3 == 1), so the
+    /// boundary walk in `head()` actually executes — a 29-byte unit lands ON a
+    /// boundary and the loop never runs, which made the previous version vacuous.
+    #[test]
+    fn classify_block_parked_arm_survives_multibyte_markdown() {
+        let md = "€".repeat(20_000); // 60 KB, well past the 40_960 scan window
+        assert_eq!(md.len(), 60_000);
+        assert!(
+            !md.is_char_boundary(40_960),
+            "fixture must straddle the window"
+        );
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                "<html></html>",
+                Some(&md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None,
+            )
+            .is_none(),
+            "multibyte content must neither panic nor be called parked"
+        );
+    }
+
     #[test]
     fn classify_block_challenge_on_cf_200() {
         // Ticket headline: a CF challenge served with HTTP 200. TIER2 "Just a
         // moment" does NOT run on 200, so a real TIER1 token (__cf_chl_f_tk=) is
         // required to reach vendor=cloudflare.
         let html = r#"<html><body><form id="challenge-form" action="/cdn-cgi/?__cf_chl_f_tk=abc"></form></body></html>"#;
-        let b = classify_block(200, Some("text/html"), html, None, false, THRESH)
-            .expect("CF challenge must be flagged");
+        let b = classify_block(
+            200,
+            Some("text/html"),
+            html,
+            None,
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("CF challenge must be flagged");
         assert_eq!(b.vendor, "cloudflare");
     }
 
@@ -1438,8 +1863,17 @@ mod tests {
             "marker must sit past the old 80KB prefix to guard the regression"
         );
         let md = "recovered looking text ".repeat(50); // > THRESH, must NOT suppress
-        let b = classify_block(200, Some("text/html"), &html, Some(&md), false, THRESH)
-            .expect("Turnstile 200 interstitial must be flagged");
+        let b = classify_block(
+            200,
+            Some("text/html"),
+            &html,
+            Some(&md),
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("Turnstile 200 interstitial must be flagged");
         assert_eq!(b.vendor, "cloudflare");
     }
 
@@ -1467,7 +1901,17 @@ mod tests {
         // Substantial recovered markdown too — the real content extracts fine.
         let md = "Real reviews and salaries content. ".repeat(50);
         assert!(
-            classify_block(200, Some("text/html"), &html, Some(&md), false, THRESH).is_none(),
+            classify_block(
+                200,
+                Some("text/html"),
+                &html,
+                Some(&md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none(),
             "a cleared managed page with a trailing challenge-platform telemetry \
              script (but no _cf_chl_opt) must not be misflagged as a challenge"
         );
@@ -1476,8 +1920,17 @@ mod tests {
     #[test]
     fn classify_block_hard_block_on_datadome_403() {
         let html = r#"<html><body><script src="https://captcha-delivery.com/c.js"></script></body></html>"#;
-        let b = classify_block(403, Some("text/html"), html, None, false, THRESH)
-            .expect("DataDome block must be flagged");
+        let b = classify_block(
+            403,
+            Some("text/html"),
+            html,
+            None,
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("DataDome block must be flagged");
         assert_eq!(b.vendor, "datadome");
     }
 
@@ -1497,8 +1950,17 @@ mod tests {
             md.len() >= THRESH,
             "fixture must exceed the guard to be meaningful"
         );
-        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
-            .expect("wikimedia datacenter block must be flagged even with substantial markdown");
+        let b = classify_block(
+            200,
+            Some("text/html"),
+            html,
+            Some(md),
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("wikimedia datacenter block must be flagged even with substantial markdown");
         assert_eq!(b.vendor, "generic_block");
     }
 
@@ -1520,6 +1982,8 @@ mod tests {
             Some(real_markdown),
             false,
             THRESH,
+            "https://example.com/",
+            None,
         )
         .expect("the exact text that silently returned success:true 198x in prod must be flagged");
         assert_eq!(b.vendor, "network_security");
@@ -1538,8 +2002,17 @@ mod tests {
             md.len() >= THRESH,
             "fixture must exceed the guard to be meaningful"
         );
-        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
-            .expect("reddit network security block must be flagged even with substantial markdown");
+        let b = classify_block(
+            200,
+            Some("text/html"),
+            html,
+            Some(md),
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("reddit network security block must be flagged even with substantial markdown");
         assert_eq!(b.vendor, "network_security");
     }
 
@@ -1556,7 +2029,17 @@ mod tests {
             errors when hitting Reddit at scale, which is a common anti-bot pattern.";
         assert!(md.len() >= THRESH);
         assert!(
-            classify_block(200, Some("text/html"), html, Some(md), false, THRESH).is_none(),
+            classify_block(
+                200,
+                Some("text/html"),
+                html,
+                Some(md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none(),
             "an article merely discussing the phrase must not be misflagged as a block"
         );
     }
@@ -1577,8 +2060,17 @@ mod tests {
             md.len() >= THRESH,
             "fixture must exceed the guard to be meaningful"
         );
-        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
-            .expect("cloudflare hard block must be flagged even with substantial markdown");
+        let b = classify_block(
+            200,
+            Some("text/html"),
+            html,
+            Some(md),
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("cloudflare hard block must be flagged even with substantial markdown");
         assert_eq!(b.vendor, "cloudflare");
     }
 
@@ -1599,7 +2091,17 @@ mod tests {
             content describing how status codes are displayed.";
         assert!(md.len() >= THRESH);
         assert!(
-            classify_block(200, Some("text/html"), html, Some(md), false, THRESH).is_none(),
+            classify_block(
+                200,
+                Some("text/html"),
+                html,
+                Some(md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none(),
             "a page merely rendering the cf-error-code marker without the block heading must not be misflagged"
         );
     }
@@ -1622,8 +2124,17 @@ mod tests {
             md.len() >= THRESH,
             "this is the real-world case: the fixture must exceed the guard"
         );
-        let b = classify_block(200, Some("text/html"), html, Some(md), false, THRESH)
-            .expect("vercel checkpoint must be flagged even with substantial markdown");
+        let b = classify_block(
+            200,
+            Some("text/html"),
+            html,
+            Some(md),
+            false,
+            THRESH,
+            "https://example.com/",
+            None,
+        )
+        .expect("vercel checkpoint must be flagged even with substantial markdown");
         assert_eq!(b.vendor, "vercel");
     }
 
@@ -1640,7 +2151,17 @@ mod tests {
             automatic previews on every pull request submitted to the repository.";
         assert!(md.len() >= THRESH);
         assert!(
-            classify_block(200, Some("text/html"), html, Some(md), false, THRESH).is_none(),
+            classify_block(
+                200,
+                Some("text/html"),
+                html,
+                Some(md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none(),
             "an article merely mentioning Vercel without the checkpoint heading must not be misflagged"
         );
     }
@@ -1651,7 +2172,19 @@ mod tests {
         // soft-block status with CF markers in the (stale) html.
         let html = r#"<html><body><form id="challenge-form" action="/cdn-cgi/?__cf_chl_f_tk=abc"></form></body></html>"#;
         let md = "x".repeat(500);
-        assert!(classify_block(403, Some("text/html"), html, Some(&md), false, THRESH).is_none());
+        assert!(
+            classify_block(
+                403,
+                Some("text/html"),
+                html,
+                Some(&md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -1666,7 +2199,9 @@ mod tests {
                 html,
                 Some("# Hello\n\nreal body"),
                 false,
-                THRESH
+                THRESH,
+                "https://example.com/",
+                None
             )
             .is_none()
         );
@@ -1675,16 +2210,52 @@ mod tests {
     #[test]
     fn classify_block_screenshot_suppresses_structural_only() {
         // Near-empty 200 shell + screenshot => structural failure suppressed.
-        assert!(classify_block(200, Some("text/html"), "", None, true, THRESH).is_none());
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                "",
+                None,
+                true,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none()
+        );
         // Positive vendor block is NOT suppressed by a screenshot.
         let html = r#"<html><body><script src="https://captcha-delivery.com/c.js"></script></body></html>"#;
-        assert!(classify_block(403, Some("text/html"), html, None, true, THRESH).is_some());
+        assert!(
+            classify_block(
+                403,
+                Some("text/html"),
+                html,
+                None,
+                true,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_some()
+        );
     }
 
     #[test]
     fn classify_block_pdf_skipped() {
         // PDF branch has empty html — must not false-flag as StructuralFailure.
-        assert!(classify_block(200, Some("application/pdf"), "", None, false, THRESH).is_none());
+        assert!(
+            classify_block(
+                200,
+                Some("application/pdf"),
+                "",
+                None,
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -1693,7 +2264,19 @@ mod tests {
         // `success:false` / `anti_bot` in prod: "Near-empty content (68 bytes)
         // with HTTP 200". It is a complete, valid file.
         let txt = "fastapi>=0.110.0\nuvicorn>=0.29.0\npydantic>=2.6\npython-multipart\n";
-        assert!(classify_block(200, Some("text/plain"), txt, Some(txt), false, THRESH).is_none());
+        assert!(
+            classify_block(
+                200,
+                Some("text/plain"),
+                txt,
+                Some(txt),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none()
+        );
         for ct in [
             "text/csv",
             "application/json",
@@ -1702,7 +2285,17 @@ mod tests {
             "text/css",
         ] {
             assert!(
-                classify_block(200, Some(ct), "x", None, false, THRESH).is_none(),
+                classify_block(
+                    200,
+                    Some(ct),
+                    "x",
+                    None,
+                    false,
+                    THRESH,
+                    "https://example.com/",
+                    None
+                )
+                .is_none(),
                 "{ct} was classified as a block"
             );
         }
@@ -1714,7 +2307,19 @@ mod tests {
         // DataDome answers XHR-shaped requests with an application/json captcha
         // stub, and that is still a block.
         let json = r#"{"url":"https://geo.captcha-delivery.com/captcha/?initialCid=x"}"#;
-        assert!(classify_block(200, Some("application/json"), json, None, false, THRESH).is_some());
+        assert!(
+            classify_block(
+                200,
+                Some("application/json"),
+                json,
+                None,
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_some()
+        );
     }
 
     #[test]
@@ -1722,17 +2327,53 @@ mod tests {
         // The guard must not blind the classifier: a wall is html or type-less.
         let html = "<html><body>You've been blocked by network security. \
                     Please log in to your Reddit account.</body></html>";
-        assert!(classify_block(200, None, html, None, false, THRESH).is_some());
+        assert!(
+            classify_block(
+                200,
+                None,
+                html,
+                None,
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_some()
+        );
     }
 
     #[test]
     fn classify_block_407_is_our_proxy_not_a_target_block() {
         // 215 records in 14 days of prod were our own DataImpulse egress failing
         // auth, stamped `structural_failure` and poisoning the routing registry.
-        assert!(classify_block(407, Some("text/html"), "", None, false, THRESH).is_none());
+        assert!(
+            classify_block(
+                407,
+                Some("text/html"),
+                "",
+                None,
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_none()
+        );
         // Everything else with an empty body stays classifiable: a near-empty
         // 403/503 is the canonical CloudFront/Akamai deny signature.
-        assert!(classify_block(403, Some("text/html"), "", None, false, THRESH).is_some());
+        assert!(
+            classify_block(
+                403,
+                Some("text/html"),
+                "",
+                None,
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_some()
+        );
     }
 
     #[test]
@@ -1742,7 +2383,19 @@ mod tests {
         // stamped `cloudflare` here and `clear_body()` throws the recovery away.
         let html = r#"<html><body><script>window._cf_chl_opt={}</script></body></html>"#;
         let md = "x".repeat(500);
-        assert!(classify_block(200, Some("text/html"), html, Some(&md), false, THRESH).is_some());
+        assert!(
+            classify_block(
+                200,
+                Some("text/html"),
+                html,
+                Some(&md),
+                false,
+                THRESH,
+                "https://example.com/",
+                None
+            )
+            .is_some()
+        );
     }
 
     fn sample_fetch(status_code: u16, html: &str) -> FetchResult {

--- a/crates/crw-renderer/src/http_only.rs
+++ b/crates/crw-renderer/src/http_only.rs
@@ -488,6 +488,7 @@ impl PageFetcher for HttpFetcher {
         };
         let mut use_proxy = proxy_first;
         let mut direct_rescue_used = false;
+        let mut origin_answered = false;
         // Set when the DIRECT egress got NOTHING back from the origin: a connect-phase
         // timeout, i.e. the blackholed SYN. See where it is set for why the shape is
         // narrowed that far and why the 422 below depends on it.
@@ -592,6 +593,18 @@ impl PageFetcher for HttpFetcher {
             };
             let send_fut = build_request(active_client).send();
             let send_result = tokio::time::timeout(remaining, send_fut).await;
+            // "The origin answered us at least once on this request." Recorded HERE,
+            // once, rather than in the four `Ok(Ok(_))` arms below, so no future arm can
+            // forget it. Direct egress only: a response relayed through the proxy could
+            // be the proxy's own (407, its 502), which proves nothing about the origin.
+            //
+            // This is the real predicate behind `direct_connect_failed`. An earlier
+            // revision used `!armed_mid_loop`, which only covers 429 and announced
+            // challenges — an origin answering 502-504, then connect-timing-out on the
+            // retry, still ended up reported as "no response from the origin".
+            if !use_proxy && matches!(send_result, Ok(Ok(_))) {
+                origin_answered = true;
+            }
             match send_result {
                 // The proxy-first attempt HUNG until its capped budget ran out.
                 // This is the case the reserve exists for: fall back to direct with
@@ -813,7 +826,16 @@ impl PageFetcher for HttpFetcher {
                     // go quiet during a real outage. Requiring the direct blackhole
                     // first means proxy congestion alone can never reach 422: a healthy
                     // origin answers the direct attempt and the proxy is never armed.
-                    direct_connect_failed = e.is_connect() && e.is_timeout();
+                    //
+                    // `!armed_mid_loop` is the third requirement and it is not
+                    // cosmetic: that flag is set only after the origin ANSWERED us
+                    // with an HTTP status (a 429 or an announced challenge). If it
+                    // did, "no response from the origin" is provably false, and a
+                    // later direct-rescue timeout must not be laundered into a 422
+                    // that blames — and refunds — a host we demonstrably reached.
+                    // Narrowed here at the source rather than at the two arms that
+                    // read it, so both inherit the same meaning.
+                    direct_connect_failed = e.is_connect() && e.is_timeout() && !origin_answered;
                 }
                 // Retry once on the same egress. Read-phase timeouts qualify (the origin
                 // connected and is slow — a retry may help). Connection-level failures
@@ -843,7 +865,31 @@ impl PageFetcher for HttpFetcher {
                     // once we switched to the proxy, a failure may be the proxy infra's
                     // fault, not the origin's, so keep it a 502 (our side) rather than
                     // blaming the caller. A post-handshake reset likewise stays 502.
-                    return Err(if e.is_connect() && !use_proxy {
+                    //
+                    // `direct_connect_failed` is the one exception, and it is the same
+                    // rule the `Err(_)` arm above already applies: it is set ONLY when the
+                    // DIRECT egress hit a connect-phase TIMEOUT, a first-hand observation
+                    // that the origin swallowed our SYNs. A proxy failure layered on top
+                    // does not overturn that. Without this the class exits as `HttpError`,
+                    // the ladder never short-circuits (`lib.rs` only stops on
+                    // `TargetUnreachable`), and a host with no listening socket is handed
+                    // lightpanda's and chrome's full budgets — measured on prod at ~38 s
+                    // per request, ~1,050 requests/day. A refused or reset proxy still
+                    // lands at 502 because a refusal is not a timeout, which is what
+                    // `proxy_connect_failure_is_not_blamed_on_the_caller` pins.
+                    if e.is_connect() && use_proxy && direct_connect_failed {
+                        // Same greppable signal the `Err(_)` arm emits, and for the same
+                        // reason: this is the one 422 shape that used to be a paging 5xx.
+                        // If our OWN direct egress is ever blocked host-wide, every origin
+                        // starts looking blackholed and this line is how an operator sees
+                        // the 422s are ours, not the callers'.
+                        tracing::warn!(
+                            url,
+                            "direct connect-timeout and proxy attempt both failed; \
+                             reporting target_unreachable (was: http_error)"
+                        );
+                    }
+                    return Err(if e.is_connect() && (!use_proxy || direct_connect_failed) {
                         CrwError::TargetUnreachable(format!("Could not reach {url}: {e}"))
                     } else {
                         CrwError::HttpError(e.to_string())
@@ -1523,6 +1569,55 @@ mod tests {
             matches!(err, CrwError::TargetUnreachable(_)),
             "a blackholing origin behind a reachable-but-hanging proxy must surface as \
              TargetUnreachable (422), not a 504; got {err:?}"
+        );
+    }
+
+    /// The third shape, and the one prod actually produces: the origin blackholes our
+    /// direct SYNs and the proxy then fails FAST (refused / DNS / TLS) rather than
+    /// hanging. That lands on `Ok(Err(_))`, not the `Err(_)` timeout arm, so before this
+    /// it exited as `HttpError` and the JS ladder never short-circuited — measured on
+    /// prod at ~38 s per request across ~1,050 requests/day, and 895 proxy arms in a
+    /// single 6-hour window with the existing 422 path firing zero times.
+    ///
+    /// Sits between the two tests above: the discriminator is still the DIRECT
+    /// connect-timeout, never the proxy's failure mode.
+    #[tokio::test]
+    async fn direct_blackhole_then_refusing_proxy_is_target_unreachable() {
+        // proxy: closed port, so the connect fails immediately (the fast-fail shape).
+        let p = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let paddr = p.local_addr().unwrap();
+        drop(p);
+        let fetcher = HttpFetcher {
+            client: reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_millis(300))
+                .build()
+                .unwrap(),
+            relaxed_client: None,
+            has_static_proxy: false,
+            ratelimit_proxy_client: Some(
+                build_client(
+                    "ua",
+                    Some(&format!("http://{paddr}")),
+                    std::time::Duration::from_secs(5),
+                    false,
+                )
+                .unwrap(),
+            ),
+            inject_stealth_headers: false,
+        };
+        let err = fetcher
+            .fetch(
+                "http://192.0.2.1/",
+                &HashMap::new(),
+                None,
+                Deadline::from_request_ms(2_000),
+            )
+            .await
+            .expect_err("origin blackholes and the proxy refuses");
+        assert!(
+            matches!(err, CrwError::TargetUnreachable(_)),
+            "a blackholing origin must surface as TargetUnreachable (422) even when the \
+             proxy fails fast rather than hanging; got {err:?}"
         );
     }
 

--- a/crates/crw-server/src/routes/scrape.rs
+++ b/crates/crw-server/src/routes/scrape.rs
@@ -112,7 +112,9 @@ pub async fn scrape(
         // these since `BlockOutcome::message()`; the machine-readable code now
         // does too, so a client can branch without matching English. Refunds are
         // unaffected — the SaaS keys on `success:false`, not on this code.
-        let error_code = if b.vendor == crw_core::types::STRUCTURAL_FAILURE_VENDOR {
+        let error_code = if b.vendor == crw_core::types::STRUCTURAL_FAILURE_VENDOR
+            || b.vendor == crw_core::types::PARKED_DOMAIN_VENDOR
+        {
             "no_usable_content"
         } else {
             "anti_bot"


### PR DESCRIPTION
Two independent fixes found by auditing four days of production logs
(2026-08-09 → 08-12, 20,012 successful scrapes and 13,443 engine traces).

## 1. Registrar parking pages were billed as content

A parking page is HTTP 200 carrying a few hundred to a few thousand bytes of
clean markdown, so it cleared both shared gates: `ScrapeData::http_error()`
returns early on the status, and `classify_block`'s markdown-substantial guard
returns `None` before `antibot::classify` runs at all. **294 of 20,012
production successes** were parking, marketplace or holding pages delivered and
billed as content.

The verdict is anchored on **the page naming its own host**. Unanchored template
literals were tried and rejected: every nginx install tutorial quotes the default
vhost verbatim, "Apache2 Ubuntu Default Page" is the title of a common
StackOverflow thread, and UDRP decisions say "this domain has been registered".
A bare token match is no better — "Insurance.com is for sale" is a real headline,
and the pattern also accepts `checkout.html` or `main.py`. Requiring the token to
equal the scraped host rejects all of them, and on the corpus the anchor cost
nothing: the token equalled the host in all 294, and it correctly rejected two
pages that named a different domain.

`under construction` and `coming soon` are **deliberately out of scope** — those
are states an origin published on purpose, so they stay truthful scrapes and stay
billable. That is 68% of the flagged population, so this does not take the class
to zero by design.

Reported as `no_usable_content`, not `anti_bot`: telling a customer that a domain
which is for sale was blocked by anti-bot is what sends them to buy proxies for a
site that does not exist.

## 2. A blackholed origin was reported as our timeout

When the direct egress hit a connect-phase timeout the fallback proxy was armed,
and a connect-level failure on that proxy exited as `HttpError` because the
verdict required `!use_proxy`. The JS ladder only short-circuits on
`TargetUnreachable`, so a host with no listening socket was handed every tier's
full budget: **~38s per request across ~1,050 requests/day**, returned as a 504
telling the caller to raise a timeout that cannot help, and paging the 5xx
watchdog as our outage rather than their dead target. Requests that do land in
`target_unreachable` today finish at **p50 2,573ms** — the same verdict arriving
on time.

`direct_connect_failed` is narrowed at its source so both arms that read it
inherit one meaning, and it now requires that the origin never answered at all.
A refused or reset proxy still stays 502, because a refusal is not a timeout.

## Benchmark impact — measured, not assumed

The parking verdict is the only change here that can move scrape-success, so it
was gated against the frozen 1,000-URL set before merge rather than after. Only
rows that are currently `ok=true` **and** under the new 16 KB body ceiling
**and** found no expected content can flip — 277 of them. Those were re-scraped
through the live API and the shipped predicate applied offline, three times.

**Result: exactly one row flips, `https://ccg.ai`**, whose `<h1>` is literally
`# ccg.ai is for sale!` served at ccg.ai. Raw scrape-success 877 → 876. The
dead-link-adjusted figure is unchanged, since that URL is a dead link by any
definition.

Nothing here touches render timing, so p50/p90 and truth-recall are unaffected.

## Verification

- 1,619 workspace tests, clippy `-D warnings` clean, fmt clean
- The shipped Rust predicate was cross-checked against an independently written
  reference over all 20,012 corpus documents: 294 matches, zero disagreement
- Reviewed to consensus over two rounds by three independent reviewers; the first
  round's blockers (unanchored literals, a truncating capture, a too-tight
  budget) are all resolved here
- A third change — clamping the JS ladder for confirmed-dead origins — was
  **dropped from this PR**: production data shows 22% of chrome-failover
  successes take longer than the proposed budget, so it traded recall for
  latency. The right fix there is a host-level breaker, tracked separately.