### PR TITLE
Lead the README with the Cloud offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@
 </p>
 
 <p align="center">
-  <a href="#one-command-install"><strong>Run locally ↓</strong></a> ·
-  <a href="https://fastcrw.com/register"><strong>Start free</strong></a> ·
+  <a href="https://fastcrw.com/register"><strong>Get 1000 free credits →</strong></a> ·
+  <a href="#one-command-install"><strong>Install</strong></a> ·
   <a href="https://docs.fastcrw.com"><strong>Docs</strong></a>
+</p>
+
+<p align="center">
+  <sub>No credit card. Continue with GitHub.</sub>
 </p>
 
 <p align="center">
@@ -34,14 +38,19 @@
 curl -fsSL https://fastcrw.com/install | sh
 ```
 
-Then set it up:
+Then point it at the Cloud:
 
 ```bash
 crw setup
 ```
 
-No account or API key is needed for local use. macOS and Linux are supported
-on Intel and ARM. [More install options →](https://docs.fastcrw.com/installation/)
+**1000 free credits, no credit card.** Managed proxies, JS rendering and search,
+with nothing to run or keep up to date.
+[Get my free key →](https://fastcrw.com/register)
+
+The same command configures a fully local install if you would rather run it
+yourself. macOS and Linux, Intel and ARM.
+[More install options →](https://docs.fastcrw.com/installation/)
 
 ## What it does
 


### PR DESCRIPTION
The top link row pointed at the local install first and the hosted offer
second, and the install section ended on "No account or API key is needed for
local use" — the last line a reader saw was a reason not to sign up.

Before:

```
Run locally ↓ · Start free · Docs
...
No account or API key is needed for local use.
```

After:

```
Get 1000 free credits → · Install · Docs
No credit card. Continue with GitHub.
...
1000 free credits, no credit card. Managed proxies, JS rendering and search,
with nothing to run or keep up to date.
Get my free key →

The same command configures a fully local install if you would rather run it
yourself.
```

Self-hosting is not removed, it moves one line down. This is an AGPL repo and
that audience is half of who arrives here.

## Where 1000 comes from

`src/lib/onboarding-rewards.ts` in crw-saas: the FREE signup grant is 500 and
the starter tasks award 500 more (GitHub star 200, X 100, first scrape 100,
Discord 50, LinkedIn 50), which `TOTAL_REWARD_CREDITS` pins with a test. One of
those tasks is starring this repo, so it is a natural next step for a reader
arriving from here.

"No credit card" and "Continue with GitHub" both match what /register shows
today, so the ad and the landing page agree.

## Follow-up for crw-saas

/register still reads "500 one-time credits". Worth raising to the full 1000 so
the number a reader clicked on is the number the page repeats back.

## Verification

Rendered through GitHub's markdown API and checked in a browser. No em-dashes,
`check-doc-links.sh` clean, every link resolves. No code paths touched.