### PR TITLE
fix(renderer): stop treating a cleared page as a Cloudflare challenge

### DIFF
--- a/crates/crw-renderer/src/cdp.rs
+++ b/crates/crw-renderer/src/cdp.rs
@@ -25,6 +25,18 @@ const TARGET_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 pub const CHALLENGE_MAX_RETRIES: u32 = 3;
 /// Delay between challenge retry polls (ms).
 pub const CHALLENGE_POLL_INTERVAL_MS: u64 = 3000;
+
+/// Wall-clock the post-navigate challenge loop can actually consume, for the
+/// retry count THIS renderer was configured with.
+///
+/// Sized off the configured value, never `CHALLENGE_MAX_RETRIES`: the loop runs
+/// `retries` iterations, so reserving the constant inflated the CDP outer
+/// timeout (and through it the auto-extended request deadline) by every retry
+/// the deployment had already turned off. Prod runs 1, so the constant was
+/// reserving two poll intervals per CDP tier that no code path could spend.
+fn challenge_retry_budget(retries: u32) -> Duration {
+    Duration::from_millis(CHALLENGE_POLL_INTERVAL_MS * u64::from(retries))
+}
 /// Maximum time to poll for content stability when a loading placeholder
 /// is detected after the initial wait.
 pub const CONTENT_STABILITY_MAX_MS: u64 = 6000;
@@ -1771,8 +1783,7 @@ impl PageFetcher for CdpRenderer {
         // SPA selector poll instead of a fixed sleep — size the budget for
         // its worst-case SPA_SELECTOR_MAX_MS rather than the old 2s default.
         let wait_dur = Duration::from_millis(wait_for_ms.unwrap_or(SPA_SELECTOR_MAX_MS));
-        let challenge_budget =
-            Duration::from_millis(CHALLENGE_POLL_INTERVAL_MS * u64::from(CHALLENGE_MAX_RETRIES));
+        let challenge_budget = challenge_retry_budget(self.challenge_max_retries);
         let stability_budget = if wait_for_ms.is_none() {
             Duration::from_millis(CONTENT_STABILITY_MAX_MS)
         } else {
@@ -3635,6 +3646,36 @@ mod tests {
         lightpanda_safe_ua, outbound_block_label, screenshot_clip, split_caller_headers,
     };
     use std::collections::HashMap;
+
+    #[test]
+    fn challenge_reserve_follows_the_configured_retry_count() {
+        use crate::cdp::{
+            CHALLENGE_MAX_RETRIES, CHALLENGE_POLL_INTERVAL_MS, CdpRenderer, challenge_retry_budget,
+        };
+        use std::time::Duration;
+        // The outer CDP timeout used to reserve CHALLENGE_MAX_RETRIES (3) poll
+        // intervals no matter what the deployment configured. Prod runs 1, so
+        // every CDP tier carried 6s of budget the loop could never spend, and
+        // that padding propagated into the auto-extended request deadline.
+        assert_eq!(challenge_retry_budget(0), Duration::ZERO);
+        assert_eq!(
+            challenge_retry_budget(1),
+            Duration::from_millis(CHALLENGE_POLL_INTERVAL_MS)
+        );
+        // A self-hoster who leaves `chrome_challenge_max_retries` unset gets
+        // CHALLENGE_MAX_RETRIES at construction, so the full reserve still has
+        // to be available — under-reserving there would turn a legitimately
+        // slow-clearing challenge into a premature timeout.
+        assert_eq!(
+            challenge_retry_budget(CHALLENGE_MAX_RETRIES),
+            Duration::from_millis(CHALLENGE_POLL_INTERVAL_MS * u64::from(CHALLENGE_MAX_RETRIES))
+        );
+        assert_eq!(
+            CdpRenderer::new("chrome", "ws://x/", 1000, 1).challenge_max_retries,
+            CHALLENGE_MAX_RETRIES,
+            "an unconfigured renderer must still default to the full retry count"
+        );
+    }
 
     #[test]
     fn budget_truncated_warning_names_the_tier_that_ran_out() {

--- a/crates/crw-renderer/src/detector.rs
+++ b/crates/crw-renderer/src/detector.rs
@@ -547,10 +547,29 @@ pub fn looks_like_cloudflare_challenge(html: &str) -> bool {
     // `crw_crawl::single::classify_block`).
     const STRONG_SCAN_LIMIT: usize = 512 * 1024;
     let strong_src = &html[..html.floor_char_boundary(STRONG_SCAN_LIMIT)];
+    // The challenge-platform entry is the ORCHESTRATE path, not the bare
+    // directory. Both live under `/cdn-cgi/challenge-platform/`, but they mean
+    // opposite things — measured live on 2026-08-18:
+    //
+    //   interstitial (rocketreach.co, glassdoor.com):
+    //       /cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1
+    //   ordinary Bot-Management response, INCLUDING a cleared page:
+    //       /cdn-cgi/challenge-platform/scripts/jsd/main.js
+    //
+    // The `/h/` segment is what separates them: the challenge orchestrator is
+    // always served from it, the telemetry loader never is.
+    //
+    // Matching the bare directory therefore fired on pages that had already been
+    // solved, which is exactly how `cloak.rs`'s accept gate came to reject its
+    // own successful solves: the sidecar returned the real page, this predicate
+    // saw the telemetry loader, and the recovery arm reported "still
+    // challenged". `crw_crawl::single::classify_block` had already dropped the
+    // bare directory for the same reason (a 783k post-solve Glassdoor capture);
+    // the two lists had drifted, and only this copy still carried it.
     const STRONG: [&str; 5] = [
         "cf-browser-verification",
         "cf-challenge-running",
-        "/cdn-cgi/challenge-platform/",
+        "challenge-platform/h/",
         "_cf_chl_opt", // substring of window._cf_chl_opt / __cf_chl_managed_tk__
         "__cf_chl_managed_tk__",
     ];

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -1904,27 +1904,35 @@ impl FallbackRenderer {
                         Err(e) => {
                             // For `is_auth_blocked` (4xx/5xx soft-block status codes), the
                             // HTTP body is almost certainly an error shell — falling back
-                            // to it silently misleads the caller. Surface the JS failure
-                            // through a warning so the post-extract layer can decide.
-                            // For `needs_js` / `is_blocked` / `is_thin_content`, the HTTP
-                            // body still has *some* useful content so the silent fallback
-                            // remains the safer default.
+                            // to it silently misleads the caller. For `needs_js` /
+                            // `is_blocked` / `is_thin_content`, the HTTP body still has
+                            // *some* useful content, so the fallback itself stays silent
+                            // and only the log level differs.
+                            //
+                            // The warning tag does NOT differ. `JS_ESCALATION_FAILED` is
+                            // how `crw_crawl::single` learns the ladder is spent
+                            // (`js_ladder_exhausted`); tagging only the soft-block arm let
+                            // a body-detected block on a plain 200 — the canonical
+                            // Turnstile-over-200 shape — re-run the ENTIRE ladder against
+                            // a site that had just failed it, doubling the wall clock for
+                            // a result that cannot differ. The sibling `render_js:true`
+                            // arm above has always tagged unconditionally; this matches it.
                             if is_auth_blocked {
                                 tracing::error!(
                                     url,
                                     status_code = result.status_code,
                                     "JS escalation failed for soft-block status; surfacing HTTP shell with warning: {e}"
                                 );
-                                let warning = format!("{JS_ESCALATION_FAILED} {e}");
-                                result.warning = Some(match result.warning.take() {
-                                    Some(prev) => format!("{warning}; {prev}"),
-                                    None => warning,
-                                });
                             } else {
                                 tracing::warn!(
                                     "JS rendering failed, falling back to HTTP result: {e}"
                                 );
                             }
+                            let warning = format!("{JS_ESCALATION_FAILED} {e}");
+                            result.warning = Some(match result.warning.take() {
+                                Some(prev) => format!("{warning}; {prev}"),
+                                None => warning,
+                            });
                             stamp_http_decision(&mut result, requested_renderer);
                             Ok(result)
                         }
@@ -4953,6 +4961,55 @@ mod tests {
             "<html><body><article>You've been blocked by network security.{}</article></body></html>",
             "x".repeat(200)
         )
+    }
+
+    /// A 200-status vendor wall must tag the ladder as exhausted, exactly like a
+    /// 403 one does.
+    ///
+    /// `crw_crawl::single` reads `JS_ESCALATION_FAILED` off the warning to decide
+    /// whether the ladder is spent (`js_ladder_exhausted`). The tag used to be
+    /// attached only on the `is_auth_blocked` arm, so a wall served under HTTP
+    /// 200 — the canonical Turnstile shape — came back untagged and the whole
+    /// ladder ran a SECOND time against a site that had just failed it, on a
+    /// deadline it had already spent.
+    #[tokio::test]
+    async fn js_escalation_failure_tags_exhaustion_on_a_200_wall() {
+        let js = Arc::new(MockFetcher {
+            name: "chrome",
+            behavior: MockBehavior::Err("Timeout after 5000ms".to_string()),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![js]);
+        // HTTP 200 carrying a challenge shell: escalation fires via `is_blocked`,
+        // NOT `is_auth_blocked` — the arm that never tagged.
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::OkStatus(
+                200,
+                "<html><head><title>Just a moment...</title></head><body>\
+                 <div id=\"cf-browser-verification\"></div></body></html>"
+                    .to_string(),
+            ),
+        });
+        r.render_js_default = None; // auto branch
+
+        let result = r
+            .fetch(
+                "https://walled.example",
+                &HashMap::new(),
+                None,
+                None,
+                None,
+                tdl(),
+            )
+            .await
+            .expect("falls back to the HTTP shell");
+
+        let warning = result.warning.unwrap_or_default();
+        assert!(
+            warning.contains(JS_ESCALATION_FAILED),
+            "a 200-status wall must report the ladder as exhausted so the caller \
+             does not re-run it; got {warning:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Three defects that together made a walled URL cost 50+ seconds and still answer
with the wall.

## 1. The cloak arm was rejecting its own successful solves

`looks_like_cloudflare_challenge` matched the bare `/cdn-cgi/challenge-platform/`
directory. Measured live on 2026-08-18:

```
interstitial (rocketreach.co, glassdoor.com):
    /cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1
ordinary Bot-Management response, INCLUDING a cleared page:
    /cdn-cgi/challenge-platform/scripts/jsd/main.js
```

`cloak.rs`'s accept gate reads this predicate, so the sidecar would return the
real page, this would see the telemetry loader, and the recovery arm would
report "still challenged". Narrowed to the `/h/` segment, which only the
orchestrator uses.

`crw_crawl::single::classify_block` had already dropped the bare directory for
exactly this reason (a 783k post-solve Glassdoor capture). The two lists had
drifted and only this copy still carried it.

Marker coverage re-verified against three live walls: `_cf_chl_opt` and the
`/h/` path are present on the interstitial and absent once it clears. A bare
`challenge-platform` removal was tried first and rejected — g2.com's wall
carries no `_cf_chl_opt`, so it would have leaked.

## 2. A 200-status wall re-ran the entire ladder

`JS_ESCALATION_FAILED` was attached only when the HTTP tier saw a soft-block
status. A body-detected wall on a plain 200 — the usual Turnstile shape — came
back untagged, so `js_ladder_exhausted` never fired and `crw_crawl::single` ran
the whole ladder a second time against a site that had just failed it, on a
deadline it had already spent. The `renderJs:true` arm has always tagged
unconditionally; this matches it.

## 3. Every CDP tier reserved budget it could not spend

The outer timeout reserved `CHALLENGE_MAX_RETRIES` poll intervals whatever the
deployment configured. Prod runs one retry, so each tier carried two unusable
intervals, and that padding propagated into the auto-extended request deadline.
Reads the configured value now, so a self-hoster leaving it unset still gets the
full reserve.

## Verification

- 1664 tests with `--features cdp,cloak`, 1645 on the default set, zero failures
- clippy `-D warnings` and fmt clean
- both new tests verified to FAIL against the old behaviour before the fix

## Deploy note

Merging this reaches prod within the hour via the pin bump, so the scrape-success
benchmark gate matters before merge, not after. Change 1 makes the cloak arm
able to accept solves it was previously discarding, so recovery should improve
rather than regress; changes 2 and 3 only remove work whose output the accept
gate rejected unconditionally.

Pairs with us/crw-saas#597, which fixes the sidecar side of the same
marker bug.