### PR TITLE
chore(plugin): rename plugin id from crw to fastcrw

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
-  "name": "crw",
+  "name": "fastcrw",
   "metadata": {
     "description": "fastCRW agent skills — scrape, crawl, map, search, parse, extract, and change-track the web with the open-source Firecrawl alternative."
   },
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "crw",
+      "name": "fastcrw",
       "source": "./",
       "category": "developer-tools"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "crw",
+  "name": "fastcrw",
   "displayName": "fastCRW",
-  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, ~14 MB RAM, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
+  "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, ~6.6 MB idle RAM, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
   "version": "0.3.0",
   "author": {
     "name": "us",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "crw",
+  "name": "fastcrw",
   "metadata": {
     "description": "fastCRW agent skills — scrape, crawl, map, search, parse, extract, and change-track the web with the open-source Firecrawl alternative."
   },
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "crw",
+      "name": "fastcrw",
       "source": "./"
     }
   ]

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "crw",
+  "name": "fastcrw",
   "displayName": "fastCRW",
   "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
   "version": "0.3.0",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "crw",
+  "name": "fastcrw",
   "metadata": {
     "description": "fastCRW agent skills — scrape, crawl, map, search, parse, extract, and change-track the web with the open-source Firecrawl alternative."
   },
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "crw",
+      "name": "fastcrw",
       "source": "./"
     }
   ]

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "crw",
+  "name": "fastcrw",
   "displayName": "fastCRW",
   "description": "Scrape, crawl, map, search, parse, extract, and change-track the web with fastCRW, the open-source, self-hostable Firecrawl alternative. Single Rust binary, Firecrawl-compatible /v1 + /v2 API, built-in web search.",
   "version": "0.3.0",


### PR DESCRIPTION
Renames the plugin and marketplace id from `crw` to `fastcrw` in all three
manifests (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`), ahead of
submitting to the Claude Code plugin directory. The listing shows the plugin id,
so it should carry the product name.

- Skill prefix changes from `crw:` to `fastcrw:` (e.g. `/fastcrw:crw-scrape`)
- Marketplace install becomes `/plugin install fastcrw@fastcrw`
- Repo, CLI binary, crates and the `crw-mcp` npm package are unchanged
- Also corrects the idle memory figure in the Claude manifest description

Verified locally against the real CLI:

    claude plugin marketplace add <worktree>   -> added marketplace: fastcrw
    claude plugin install fastcrw@fastcrw      -> installed
    claude plugin details fastcrw@fastcrw      -> 13 skills, 1 MCP server

No Rust sources touched.