### PR TITLE
Satisfy the lints Rust 1.98 turned on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "crw-core",
  "hex",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "base64",
  "clap",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "crw-core",
  "futures",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-browse/src/lib.rs
+++ b/crates/crw-browse/src/lib.rs
@@ -1,5 +1,17 @@
 // crw-browse — MCP server for interactive browser automation over CDP.
 
+// `ErrorResponse` is not an error code we translate at the boundary, it IS the
+// MCP payload we send back: code, message, retry hint, the pattern a policy
+// allowed, the count of items done before the failure. Rust 1.98's clippy flags
+// it as a large `Err` variant, and the mechanical answer is to box it. That
+// trades one memcpy for a heap allocation on every error path, in a crate where
+// each operation is a CDP round-trip measured in milliseconds, and it puts a
+// `Box` in twenty-one public signatures for no reader's benefit.
+//
+// Scoped to this crate so every other lint stays on, and so the decision is
+// visible here rather than buried in a CI flag.
+#![allow(clippy::result_large_err)]
+
 pub mod errors;
 pub mod response;
 pub mod server;

--- a/crates/crw-browse/src/session.rs
+++ b/crates/crw-browse/src/session.rs
@@ -75,6 +75,22 @@ const SHORT_ID_RETRIES: u32 = 5;
 /// base62 alphabet size used for short_id generation.
 const SHORT_ID_LEN: usize = 4;
 
+/// The outcome of resolving a `@e<N>` ref against the current snapshot.
+///
+/// Each variant becomes a different error for the caller, which is why they
+/// are named: `NoDomNode` means the ref was issued but the AX node has no DOM
+/// counterpart, while `Unknown` means the ref is not in the map at all and the
+/// snapshot needs retaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefLookup {
+    /// The ref maps to a live DOM node id.
+    Node(i64),
+    /// The ref exists in the map but carries no DOM node.
+    NoDomNode,
+    /// The ref is absent: stale, never issued, or malformed.
+    Unknown,
+}
+
 /// A single browser session — one CDP WebSocket, one ref registry.
 pub struct BrowserSession {
     pub id: Uuid,
@@ -254,14 +270,16 @@ impl BrowserSession {
         self.ref_map.lock().await.clear();
     }
 
-    /// Look up a `@e<N>` ref. Returns `Ok(Some(id))` when the ref maps to a
-    /// DOM node, `Ok(None)` when the ref exists but the AX node had no DOM
-    /// counterpart (caller should surface `ELEMENT_NOT_FOUND`), and
-    /// `Err(())` when the ref isn't in the map at all (caller should surface
-    /// `NODE_STALE` and ask the LLM to re-snapshot).
-    pub async fn lookup_ref(&self, ref_id: &str) -> Result<Option<i64>, ()> {
+    /// Look up a `@e<N>` ref. The three outcomes are distinct and the caller
+    /// maps each to a different error, so they are named rather than encoded
+    /// as `Result<Option<_>, ()>`.
+    pub async fn lookup_ref(&self, ref_id: &str) -> RefLookup {
         let map = self.ref_map.lock().await;
-        map.get(ref_id).copied().ok_or(())
+        match map.get(ref_id).copied() {
+            Some(Some(id)) => RefLookup::Node(id),
+            Some(None) => RefLookup::NoDomNode,
+            None => RefLookup::Unknown,
+        }
     }
 
     pub async fn last_url(&self) -> Option<String> {

--- a/crates/crw-browse/src/tools/common.rs
+++ b/crates/crw-browse/src/tools/common.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::errors::{ErrorCode, ErrorResponse, RetryHint};
 use crate::response::ToolResponse;
-use crate::session::BrowserSession;
+use crate::session::{BrowserSession, RefLookup};
 
 /// Upper bound for per-call `timeout_ms` — anything larger gets clamped. Keeps
 /// a rogue client from pinning a CDP session for hours on a typoed value. When
@@ -73,12 +73,12 @@ pub(crate) async fn resolve_ref(
     ref_id: &str,
 ) -> Result<i64, ErrorResponse> {
     match session.lookup_ref(ref_id).await {
-        Ok(Some(id)) => Ok(id),
-        Ok(None) => Err(ErrorResponse::new(
+        RefLookup::Node(id) => Ok(id),
+        RefLookup::NoDomNode => Err(ErrorResponse::new(
             ErrorCode::ElementNotFound,
             format!("ref {ref_id} resolves to an AX node with no DOM mapping"),
         )),
-        Err(()) => {
+        RefLookup::Unknown => {
             let max = session.max_ref();
             let parsed = crate::session::parse_ref_index(ref_id);
             let is_known_range = parsed.is_some_and(|n| n >= 1 && n <= max);


### PR DESCRIPTION
CI has been red on every branch since yesterday, with no code change behind it.

Rust 1.98.0 shipped 2026-08-20. `.github/workflows/ci.yml` pins the action SHA
but installs `stable`, and there is no `rust-toolchain.toml`, so the next run of
anything picked up the new compiler:

```
stable-x86_64-unknown-linux-gnu updated - rustc 1.98.0 (from rustc 1.97.1)
...
error: could not compile `crw-browse` (lib) due to 18 previous errors
make: *** [Makefile:17: clippy] Error 101
```

All eighteen are new or newly-stricter clippy lints, promoted to errors by
`-D warnings`. Reproduced locally on 1.98.0 and fixed at the source. Pinning the
toolchain instead would have moved the same surprise to the next release.

## `result_unit_err`, one site

`lookup_ref` encoded three outcomes as `Result<Option<i64>, ()>`: mapped to a
DOM node, present but with no DOM counterpart, absent entirely. The caller turns
each into a different error, so they are now a named enum:

```rust
pub enum RefLookup { Node(i64), NoDomNode, Unknown }
```

One call site, and the signature says what it means now.

## `result_large_err`, seventeen sites

These are functions returning `ErrorResponse`. That type is not an error code we
translate at the boundary, it is the MCP payload we send back: code, message,
retry hint, the pattern a policy allowed, the count of items completed before
the failure.

The mechanical fix is `Box<ErrorResponse>`. That trades one memcpy for a heap
allocation on every error path, in a crate where each operation is a CDP
round-trip measured in milliseconds, and puts a `Box` in twenty-one public
signatures for no reader's benefit. Allowed at the crate root instead, with the
reasoning written above the attribute so the decision lives in the source rather
than in a CI flag. Every other lint stays on, and the allow is scoped to this
one crate.

## Also here

`Cargo.lock` had the workspace members still pinned at `0.30.0` after the
`0.31.0` release; cargo corrected it on the first build. Unrelated to the lint
work but it would otherwise show up as noise in the next PR that runs a build.

## Verification

```
rustup toolchain install 1.98.0
cargo clippy --workspace --all-targets -- -D warnings     clean
cargo fmt --check                                          clean
cargo test --workspace (pre-commit hook)                   pass
```

`crw-browse` was the only crate affected; the rest of the workspace was already
1.98-clean.

## Worth doing separately

Nothing pins the toolchain, so the next Rust release can do this again on a day
nobody is expecting it. Either a `rust-toolchain.toml` with a deliberate bump
cadence, or a scheduled job that runs clippy on `beta` so the warning arrives
before the breakage does.