### PR TITLE
docs: add crw_cancel_extract to two stale MCP tool lists

### DIFF
--- a/docs/crw-browse/index.html
+++ b/docs/crw-browse/index.html
@@ -357,7 +357,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
 </tr>
 <tr>
 <td><strong>Tools</strong></td>
-<td><code>crw_scrape</code>, <code>crw_crawl</code>, <code>crw_map</code>, <code>crw_extract</code>, <code>crw_check_extract_status</code>, <code>crw_search</code>, <code>crw_parse_file</code>, <code>crw_check_crawl_status</code></td>
+<td><code>crw_scrape</code>, <code>crw_crawl</code>, <code>crw_map</code>, <code>crw_extract</code>, <code>crw_check_extract_status</code>, <code>crw_cancel_extract</code>, <code>crw_search</code>, <code>crw_parse_file</code>, <code>crw_check_crawl_status</code></td>
 <td><code>goto</code>, <code>tree</code>, <code>click</code>, <code>fill</code>, <code>type_text</code>, <code>evaluate</code>, <code>text</code>, <code>html</code>, <code>wait</code>, <code>console</code>, <code>network</code>, <code>storage</code>, <code>screenshot</code>, <code>script</code></td>
 </tr>
 <tr>

--- a/docs/docs/crw-browse.md
+++ b/docs/docs/crw-browse.md
@@ -25,7 +25,7 @@ The short rule: if your agent needs to *interact* (click, type, fill) or read th
 | **Purpose** | Bulk scrape / crawl / search | Stateful browser interaction |
 | **Session** | Stateless (each call independent) | Persistent session across calls |
 | **State** | None carried between calls | Cookies, auth, DOM state, scroll position all persist |
-| **Tools** | `crw_scrape`, `crw_crawl`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_search`, `crw_parse_file`, `crw_check_crawl_status` | `goto`, `tree`, `click`, `fill`, `type_text`, `evaluate`, `text`, `html`, `wait`, `console`, `network`, `storage`, `screenshot`, `script` |
+| **Tools** | `crw_scrape`, `crw_crawl`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_cancel_extract`, `crw_search`, `crw_parse_file`, `crw_check_crawl_status` | `goto`, `tree`, `click`, `fill`, `type_text`, `evaluate`, `text`, `html`, `wait`, `console`, `network`, `storage`, `screenshot`, `script` |
 | **Browser required?** | Optional (HTTP-only mode works without CDP) | Required (must have Chrome or Lightpanda running separately) |
 | **Cloud option** | fastcrw.com | Self-hosted only |
 | **Availability** | All modes (embedded + proxy + HTTP) | Self-hosted binary only |

--- a/docs/docs/migrate-from-firecrawl.md
+++ b/docs/docs/migrate-from-firecrawl.md
@@ -299,7 +299,7 @@ The following table lists the gaps documented in [the capability matrix](https:/
 | **Fire-engine anti-bot** | Firecrawl Cloud only | Not available (same as Firecrawl self-host) | For heavy bot-protected pages, compare output quality on real targets. |
 | **Screenshot format** | Supported | Supported on an instance with a capture-capable browser tier (Chrome or Playwright); LightPanda and Camoufox cannot capture | Check `screenshot.supported` on `GET /v1/capabilities` before relying on it. |
 | **`data.metadata` field names** | Some keys differ | Minor divergence on a few keys | Inspect `metadata` on a real response; don't assume key names are identical. |
-| **MCP tool names** | `firecrawl_scrape`, `firecrawl_crawl`, … | `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_search`, `crw_parse_file` | Update any MCP client tool-name references. |
+| **MCP tool names** | `firecrawl_scrape`, `firecrawl_crawl`, … | `crw_scrape`, `crw_crawl`, `crw_check_crawl_status`, `crw_map`, `crw_extract`, `crw_check_extract_status`, `crw_cancel_extract`, `crw_search`, `crw_parse_file` | Update any MCP client tool-name references. |
 
 ---
 

--- a/docs/migrate-from-firecrawl/index.html
+++ b/docs/migrate-from-firecrawl/index.html
@@ -562,7 +562,7 @@ console.log(result.json);</code></pre></div>
 <tr>
 <td><strong>MCP tool names</strong></td>
 <td><code>firecrawl_scrape</code>, <code>firecrawl_crawl</code>, …</td>
-<td><code>crw_scrape</code>, <code>crw_crawl</code>, <code>crw_check_crawl_status</code>, <code>crw_map</code>, <code>crw_extract</code>, <code>crw_check_extract_status</code>, <code>crw_search</code>, <code>crw_parse_file</code></td>
+<td><code>crw_scrape</code>, <code>crw_crawl</code>, <code>crw_check_crawl_status</code>, <code>crw_map</code>, <code>crw_extract</code>, <code>crw_check_extract_status</code>, <code>crw_cancel_extract</code>, <code>crw_search</code>, <code>crw_parse_file</code></td>
 <td>Update any MCP client tool-name references.</td>
 </tr>
 </tbody></table>


### PR DESCRIPTION
## Problem

`crw_cancel_extract` has shipped in the engine since it gained
`DELETE /v1/extract/{id}` (`crates/crw-server/src/routes/v1/mod.rs`, handler in
`crates/crw-server/src/routes/extract.rs`, MCP dispatch in
`crates/crw-server/src/routes/mcp.rs`). Most docs pages already say nine tools and
list it, but two enumerations were left behind:

- `docs/docs/crw-browse.md` — the crw-mcp vs crw-browse comparison table
- `docs/docs/migrate-from-firecrawl.md` — the MCP tool-name mapping row

Both list `crw_check_extract_status` and then skip straight to `crw_search`, so a
reader migrating from Firecrawl never learns the cancel tool exists.

## Change

Added the tool to both lists and regenerated the affected static pages with
`scripts/build-docs-pages.mjs`. The generator touched only the two corresponding
`index.html` files, no unrelated churn.

## Checks

- `scripts/docs-guards.sh` passes, including the SKILL.md divergence guard
- No Rust touched, so the pre-commit cargo gate is skipped by design

## Not in this PR

`docs/docs/mcp-clients.md`, `mcp.md`, `glossary.md`, `recipe-mcp-5min.md` and
`docs/agent-onboarding/SKILL.md` were already correct at nine tools.