### PR TITLE
Move the Firecrawl migration guide into Get Started

### DIFF
--- a/docs/site.config.js
+++ b/docs/site.config.js
@@ -19,7 +19,7 @@ export default {
     {
       label: "Start",
       href: "/quick-start",
-      match: ["introduction", "quick-start", "choose-endpoint", "authentication", "playground", "rest-api", "installation"],
+      match: ["introduction", "quick-start", "migrate-from-firecrawl", "choose-endpoint", "authentication", "playground", "rest-api", "installation"],
     },
     {
       label: "Endpoints",
@@ -34,7 +34,7 @@ export default {
     {
       label: "Guides",
       href: "/recipe-rag",
-      match: ["recipe-rag", "recipe-mcp-5min", "recipe-monitoring", "recipe-js-spa", "recipe-batch", "recipe-product-catalog", "recipe-pdf", "migrate-from-firecrawl", "troubleshooting"],
+      match: ["recipe-rag", "recipe-mcp-5min", "recipe-monitoring", "recipe-js-spa", "recipe-batch", "recipe-product-catalog", "recipe-pdf", "troubleshooting"],
     },
     {
       label: "Self-Host",
@@ -61,6 +61,7 @@ export default {
       children: [
         { title: "Introduction", slug: "introduction", icon: "rocket" },
         { title: "Quick Start", slug: "quick-start", icon: "play" },
+        { title: "Migrate from Firecrawl", slug: "migrate-from-firecrawl", icon: "git-branch" },
         { title: "Choose Your Endpoint", slug: "choose-endpoint", icon: "git-branch" },
         { title: "Authentication", slug: "authentication", icon: "key" },
         { title: "API Playground", slug: "playground", icon: "play" },
@@ -108,7 +109,6 @@ export default {
         { title: "Batch-Scrape a URL List", slug: "recipe-batch", icon: "layers" },
         { title: "Product Catalog Extraction", slug: "recipe-product-catalog", icon: "zap" },
         { title: "Parse PDF Reports", slug: "recipe-pdf", icon: "file-text" },
-        { title: "Migrate from Firecrawl", slug: "migrate-from-firecrawl", icon: "git-branch" },
         { title: "Troubleshooting / FAQ", slug: "troubleshooting", icon: "info" },
       ],
     },

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,6 +3,7 @@
   <url><loc>https://docs.fastcrw.com/</loc><priority>1.0</priority><changefreq>weekly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/introduction</loc><priority>0.9</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/quick-start</loc><priority>0.9</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://docs.fastcrw.com/migrate-from-firecrawl</loc><priority>0.9</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/choose-endpoint</loc><priority>0.9</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/authentication</loc><priority>0.9</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/playground</loc><priority>0.9</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
@@ -30,7 +31,6 @@
   <url><loc>https://docs.fastcrw.com/recipe-batch</loc><priority>0.6</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/recipe-product-catalog</loc><priority>0.6</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/recipe-pdf</loc><priority>0.6</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://docs.fastcrw.com/migrate-from-firecrawl</loc><priority>0.6</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/troubleshooting</loc><priority>0.6</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/self-hosting</loc><priority>0.7</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://docs.fastcrw.com/docker</loc><priority>0.7</priority><changefreq>monthly</changefreq><lastmod>2026-08-21</lastmod></url>


### PR DESCRIPTION
The guide sat eighth of nine under "Guides & Recipes", below the RAG recipe, the
SPA recipe and PDF parsing:

```
Guides & Recipes
  Build a RAG Knowledge Base
  Claude Web Access in 5 Min
  Monitor a Page → Slack
  Scrape a JS-Heavy SPA
  Batch-Scrape a URL List
  Product Catalog Extraction
  Parse PDF Reports
  Migrate from Firecrawl        <- here
  Troubleshooting / FAQ
```

People arriving from Firecrawl are the audience this project most wants to
reach, and they were being asked to scroll past seven unrelated recipes to find
the one page written for them. It now sits directly under Quick Start in Get
Started.

The `navTabs` match list moves with it. Without that the page renders inside the
Start section while highlighting the Guides tab, which is the kind of small
wrongness nobody reports and everybody notices.

Verified: `check-doc-links` and `docs-guards` pass, static pages regenerated
(49/49). Content of the guide itself is unchanged here; it was rewritten in
#450, which is merged and live.