### PR TITLE
feat(setup): register MCP with detected agents on scripted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,29 @@
 curl -fsSL https://fastcrw.com/install | sh
 ```
 
-Then point it at the Cloud:
+Runs local and free, no account needed. To use the Cloud, paste your key into
+the same command and it installs the binary, connects the key, and registers the
+MCP server with the AI coding tools you already have:
 
 ```bash
-crw setup
+curl -fsSL https://fastcrw.com/install | CRW_API_KEY=crw_live_... sh
 ```
+
+```bash
+crw search "rust tutorials"
+```
+
+Claude Code, Cursor, Codex, Gemini CLI, OpenCode and Windsurf are picked up
+automatically when they are already set up; nothing else is touched, and your
+key stays in `~/.config/crw/config.toml` rather than being copied into each
+tool. Add `CRW_NO_AGENTS=1` to skip that step, or run `crw setup` on its own to
+choose interactively.
 
 **1000 free credits, no credit card.** Managed proxies, JS rendering and search,
 with nothing to run or keep up to date.
 [Get my free key →](https://fastcrw.com/register)
 
-The same command configures a fully local install if you would rather run it
-yourself. macOS and Linux, Intel and ARM.
+macOS and Linux, Intel and ARM.
 [More install options →](https://docs.fastcrw.com/installation/)
 
 ## What it does

--- a/crates/crw-cli/src/commands/setup/agents.rs
+++ b/crates/crw-cli/src/commands/setup/agents.rs
@@ -2,9 +2,16 @@
 //!
 //! The npm `crw-mcp` package owns the per-agent config formats. This module
 //! deliberately does only three things: mirror its lightweight directory
-//! detection, ask for explicit consent, and delegate the selected targets to
-//! that installer. Keeping the mutation logic in one place prevents the Rust
+//! detection, establish consent, and delegate the selected targets to that
+//! installer. Keeping the mutation logic in one place prevents the Rust
 //! wizard and npm entry point from drifting.
+//!
+//! Consent has two shapes. The interactive wizard asks which tools to touch.
+//! The scripted `--api-key` path (what `curl … | CRW_API_KEY=… sh` runs) takes
+//! the command the user deliberately pasted as the consent and registers every
+//! detected tool, because a piped installer has no tty to prompt on. Either way
+//! `--no-agents` opts out, only already-configured tools are touched, and the
+//! installer merges rather than replaces.
 
 use crate::commands::setup::{shell, ui};
 use dialoguer::{MultiSelect, Select};
@@ -122,6 +129,36 @@ pub fn offer_install() {
     }
 
     run_installer(&selected);
+}
+
+/// Register with every detected tool without prompting.
+///
+/// Used by the scripted `--api-key` path, which runs under `curl … | sh` and
+/// therefore has no tty to ask on. Announces what it touched instead of asking
+/// first; `--no-agents` is the opt-out. Non-fatal like [`offer_install`]: a
+/// failed integration must never fail an otherwise valid setup.
+pub fn install_detected() {
+    let Some(home) = shell::home_dir() else {
+        return;
+    };
+    let detected = detect_agents(&home);
+    if detected.is_empty() {
+        return;
+    }
+
+    println!();
+    ui::print_section_header("AI TOOL INTEGRATION");
+    ui::print_detail(&format!(
+        "Detected: {}",
+        detected
+            .iter()
+            .map(|agent| agent.name)
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    ui::print_detail("Skip this with `crw setup --api-key <KEY> --no-agents`.");
+
+    run_installer(&detected);
 }
 
 fn detect_agents(home: &Path) -> Vec<Agent> {

--- a/crates/crw-cli/src/commands/setup/mod.rs
+++ b/crates/crw-cli/src/commands/setup/mod.rs
@@ -39,6 +39,15 @@ pub struct SetupArgs {
     #[arg(long, value_name = "KEY", conflicts_with_all = ["local", "reset", "reset_shell"])]
     pub api_key: Option<String>,
 
+    /// Skip registering the CRW MCP server and skill with your AI coding tools.
+    ///
+    /// Registration is on by default: the interactive wizard asks which tools
+    /// to use, and `--api-key` installs into every detected one. Only tools
+    /// that are already configured are touched, and the installer merges into
+    /// their existing MCP config rather than replacing it.
+    #[arg(long)]
+    pub no_agents: bool,
+
     /// Disable colored output.
     #[arg(long)]
     pub no_color: bool,
@@ -101,10 +110,13 @@ pub async fn run(args: SetupArgs) {
         }
     }
 
-    // MCP registration is a post-setup convenience, never part of scripted
-    // setup. `--api-key` is intentionally non-interactive even when the caller
-    // did not repeat `--non-interactive`.
-    let offer_agent_setup = !args.non_interactive && args.api_key.is_none();
+    // MCP registration runs by default, because connecting an agent is the
+    // point of setup rather than an afterthought. `--api-key` arrives from a
+    // piped installer with no tty, so it registers every detected tool and
+    // announces it; the interactive wizard still asks which ones. `--no-agents`
+    // opts out of both.
+    let scripted_agent_setup = args.api_key.is_some();
+    let agent_setup = !args.no_agents && (scripted_agent_setup || !args.non_interactive);
 
     // If specific mode is requested, run that directly
     let result = if let Some(key) = args.api_key.clone() {
@@ -136,8 +148,12 @@ pub async fn run(args: SetupArgs) {
 
     match result {
         Ok(()) => {
-            if offer_agent_setup {
-                agents::offer_install();
+            if agent_setup {
+                if scripted_agent_setup {
+                    agents::install_detected();
+                } else {
+                    agents::offer_install();
+                }
             }
         }
         Err(e) => {

--- a/crates/crw-cli/src/main.rs
+++ b/crates/crw-cli/src/main.rs
@@ -181,6 +181,7 @@ async fn main() {
             cloud: false,
             local: false,
             api_key: None,
+            no_agents: false,
             no_color: false,
             reset_shell: false,
             reset: true,

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,9 @@
 #   CRW_INSTALL_DIR=~/.local/bin   Custom install directory
 #   CRW_BINARY=crw-mcp    Install crw-mcp (MCP server) or crw-server instead of
 #                         the default crw CLI
+#   CRW_API_KEY=crw_live_…  Connect to CRW Cloud and register the MCP server
+#                         with every detected AI coding tool, in one command
+#   CRW_NO_AGENTS=1       With CRW_API_KEY, skip the AI-tool registration
 
 set -eu
 
@@ -183,8 +186,16 @@ install() {
       echo ""
       info "Connecting to CRW Cloud with your API key…"
       echo ""
-      "${INSTALL_DIR}/${BINARY}" setup --api-key "${CRW_API_KEY}" \
-        || info "Cloud connect failed. Run 'crw setup --api-key <key>' to retry."
+      # Registration into detected AI tools is part of the same command; the
+      # pasted CRW_API_KEY is the consent a piped installer cannot prompt for.
+      # CRW_NO_AGENTS=1 opts out.
+      if [ -n "${CRW_NO_AGENTS:-}" ]; then
+        "${INSTALL_DIR}/${BINARY}" setup --api-key "${CRW_API_KEY}" --no-agents \
+          || info "Cloud connect failed. Run 'crw setup --api-key <key>' to retry."
+      else
+        "${INSTALL_DIR}/${BINARY}" setup --api-key "${CRW_API_KEY}" \
+          || info "Cloud connect failed. Run 'crw setup --api-key <key>' to retry."
+      fi
     else
       echo ""
       echo "  Run:       crw https://example.com"


### PR DESCRIPTION
## What changed

`crw setup --api-key` previously skipped agent registration entirely
(`offer_agent_setup = !non_interactive && api_key.is_none()`), so the
one-command install left a working binary and a written `config.toml`
but nothing wired into the tool the user actually works in. That is the
path a piped installer runs, which put the highest-value step behind a
second manual command.

- `setup/agents.rs`: new `install_detected()`, the prompt-free sibling of
  `offer_install()`. Same detection, same delegation to `crw-mcp`.
- `setup/mod.rs`: new `--no-agents` flag. Registration is on by default;
  `--api-key` registers every detected tool and announces it, the
  interactive wizard still asks which ones.
- `install.sh`: `CRW_NO_AGENTS=1` passes `--no-agents` through; the two
  new env vars are documented in the header.
- `README.md`: leads with the single command that ends in a working
  `crw search` instead of install-then-configure.
- `Cargo.lock`: picks up the 0.30.0 -> 0.31.0 bump the manifests already
  carried (it was stale on main).

## Safety

Consent for the scripted path is the command the user deliberately
pasted, since a piped installer has no tty to prompt on. Everything the
registration touches was already true of the interactive path:

- only tools whose config dir already exists are detected
- the npm installer merges into `mcpServers` rather than replacing it,
  and restores the previous file if the write fails
- `--from-config` keeps the key in `config.toml`; it is not copied into
  any agent config
- a missing `npx` is non-fatal and prints the manual command

## Verified

Ran end to end against an isolated `HOME` with a pre-existing MCP server
in `.cursor/mcp.json` and a real API key:

- detected Cursor + Codex, registered both
- the pre-existing `existing-server` entry survived untouched
- `config.toml` written with `api_url` + `api_key`
- the real key appears nowhere outside `config.toml`
- `crw search "rust web scraping"` returned live results
- `--no-agents` left `.cursor` untouched while still configuring cloud

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
and `cargo test --workspace` (1645 passed) all clean.

## Deploy note

A merge here reaches prod within the hour via `bump-saas-pin` -> deploq,
it is not release-gated. The matching crw-saas onboarding change (which
surfaces this command to users) depends on this being live first, so it
should merge after.