### PR TITLE
docs: tag README and docs signup CTAs for link attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <a href="https://fastcrw.com/register"><strong>Get 1000 free credits →</strong></a> ·
+  <a href="https://fastcrw.com/register?ref=gh-hero"><strong>Get 1000 free credits →</strong></a> ·
   <a href="#one-command-install"><strong>Install</strong></a> ·
   <a href="https://docs.fastcrw.com"><strong>Docs</strong></a>
 </p>
@@ -46,7 +46,7 @@ crw setup
 
 **1000 free credits, no credit card.** Managed proxies, JS rendering and search,
 with nothing to run or keep up to date.
-[Get my free key →](https://fastcrw.com/register)
+[Get my free key →](https://fastcrw.com/register?ref=gh-quickstart)
 
 The same command configures a fully local install if you would rather run it
 yourself. macOS and Linux, Intel and ARM.
@@ -89,7 +89,7 @@ crw search "rust async runtime"    # search, after `crw setup`
 
 ### Python SDK
 
-Using Cloud? [Get an API key](https://fastcrw.com/register), then export it once:
+Using Cloud? [Get an API key](https://fastcrw.com/register?ref=gh-sdk), then export it once:
 
 ```bash
 export CRW_API_KEY="crw_live_..."
@@ -144,7 +144,7 @@ also do this step, so either path is enough.
 | | Managed API | Local / self-hosted |
 |---|---|---|
 | Best for | Zero infrastructure and managed scaling | Data control, private networks, or custom infrastructure |
-| Start | [Create an API key](https://fastcrw.com/register), then `crw setup` | Install and run `crw <URL>` |
+| Start | [Create an API key](https://fastcrw.com/register?ref=gh-table), then `crw setup` | Install and run `crw <URL>` |
 | Operations | Managed proxies, billing, and hosted capabilities | You choose renderers, search, auth, proxies, and capacity |
 
 Capabilities and response shapes can differ by deployment:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="#安装"><strong>本地运行 ↓</strong></a> ·
-  <a href="https://fastcrw.com/register"><strong>使用托管 API</strong></a> ·
+  <a href="https://fastcrw.com/register?ref=gh-zh"><strong>使用托管 API</strong></a> ·
   <a href="https://docs.fastcrw.com"><strong>文档</strong></a> ·
   <a href="README.md"><strong>English</strong></a>
 </p>

--- a/docs/agent-onboarding/index.html
+++ b/docs/agent-onboarding/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-agent-onboarding-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -569,7 +569,7 @@ elif resp.status_code == 429:
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-agent-onboarding-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-architecture-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -446,7 +446,7 @@ Client → GET /v1/crawl/{id}
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-architecture-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/authentication/index.html
+++ b/docs/authentication/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-authentication-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -368,7 +368,7 @@ api_keys = [&quot;crw_live_key-1234&quot;, &quot;crw_live_key-5678&quot;]</code>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-authentication-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/capabilities/index.html
+++ b/docs/capabilities/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-capabilities-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -660,7 +660,7 @@ else:
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-capabilities-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-changelog-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -1229,7 +1229,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-changelog-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/choose-endpoint/index.html
+++ b/docs/choose-endpoint/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-choose-endpoint-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -494,7 +494,7 @@ curl https://api.fastcrw.com/v1/crawl/{id} \
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-choose-endpoint-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/compatibility/index.html
+++ b/docs/compatibility/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-compatibility-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -392,7 +392,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-compatibility-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/configuration/index.html
+++ b/docs/configuration/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-configuration-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -626,7 +626,7 @@ CRW_CONFIG=config.stealth crw-server</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-configuration-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/crates/index.html
+++ b/docs/crates/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-crates-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -492,7 +492,7 @@ resolves to.</p>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-crates-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/crawling/index.html
+++ b/docs/crawling/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-crawling-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -547,7 +547,7 @@ console.log((await status.json()).status);</code></pre></div><div class="code-ta
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-crawling-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/credit-costs/index.html
+++ b/docs/credit-costs/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-credit-costs-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -457,7 +457,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-credit-costs-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/crw-browse/index.html
+++ b/docs/crw-browse/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-crw-browse-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -662,7 +662,7 @@ crw-browse \
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-crw-browse-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/docker/index.html
+++ b/docs/docker/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-docker-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -555,7 +555,7 @@ itself.</p>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-docker-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -9,7 +9,7 @@
     <div class="page-capability"><strong>Start with:</strong> one scrape target, daily schedule</div>
   </div>
   <div class="page-actions">
-    <a class="page-btn primary" href="https://fastcrw.com/register" target="_blank" rel="noopener">Get API Key</a>
+    <a class="page-btn primary" href="https://fastcrw.com/register?ref=docs-monitoring-inline" target="_blank" rel="noopener">Get API Key</a>
     <a class="page-btn secondary" href="#crawling">View Crawl</a>
   </div>
 </div>

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -8,7 +8,7 @@
     <div class="page-capability"><strong>Free tier:</strong> 1000 credits, no card required</div>
   </div>
   <div class="page-actions">
-    <a class="page-btn primary" href="https://fastcrw.com/register" target="_blank" rel="noopener">Get API key</a>
+    <a class="page-btn primary" href="https://fastcrw.com/register?ref=docs-quick-start-inline" target="_blank" rel="noopener">Get API key</a>
     <a class="page-btn secondary" href="https://fastcrw.com/playground" target="_blank" rel="noopener">Open Playground</a>
   </div>
 </div>
@@ -22,13 +22,13 @@
 
 - **Terminal** — macOS Terminal, Linux shell, or Windows [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
 - **`curl`** — ships with macOS 10.15+ and most Linux distros; Windows users can use WSL or [download curl](https://curl.se/windows/)
-- **A free account** at [fastcrw.com/register](https://fastcrw.com/register) — 1000 credits, one-time, no card required
+- **A free account** at [fastcrw.com/register](https://fastcrw.com/register?ref=docs-quick-start-inline) — 1000 credits, one-time, no card required
 - **Node.js 18+** — only for the MCP path (optional, described at the bottom of this page)
 :::
 
 ## Get a key
 
-Register at [fastcrw.com/register](https://fastcrw.com/register). Once you confirm your email, your API key appears on the dashboard. Your account starts with **1000 free credits** — one credit equals one basic scrape request, so you have plenty to explore.
+Register at [fastcrw.com/register](https://fastcrw.com/register?ref=docs-quick-start-inline). Once you confirm your email, your API key appears on the dashboard. Your account starts with **1000 free credits** — one credit equals one basic scrape request, so you have plenty to explore.
 
 Copy the key and keep it somewhere safe. You will paste it into the `Authorization` header below.
 

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -20,7 +20,7 @@
   <div class="playground-copy">Use a small query and <code>limit: 5</code> first. Add <code>scrapeOptions</code> only when you already know you need page content from those search results.</div>
   <div class="playground-actions">
     <a class="page-btn primary" href="https://fastcrw.com/playground" target="_blank" rel="noopener">Open Playground</a>
-    <a class="page-btn secondary" href="https://fastcrw.com/register" target="_blank" rel="noopener">Get API Key</a>
+    <a class="page-btn secondary" href="https://fastcrw.com/register?ref=docs-search-inline" target="_blank" rel="noopener">Get API Key</a>
   </div>
 </div>
 

--- a/docs/error-codes/index.html
+++ b/docs/error-codes/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-error-codes-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -491,7 +491,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-error-codes-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/extract/index.html
+++ b/docs/extract/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-extract-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -555,7 +555,7 @@ managed and self-hosted parity.</p>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-extract-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-glossary-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -332,7 +332,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-glossary-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/index.html
+++ b/docs/index.html
@@ -254,7 +254,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-home-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -299,7 +299,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-home-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-installation-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -393,7 +393,7 @@ curl http://localhost:3000/health</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-installation-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/integrations/index.html
+++ b/docs/integrations/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-integrations-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -650,7 +650,7 @@ console.log(data.markdown);</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-integrations-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/introduction/index.html
+++ b/docs/introduction/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-introduction-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -457,7 +457,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-introduction-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/js-rendering/index.html
+++ b/docs/js-rendering/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-js-rendering-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -615,7 +615,7 @@ is skipped rather than failing every request.</p>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-js-rendering-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-map-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -506,7 +506,7 @@ early on <code>limit</code>, <code>timeout</code>, or the internal sitemap budge
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-map-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/mcp-clients/index.html
+++ b/docs/mcp-clients/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-mcp-clients-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -718,7 +718,7 @@ CRW_API_KEY = &quot;YOUR_API_KEY&quot;</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-mcp-clients-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-mcp-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -940,7 +940,7 @@ codex mcp add crw -- npx crw-mcp</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-mcp-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/migrate-from-firecrawl/index.html
+++ b/docs/migrate-from-firecrawl/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-migrate-from-firecrawl-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -647,7 +647,7 @@ print(&quot;All checks passed — safe to promote to production.&quot;)</code></
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-migrate-from-firecrawl-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/monitoring/index.html
+++ b/docs/monitoring/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-monitoring-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -293,7 +293,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
     <div class="page-capability"><strong>Start with:</strong> one scrape target, daily schedule</div>
   </div>
   <div class="page-actions">
-    <a class="page-btn primary" href="https://fastcrw.com/register" target="_blank" rel="noopener">Get API Key</a>
+    <a class="page-btn primary" href="https://fastcrw.com/register?ref=docs-monitoring-inline" target="_blank" rel="noopener">Get API Key</a>
     <a class="page-btn secondary" href="/crawling">View Crawl</a>
   </div>
 </div><h2 id="what-this-is-for">What this is for</h2>
@@ -930,7 +930,7 @@ Authorization: Bearer $CRW_API_KEY</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-monitoring-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/output-formats/index.html
+++ b/docs/output-formats/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-output-formats-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -794,7 +794,7 @@ appends <code>/responses</code>; a complete endpoint URL is also accepted unchan
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-output-formats-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/pdf-parsing/index.html
+++ b/docs/pdf-parsing/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-pdf-parsing-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -765,7 +765,7 @@ sandbox              = false      # isolate each parse in a child process</code>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-pdf-parsing-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-playground-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -324,7 +324,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-playground-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/proxies/index.html
+++ b/docs/proxies/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-proxies-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -442,7 +442,7 @@ WITH_CHROME=1 ./scripts/verify-proxy-rotation.sh   # also exercises the JS path<
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-proxies-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/quick-start/index.html
+++ b/docs/quick-start/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-quick-start-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -292,7 +292,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
     <div class="page-capability"><strong>Free tier:</strong> 1000 credits, no card required</div>
   </div>
   <div class="page-actions">
-    <a class="page-btn primary" href="https://fastcrw.com/register" target="_blank" rel="noopener">Get API key</a>
+    <a class="page-btn primary" href="https://fastcrw.com/register?ref=docs-quick-start-inline" target="_blank" rel="noopener">Get API key</a>
     <a class="page-btn secondary" href="https://fastcrw.com/playground" target="_blank" rel="noopener">Open Playground</a>
   </div>
 </div><h2 id="prerequisites">Prerequisites</h2>
@@ -302,11 +302,11 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
 <div class="callout callout-info"><div class="callout-icon"></div><div class="callout-content">**Prerequisites**<ul>
 <li><strong>Terminal</strong> — macOS Terminal, Linux shell, or Windows <a href="https://learn.microsoft.com/en-us/windows/wsl/install">WSL</a></li>
 <li><strong><code>curl</code></strong> — ships with macOS 10.15+ and most Linux distros; Windows users can use WSL or <a href="https://curl.se/windows/">download curl</a></li>
-<li><strong>A free account</strong> at <a href="https://fastcrw.com/register">fastcrw.com/register</a> — 1000 credits, one-time, no card required</li>
+<li><strong>A free account</strong> at <a href="https://fastcrw.com/register?ref=docs-quick-start-inline">fastcrw.com/register</a> — 1000 credits, one-time, no card required</li>
 <li><strong>Node.js 18+</strong> — only for the MCP path (optional, described at the bottom of this page)</div></div></li>
 </ul>
 <h2 id="get-a-key">Get a key</h2>
-<p>Register at <a href="https://fastcrw.com/register">fastcrw.com/register</a>. Once you confirm your email, your API key appears on the dashboard. Your account starts with <strong>1000 free credits</strong> — one credit equals one basic scrape request, so you have plenty to explore.</p>
+<p>Register at <a href="https://fastcrw.com/register?ref=docs-quick-start-inline">fastcrw.com/register</a>. Once you confirm your email, your API key appears on the dashboard. Your account starts with <strong>1000 free credits</strong> — one credit equals one basic scrape request, so you have plenty to explore.</p>
 <p>Copy the key and keep it somewhere safe. You will paste it into the <code>Authorization</code> header below.</p>
 <h2 id="first-scrape">First scrape</h2>
 <p>Paste your key in place of <code>YOUR_API_KEY</code> and run:</p>
@@ -407,7 +407,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-quick-start-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/rate-limits/index.html
+++ b/docs/rate-limits/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-rate-limits-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -436,7 +436,7 @@ if (res.status === 402) {
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-rate-limits-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-batch/index.html
+++ b/docs/recipe-batch/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-batch-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -655,7 +655,7 @@ data[]        — Document objects for this page
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-batch-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-js-spa/index.html
+++ b/docs/recipe-js-spa/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-js-spa-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -586,7 +586,7 @@ Only pin a browser renderer when HTTP-only clearly fails. Plain HTTP fetches tak
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-js-spa-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-mcp-5min/index.html
+++ b/docs/recipe-mcp-5min/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-mcp-5min-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -461,7 +461,7 @@ All 9 tools registered by `crw-mcp`:
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-mcp-5min-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-monitoring/index.html
+++ b/docs/recipe-monitoring/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-monitoring-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -675,7 +675,7 @@ Diff: https://fastcrw.com/dashboard (monitor → latest check)</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-monitoring-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-pdf/index.html
+++ b/docs/recipe-pdf/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-pdf-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -698,7 +698,7 @@ automatically — you do not change your call.</p>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-pdf-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-product-catalog/index.html
+++ b/docs/recipe-product-catalog/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-product-catalog-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -755,7 +755,7 @@ re-runs. Pages that have not changed come back with <code>changeTracking.status:
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-product-catalog-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/recipe-rag/index.html
+++ b/docs/recipe-rag/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-rag-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -710,7 +710,7 @@ before re-embedding — avoids re-embedding unchanged content.</li>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-recipe-rag-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/research-api/index.html
+++ b/docs/research-api/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-research-api-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -400,7 +400,7 @@ the roadmap.</li>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-research-api-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/response-shapes/index.html
+++ b/docs/response-shapes/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-response-shapes-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -440,7 +440,7 @@ reachable sitemap, and partial when discovery stops early on <code>limit</code> 
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-response-shapes-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/rest-api/index.html
+++ b/docs/rest-api/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-rest-api-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -418,7 +418,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-rest-api-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/scraping/index.html
+++ b/docs/scraping/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-scraping-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -652,7 +652,7 @@ console.log(body.data.markdown);</code></pre></div><div class="code-tab-panel" d
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-scraping-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/sdk-examples/index.html
+++ b/docs/sdk-examples/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-sdk-examples-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -517,7 +517,7 @@ console.log(data);</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-sdk-examples-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/sdk-reference/index.html
+++ b/docs/sdk-reference/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-sdk-reference-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -881,7 +881,7 @@ a message that explains why and how to switch mode.</p>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-sdk-reference-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-search-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -302,7 +302,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
   <div class="playground-copy">Use a small query and <code>limit: 5</code> first. Add <code>scrapeOptions</code> only when you already know you need page content from those search results.</div>
   <div class="playground-actions">
     <a class="page-btn primary" href="https://fastcrw.com/playground" target="_blank" rel="noopener">Open Playground</a>
-    <a class="page-btn secondary" href="https://fastcrw.com/register" target="_blank" rel="noopener">Get API Key</a>
+    <a class="page-btn secondary" href="https://fastcrw.com/register?ref=docs-search-inline" target="_blank" rel="noopener">Get API Key</a>
   </div>
 </div><div class="callout callout-note"><div class="callout-icon"></div><div class="callout-content">**Self-hosted users**: `docker compose up` boots the search sidecar automatically (reachable inside the Compose network as `searxng:8080`). `/v1/search` is live on `http://localhost:3000` with no extra setup. To point at a search backend you already run instead, set `CRW_SEARCH__SEARCH_BACKEND_URL=http://your-host:8080` and remove the `searxng` service from your compose file. To disable search entirely, set `[search].enabled = false` — the route returns a clear `search_disabled` error (HTTP 503). See the [Docker → Search backend](/docker) section for the full setup, the `SEARXNG_BASE_URL` vs `search_backend_url` distinction, and cold-start timing.</div></div><h2 id="searching-the-web-with-crw">Searching the web with CRW</h2>
 <h3 id="v1search">/v1/search</h3>
@@ -788,7 +788,7 @@ with nothing to report are omitted, not emitted as <code>null</code> or <code>[]
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-search-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/self-hosting-hardening/index.html
+++ b/docs/self-hosting-hardening/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-self-hosting-hardening-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -477,7 +477,7 @@ model    = &quot;gpt-4o-mini&quot;</code></pre>
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-self-hosting-hardening-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/self-hosting/index.html
+++ b/docs/self-hosting/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-self-hosting-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -412,7 +412,7 @@ that need it. Full details: <a href="/js-rendering">JS rendering → Camoufox</a
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-self-hosting-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/troubleshooting/index.html
+++ b/docs/troubleshooting/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-troubleshooting-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -698,7 +698,7 @@ if data[&quot;balance&quot;] &lt; 100:
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-troubleshooting-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/docs/v2-api/index.html
+++ b/docs/v2-api/index.html
@@ -252,7 +252,7 @@ crw search "renewable energy trends 2024" --json --fields title,url,snippet --li
           <span>us/crw</span>
         </a>
         <a href="https://fastcrw.com" target="_blank" rel="noopener" class="navbar-link">Status</a>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
+        <a href="https://fastcrw.com/register?ref=docs-v2-api-nav" target="_blank" rel="noopener" class="navbar-signup">Sign Up</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="5"></circle>
@@ -1402,7 +1402,7 @@ const result = await crw.extract({
         </div>
         <div class="toc-cta-title">Ready to scrape?</div>
         <div class="toc-cta-desc">Sign up and get 1000 free credits instantly. No credit card required.</div>
-        <a href="https://fastcrw.com/register" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
+        <a href="https://fastcrw.com/register?ref=docs-v2-api-cta" target="_blank" rel="noopener" class="toc-cta-btn primary">Get started, 1000 free credits</a>
         <a href="https://github.com/us/crw" target="_blank" rel="noopener" class="toc-cta-btn outline">View on GitHub</a>
       </div>
     </aside>

--- a/scripts/build-docs-pages.mjs
+++ b/scripts/build-docs-pages.mjs
@@ -166,6 +166,13 @@ function buildPage(slug, title, description, content) {
     `<meta name="twitter:description" content="${escHtml(description)}">`
   );
 
+  // ── Signup CTA attribution ──
+  // The template's two /register CTAs are tagged for the docs home page; every
+  // generated page rewrites them to its own slug. Referers from docs arrive
+  // truncated to the origin (strict-origin-when-cross-origin), so without this
+  // all 58 pages collapse into one row and we cannot tell which doc converts.
+  page = page.split("ref=docs-home-").join(`ref=docs-${slug}-`);
+
   // ── Article: inject pre-rendered content ──
   page = page.replace(
     /<article id="article" role="main"><\/article>/,


### PR DESCRIPTION
## Why

Every signup link on the repo and on docs.fastcrw.com pointed at a bare
`/register`. Measured over 30 days on the funnel data, those two surfaces are
the highest-converting entry points we have (github 113 visitors / 17 signups,
docs 57 / 8), but each is a single undifferentiated row: there is no way to tell
which README CTA or which docs page produced them.

The referer header cannot answer it either. Docs referers arrive truncated to
the origin under `strict-origin-when-cross-origin` (125 hits on
`https://docs.fastcrw.com/` against 2 on any deep page), and every README link
reports the same `https://github.com/us/crw`.

## What changed

- `README.md` and `README.zh-CN.md`: the signup CTAs carry `?ref=gh-<slot>`
  (`hero`, `quickstart`, `sdk`, `table`, `zh`).
- `docs/index.html`: the navbar and TOC CTAs carry `?ref=docs-home-<slot>`.
  `scripts/build-docs-pages.mjs` rewrites `docs-home-` to the page's own slug
  when generating each page, so `docs/scraping/index.html` emits
  `?ref=docs-scraping-nav` and `?ref=docs-scraping-cta`.
- `docs/docs/{quick-start,search,monitoring}.md`: inline signup links carry
  `?ref=docs-<slug>-inline`.
- The 49 generated pages are regenerated to match.

## Notes

- **Visible link text is unchanged everywhere.** The slug lives only in the
  `href`, including where the anchor text is itself the URL
  (`[fastcrw.com/register](...)` in quick-start).
- **`docs/sitemap.xml` is deliberately left alone.** Regenerating bumped
  `lastmod` on all 50 URLs, which would report 50 content updates to crawlers
  for a query-string change.
- The install command `curl -fsSL https://fastcrw.com/install | sh` is
  untouched.
- No behaviour change in the engine; markdown, static HTML and the docs
  generator only.

## Follow-up in the private repo

A companion change drops the `ref` parameter from the address bar on arrival
via `history.replaceState`. The edge middleware records the full URL
server-side before first paint, so the slug is captured either way and the
reader never sees a tracking string.