### PR TITLE
docs(scraping): document maxAge and what the cloud cache does

### DIFF
--- a/docs/docs/migrate-from-firecrawl.md
+++ b/docs/docs/migrate-from-firecrawl.md
@@ -10,7 +10,7 @@
 
 The core request shape is intentionally compatible. These work against fastCRW with no modification when you point the client at the right base URL:
 
-- `/v1/scrape` — same body fields (`url`, `formats`, `onlyMainContent`, `waitFor`, etc.)
+- `/v1/scrape` — same body fields (`url`, `formats`, `onlyMainContent`, `waitFor`, `maxAge`, etc.)
 - `/v1/crawl` + `/v1/crawl/{id}` polling
 - `/v1/map`
 - `/v1/search`

--- a/docs/docs/scraping.md
+++ b/docs/docs/scraping.md
@@ -143,6 +143,7 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `filterMode` | string | -- | `bm25` or `cosine` |
 | `topK` | number | `5` | Number of top chunks to keep |
 | `proxy` | string | -- | Per-request proxy URL |
+| `maxAge` | number | `3600000` | Cloud only. How old a cached copy of this exact request may be, in milliseconds. `0` forces a fresh fetch. Capped at 24 hours. See [Caching](#caching) |
 | `country` | string | -- | 2-letter ISO 3166-1 alpha-2 country code (lowercase, e.g. `us`, `gb`, `de`). Routes the request through the named residential pool when the `chrome_proxy` renderer tier is configured. Ignored if no proxy tier is set up. See [JS rendering — Per-request country](#js-rendering) |
 | `stealth` | boolean | -- | Override global stealth setting |
 | `jsonSchema` | object | -- | Schema for structured extraction |
@@ -157,6 +158,39 @@ That is the default CRW success shape: requested content plus a compact metadata
 | `debug` | boolean | `false` | When `true`, includes a `debugExtraction` field in the response with a trace of every extraction candidate considered and why one was selected. |
 | `parsers` | object[] | PDF auto-parsed | Firecrawl-compatible document parser directives. Omit for the default (PDFs auto-converted to markdown). Pass `[]` to disable PDF parsing. Pass `[{"type":"pdf","maxPages":10}]` to cap pages. Accepted fields: `type` (`"pdf"`), `mode` (`"auto"` \| `"fast"` \| `"ocr"`), `maxPages`. |
 | `actions` | any | -- | Rejected with a clear error; use `cssSelector` or `xpath` instead |
+
+## Caching
+
+On the hosted API an identical repeat of the same request is served from cache
+for one hour by default. Identical means the whole request body: a different
+`formats`, `renderer`, `onlyMainContent` or `country` is a different request and
+fetches fresh. Caches are per account, never shared between customers.
+
+```json
+{ "url": "https://example.com", "formats": ["markdown"], "maxAge": 0 }
+```
+
+Use `maxAge` to choose your own trade-off:
+
+| You are scraping | Suggested `maxAge` |
+|---|---|
+| Live prices, flight positions, availability, anything that moves by the minute | `0` |
+| News and feeds | a few minutes, e.g. `300000` |
+| Documentation, reference pages, filings, archived records | hours, up to the 24h ceiling |
+
+`0` disables the cache for that call and always fetches. The ceiling is 24 hours,
+so a page can never be pinned for longer than a day.
+
+Two things are never cached, whatever you pass:
+
+- **`changeTracking`.** It compares a live fetch against the `previous` snapshot
+  you send, so replaying an earlier answer would hide the very change you asked
+  about.
+- **Failed scrapes.** A block page or an error is never stored, so a retry always
+  gets a real attempt.
+
+A cached response is billed the same as a fresh one — caching buys latency, not
+a discount.
 
 ## Formats
 


### PR DESCRIPTION
Docs only.

## Why

The hosted API has cached repeat scrapes for an hour since 2026-08-25, and `maxAge` has existed to control it since the same day. Neither was documented, and the effect is measurable: over **seven days of production traffic, zero requests set `maxAge`**. The control shipped and nobody could reach it.

That cuts both ways, and the protective direction matters more:

- A customer polling live flight positions and listing prices every 5-10 minutes needs `maxAge: 0`. Today they cannot know it exists.
- A customer scraping filings, rankings and reference pages could raise it to hours and get the same answer faster.

Measured repeat gaps say most callers land inside the default anyway (76% of repeats arrive within the hour), so this is about giving the two tails a way out, not about changing the default.

## What it adds

- `maxAge` in the parameter table: milliseconds, default `3600000`, `0` forces fresh, capped at 24h.
- A **Caching** section: what counts as an identical request (the whole body — a different `formats`/`renderer`/`country` fetches fresh), that caches are per account and never shared between customers, and a small table suggesting a value by content type.
- What is never cached whatever you pass: `changeTracking` (it diffs a live fetch against the `previous` snapshot you send, so replaying an earlier answer would hide the change you asked about) and failed scrapes (so a retry really retries).
- That a cached response costs the same credit as a fresh one — caching buys latency, not a discount.

`maxAge` also appears in the Firecrawl migration page's field list, since it is the same name there.

Markdown only. The static HTML is regenerated by the indexing workflow, as usual.