### PR TITLE
feat: enhance crawl error diagnostics and configurable headers

### DIFF
--- a/crates/crw-cli/src/commands/crawl.rs
+++ b/crates/crw-cli/src/commands/crawl.rs
@@ -153,6 +153,8 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         country: None,
         proxy_list: Vec::new(),
         proxy_rotation: None,
+        // No CLI flag for per-request headers, same as `crw scrape`.
+        headers: std::collections::HashMap::new(),
     };
 
     let id = Uuid::new_v4();
@@ -244,7 +246,19 @@ pub async fn run(mut args: CrawlArgs) -> Result<(), CmdError> {
         // Check if done
         match state.status {
             CrawlStatus::Completed => {
-                eprintln!("Crawl completed: {} pages", state.completed);
+                // `completed` counts every URL the crawl finished with, and
+                // that now includes the ones it could not read. Report the
+                // pages the caller actually got, and name the rest rather than
+                // folding them into the same number.
+                let scraped = state.completed.saturating_sub(state.blocked);
+                if state.blocked > 0 {
+                    eprintln!(
+                        "Crawl completed: {scraped} pages ({} unreadable)",
+                        state.blocked
+                    );
+                } else {
+                    eprintln!("Crawl completed: {scraped} pages");
+                }
                 break;
             }
             CrawlStatus::Failed => {

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -477,7 +477,7 @@ fn default_true() -> bool {
 }
 
 /// Metadata about a scraped page.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PageMetadata {
     pub title: Option<String>,
@@ -652,7 +652,7 @@ pub struct ScrapedImage {
 }
 
 /// Data returned for a single scraped page.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ScrapeData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -724,6 +724,8 @@ pub struct ScrapeData {
     /// Credit cost attributed to this page (0 = not yet priced).
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub credit_cost: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     pub metadata: PageMetadata,
     /// Extraction debug trace; populated only when the request opts in.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1147,6 +1149,8 @@ pub struct CrawlRequest {
     /// `sticky_per_host`). `None` = server default (`sticky_per_host`).
     #[serde(default, alias = "proxy_rotation")]
     pub proxy_rotation: Option<crate::proxy::ProxyRotation>,
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, String>,
 }
 
 /// Resolve the effective `render_js` decision from a per-request value and the
@@ -5125,4 +5129,20 @@ pub struct ChangeTrackingResult {
     /// True when the diff AST was truncated (mirrors `DiffAst.truncated`).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
+}
+
+#[cfg(test)]
+mod additional_tests {
+    use super::*;
+
+    #[test]
+    fn crawl_request_headers_round_trip() {
+        let json = serde_json::json!({
+            "url": "https://example.com",
+            "headers": { "X-Custom": "1", "User-Agent": "test" }
+        });
+        let req: CrawlRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(req.headers.get("X-Custom"), Some(&"1".to_string()));
+        assert_eq!(req.headers.len(), 2);
+    }
 }

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -724,8 +724,6 @@ pub struct ScrapeData {
     /// Credit cost attributed to this page (0 = not yet priced).
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub credit_cost: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
     pub metadata: PageMetadata,
     /// Extraction debug trace; populated only when the request opts in.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -983,10 +981,13 @@ pub struct BlockOutcome {
 /// See `message()` for why the customer-facing wording splits here.
 pub const STRUCTURAL_FAILURE_VENDOR: &str = "structural_failure";
 
-/// `BlockOutcome::vendor` for "the origin answered with an error status and this
-/// is its error page". Not an anti-bot verdict, but the same consequence for the
-/// caller and for billing, and the crawl/batch surfaces have nowhere else to say
-/// it: they return an array of documents, not an envelope with an error code.
+/// `BlockOutcome::vendor` for an HTTP-level failure to get the page: the origin
+/// answered with an error status and this is its error page, its CDN answered
+/// that it could not reach the origin, or, on the crawl path, the request did
+/// not complete at all and `metadata.statusCode` is `0`. Not an anti-bot
+/// verdict, but the same consequence for the caller and for billing, and the
+/// crawl/batch surfaces have nowhere else to say it: they return an array of
+/// documents, not an envelope with an error code.
 pub const HTTP_ERROR_VENDOR: &str = "http_error";
 
 /// `BlockOutcome::vendor` for a registrar parking page, a domain-marketplace listing
@@ -1149,8 +1150,13 @@ pub struct CrawlRequest {
     /// `sticky_per_host`). `None` = server default (`sticky_per_host`).
     #[serde(default, alias = "proxy_rotation")]
     pub proxy_rotation: Option<crate::proxy::ProxyRotation>,
+    /// Extra request headers applied to every page this crawl fetches, with the
+    /// same semantics as [`ScrapeRequest::headers`], including its warning: on
+    /// a browser render `Network.setExtraHTTPHeaders` decorates every request
+    /// the page makes, subresources included, so cross-origin-sensitive
+    /// credentials do not belong here.
     #[serde(default)]
-    pub headers: std::collections::HashMap<String, String>,
+    pub headers: HashMap<String, String>,
 }
 
 /// Resolve the effective `render_js` decision from a per-request value and the
@@ -3286,6 +3292,23 @@ mod tests {
     }
 
     #[test]
+    fn crawl_request_headers_round_trip_and_default_empty() {
+        let req: CrawlRequest = serde_json::from_value(serde_json::json!({
+            "url": "https://example.com",
+            "headers": { "X-Custom": "1", "User-Agent": "test" }
+        }))
+        .unwrap();
+        assert_eq!(req.headers.get("X-Custom"), Some(&"1".to_string()));
+        assert_eq!(req.headers.get("User-Agent"), Some(&"test".to_string()));
+
+        // Absent `headers` must stay an empty map, not a deserialize error, so
+        // every crawl body written before this field existed still parses.
+        let bare: CrawlRequest =
+            serde_json::from_value(serde_json::json!({ "url": "https://example.com" })).unwrap();
+        assert!(bare.headers.is_empty());
+    }
+
+    #[test]
     fn crawl_request_requires_url_field() {
         let result: Result<CrawlRequest, _> = serde_json::from_value(serde_json::json!({}));
         assert!(result.is_err());
@@ -5129,20 +5152,4 @@ pub struct ChangeTrackingResult {
     /// True when the diff AST was truncated (mirrors `DiffAst.truncated`).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
-}
-
-#[cfg(test)]
-mod additional_tests {
-    use super::*;
-
-    #[test]
-    fn crawl_request_headers_round_trip() {
-        let json = serde_json::json!({
-            "url": "https://example.com",
-            "headers": { "X-Custom": "1", "User-Agent": "test" }
-        });
-        let req: CrawlRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.headers.get("X-Custom"), Some(&"1".to_string()));
-        assert_eq!(req.headers.len(), 2);
-    }
 }

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -90,9 +90,14 @@ fn enqueue_discovered_links(
             if !is_safe_url(&link_url) {
                 continue;
             }
-            let link_host = link_url.host_str().unwrap_or("");
-            let link_origin = format!("{}://{}", link_url.scheme(), link_host);
-            if link_origin != origin {
+            // Full origin, port included. `map` next door already compares
+            // this way (`discover_urls`). Building it as scheme + host dropped
+            // the port, so a seed on `https://example.com/` treated
+            // `https://example.com:8443/` as the same site and crawled it. That
+            // was merely over-broad while the crawl sent no headers of its own;
+            // with `CrawlRequest::headers` it would replay the caller's
+            // credentials to a different service on the same host.
+            if link_url.origin().ascii_serialization() != origin {
                 continue;
             }
             let normalized = normalize_url(&link);
@@ -102,6 +107,53 @@ fn enqueue_discovered_links(
             }
         }
     }
+}
+
+/// Build the placeholder document a crawl returns for a URL it could not read.
+///
+/// Carries only the URL, the status (0 when there was no response at all) and
+/// the reason, stamped through the same `block` field the scrape and batch
+/// paths already use, so every surface that already understands "this document
+/// is not a page you asked for" understands this one too, and the caller's
+/// `completed - blocked` billing keeps it free.
+fn failed_page(url: &str, status_code: u16, reason: String) -> ScrapeData {
+    ScrapeData {
+        metadata: crw_core::types::PageMetadata {
+            source_url: url.to_string(),
+            status_code,
+            ..Default::default()
+        },
+        block: Some(crw_core::types::BlockOutcome {
+            vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
+            reason,
+        }),
+        ..Default::default()
+    }
+}
+
+/// Record a failed page and publish progress, mirroring the success path's
+/// bookkeeping so `completed`, `blocked` and `total` never disagree.
+fn push_failed_page(
+    data: ScrapeData,
+    id: Uuid,
+    state_tx: &tokio::sync::watch::Sender<CrawlState>,
+    results: &mut Vec<ScrapeData>,
+    blocked: &mut u32,
+    total: u32,
+) {
+    results.push(data);
+    *blocked += 1;
+    // Progress carries no data: the full array ships once, in Completed.
+    let _ = state_tx.send(CrawlState {
+        id,
+        success: true,
+        status: CrawlStatus::InProgress,
+        total,
+        completed: results.len() as u32,
+        blocked: *blocked,
+        data: Vec::new(),
+        error: None,
+    });
 }
 
 /// Run a BFS crawl starting from a URL.
@@ -176,13 +228,11 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
         }
     };
 
-    let origin = match base_url.host_str() {
-        Some(host) => format!("{}://{}", base_url.scheme(), host),
-        None => {
-            send_failed(id, &state_tx, "URL has no host".into());
-            return;
-        }
-    };
+    if base_url.host_str().is_none() {
+        send_failed(id, &state_tx, "URL has no host".into());
+        return;
+    }
+    let origin = base_url.origin().ascii_serialization();
 
     // Robots/sitemap egress must match the page egress: prefer the per-crawl
     // BYOP pool, then the config rotator, then the legacy single `proxy`. Never
@@ -300,62 +350,43 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(url, error = %e, "Crawl: failed to fetch page");
-                let mut md = crw_core::types::PageMetadata::default();
-                md.source_url = url.clone();
-                let mut data = ScrapeData::default();
-                data.metadata = md;
-                data.error = Some(e.to_string());
-                data.block = Some(crw_core::types::BlockOutcome {
-                    vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
-                    reason: e.to_string(),
-                });
-                
-                results.push(data);
-                blocked += 1;
-                let _ = state_tx.send(CrawlState {
+                push_failed_page(
+                    failed_page(&url, 0, e.to_string()),
                     id,
-                    success: true,
-                    status: CrawlStatus::InProgress,
-                    total: total_pages as u32,
-                    completed: results.len() as u32,
-                    blocked,
-                    data: Vec::new(),
-                    error: None,
-                });
+                    &state_tx,
+                    &mut results,
+                    &mut blocked,
+                    visited.len() as u32,
+                );
                 continue;
             }
         };
 
         // The CDN answered for a dead origin, so this page has no content and no
-        // links worth following — its body is the CDN's error page.
+        // links worth following: its body is the CDN's error page. It is
+        // recorded as a blocked page rather than a crawled one: a crawl of a
+        // site whose origin is down was reporting `completed: 1` with
+        // Cloudflare's apology as the page. `blocked` keeps it out of the bill
+        // (the caller charges `completed - blocked`) while the caller can still
+        // see which URL failed and why.
         if crate::single::is_cdn_origin_error(fetch_result.status_code) {
             tracing::warn!(
                 url,
                 status = fetch_result.status_code,
                 "Crawl: CDN could not reach the origin"
             );
-            let mut md = crw_core::types::PageMetadata::default();
-            md.source_url = url.clone();
-            md.status_code = fetch_result.status_code;
-            let mut data = ScrapeData::default();
-            data.metadata = md;
-            data.error = Some("CDN could not reach origin".to_string());
-            data.block = Some(crw_core::types::BlockOutcome {
-                vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
-                reason: "CDN origin error".to_string(),
-            });
-            results.push(data);
-            blocked += 1;
-            let _ = state_tx.send(CrawlState {
+            push_failed_page(
+                failed_page(
+                    &url,
+                    fetch_result.status_code,
+                    "CDN could not reach origin".to_string(),
+                ),
                 id,
-                success: true,
-                status: CrawlStatus::InProgress,
-                total: total_pages as u32,
-                completed: results.len() as u32,
-                blocked,
-                data: Vec::new(),
-                error: None,
-            });
+                &state_tx,
+                &mut results,
+                &mut blocked,
+                visited.len() as u32,
+            );
             continue;
         }
 
@@ -394,6 +425,18 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
                 Ok(data) => data,
                 Err(err) => {
                     tracing::warn!(url, error = %err, "Crawl: PDF conversion failed");
+                    push_failed_page(
+                        failed_page(
+                            &url,
+                            fetch_result.status_code,
+                            format!("PDF conversion failed: {err}"),
+                        ),
+                        id,
+                        &state_tx,
+                        &mut results,
+                        &mut blocked,
+                        visited.len() as u32,
+                    );
                     continue;
                 }
             }
@@ -432,6 +475,18 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
                 Ok(data) => data,
                 Err(err) => {
                     tracing::warn!(url, error = %err, "Crawl: extraction failed");
+                    push_failed_page(
+                        failed_page(
+                            &url,
+                            fetch_result.status_code,
+                            format!("extraction failed: {err}"),
+                        ),
+                        id,
+                        &state_tx,
+                        &mut results,
+                        &mut blocked,
+                        visited.len() as u32,
+                    );
                     continue;
                 }
             }
@@ -1170,6 +1225,40 @@ mod tests {
         );
     }
 
+    /// A page the crawl could not read must come back marked, not silently
+    /// dropped and not billable: `block` is what every surface (v1, v2, the
+    /// SaaS biller's `completed - blocked`) already reads to tell a real page
+    /// from a refused one.
+    #[test]
+    fn failed_page_is_marked_blocked_and_carries_the_reason() {
+        let d = failed_page("https://example.com/dead", 0, "connect timeout".into());
+        assert_eq!(d.metadata.source_url, "https://example.com/dead");
+        // No response at all, so there is no status to report.
+        assert_eq!(d.metadata.status_code, 0);
+        assert!(d.markdown.is_none() && d.html.is_none());
+        let block = d.block.expect("a failed page must be marked");
+        assert_eq!(block.vendor, crw_core::types::HTTP_ERROR_VENDOR);
+        assert_eq!(block.reason, "connect timeout");
+        // Not priced by the engine; the caller excludes blocked pages anyway.
+        assert_eq!(d.credit_cost, 0);
+    }
+
+    /// The CDN-origin-error case keeps the status it answered with, so a caller
+    /// can tell a 523 apart from a transport failure.
+    #[test]
+    fn failed_page_keeps_an_upstream_status_code() {
+        let d = failed_page(
+            "https://example.com/x",
+            523,
+            "CDN could not reach origin".into(),
+        );
+        assert_eq!(d.metadata.status_code, 523);
+        assert_eq!(
+            d.block.map(|b| b.reason).as_deref(),
+            Some("CDN could not reach origin")
+        );
+    }
+
     #[test]
     fn normalize_url_lowercase() {
         assert_eq!(
@@ -1806,33 +1895,45 @@ mod tests {
         assert_eq!(queue[0].0, "https://example.com/real-page");
     }
 
+    /// A different port is a different origin, matching `discover_urls`'s BFS
+    /// phase. This used to be pinned the other way and labelled a known bug:
+    /// harmless while the crawl sent no caller headers, a credential-scope hole
+    /// the moment `CrawlRequest::headers` existed, since an admin console on
+    /// `:9999` would receive the seed's `Authorization`.
     #[test]
-    fn enqueue_same_host_different_port_treated_as_same_origin() {
-        // BUG: `enqueue_discovered_links` (and the `origin` it's called
-        // with, built in `run_crawl_inner` as `scheme://host` with no port)
-        // ignores the port entirely when deciding same-origin. A link to a
-        // different port on the same host is followed as if it were the
-        // same site — unlike `discover_urls`'s BFS phase, which explicitly
-        // uses the full `Url::origin()` (scheme+host+port) and documents
-        // why dropping the port would be wrong. Documenting current
-        // behavior; production code left untouched per the test rules.
+    fn enqueue_same_host_different_port_is_a_different_origin() {
         let html = links_html(&["https://example.com:9999/admin"]);
         let mut visited = HashSet::new();
         let mut queue = VecDeque::new();
         enqueue_discovered_links(
             &html,
             "https://example.com/",
-            "https://example.com", // port-less origin, as run_crawl_inner builds it
+            "https://example.com",
             100,
             &mut visited,
             &mut queue,
             0,
         );
-        assert_eq!(
-            queue.len(),
-            1,
-            "a different port on the same host is currently treated as same-origin"
+        assert!(queue.is_empty(), "a different port must not be followed");
+    }
+
+    /// The default port is not a different origin: `Url::origin()` omits it, so
+    /// an explicit `:443` link from a plain `https://` seed still gets crawled.
+    #[test]
+    fn enqueue_explicit_default_port_is_still_same_origin() {
+        let html = links_html(&["https://example.com:443/page"]);
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        enqueue_discovered_links(
+            &html,
+            "https://example.com/",
+            "https://example.com",
+            100,
+            &mut visited,
+            &mut queue,
+            0,
         );
+        assert_eq!(queue.len(), 1);
     }
 
     #[test]

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -285,11 +285,9 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
             }
             None => renderer.pick_proxy_for_url(&url),
         };
-        let empty_headers: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
         let fetch_fut = renderer.fetch(
             &url,
-            &empty_headers,
+            &req.headers,
             effective_render_js,
             req.wait_for,
             pinned_renderer,
@@ -302,21 +300,62 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(url, error = %e, "Crawl: failed to fetch page");
+                let mut md = crw_core::types::PageMetadata::default();
+                md.source_url = url.clone();
+                let mut data = ScrapeData::default();
+                data.metadata = md;
+                data.error = Some(e.to_string());
+                data.block = Some(crw_core::types::BlockOutcome {
+                    vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
+                    reason: e.to_string(),
+                });
+                
+                results.push(data);
+                blocked += 1;
+                let _ = state_tx.send(CrawlState {
+                    id,
+                    success: true,
+                    status: CrawlStatus::InProgress,
+                    total: total_pages as u32,
+                    completed: results.len() as u32,
+                    blocked,
+                    data: Vec::new(),
+                    error: None,
+                });
                 continue;
             }
         };
 
         // The CDN answered for a dead origin, so this page has no content and no
-        // links worth following — its body is the CDN's error page. Skipped like
-        // any other failed fetch (the `continue` above) rather than counted as a
-        // crawled page: a crawl of a site whose origin is down was reporting
-        // `completed: 1` with Cloudflare's apology as the page.
+        // links worth following — its body is the CDN's error page.
         if crate::single::is_cdn_origin_error(fetch_result.status_code) {
             tracing::warn!(
                 url,
                 status = fetch_result.status_code,
                 "Crawl: CDN could not reach the origin"
             );
+            let mut md = crw_core::types::PageMetadata::default();
+            md.source_url = url.clone();
+            md.status_code = fetch_result.status_code;
+            let mut data = ScrapeData::default();
+            data.metadata = md;
+            data.error = Some("CDN could not reach origin".to_string());
+            data.block = Some(crw_core::types::BlockOutcome {
+                vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
+                reason: "CDN origin error".to_string(),
+            });
+            results.push(data);
+            blocked += 1;
+            let _ = state_tx.send(CrawlState {
+                id,
+                success: true,
+                status: CrawlStatus::InProgress,
+                total: total_pages as u32,
+                completed: results.len() as u32,
+                blocked,
+                data: Vec::new(),
+                error: None,
+            });
             continue;
         }
 

--- a/crates/crw-crawl/tests/crawl_headers_and_failures.rs
+++ b/crates/crw-crawl/tests/crawl_headers_and_failures.rs
@@ -1,0 +1,213 @@
+//! Integration tests for the two behaviours `/v1/crawl` gained together:
+//! caller-supplied request headers reaching every page, and a URL the crawl
+//! could not read coming back marked instead of silently vanishing.
+//!
+//! Both are exercised through `run_crawl` against a mock origin, because the
+//! unit tests around them cannot fail if the wiring is removed: reverting the
+//! fetch call to an empty header map, or deleting the failure branches, leaves
+//! every serde-level test green.
+
+use std::sync::Arc;
+
+use crw_core::config::{RendererConfig, RendererMode, StealthConfig};
+use crw_core::types::{CrawlRequest, CrawlState, CrawlStatus, OutputFormat};
+use crw_crawl::crawl::{CrawlOptions, run_crawl};
+use crw_renderer::FallbackRenderer;
+use uuid::Uuid;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// wiremock binds to loopback, which the SSRF guard rejects by default.
+fn allow_loopback() {
+    // SAFETY: set before any crawl runs; tests in this file share one process.
+    unsafe {
+        std::env::set_var("CRW_ALLOW_LOOPBACK_FOR_TESTS", "1");
+    }
+}
+
+/// An HTTP-only renderer: these tests exercise crawl bookkeeping, not JS.
+async fn renderer() -> Arc<FallbackRenderer> {
+    allow_loopback();
+    let cfg = RendererConfig {
+        mode: RendererMode::None,
+        ..Default::default()
+    };
+    Arc::new(
+        FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default())
+            .expect("renderer builds in http-only mode"),
+    )
+}
+
+fn request(url: String) -> CrawlRequest {
+    CrawlRequest {
+        url,
+        max_depth: Some(0),
+        max_pages: Some(1),
+        formats: vec![OutputFormat::Markdown],
+        only_main_content: false,
+        json_schema: None,
+        render_js: Some(false),
+        wait_for: None,
+        renderer: None,
+        country: None,
+        proxy_list: Vec::new(),
+        proxy_rotation: None,
+        headers: std::collections::HashMap::new(),
+    }
+}
+
+/// Drive one crawl to completion and hand back the terminal state.
+async fn run(req: CrawlRequest) -> CrawlState {
+    let id = Uuid::new_v4();
+    let (state_tx, state_rx) = tokio::sync::watch::channel(CrawlState {
+        id,
+        success: false,
+        status: CrawlStatus::InProgress,
+        total: 0,
+        completed: 0,
+        blocked: 0,
+        data: Vec::new(),
+        error: None,
+    });
+    run_crawl(CrawlOptions {
+        id,
+        req,
+        renderer: renderer().await,
+        max_concurrency: 1,
+        respect_robots: false,
+        requests_per_second: 100.0,
+        user_agent: "crw-test-default-ua",
+        state_tx,
+        llm_config: None,
+        proxy: None,
+        jitter_factor: 0.0,
+        deadline_ms_per_page: 15_000,
+        per_host_max_concurrent: 1,
+        normalize_tables: false,
+        http_retry_threshold_bytes: 0,
+    })
+    .await;
+    state_rx.borrow().clone()
+}
+
+/// The crawl used to hand the renderer an empty header map, so a documented
+/// `headers` field did nothing on this path. The mock only answers when both
+/// the custom header and the overridden User-Agent arrive.
+#[tokio::test]
+async fn caller_headers_reach_every_page_of_the_crawl() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .and(header("X-Crw-Test", "probe"))
+        .and(header("User-Agent", "crw-header-probe/1.0"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><h1>Header page</h1></body></html>")
+                .insert_header("content-type", "text/html"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut req = request(format!("{}/", server.uri()));
+    req.headers.insert("X-Crw-Test".into(), "probe".into());
+    req.headers
+        .insert("User-Agent".into(), "crw-header-probe/1.0".into());
+
+    let state = run(req).await;
+
+    // A missing header would leave the mock unmatched, so the page would come
+    // back as a failure instead of content.
+    assert_eq!(state.blocked, 0, "headers did not reach the origin");
+    assert_eq!(state.data.len(), 1);
+    assert!(
+        state.data[0]
+            .markdown
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Header page")
+    );
+}
+
+/// Without the headers the same mock does not match, which is what makes the
+/// assertion above meaningful rather than vacuous.
+#[tokio::test]
+async fn the_header_probe_fails_when_the_headers_are_absent() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .and(header("X-Crw-Test", "probe"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("<html><body>ok</body></html>"))
+        .mount(&server)
+        .await;
+
+    let state = run(request(format!("{}/", server.uri()))).await;
+    assert!(
+        state.data.first().and_then(|d| d.markdown.as_deref()) != Some("ok"),
+        "the mock matched without the header, so the header test proves nothing"
+    );
+}
+
+/// A CDN answering for a dead origin used to be dropped on the floor: the
+/// caller got `completed: 0`, an empty array, and no way to learn which URL
+/// failed. It now comes back marked, and marked is what keeps it unbilled,
+/// since the caller charges `completed - blocked`.
+#[tokio::test]
+async fn a_cdn_origin_error_comes_back_marked_and_unbilled() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(523))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/", server.uri());
+    let state = run(request(url.clone())).await;
+
+    assert_eq!(state.status, CrawlStatus::Completed);
+    assert_eq!(state.completed, 1);
+    assert_eq!(state.blocked, 1);
+    assert_eq!(
+        state.completed - state.blocked,
+        0,
+        "a page nobody could read must not be billable"
+    );
+
+    let doc = state.data.first().expect("the failed URL must be reported");
+    assert_eq!(doc.metadata.source_url, url);
+    assert_eq!(doc.metadata.status_code, 523);
+    assert!(doc.markdown.is_none(), "there is no page to return");
+    let block = doc.block.as_ref().expect("failure must be marked");
+    assert_eq!(block.vendor, crw_core::types::HTTP_ERROR_VENDOR);
+    assert_eq!(block.reason, "CDN could not reach origin");
+}
+
+/// A page that answers normally is untouched by any of the above: no block, and
+/// it stays billable. Guards against the failure branches over-triggering.
+#[tokio::test]
+async fn a_healthy_page_is_neither_marked_nor_counted_blocked() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(
+                    "<html><body><h1>Real page</h1><p>Body text here.</p></body></html>",
+                )
+                .insert_header("content-type", "text/html"),
+        )
+        .mount(&server)
+        .await;
+
+    let state = run(request(format!("{}/", server.uri()))).await;
+
+    assert_eq!(state.completed, 1);
+    assert_eq!(state.blocked, 0);
+    assert!(state.data[0].block.is_none());
+    assert!(
+        state.data[0]
+            .markdown
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Real page")
+    );
+}

--- a/crates/crw-server/openapi/openapi.json
+++ b/crates/crw-server/openapi/openapi.json
@@ -1705,6 +1705,13 @@
             "minimum": 0,
             "default": 2
           },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Custom HTTP request headers applied to every page the crawl fetches. On a browser render they apply to every request the page makes, subresources included, so avoid cross-origin-sensitive credentials here."
+          },
           "scrapeOptions": {
             "$ref": "#/components/schemas/CrawlScrapeOptions"
           },
@@ -2527,6 +2534,13 @@
             "type": "integer",
             "minimum": 0,
             "description": "Milliseconds to wait after JS rendering on each page."
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Custom HTTP request headers applied to every page the crawl fetches. On a browser render they apply to every request the page makes, subresources included, so avoid cross-origin-sensitive credentials here."
           }
         }
       }

--- a/crates/crw-server/src/routes/crawl.rs
+++ b/crates/crw-server/src/routes/crawl.rs
@@ -174,6 +174,30 @@ mod tests {
         assert!(req.only_main_content);
     }
 
+    /// `headers` arrives either flat or nested, like every other per-page key.
+    #[test]
+    fn headers_lift_out_of_scrape_options() {
+        let req = parse(json!({
+            "url": "https://example.com",
+            "scrapeOptions": { "headers": { "X-Env": "staging" } },
+        }));
+        assert_eq!(req.headers.get("X-Env"), Some(&"staging".to_string()));
+
+        let req = parse(json!({
+            "url": "https://example.com",
+            "headers": { "X-Env": "prod" },
+        }));
+        assert_eq!(req.headers.get("X-Env"), Some(&"prod".to_string()));
+
+        // Nothing supplied stays an empty map, so pre-existing bodies are
+        // byte-for-byte unaffected.
+        assert!(
+            parse(json!({ "url": "https://example.com" }))
+                .headers
+                .is_empty()
+        );
+    }
+
     #[test]
     fn a_non_object_scrape_options_is_ignored_not_fatal() {
         // A caller sending `scrapeOptions: null` (some SDKs do) must not 400.

--- a/crates/crw-server/src/routes/v2/adapters.rs
+++ b/crates/crw-server/src/routes/v2/adapters.rs
@@ -98,10 +98,13 @@ pub fn to_v2_document(data: ScrapeData, proxy_used: &str, scrape_id: String) -> 
         concurrency_limited: false,
         // Engine does not price requests (the SaaS layer bills); surface
         // whatever the engine attributed, defaulting to 1 like the live API.
-        credits_used: if data.credit_cost == 0 {
-            1
-        } else {
-            data.credit_cost
+        // A blocked page is 0: nobody is charged for it, the envelope total at
+        // `build_crawl_status` already excludes it, and this field disagreeing
+        // was the only place a refused page still advertised a credit.
+        credits_used: match (data.block.is_some(), data.credit_cost) {
+            (true, _) => 0,
+            (false, 0) => 1,
+            (false, c) => c,
         },
         scrape_id,
         page_count: m.page_count,
@@ -611,6 +614,21 @@ mod tests {
         data.credit_cost = 0;
         let doc = to_v2_document(data, "basic", "sid".to_string());
         assert_eq!(doc.metadata.credits_used, 1);
+    }
+
+    /// `block` is set on an anti-bot wall, an origin error page, and now on a
+    /// URL the crawl could not read at all. None of the three is billed, so
+    /// none of them may report a credit on the document either.
+    #[test]
+    fn a_blocked_document_reports_zero_credits() {
+        let mut data = fake_doc("https://x");
+        data.credit_cost = 0;
+        data.block = Some(crw_core::types::BlockOutcome {
+            vendor: crw_core::types::HTTP_ERROR_VENDOR.to_string(),
+            reason: "CDN could not reach origin".to_string(),
+        });
+        let doc = to_v2_document(data, "basic", "sid".to_string());
+        assert_eq!(doc.metadata.credits_used, 0);
     }
 
     #[test]

--- a/crates/crw-server/src/routes/v2/crawl.rs
+++ b/crates/crw-server/src/routes/v2/crawl.rs
@@ -8,6 +8,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crw_core::error::CrwError;
@@ -75,6 +76,7 @@ pub struct PageQuery {
 /// Internal projection of a v2 `scrapeOptions` object.
 pub(crate) struct ScrapeOpts {
     pub formats: Vec<OutputFormat>,
+    pub headers: HashMap<String, String>,
     pub json_schema: Option<Value>,
     pub only_main_content: bool,
     pub wait_for: Option<u64>,
@@ -85,6 +87,7 @@ pub(crate) struct ScrapeOpts {
 pub(crate) fn scrape_opts_to_internal(opts: &Option<Value>) -> Result<ScrapeOpts, CrwError> {
     let mut out = ScrapeOpts {
         formats: vec![OutputFormat::Markdown],
+        headers: HashMap::new(),
         json_schema: None,
         only_main_content: true,
         wait_for: None,
@@ -98,6 +101,19 @@ pub(crate) fn scrape_opts_to_internal(opts: &Option<Value>) -> Result<ScrapeOpts
             let d = decompose(&specs).map_err(CrwError::InvalidRequest)?;
             out.formats = d.formats;
             out.json_schema = d.json_schema;
+        }
+        // Firecrawl carries per-page request headers here, and `/v2/scrape`
+        // already honours its own `headers`. Dropping them on the crawl path
+        // would be the same silent-ignore failure as #346, so a non-object (or
+        // a non-string value) is an error rather than a quiet no-op.
+        if let Some(h) = m.get("headers")
+            && !h.is_null()
+        {
+            out.headers = serde_json::from_value(h.clone()).map_err(|e| {
+                CrwError::InvalidRequest(format!(
+                    "scrapeOptions.headers must be an object of strings: {e}"
+                ))
+            })?;
         }
         if let Some(b) = m.get("onlyMainContent").and_then(Value::as_bool) {
             out.only_main_content = b;
@@ -151,6 +167,7 @@ pub async fn start_crawl(
         country: v2.country,
         proxy_list: v2.proxy_list,
         proxy_rotation: v2.proxy_rotation,
+        headers: opts.headers,
     };
     validate_crawl_renderer(&req, &state)?;
 
@@ -279,13 +296,52 @@ mod tests {
         // "No scrapeOptions at all", "scrapeOptions without renderJs" and an
         // explicit null must all stay None so the server's render_js_default
         // still applies.
-        assert_eq!(scrape_opts_to_internal(&None).unwrap().render_js, None);
         for opts in [
             serde_json::json!({ "onlyMainContent": false }),
             serde_json::json!({ "renderJs": null }),
         ] {
             let parsed = scrape_opts_to_internal(&Some(opts.clone())).unwrap();
             assert_eq!(parsed.render_js, None, "{opts}");
+        }
+        assert_eq!(scrape_opts_to_internal(&None).unwrap().render_js, None);
+    }
+
+    /// Firecrawl bodies put per-page headers under `scrapeOptions`, and
+    /// `/v2/scrape` already honours its own `headers`. A crawl that dropped
+    /// them would be the same silent-ignore as #346.
+    #[test]
+    fn scrape_options_headers_reach_the_crawl_request() {
+        let opts = Some(serde_json::json!({
+            "headers": { "Authorization": "Bearer x", "X-Env": "staging" }
+        }));
+        let parsed = scrape_opts_to_internal(&opts).unwrap();
+        assert_eq!(
+            parsed.headers.get("Authorization"),
+            Some(&"Bearer x".to_string())
+        );
+        assert_eq!(parsed.headers.get("X-Env"), Some(&"staging".to_string()));
+
+        // Absent or null stays empty rather than erroring.
+        assert!(scrape_opts_to_internal(&None).unwrap().headers.is_empty());
+        assert!(
+            scrape_opts_to_internal(&Some(serde_json::json!({ "headers": null })))
+                .unwrap()
+                .headers
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_malformed_scrape_options_headers_is_rejected_not_ignored() {
+        for bad in [
+            serde_json::json!({ "headers": "Authorization: x" }),
+            serde_json::json!({ "headers": { "X-Num": 1 } }),
+            serde_json::json!({ "headers": ["a", "b"] }),
+        ] {
+            assert!(
+                scrape_opts_to_internal(&Some(bad.clone())).is_err(),
+                "should reject {bad}"
+            );
         }
     }
 

--- a/crates/crw-server/src/state.rs
+++ b/crates/crw-server/src/state.rs
@@ -1179,6 +1179,7 @@ mod tests {
             country: None,
             proxy_list: Vec::new(),
             proxy_rotation: None,
+            headers: std::collections::HashMap::new(),
         }
     }
 

--- a/docs/docs/crawling.md
+++ b/docs/docs/crawling.md
@@ -163,6 +163,7 @@ Poll response:
 | `renderJs` | boolean or null | `null` | `true` forces JS on every page, `false` skips JS, `null` uses auto-detect or the server's `render_js_default` |
 | `waitFor` | number | -- | Milliseconds to wait after JS rendering on each page |
 | `renderer` | string | `auto` | Pin every crawled page to a specific renderer: `auto`, `lightpanda`, `chrome`, `chrome_proxy`, `playwright`, or `camoufox`. Non-`auto` values hard-pin (no fallback) and imply `renderJs:true` unless `renderJs:false` is set. Validation runs once at crawl start — invalid combinations return HTTP 400 before the job is queued. Per-page failures of a pinned renderer are logged and skipped, so failed pages may be missing from results — see [JS rendering](#js-rendering) for the resilience tradeoff |
+| `headers` | object | `{}` | Custom HTTP headers applied to every page the crawl fetches, forwarded on both the HTTP and browser render paths. A `User-Agent` here overrides the default. On a browser render they apply to every request the page makes (subresources included), so avoid putting cross-origin-sensitive credentials like `Authorization` here |
 | `country` | string | -- | 2-letter ISO 3166-1 alpha-2 country code (lowercase, e.g. `us`, `gb`, `de`). Routes every page in the crawl through the named residential pool when the `chrome_proxy` renderer tier is configured. Ignored if no proxy tier is set up |
 
 ## Scrape options and extraction

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1705,6 +1705,13 @@
             "minimum": 0,
             "default": 2
           },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Custom HTTP request headers applied to every page the crawl fetches. On a browser render they apply to every request the page makes, subresources included, so avoid cross-origin-sensitive credentials here."
+          },
           "scrapeOptions": {
             "$ref": "#/components/schemas/CrawlScrapeOptions"
           },
@@ -2527,6 +2534,13 @@
             "type": "integer",
             "minimum": 0,
             "description": "Milliseconds to wait after JS rendering on each page."
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Custom HTTP request headers applied to every page the crawl fetches. On a browser render they apply to every request the page makes, subresources included, so avoid cross-origin-sensitive credentials here."
           }
         }
       }


### PR DESCRIPTION
This PR adds configurable User-Agent headers to the Crawl request, and emits failed fetches as ScrapeData objects with an error field to improve visibility.