### PR TITLE
fix(renderer): keep the HTTP shell from resurrecting a refused wall

### DIFF
--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -1690,7 +1690,22 @@ impl FallbackRenderer {
                         // pixels), and an explicit renderer pin is a caller
                         // contract that forbids silent substitution. Both fail
                         // closed, matching the no-renderer arm directly above.
-                        Err(e) if screenshot_requested() || is_hard_pinned => Err(e),
+                        // The HTTP shell substitutes for a failed ladder so the
+                        // caller gets content instead of nothing. But when that
+                        // shell IS the wall the ladder just refused to clear,
+                        // returning it hands back exactly what every tier
+                        // rejected, as a billed success. Fail instead; a shell
+                        // that is not a wall still substitutes as before.
+                        Err(e)
+                            if screenshot_requested()
+                                || is_hard_pinned
+                                || detector::looks_like_generic_bot_wall(
+                                    &http_result.html,
+                                    http_result.truncated,
+                                ) =>
+                        {
+                            Err(e)
+                        }
                         Err(e) => {
                             if is_auth_blocked {
                                 tracing::error!(
@@ -1911,9 +1926,16 @@ impl FallbackRenderer {
                         .await
                     {
                         Ok(js_result) => Ok(js_result),
-                        Err(e) if is_hard_pinned => {
-                            // User explicitly pinned a renderer — surface the error
-                            // instead of silently returning the (likely useless) HTTP body.
+                        Err(e)
+                            if is_hard_pinned
+                                || detector::looks_like_generic_bot_wall(
+                                    &result.html,
+                                    result.truncated,
+                                ) =>
+                        {
+                            // Pinned: the caller's contract forbids substitution.
+                            // Wall: see the sibling arm — the shell is the very
+                            // thing the ladder rejected, so it is not a fallback.
                             Err(e)
                         }
                         Err(e) => {
@@ -4881,6 +4903,43 @@ mod tests {
                 chosen: RendererKind::Chrome
             })
         ));
+    }
+
+    /// The ladder correctly refuses a wall, and then the HTTP-shell fallback
+    /// hands the same wall back anyway. Prod log, 2026-09-03: "JS escalation
+    /// failed for soft-block status; surfacing HTTP shell with warning: ...
+    /// blocked by an anti-bot wall that none of the 3 renderer tier(s)
+    /// attempted could clear". The ladder's verdict has to survive that
+    /// substitution, or rejecting the wall upstream buys nothing.
+    #[tokio::test]
+    async fn http_shell_fallback_does_not_resurrect_a_wall() {
+        let wall = "<html><body><h1>Security Check</h1>\
+                    <p>Checking your browser before accessing the site</p></body></html>";
+        let lp = Arc::new(MockFetcher {
+            name: "lightpanda",
+            behavior: MockBehavior::Ok(wall.to_string()),
+        }) as Arc<dyn PageFetcher>;
+        let mut r = make_renderer_with_mocks(vec![lp]);
+        r.http = Arc::new(MockFetcher {
+            name: "http",
+            behavior: MockBehavior::Ok(wall.to_string()),
+        });
+
+        let out = r
+            .fetch(
+                "https://example.com",
+                &HashMap::new(),
+                Some(true),
+                None,
+                None,
+                tdl(),
+            )
+            .await;
+        assert!(
+            out.is_err(),
+            "the wall must not come back through the HTTP shell: {:?}",
+            out.ok().map(|r| (r.rendered_with, r.html.len()))
+        );
     }
 
     /// Prod shipped an anti-bot interstitial to a paying customer as


### PR DESCRIPTION
Third and final link in the chain #494 → #496 → this. Each fix was correct and each time prod showed the wall still coming back, because the next layer down handed it over again.

## The evidence

#496 made the ladder tail refuse a wall. It works — the engine's own log on prod says so:

```
ERROR crw_renderer: JS escalation failed for soft-block status; surfacing HTTP shell
with warning: blocked by an anti-bot wall that none of the 3 renderer tier(s)
attempted could clear      status_code=403
```

Read that line carefully: my guard fired, returned the error, and the caller then **surfaced the HTTP shell anyway**. The shell is the same wall, so the customer still got `success: true` and a credit.

## The fix

When the JS ladder fails, the HTTP body substitutes for it so the caller gets content instead of nothing. Both fallback arms already decline to substitute in two cases: the caller pinned a renderer, or asked for a screenshot — contracts a silent substitution would break.

A wall belongs in the same set, for the same reason: it is not a fallback, it is the failure repeated. Added to the existing guard expression at both sites rather than as a new branch.

A shell that is **not** a wall still substitutes exactly as before, so the recall this fallback exists to protect is untouched.

## Verification

- `cargo test --workspace`: 4227 passed
- `cargo test -p crw-renderer --features camoufox,cloak,cdp`: 1025 passed
- clippy clean in both configurations, fmt clean
- New test `http_shell_fallback_does_not_resurrect_a_wall`; disabling both guards makes it fail, so it pins the behaviour rather than passing incidentally

## Why this took three PRs

Worth recording, since the chain is instructive:

- **#494** threaded the renderer truncation flag into the detector. A real bug — a budget-truncated body has no closing `</body>` and extracted as an empty string — but not this symptom. I diagnosed it from the `truncated: true` flag in the live response without checking whether the body actually lacked the tag. It did not.
- **#496** found the ladder tail returning a rejected body as "the best of what we tried". Also real, also not sufficient on its own.
- **This** is the layer that was undoing both.

I verified each one against prod after it deployed rather than assuming, which is the only reason the second and third links were found at all.