### PR TITLE
feat(config): let the LightPanda escalation target a renderer that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ Embedding license: hello@fastcrw.com.
   <a href="https://github.com/paoloantinori" title="paoloantinori"><img src="https://github.com/paoloantinori.png?size=96" width="48" height="48" alt="paoloantinori"/></a>
   <a href="https://github.com/VIVAAN-DHAWAN" title="VIVAAN-DHAWAN"><img src="https://github.com/VIVAAN-DHAWAN.png?size=96" width="48" height="48" alt="VIVAAN-DHAWAN"/></a>
   <a href="https://github.com/mj520" title="mj520"><img src="https://github.com/mj520.png?size=96" width="48" height="48" alt="mj520"/></a>
-  <a href="https://github.com/rqi14" title="rqi14"><img src="https://github.com/rqi14.png?size=96" width="48" height="48" alt="rqi14"/></a>
 </p>
 <!-- contributors:end -->
 

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -430,12 +430,60 @@ async fn scrape_url_inner(
         // and hide the real outcome behind a fabricated timeout.
         let escalation_budget = deadline.remaining();
         let has_escalation_budget = escalation_budget >= crw_renderer::MIN_TIER_BUDGET;
+        // If the prior tier was lightpanda (returned 200 with thin/no content that
+        // fooled the renderer-level thinness check), escalate to chrome, and when
+        // this deployment runs no Chrome sidecar, to whatever stronger tier it does
+        // have. Pinning the bare literal made the second case a dead end: the pool
+        // rejects a name it does not hold outright, so the escalation failed on the
+        // pin rather than on the page and a configured, healthy tier was never
+        // reached. Chrome stays the first choice so a pool that holds it behaves
+        // exactly as before, including for a host the preference learner has already
+        // promoted to chrome; `auto_ladder_names` supplies the fallback and drops
+        // the tiers the auto chain would not have entered by itself.
+        // `None` means there is nothing above lightpanda, so the escalation is
+        // skipped rather than dispatched: "auto" would re-render the same tier for
+        // the same thin result, and a pin the pool cannot satisfy only produces a
+        // misleading failure.
+        // Otherwise (http tier), pass the caller's pin through, or `None` so
+        // the chain decides and chrome is reached through the existing
+        // failover path.
+        let escalation_target: Option<&str> = if prior_renderer == Some("lightpanda") {
+            renderer.lightpanda_escalation_target()
+        } else {
+            pinned
+        };
+        let has_escalation_target =
+            escalation_target.is_some() || prior_renderer != Some("lightpanda");
         let should_escalate = (md_is_byte_thin || escalate_for_quality)
             && used_low_tier
             && !js_ladder_exhausted
             && should_escalate_status
             && escalation_eligible
-            && has_escalation_budget;
+            && has_escalation_budget
+            && has_escalation_target;
+        if (md_is_byte_thin || escalate_for_quality)
+            && used_low_tier
+            && should_escalate_status
+            && escalation_eligible
+            && has_escalation_budget
+            && !has_escalation_target
+        {
+            tracing::debug!(
+                url = %req.url,
+                pool = ?renderer.auto_ladder_names(),
+                "skipping JS escalation: no tier above lightpanda in this pool"
+            );
+            // Say so on the response as well. The thin body ships as a
+            // success, and without this line nothing tells the operator that
+            // the deployment has no browser tier to render the page with.
+            let skip_warning = "JS escalation skipped: no chrome tier is configured above \
+                                lightpanda; add one for full SPA rendering"
+                .to_string();
+            effective_warning = Some(match effective_warning {
+                Some(w) => format!("{w}; {skip_warning}"),
+                None => skip_warning,
+            });
+        }
         if (md_is_byte_thin || escalate_for_quality)
             && used_low_tier
             && should_escalate_status
@@ -450,16 +498,6 @@ async fn scrape_url_inner(
             );
         }
         if should_escalate {
-            // If the prior tier was lightpanda (returned 200 with thin/no content
-            // that fooled the renderer-level thinness check), force chrome on the
-            // escalation. Falling back to "auto" would just hit lightpanda again.
-            // Otherwise (http tier), let the chain decide so chrome can be reached
-            // through the existing failover path.
-            let escalation_target: Option<&str> = if prior_renderer == Some("lightpanda") {
-                Some("chrome")
-            } else {
-                pinned
-            };
             let quality_score_before = md_quality.as_ref().map(|q| q.score);
             tracing::info!(
                 url = %req.url,

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -1245,6 +1245,68 @@ impl FallbackRenderer {
         self.js_renderers.iter().map(|r| r.name()).collect()
     }
 
+    /// The JS tiers the auto chain may enter on its own, in construction order.
+    ///
+    /// Drops the two tiers a name-pin would otherwise smuggle past a gate
+    /// `fetch_with_js` applies:
+    ///
+    /// * camoufox held out by `include_in_auto = false`: an internally chosen
+    ///   escalation must not override a deliberate opt-out;
+    /// * chrome_proxy under `auto_egress_escalation`, where the chain lifts it
+    ///   out of the ladder and holds it as a hard-block-gated, load-shed
+    ///   recovery arm. Pinning it by name skips that gate and puts a paid
+    ///   residential render on every page instead of the blocked ones.
+    ///
+    /// This is construction order, not the per-request order: `fetch_with_js`
+    /// reorders for a host the preference learner has promoted, and filters for
+    /// a screenshot. Callers that need one tier should express which one they
+    /// want rather than trusting position alone.
+    pub fn auto_ladder_names(&self) -> Vec<&str> {
+        self.js_renderers
+            .iter()
+            .map(|r| r.name())
+            .filter(|name| *name != "chrome_proxy" || !self.auto_egress_escalation)
+            .filter(|name| {
+                #[cfg(feature = "camoufox")]
+                {
+                    *name != "camoufox" || self.camoufox_in_auto
+                }
+                #[cfg(not(feature = "camoufox"))]
+                {
+                    let _ = name;
+                    true
+                }
+            })
+            .collect()
+    }
+
+    /// Which tier a post-LightPanda escalation should aim at, or `None` when
+    /// this pool has nothing above lightpanda and the escalation should be
+    /// skipped rather than dispatched.
+    ///
+    /// chrome first, so a pool that holds it behaves exactly as the old
+    /// hardcoded target did, including for a host the preference learner has
+    /// promoted to chrome. Otherwise the next tier in [`Self::auto_ladder_names`],
+    /// which is what makes the escalation work on a deployment that runs no
+    /// Chrome sidecar instead of failing on a pin the pool cannot satisfy.
+    ///
+    /// playwright is never chosen: it has no `RendererKind`, so a render on it
+    /// carries no breaker, no `renderDecision` and no `creditCost`. It stays
+    /// reachable through the auto chain and an explicit pin, as before.
+    pub fn lightpanda_escalation_target(&self) -> Option<&str> {
+        let ladder = self.auto_ladder_names();
+        ladder
+            .iter()
+            .copied()
+            .find(|name| *name == "chrome")
+            .or_else(|| {
+                ladder
+                    .iter()
+                    .copied()
+                    .find(|name| *name != "lightpanda" && *name != "playwright")
+            })
+    }
+
     /// Whether this instance can actually capture a screenshot: at least one
     /// constructed JS renderer speaks CDP `Page.captureScreenshot`. Both the
     /// build features (no CDP feature ⇒ no tier is constructable) and the
@@ -3688,6 +3750,127 @@ mod tests {
             r.js_renderer_names(),
             vec!["lightpanda", "chrome", "chrome_proxy"]
         );
+    }
+
+    /// The escalation after a thin LightPanda body picks the first non-lightpanda
+    /// entry of `auto_ladder_names`. Pinning a fixed name instead dead-ends on any
+    /// pool that does not hold it, so these four shapes are what that choice has
+    /// to get right.
+    #[cfg(feature = "cdp")]
+    #[test]
+    fn lightpanda_escalation_target_picks_a_tier_the_pool_actually_holds() {
+        let ladder = |cfg: &RendererConfig| {
+            let r =
+                FallbackRenderer::new(cfg, "crw-test", None, &StealthConfig::default()).unwrap();
+            r.lightpanda_escalation_target().map(str::to_string)
+        };
+        let lp = || {
+            Some(CdpEndpoint {
+                ws_url: "ws://127.0.0.1:9222/".into(),
+            })
+        };
+        let ep = |p: &str| {
+            Some(CdpEndpoint {
+                ws_url: format!("ws://127.0.0.1:{p}/"),
+            })
+        };
+
+        // Production shape: chrome present, so the target is unchanged.
+        assert_eq!(
+            ladder(&RendererConfig {
+                mode: RendererMode::Auto,
+                lightpanda: lp(),
+                chrome: ep("9223"),
+                chrome_proxy: ep("9224"),
+                ..Default::default()
+            }),
+            Some("chrome".to_string())
+        );
+
+        // No chrome sidecar: the escalation must reach the tier that IS configured
+        // instead of failing on a pin the pool cannot satisfy.
+        assert_eq!(
+            ladder(&RendererConfig {
+                mode: RendererMode::Auto,
+                lightpanda: lp(),
+                chrome_proxy: ep("9224"),
+                ..Default::default()
+            }),
+            Some("chrome_proxy".to_string())
+        );
+        // playwright is untracked (no `RendererKind`), so it is not a target.
+        assert_eq!(
+            ladder(&RendererConfig {
+                mode: RendererMode::Auto,
+                lightpanda: lp(),
+                playwright: ep("9225"),
+                ..Default::default()
+            }),
+            None
+        );
+
+        // Nothing stronger than lightpanda: no target, so no unsatisfiable pin.
+        assert_eq!(
+            ladder(&RendererConfig {
+                mode: RendererMode::Auto,
+                lightpanda: lp(),
+                ..Default::default()
+            }),
+            None
+        );
+
+        // chrome stays the first choice even when it is not first in construction
+        // order, so a pool that already reached chrome keeps reaching chrome.
+        assert_eq!(
+            ladder(&RendererConfig {
+                mode: RendererMode::Auto,
+                lightpanda: lp(),
+                playwright: ep("9225"),
+                chrome: ep("9223"),
+                ..Default::default()
+            }),
+            Some("chrome".to_string())
+        );
+
+        // Under auto_egress_escalation the chain lifts chrome_proxy out of the
+        // ladder and gates it behind a hard block, so it must not become the
+        // escalation target: pinning it by name would skip that gate and put a
+        // paid residential render on every thin page.
+        assert_eq!(
+            ladder(&RendererConfig {
+                mode: RendererMode::Auto,
+                lightpanda: lp(),
+                chrome_proxy: ep("9224"),
+                auto_egress_escalation: true,
+                ..Default::default()
+            }),
+            None
+        );
+    }
+
+    /// A camoufox held out of the auto chain is constructed and pinnable, but an
+    /// internally chosen escalation must not reach it: naming it bypasses the
+    /// exclusion, which would override a deliberate `include_in_auto = false`.
+    #[cfg(all(feature = "cdp", feature = "camoufox"))]
+    #[test]
+    fn auto_ladder_names_respects_the_camoufox_opt_out() {
+        let with_lp = |include_in_auto: bool| {
+            let mut cfg = camoufox_cfg(RendererMode::Auto, include_in_auto);
+            cfg.lightpanda = Some(CdpEndpoint {
+                ws_url: "ws://127.0.0.1:9222/".into(),
+            });
+            FallbackRenderer::new(&cfg, "crw-test", None, &StealthConfig::default()).unwrap()
+        };
+
+        let held_out = with_lp(false);
+        assert!(
+            held_out.js_renderer_names().contains(&"camoufox"),
+            "the tier is still constructed so an explicit pin can reach it"
+        );
+        assert_eq!(held_out.auto_ladder_names(), vec!["lightpanda"]);
+
+        let in_chain = with_lp(true);
+        assert_eq!(in_chain.auto_ladder_names(), vec!["lightpanda", "camoufox"]);
     }
 
     /// The HTTP tier decodes every non-PDF body as HTML regardless of its


### PR DESCRIPTION
## The dead end

`scrape_url_inner` escalates after a thin LightPanda body and hardcodes the next tier:

https://github.com/us/crw/blob/c74bcf3/crates/crw-crawl/src/single.rs#L456-L462

```rust
let escalation_target: Option<&str> = if prior_renderer == Some("lightpanda") {
    Some("chrome")
} else {
    pinned
};
```

The pool has no tolerance for a name it does not hold — a pinned renderer that is absent is a hard error, not a fallback:

https://github.com/us/crw/blob/c74bcf3/crates/crw-renderer/src/lib.rs#L2401

```rust
"requested renderer '{}' not in pool [{}]"
```

Those two compose into a dead end on any deployment that runs no Chrome CDP sidecar. Every post-LightPanda escalation is pinned to a tier that cannot be constructed, so it fails on the *pin* rather than on the page — and stronger tiers that **are** configured and healthy (camoufox in particular) are never reached. The `else` arm already defers to the chain so the http tier can find chrome through the normal failover path; only the LightPanda arm is nailed shut.

## The change

`extraction.lightpanda_escalation_renderer`, `#[serde(default)]` → `"chrome"`. An install that does not set it is byte-identical to today; the only behaviour that changes is for a config that opts in. Env: `CRW_EXTRACTION__LIGHTPANDA_ESCALATION_RENDERER`.

## Why this is not visible upstream

Same shape as #485: a dead path that only a particular *deployment form* exposes. If you run the Chrome sidecar, the hardcoded name is always correct and the branch is invisible. It is only wrong for installs whose ladder tops out somewhere else, and those installs cannot report it as a renderer bug because the error surfaces as a pool-membership error, not a scrape failure.

## Tests

The sister key `lightpanda_retry_threshold_bytes` is covered by a default assertion and a TOML-override assertion; the new key gets one of each, in the same two tests:

- `config::tests::extraction_config_defaults` — asserts the default is `"chrome"`
- `config::tests::extraction_config_toml_scalar_overrides` — asserts a TOML override lands

```
$ cargo test -p crw-core
test result: ok. 499 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 13 passed; 0 failed (config_tests)
test result: ok. 2 passed; 0 failed (api_casing)
test result: ok. 3 passed; 0 failed (error_tests)
test result: ok. 21 passed; 0 failed (types_tests)

$ cargo fmt --check   # clean
$ cargo clippy --workspace --all-targets   # no new warnings
```

`cargo test -p crw-crawl --lib` is green except `pdf::tests::convert_pdf_bytes_*` (2), which fail identically on unmodified `c74bcf3` on this machine — a local pdfium/native-lib issue on Windows, not related to this change.