### PR TITLE
ci: build and test the camoufox tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,14 @@ jobs:
       - name: Test crw-server without the cdp feature
         run: cargo test -p crw-server
 
-      # `camoufox` is default-off in every crate, so `cargo test --workspace`
-      # never compiles the tier or its tests. Without this step the whole
-      # camoufox module, including its wall/challenge classification, is
-      # invisible to the gate.
-      - name: Test the camoufox tier
-        run: cargo test -p crw-renderer --features camoufox
+      # `camoufox` and `cloak` are default-off in every crate, so
+      # `cargo test --workspace` never compiles those tiers or their tests.
+      # Without this step the whole camoufox module, including its
+      # wall/challenge classification, is invisible to the gate. `cdp` is
+      # included because the tests that cover how these tiers interact with
+      # the ladder are gated on it too.
+      - name: Test the camoufox and cloak tiers
+        run: cargo test -p crw-renderer --features cdp,camoufox,cloak
 
   sdk-ts:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,13 @@ jobs:
       - name: Test crw-server without the cdp feature
         run: cargo test -p crw-server
 
+      # `camoufox` is default-off in every crate, so `cargo test --workspace`
+      # never compiles the tier or its tests. Without this step the whole
+      # camoufox module, including its wall/challenge classification, is
+      # invisible to the gate.
+      - name: Test the camoufox tier
+        run: cargo test -p crw-renderer --features camoufox
+
   sdk-ts:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
`camoufox` is default-off in `crw-renderer`, `crw-server` and `crw-cli`, and no workflow passes
the feature, so `cargo test --workspace` never compiles the module. Every test the tier has,
including its wall and challenge classification, is currently invisible to the gate.

Adds one step to the `check` job:

```yaml
- name: Test the camoufox tier
  run: cargo test -p crw-renderer --features camoufox
```

Local run on this branch: `cargo test -p crw-renderer --features camoufox` is 15 passed,
0 failed.

Standalone rather than folded into a feature branch, because the gap exists today and is worth
closing whether or not any particular camoufox change lands. Relevant to the review of #507,
whose tests this is what makes CI actually run.
