### PR TITLE
fix(renderer): give the chrome_proxy recovery arm time to finish

### DIFF
--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -554,11 +554,20 @@ pub const MIN_TIER_BUDGET: Duration = Duration::from_millis(500);
 /// hard-blocked scrapes (which would otherwise fail) pay the extra time, and the
 /// SaaS→engine fetch tolerates up to 120s (`crw-client.ts TIMEOUT_MS`).
 ///
-/// ponytail: the EFFECTIVE render budget is `min(this, chrome_nav_budget_ms)`
-/// (cdp.rs `nav_budget = self.nav_budget.min(deadline.remaining())`), and
-/// `chrome_nav_budget_ms` defaults to 12_000 — keep the two equal; raising this
-/// above `chrome_nav_budget_ms` does nothing until that also moves.
-pub(crate) const CHROME_PROXY_ARM_BUDGET_MS: u64 = 12_000;
+/// Sized from a live measurement (2026-09-08, `www.carfax.ca` behind Azure Front
+/// Door): a residential Chrome render of the page takes 12.3 to 16.3 s end to
+/// end, so the previous 12_000 ms let the arm finish on 2 of 11 attempts while a
+/// pinned `chrome_proxy` with a larger budget cleared the wall 6 of 6 times.
+/// 20 s covers the measured worst case with headroom. Only the hard-blocked
+/// tail pays for it: the arm never runs on a scrape the ladder already served.
+///
+/// ponytail: the EFFECTIVE render budget is `min(this, nav_budget)` (cdp.rs
+/// `nav_budget = self.nav_budget.min(deadline.remaining())`), which is why the
+/// chrome_proxy tier is built with `chrome_nav_budget_ms.max(this)` below.
+/// Raising this alone does nothing; raising `chrome_nav_budget_ms` would also
+/// slow the direct chrome tier on the hot path, so the max is applied to the
+/// proxy tier only.
+pub(crate) const CHROME_PROXY_ARM_BUDGET_MS: u64 = 20_000;
 
 // Concurrency permits for the chrome_proxy auto-egress recovery arm are sized to
 // `config.chrome_proxy_pool_size()` at construction (see `chrome_proxy_arm_sem`) —
@@ -923,7 +932,7 @@ impl FallbackRenderer {
                         config.chrome_proxy_pool_size(),
                     )
                     .with_user_agent(&effective_ua)
-                    .with_nav_budget(config.chrome_nav_budget_ms)
+                    .with_nav_budget(config.chrome_nav_budget_ms.max(CHROME_PROXY_ARM_BUDGET_MS))
                     .with_challenge_retries(
                         config
                             .chrome_challenge_max_retries


### PR DESCRIPTION
## What changed

- `CHROME_PROXY_ARM_BUDGET_MS` 12 s to 20 s in `crates/crw-renderer/src/lib.rs`.
- The `chrome_proxy` tier's navigation budget is `chrome_nav_budget_ms.max(CHROME_PROXY_ARM_BUDGET_MS)`, since the effective render budget is the smaller of the two. The direct `chrome` tier keeps `chrome_nav_budget_ms`.

## Why

Measured 2026-09-08 against `www.carfax.ca` (Azure Front Door 403 on every datacenter IP): the engine already classifies the page as a hard block and fires the residential recovery arm, but a residential Chrome render of that page takes 12.3 to 16.3 s end to end. With a 12 s arm the auto path succeeded on 2 of 11 attempts; with `chrome_proxy` pinned and a larger budget it succeeded 6 of 6 (7.7k characters of real markdown).

## Effect

- Non-blocked traffic: none. The arm only runs when the ladder already failed with a hard block.
- Hard-blocked requests that the arm now clears return content at ~20 to 23 s wall instead of a 403 at ~15 s. A caller `timeout` below that returns 504 as before.
- `chrome_proxy` pool permits are held up to 20 s instead of 12 s on those requests. Watch `render_route_decision_total{tier="chromeProxy",decision="armShed"}` after deploy.

ref #189
