### PR TITLE
fix(release): read the crate checksum from the sparse index

### DIFF
--- a/scripts/release/lib.sh
+++ b/scripts/release/lib.sh
@@ -34,12 +34,41 @@ crate_version_present() {
     | jq -e --arg v "$version" '.version.num == $v' >/dev/null 2>&1
 }
 
-# crates.io cksum for an existing version (sha256 of .crate file).
+# Sparse-index path for a crate name, per the registry index protocol:
+# 1 char -> `1/<name>`, 2 -> `2/<name>`, 3 -> `3/<first>/<name>`,
+# 4+ -> `<first two>/<next two>/<name>`. Names are lowercased in the index.
+crate_index_path() {
+  local name
+  name=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case ${#name} in
+    1) printf '1/%s' "$name" ;;
+    2) printf '2/%s' "$name" ;;
+    3) printf '3/%s/%s' "${name:0:1}" "$name" ;;
+    *) printf '%s/%s/%s' "${name:0:2}" "${name:2:2}" "$name" ;;
+  esac
+}
+
+# crates.io cksum for an existing version (sha256 of the .crate file), read from
+# the sparse index rather than the v1 API.
+#
+# The v1 API's `/crates/<name>/<version>` response no longer carries
+# `version.cksum` (verified 2026-09-10: absent for every crate queried), so the
+# old lookup silently returned an empty string. Because the caller compared that
+# empty value against the local sha directly, every idempotent re-publish failed
+# as a "content mismatch" and told the maintainer to bump the version. The
+# sparse index is the registry protocol itself and is where the checksum is
+# authoritative.
+#
+# Prints the checksum and returns 0 on success; prints nothing and returns 1
+# when the index or the version cannot be read, so the caller can tell "unknown"
+# apart from "different".
 crate_version_cksum() {
-  local crate="$1" version="$2"
-  curl -fsSL -H "User-Agent: crw-release" \
-    "https://crates.io/api/v1/crates/${crate}/${version}" 2>/dev/null \
-    | jq -r '.version.cksum // empty'
+  local crate="$1" version="$2" body sum
+  body=$(curl -fsSL --retry 3 --retry-connrefused -H "User-Agent: crw-release" \
+    "https://index.crates.io/$(crate_index_path "$crate")" 2>/dev/null) || return 1
+  sum=$(printf '%s' "$body" | jq -r --arg v "$version" 'select(.vers == $v) | .cksum' 2>/dev/null | head -1)
+  [ -n "$sum" ] || return 1
+  printf '%s' "$sum"
 }
 
 # Parse a workspace member's local version from its Cargo.toml.

--- a/scripts/release/publish_crate.sh
+++ b/scripts/release/publish_crate.sh
@@ -50,7 +50,18 @@ endgroup
 local_path="target/package/${crate}-${version}.crate"
 [ -f "$local_path" ] || die "expected $local_path after cargo package"
 local_sha=$(sha256sum "$local_path" | awk '{print $1}')
-remote_sha=$(crate_version_cksum "$crate" "$version")
+# An unreadable checksum is NOT evidence of a mismatch. Keeping the two apart
+# matters: the old code compared the local sha against whatever the lookup
+# returned, so an empty result failed the release with "content mismatch" and
+# told the maintainer to bump the version, for content that was in fact
+# identical. Say what is actually known instead.
+remote_sha=""
+if ! remote_sha=$(crate_version_cksum "$crate" "$version"); then
+  err "$crate@$version is already on crates.io but its checksum could not be read"
+  err "from the sparse index, so this run cannot confirm the upload matches."
+  err "Re-run once the index is reachable; do NOT bump the version on this alone."
+  exit 1
+fi
 if [ "$local_sha" != "$remote_sha" ]; then
   err "$crate@$version content mismatch — local=$local_sha remote=$remote_sha"
   err "crates.io is immutable; cannot republish. Bump the version."

--- a/scripts/release/test_guards.py
+++ b/scripts/release/test_guards.py
@@ -248,6 +248,158 @@ def test_audit_anti_vacuity(tmp_path):
     assert run_audit(tmp_path).returncode == 1
 
 
+# ── crates.io checksum lookup ────────────────────────────────────────────
+#
+# `publish_crate.sh` treats "already uploaded" as success only when the local
+# .crate sha matches the published one. The lookup used to read
+# `version.cksum` from the crates.io v1 API, and that field is no longer in the
+# response (verified 2026-09-10: absent for every crate). The helper returned an
+# empty string with rc 0, the caller compared it straight against the local sha,
+# and the v0.34.0 release died on "content mismatch — local=8e9006f... remote="
+# for content that was in fact byte-identical, telling the maintainer to bump the
+# version. These pin the two halves of that: the lookup must fail loudly rather
+# than return empty, and the caller must not call an unreadable checksum a
+# mismatch.
+#
+# `curl` and `cargo` are stubbed on PATH, so the REAL bash runs with no network.
+
+LIB = REPO / "scripts" / "release" / "lib.sh"
+PUBLISH_CRATE = REPO / "scripts" / "release" / "publish_crate.sh"
+
+INDEX_BODY = (
+    '{"name":"crw-mcp-proto","vers":"0.33.0","cksum":"aaaa","yanked":false}\n'
+    '{"name":"crw-mcp-proto","vers":"0.34.0","cksum":"bbbb","yanked":false}\n'
+)
+
+
+def _stub_bin(dirpath: Path, name: str, body: str) -> None:
+    """Put an executable stub on PATH."""
+    f = dirpath / name
+    _write(f, "#!/usr/bin/env bash\n" + body)
+    f.chmod(0o755)
+
+
+def _curl_stub(bindir: Path, index_body: str | None, present: bool = True) -> str:
+    """A curl that answers the index URL and the v1 API URL, and nothing else.
+
+    `index_body is None` simulates an unreachable index (curl -f exit 22). The
+    body is written to a file rather than inlined, so the stub stays free of
+    heredocs whose terminator would have to survive shell quoting.
+    """
+    if index_body is None:
+        serve_index = "exit 22"
+    else:
+        body_file = bindir / "index_body.txt"
+        _write(body_file, index_body)
+        serve_index = f'cat "{body_file}"'
+    num = '{"version":{"num":"0.34.0"}}' if present else '{"errors":[]}'
+    return f"""
+url="${{@: -1}}"
+case "$url" in
+  *index.crates.io*) {serve_index} ;;
+  *api/v1/crates*)   printf '%s' '{num}' ;;
+  *) exit 22 ;;
+esac
+"""
+
+
+def _cksum(tmp_path: Path, crate: str, version: str, index_body, present=True):
+    """Call the real `crate_version_cksum` with a stubbed curl."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    _stub_bin(bindir, "curl", _curl_stub(bindir, index_body, present))
+    env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    return subprocess.run(
+        ["bash", "-c", f'set -euo pipefail; source "{LIB}"; crate_version_cksum "{crate}" "{version}"'],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_crate_index_path_follows_the_registry_protocol(tmp_path):
+    out = subprocess.run(
+        ["bash", "-c", f'source "{LIB}"; for n in a ab abc crw-core CRW-Core; do crate_index_path "$n"; echo; done'],
+        capture_output=True, text=True,
+    ).stdout.split()
+    assert out == ["1/a", "2/ab", "3/a/abc", "cr/w-/crw-core", "cr/w-/crw-core"], out
+
+
+def test_crate_cksum_reads_the_requested_version_from_the_index(tmp_path):
+    r = _cksum(tmp_path, "crw-mcp-proto", "0.34.0", INDEX_BODY)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "bbbb", f"got {r.stdout!r} (must not pick another version)"
+
+
+def test_crate_cksum_fails_when_the_version_is_absent(tmp_path):
+    r = _cksum(tmp_path, "crw-mcp-proto", "9.9.9", INDEX_BODY)
+    assert r.returncode != 0, "an absent version must fail, not return empty-success"
+    assert r.stdout == "", r.stdout
+
+
+def test_crate_cksum_fails_when_the_index_is_unreachable(tmp_path):
+    r = _cksum(tmp_path, "crw-mcp-proto", "0.34.0", None)
+    assert r.returncode != 0, "an unreachable index must fail, not return empty-success"
+    assert r.stdout == "", r.stdout
+
+
+def test_unreadable_cksum_is_not_reported_as_a_content_mismatch(tmp_path):
+    """The v0.34.0 failure, pinned end to end through the real script."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    work = tmp_path / "work"
+    (work / "target" / "package").mkdir(parents=True, exist_ok=True)
+    _write(work / "target" / "package" / "crw-mcp-proto-0.34.0.crate", "payload")
+
+    _stub_bin(bindir, "curl", _curl_stub(bindir, None))  # index unreachable
+    _stub_bin(bindir, "cargo", """
+case "${1:-}" in
+  publish) echo "error: crate crw-mcp-proto@0.34.0 already exists on crates.io index" >&2; exit 101 ;;
+  package) exit 0 ;;
+  *) exit 0 ;;
+esac
+""")
+    env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    r = subprocess.run(
+        ["bash", str(PUBLISH_CRATE), "crw-mcp-proto", "0.34.0", "--source-dir", str(work)],
+        capture_output=True, text=True, env=env,
+    )
+    combined = r.stdout + r.stderr
+    assert r.returncode != 0, "an unverifiable upload must still fail the release"
+    assert "checksum could not be read" in combined, combined
+    assert "content mismatch" not in combined, "an unknown checksum is not a mismatch"
+    assert "Bump the version" not in combined, "must not advise bumping on an unreadable checksum"
+
+
+def test_matching_cksum_is_an_idempotent_skip(tmp_path):
+    """The happy path the v0.34.0 run should have taken."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    work = tmp_path / "work"
+    (work / "target" / "package").mkdir(parents=True, exist_ok=True)
+    crate_file = work / "target" / "package" / "crw-mcp-proto-0.34.0.crate"
+    _write(crate_file, "payload")
+    import hashlib
+
+    real = hashlib.sha256(crate_file.read_bytes()).hexdigest()
+    body = f'{{"name":"crw-mcp-proto","vers":"0.34.0","cksum":"{real}","yanked":false}}\n'
+
+    _stub_bin(bindir, "curl", _curl_stub(bindir, body))
+    _stub_bin(bindir, "cargo", """
+case "${1:-}" in
+  publish) echo "error: crate crw-mcp-proto@0.34.0 already exists on crates.io index" >&2; exit 101 ;;
+  package) exit 0 ;;
+  *) exit 0 ;;
+esac
+""")
+    env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    r = subprocess.run(
+        ["bash", str(PUBLISH_CRATE), "crw-mcp-proto", "0.34.0", "--source-dir", str(work)],
+        capture_output=True, text=True, env=env,
+    )
+    combined = r.stdout + r.stderr
+    assert r.returncode == 0, combined
+    assert "cksum matches" in combined, combined
+
+
 def _run_standalone() -> int:
     """Minimal runner so the suite works without pytest installed.
 


### PR DESCRIPTION
`publish_crate.sh` treats "already uploaded" as success only when the local
`.crate` sha matches the published one. That check has been silently broken:
crates.io's `/api/v1/crates/<name>/<version>` response no longer carries
`version.cksum`.

Checked against the live registry on 2026-09-10, the field is absent for every
crate:

```
$ curl -fsSL https://crates.io/api/v1/crates/crw-mcp-proto/0.34.0 | jq '.version.cksum'
null
```

So `crate_version_cksum` returned an empty string with rc 0, and the caller
compared it straight against the local sha. Every idempotent re-publish therefore
failed as a content mismatch. The v0.34.0 release (run 34490023731) died there:

```
error: crate crw-mcp-proto@0.34.0 already exists on crates.io index
crw-mcp-proto@0.34.0 content mismatch - local=8e9006f12b5e8da3434b167991cc75b6168e1c32f07eb17ee5b54201e00d3b3c remote=
crates.io is immutable; cannot republish. Bump the version.
```

The sparse index reports that same `8e9006f12b...` for the version, so the upload
matched and the run should have taken the idempotent-skip path. The advice to
bump the version was wrong, and would have burned a version number over a lookup
that simply failed.

## Change

- `crate_version_cksum` reads the checksum from `index.crates.io` (the registry
  index protocol, where the value is authoritative) instead of the v1 API, and
  returns non-zero when the index or the version cannot be read rather than
  printing nothing and succeeding. `crate_index_path` implements the documented
  1/2/3/4+ prefix layout.
- `publish_crate.sh` separates "unknown" from "different". An unverifiable upload
  still fails the release, because blessing it would defeat the guard, but it no
  longer reports a content mismatch or advises a version bump when the checksum
  could not be read.
- `crate_version_present` is unchanged: it reads `.version.num`, which the v1 API
  still returns.

## Tests

Six tests added to the existing guard suite (`scripts/release/test_guards.py`,
already run by CI). They stub `curl` and `cargo` on PATH so the real scripts run
with no network:

```
test_crate_index_path_follows_the_registry_protocol
test_crate_cksum_reads_the_requested_version_from_the_index
test_crate_cksum_fails_when_the_version_is_absent
test_crate_cksum_fails_when_the_index_is_unreachable
test_unreadable_cksum_is_not_reported_as_a_content_mismatch
test_matching_cksum_is_an_idempotent_skip
```

All six fail against the code on `main` and pass with this change; the suite is
14/14 locally.

## Deploy notes

Release-pipeline only, no engine or API surface is touched. The next release that
hits the already-uploaded path takes the idempotent-skip branch instead of
failing, which is what `publish-crates` needed on the last two runs.
