### PR TITLE
ci: pin npm to 11 in the release jobs and accept npm 12's view shape

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,9 +335,11 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       # Trusted publishing needs npm 11.5.1 or later; the npm bundled with
-      # Node 22 is older.
+      # Node 22 is older. Pinned to the 11 line: npm 12 changed the JSON shape
+      # of `npm view <pkg>@<version> <field> --json` (it wraps the value in an
+      # array), which the verify scripts read.
       - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Download and verify platform release assets
         shell: bash
@@ -592,9 +594,11 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       # Trusted publishing needs npm 11.5.1 or later; the npm bundled with
-      # Node 22 is older.
+      # Node 22 is older. Pinned to the 11 line: npm 12 changed the JSON shape
+      # of `npm view <pkg>@<version> <field> --json` (it wraps the value in an
+      # array), which the verify scripts read.
       - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Build + test
         shell: bash

--- a/scripts/release/verify_npm.sh
+++ b/scripts/release/verify_npm.sh
@@ -43,7 +43,9 @@ for p in crw-mcp crw-mcp-darwin-x64 crw-mcp-darwin-arm64 \
 done
 
 # 2. optionalDependencies pin assertion — catches stale pin sneak-through
-deps_json=$(npm view "crw-mcp@$v" optionalDependencies --json 2>/dev/null || echo '{}')
+# npm 12 wraps a single-version `view` result in an array; accept both shapes.
+deps_json=$(npm view "crw-mcp@$v" optionalDependencies --json 2>/dev/null \
+  | jq 'if type == "array" then .[0] // {} else . end' 2>/dev/null || echo '{}')
 for p in crw-mcp-darwin-x64 crw-mcp-darwin-arm64 \
          crw-mcp-linux-x64 crw-mcp-linux-arm64; do
   pin=$(printf '%s' "$deps_json" | jq -r --arg p "$p" '.[$p] // "MISSING"')


### PR DESCRIPTION
## What changed

- `release.yml`: the two npm jobs install `npm@11` instead of `npm@latest`. Trusted publishing needs 11.5.1 or later; npm 12 changed the JSON shape of `npm view <pkg>@<version> <field> --json` (it wraps the value in an array).
- `scripts/release/verify_npm.sh`: the `optionalDependencies` read accepts both the object and the array shape.

## Why

The v0.34.0 rerun published every package (all idempotent "already on npm") and then failed in the verify step with `jq: Cannot index array with string`, because the job had picked up npm 12. Verified locally: npm 11.17 returns an object, npm 12.0.2 returns a one-element array; the script passes against the published 0.34.0 with either.