### PR TITLE
docs: TLS-fingerprint walls, where the impersonated tier helps

### DIFF
--- a/docs/docs/js-rendering.md
+++ b/docs/docs/js-rendering.md
@@ -84,7 +84,7 @@ When `mode = "auto"` and you have multiple renderers configured (e.g., LightPand
 | `chrome_proxy` | Hard-pin to residential-proxy Chrome tier — no fallback |
 | `playwright` | Hard-pin to Playwright — no fallback |
 | `camoufox` | Hard-pin to the opt-in Camoufox stealth tier (REST) — no fallback. Requires a build with `--features camoufox` and a configured `[renderer.camoufox]` endpoint |
-| `impersonated-http` | Hard-pin to the Chrome-impersonating HTTP tier (real Chrome TLS/JA3/HTTP2 fingerprint via wreq, no JS engine), no fallback. Requires a build with `--features impersonated` (`GET /v1/capabilities` lists it when present); a wall-shaped result surfaces as an error rather than a billed success, while ordinary non-wall answers (a 404, a PDF, a thin page) come back as results |
+| `impersonated-http` | Hard-pin to the Chrome-impersonating HTTP tier (real Chrome TLS/JA3/HTTP2 fingerprint via wreq, no JS engine), no fallback. Requires a build with `--features impersonated` (`GET /v1/capabilities` lists it when present); a wall-shaped result surfaces as an error rather than a billed success, while ordinary non-wall answers (a 404, a PDF, a thin page) come back as results. See [TLS-fingerprint walls](/docs/tls-fingerprint-walls) for which site classes this helps with and how to tell a fingerprint wall from a JS gate or an IP-rate block |
 
 ### Pinned implies JS
 

--- a/docs/docs/tls-fingerprint-walls.md
+++ b/docs/docs/tls-fingerprint-walls.md
@@ -1,41 +1,80 @@
-# TLS-fingerprint walls
+<div class="page-intro">
+  <div class="page-kicker">Deploy</div>
+  <h1>TLS-fingerprint walls</h1>
+  <p class="page-subtitle">Some sites block non-browser clients by fingerprinting the connection itself. This page tells you which site shapes the <code>impersonated-http</code> tier clears, which ones need a browser, and how to tell the difference from your own egress.</p>
+  <div class="page-capabilities">
+    <div class="page-capability"><strong>Covers:</strong> scrape · renderer tiers · self-hosting</div>
+    <div class="page-capability"><strong>Verified against:</strong> crates/crw-renderer/src/impersonated.rs · crates/crw-renderer/src/detector.rs · live wall probes (September 2026)</div>
+  </div>
+</div>
 
-Some sites block non-browser HTTP clients by fingerprinting the connection itself: the TLS ClientHello (JA3/JA4), the HTTP/2 SETTINGS frame, and the header order and case are evaluated before the body is read. A wrong-looking fingerprint gets a wall: an HTTP 200 carrying a useless interstitial page, a short obfuscated JavaScript stub, or a bare 400/403. Changing the User-Agent does nothing, because the verdict was made at the handshake.
+Some sites reject non-browser HTTP clients before reading a single byte of the request: the TLS ClientHello (JA3/JA4), the HTTP/2 SETTINGS frame, and the header order and case are fingerprinted at the handshake, and a wrong-looking fingerprint gets a wall. Changing the `User-Agent` does nothing, because the verdict was already made.
 
-The `impersonated-http` renderer tier exists for these sites: a plain HTTP fetch presenting a real Chrome TLS/JA3/HTTP2 fingerprint, no browser and no JavaScript. In the auto chain it runs between the plain HTTP tier and the browser ladder, and only when the plain tier hit a wall-shaped response. See [JS rendering](/docs/js-rendering) for the tier's mechanics and pin semantics.
+The [`impersonated-http`](/docs/js-rendering) renderer tier exists for these sites: a plain HTTP fetch presenting a real Chrome TLS/JA3/HTTP2 fingerprint, with no browser and no JavaScript. In the auto chain it runs between the plain HTTP tier and the browser ladder, and only when the plain tier hit a wall-shaped response. This page is about *which sites* are in scope, because the pattern matters more than any specific domain: walls rotate.
 
-This page is about *which sites* are in scope. The pattern matters more than any specific domain, because walls rotate.
+## What the wall looks like
 
-## Three gate shapes
+**Symptom:** the scrape succeeds (`success: true`, HTTP 200) but the markdown is a useless stub: an interstitial page asking the reader to click a button, a few kilobytes of obfuscated JavaScript, or an error shell. The same URL renders fine in a browser, and `metadata.renderedWith` says `http`.
 
-**TLS-only gate.** The fingerprint is the whole check. Impersonation clears it and no browser is needed. Verified examples (September 2026, residential IP, plain client vs `impersonated-http` pin):
+That last field is the tell. A wall is not an error: the origin answers `200` and returns a page, so everything downstream of the fetcher sees a normal response. The auto chain detects the shape and escalates; `metadata.renderedWith` and `renderDecision` in the response tell you which tier ended up serving the page.
 
-- `amazon.it` product pages: the plain tier receives a 200 interstitial ("Fai clic sul pulsante qui sotto per continuare a fare acquisti"), the impersonated tier receives the real product page. The wall is per-request intermittent: the same plain client sometimes gets the real page, which is why the auto chain re-decides on every request.
-- Temu catalog pages: the plain tier receives a ~3KB obfuscated anti-bot stub, the impersonated tier the real page.
-- Public Facebook pages: the plain tier a 400 error page, the impersonated tier the real page.
+## Which sites are in scope
 
-**JavaScript gate.** The site serves the same shell or challenge to every client that does not execute JavaScript. Impersonation cannot help; the browser ladder is the right tier. Observed with identical responses on both clients: X, Booking.com (a script-based AWS WAF challenge), Zara, LinkedIn, Glassdoor, `www.reddit.com` (the old-reddit host serves plain HTML and needs neither).
+Sites split into three shapes when they block non-browser clients. Only the first is what `impersonated-http` fixes.
 
-**Combined gate.** A fingerprint vendor (DataDome, Akamai, PerimeterX) layers a JavaScript or cookie challenge on top of the TLS check. From a residential IP these often let both clients through; from datacenter IPs the wall engages and clearing the TLS half is necessary but not sufficient. Observed in this state: Vinted, Subito.it, AliExpress, Airbnb. Expect to pair the impersonated tier with a browser or a residential egress here.
+**TLS-only gate.** The fingerprint is the whole check; impersonation clears it and no browser is needed. Verified against the live walls in September 2026:
 
-**Not a fingerprint problem.** A block that returns the identical error to two different TLS stacks is an IP-rate or reputation block, not a fingerprint wall. eBay demonstrated this: fine in the morning, 403 for every client after heavy probing from the same address, self-healing with time. Impersonation is wasted budget on these; the fix is pacing, or a different egress.
+- `amazon.it` product pages: the plain tier receives a 200 interstitial, the impersonated tier the real product page. The wall is per-request intermittent, so the same plain client sometimes gets the real page, which is why the auto chain re-decides on every request.
+- Temu catalog pages: a ~3KB obfuscated anti-bot stub versus the real page.
+- Public Facebook pages: a 400 error page versus the real page.
 
-## Diagnosing a blocked site on your network
+**JavaScript gate.** The site serves the same shell or challenge to every client that does not execute JavaScript, fingerprint notwithstanding. Impersonation cannot help; a browser tier is the right answer. Sites observed answering both clients identically: X, Booking.com (a script-based AWS WAF challenge), Zara, LinkedIn, Glassdoor, `www.reddit.com` (the old-reddit host serves plain HTML and needs neither).
 
-The wall landscape depends on your egress IP, so test from wherever crw runs:
+**Combined gate.** A fingerprint vendor (DataDome, Akamai, PerimeterX) layers a JavaScript or cookie challenge on top of the TLS check. From a residential IP these often let both clients through; from datacenter egress the wall engages, and clearing the TLS half is necessary but not sufficient. Observed in this state: Vinted, Subito.it, AliExpress, Airbnb. Pair the impersonated tier with a browser or a residential egress here.
 
-1. Scrape the URL with `renderJs:false` and read `metadata.renderedWith` and the body. A 200 with a tiny body whose visible text is one "verify / continue shopping" sentence is a wall.
-2. Scrape again with `renderer:"impersonated-http"`.
-3. Compare. Real content from the pin means a TLS-only gate and the auto chain will handle it unattended. The same wall from the pin means the site wants JavaScript or cookies; use a browser tier. The same error from both means rate limiting; slow down.
+> **Not a fingerprint problem.** A block that returns the identical error to two
+> different TLS stacks is an IP-rate or reputation block, not a fingerprint wall.
+> eBay behaves this way under heavy probing from one address: the same 403 for
+> every client, self-healing with time. Impersonation is wasted budget on these;
+> the fix is pacing, or a different egress.
 
-`GET /v1/capabilities` lists `impersonated-http` when the build and config enable it.
+## Diagnose from your own egress
 
-## Detector scope and how to extend it
+The wall landscape depends on the IP crw egresses from, so test from wherever your instance runs:
 
-Escalation into the tier is driven by the wall detectors, and the phrase list is deliberately narrow: only interstitial sentences verified against a live wall are listed, because a false wall escalates to browsers and can latch the host to proxy egress. As of v0.35.1 the list carries the verified it-IT Amazon sentence; the English "click the button below to continue shopping" is deliberately absent, since it is ordinary retail copy (empty-cart and order-confirmation pages carry it verbatim) and was never verified against a live wall.
+1. Scrape the URL with `renderJs:false` and read `metadata.renderedWith` and the body. A 200 with a tiny body whose visible text is one "verify" or "continue shopping" sentence is a wall.
+2. Scrape again with `renderer:"impersonated-http"`:
+3. Compare. Real content from the pin means a TLS-only gate, and the auto chain will handle it unattended. The same wall from the pin means the site wants JavaScript or cookies; use a browser tier. The same error from both means rate limiting; slow down.
+
+```bash
+# cURL — step 2: the impersonated pin (managed cloud)
+curl -X POST https://api.fastcrw.com/v1/scrape \
+  -H "Authorization: Bearer $CRW_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.example-walled.com/product/123",
+    "renderer": "impersonated-http"
+  }'
+```
+
+```bash
+# cURL — self-hosted: same call against your own instance
+curl -X POST http://localhost:3030/v1/scrape \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.example-walled.com/product/123",
+    "renderer": "impersonated-http"
+  }'
+```
+
+`GET /v1/capabilities` lists `impersonated-http` when the build and config enable it, so a client can gate the pin before sending traffic.
+
+## Extending the wall detector
+
+Escalation into the tier is driven by the wall detectors, and the phrase list is deliberately narrow: only interstitial sentences verified against a live wall are listed, because a false wall escalates to browsers and can latch the host to proxy egress. As of v0.35.1 the list carries the verified it-IT Amazon sentence; the English "click the button below to continue shopping" is deliberately absent, since it is ordinary retail copy that empty-cart and order-confirmation pages carry verbatim.
 
 To cover another marketplace: capture the interstitial its wall actually serves in your locale (the plain-tier body), confirm the sentence is unique to the wall and not normal copy on real pages, then open a PR adding that exact sentence plus a positive test with the captured fixture and a negative test with a real page that quotes it.
 
-## Preset maintenance
+## When the fingerprint ages
 
-The tier impersonates a pinned Chrome version. When sites start rejecting that fingerprint, the failure mode is a graceful fall-through to the browser ladder, not an error. The `#[ignore]` live tests in `crates/crw-renderer/src/impersonated.rs` are the sentinel: they fail when the pinned preset stops clearing a known wall, which is the signal to bump the preset.
+The tier impersonates a pinned Chrome version, and sites eventually start rejecting old fingerprints. The failure mode is graceful: the hop's result fails the accept gate and the chain falls through to the browser ladder, so pages keep working, slower. The `#[ignore]` live tests in `crates/crw-renderer/src/impersonated.rs` are the sentinel: they fail when the pinned preset stops clearing a known wall, which is the signal to bump the preset.

--- a/docs/docs/tls-fingerprint-walls.md
+++ b/docs/docs/tls-fingerprint-walls.md
@@ -1,0 +1,41 @@
+# TLS-fingerprint walls
+
+Some sites block non-browser HTTP clients by fingerprinting the connection itself: the TLS ClientHello (JA3/JA4), the HTTP/2 SETTINGS frame, and the header order and case are evaluated before the body is read. A wrong-looking fingerprint gets a wall: an HTTP 200 carrying a useless interstitial page, a short obfuscated JavaScript stub, or a bare 400/403. Changing the User-Agent does nothing, because the verdict was made at the handshake.
+
+The `impersonated-http` renderer tier exists for these sites: a plain HTTP fetch presenting a real Chrome TLS/JA3/HTTP2 fingerprint, no browser and no JavaScript. In the auto chain it runs between the plain HTTP tier and the browser ladder, and only when the plain tier hit a wall-shaped response. See [JS rendering](/docs/js-rendering) for the tier's mechanics and pin semantics.
+
+This page is about *which sites* are in scope. The pattern matters more than any specific domain, because walls rotate.
+
+## Three gate shapes
+
+**TLS-only gate.** The fingerprint is the whole check. Impersonation clears it and no browser is needed. Verified examples (September 2026, residential IP, plain client vs `impersonated-http` pin):
+
+- `amazon.it` product pages: the plain tier receives a 200 interstitial ("Fai clic sul pulsante qui sotto per continuare a fare acquisti"), the impersonated tier receives the real product page. The wall is per-request intermittent: the same plain client sometimes gets the real page, which is why the auto chain re-decides on every request.
+- Temu catalog pages: the plain tier receives a ~3KB obfuscated anti-bot stub, the impersonated tier the real page.
+- Public Facebook pages: the plain tier a 400 error page, the impersonated tier the real page.
+
+**JavaScript gate.** The site serves the same shell or challenge to every client that does not execute JavaScript. Impersonation cannot help; the browser ladder is the right tier. Observed with identical responses on both clients: X, Booking.com (a script-based AWS WAF challenge), Zara, LinkedIn, Glassdoor, `www.reddit.com` (the old-reddit host serves plain HTML and needs neither).
+
+**Combined gate.** A fingerprint vendor (DataDome, Akamai, PerimeterX) layers a JavaScript or cookie challenge on top of the TLS check. From a residential IP these often let both clients through; from datacenter IPs the wall engages and clearing the TLS half is necessary but not sufficient. Observed in this state: Vinted, Subito.it, AliExpress, Airbnb. Expect to pair the impersonated tier with a browser or a residential egress here.
+
+**Not a fingerprint problem.** A block that returns the identical error to two different TLS stacks is an IP-rate or reputation block, not a fingerprint wall. eBay demonstrated this: fine in the morning, 403 for every client after heavy probing from the same address, self-healing with time. Impersonation is wasted budget on these; the fix is pacing, or a different egress.
+
+## Diagnosing a blocked site on your network
+
+The wall landscape depends on your egress IP, so test from wherever crw runs:
+
+1. Scrape the URL with `renderJs:false` and read `metadata.renderedWith` and the body. A 200 with a tiny body whose visible text is one "verify / continue shopping" sentence is a wall.
+2. Scrape again with `renderer:"impersonated-http"`.
+3. Compare. Real content from the pin means a TLS-only gate and the auto chain will handle it unattended. The same wall from the pin means the site wants JavaScript or cookies; use a browser tier. The same error from both means rate limiting; slow down.
+
+`GET /v1/capabilities` lists `impersonated-http` when the build and config enable it.
+
+## Detector scope and how to extend it
+
+Escalation into the tier is driven by the wall detectors, and the phrase list is deliberately narrow: only interstitial sentences verified against a live wall are listed, because a false wall escalates to browsers and can latch the host to proxy egress. As of v0.35.1 the list carries the verified it-IT Amazon sentence; the English "click the button below to continue shopping" is deliberately absent, since it is ordinary retail copy (empty-cart and order-confirmation pages carry it verbatim) and was never verified against a live wall.
+
+To cover another marketplace: capture the interstitial its wall actually serves in your locale (the plain-tier body), confirm the sentence is unique to the wall and not normal copy on real pages, then open a PR adding that exact sentence plus a positive test with the captured fixture and a negative test with a real page that quotes it.
+
+## Preset maintenance
+
+The tier impersonates a pinned Chrome version. When sites start rejecting that fingerprint, the failure mode is a graceful fall-through to the browser ladder, not an error. The `#[ignore]` live tests in `crates/crw-renderer/src/impersonated.rs` are the sentinel: they fail when the pinned preset stops clearing a known wall, which is the signal to bump the preset.

--- a/docs/site.config.js
+++ b/docs/site.config.js
@@ -120,6 +120,7 @@ export default {
         { title: "Configuration", slug: "configuration", icon: "settings" },
         { title: "Hardening", slug: "self-hosting-hardening", icon: "alert" },
         { title: "JS Rendering", slug: "js-rendering", icon: "zap" },
+        { title: "TLS-fingerprint walls", slug: "tls-fingerprint-walls", icon: "shield" },
         { title: "Proxies", slug: "proxies", icon: "shield" },
       ],
     },


### PR DESCRIPTION
Follow-up to #527, documentation only.

While validating the impersonated-http tier I ran an A/B probe (plain HTTP vs the impersonated pin, same egress) across the site classes people actually ask about, and the result is worth shipping as a page rather than staying in a PR thread: the wall landscape splits into three gate shapes, and only one of them is what the tier fixes.

The new page (`docs/tls-fingerprint-walls.md`, linked from the JS-rendering pin table) covers:

- **The three gate shapes**, with verified examples and dates: TLS-only gates (amazon.it's interstitial, Temu's obfuscated stub, Facebook's 400-on-plain), JavaScript gates where impersonation cannot help (X, Booking's script challenge, Zara, LinkedIn, Glassdoor, www.reddit.com), and combined vendor gates (DataDome/Akamai) that only engage fully from datacenter egress.
- **The anti-pattern**: a block returning the identical error to two different TLS stacks is an IP-rate block (eBay demonstrated it live during the probe), and impersonation is wasted budget there.
- **A three-step diagnosis** runnable from whatever egress a deployment uses, since the landscape is egress-dependent.
- **The extension recipe** for other marketplaces: capture the wall's actual interstitial sentence, verify it is unique to the wall (the English "click the button below to continue shopping" is deliberately absent because empty-cart pages carry it verbatim), then add the exact sentence with positive and negative fixtures. This is the same discipline #527 applied to the it-IT phrase.
- **Preset maintenance**: the graceful fall-through behavior when the pinned Chrome fingerprint ages, and the `#[ignore]` live tests as the sentinel.

Local checks: `scripts/docs-guards.sh` and `scripts/check-doc-links.sh` pass (the page is registered in `docs/site.config.js`; 50 known slugs, no broken links).
