### PR TITLE
fix(extract): stop corrupting markdown for non-HTML sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crw-browse"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "crw-cli"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "crw-core"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "config",
  "crw-mcp-proto",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "crw-crawl"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "crw-core",
  "crw-diff",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "crw-diff"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "crw-core",
  "hex",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "crw-extract"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "crw-core",
  "ego-tree",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "crw-mcp-proto"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "jsonschema",
  "serde",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "crw-renderer"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "crw-search"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "crw-core",
  "futures",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "crw-server"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "axum",
  "axum-test",

--- a/crates/crw-core/src/lib.rs
+++ b/crates/crw-core/src/lib.rs
@@ -35,3 +35,4 @@ pub use error::{CrwError, CrwResult};
 pub use proxy::{ProxyEntry, ProxyRotation, ProxyRotator, redact_proxy_url};
 pub use reserved_sem::{BatchGate, LanePermit, ReservedSemaphore};
 pub use scrape_class::{REQUEST_CLASS, ScrapeClass, current_scrape_class};
+pub use types::is_html_like_content_type;

--- a/crates/crw-core/src/types.rs
+++ b/crates/crw-core/src/types.rs
@@ -1203,6 +1203,27 @@ pub fn resolve_pinned_renderer(req: Option<RequestedRenderer>) -> Option<&'stati
     req.and_then(|r| r.pinned_name())
 }
 
+/// Is this declared content type actually HTML (or HTML-like markup)?
+///
+/// Shared by the renderer (deciding whether a browser render can add
+/// anything to a body) and the extractor (deciding whether it is safe to run
+/// an HTML parser / HTML-to-markdown converter over the body at all). Absent
+/// or unrecognised types stay eligible: a server that omits `Content-Type`
+/// is still overwhelmingly likely to be serving HTML.
+pub fn is_html_like_content_type(content_type: Option<&str>) -> bool {
+    match content_type {
+        None => true,
+        Some(ct) => {
+            let ct = ct.trim().to_ascii_lowercase();
+            ct.is_empty()
+                || ct == "text/html"
+                || ct == "application/xhtml+xml"
+                || ct == "application/xml"
+                || ct == "text/xml"
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/crw-crawl/src/crawl.rs
+++ b/crates/crw-crawl/src/crawl.rs
@@ -451,6 +451,7 @@ async fn run_crawl_inner(opts: CrawlOptions<'_>) {
             // async fan-out.
             match crate::extract_pool::extract_offloaded(crw_extract::OwnedExtractInput {
                 raw_html: fetch_result.html.clone(),
+                content_type: fetch_result.content_type.clone(),
                 source_url: fetch_result.url.clone(),
                 status_code: fetch_result.status_code,
                 rendered_with: fetch_result.rendered_with.clone(),

--- a/crates/crw-crawl/src/single.rs
+++ b/crates/crw-crawl/src/single.rs
@@ -275,6 +275,7 @@ async fn scrape_url_inner(
     ) -> crw_extract::OwnedExtractInput {
         crw_extract::OwnedExtractInput {
             raw_html: fr.html.clone(),
+            content_type: fr.content_type.clone(),
             source_url: fr.url.clone(),
             status_code: fr.status_code,
             rendered_with: fr.rendered_with.clone(),

--- a/crates/crw-extract/examples/check_prepend.rs
+++ b/crates/crw-extract/examples/check_prepend.rs
@@ -11,6 +11,7 @@ fn main() {
     </body></html>"##;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://www.raspberrypi.com/news/x/",
         status_code: 200,
         rendered_with: Some("http".into()),

--- a/crates/crw-extract/examples/offline_corpus.rs
+++ b/crates/crw-extract/examples/offline_corpus.rs
@@ -35,6 +35,7 @@ fn main() {
         } else {
             crw_extract::extract(ExtractOptions {
                 raw_html: html,
+                content_type: None,
                 source_url: url,
                 status_code: 200,
                 rendered_with: Some("http".into()),

--- a/crates/crw-extract/src/lib.rs
+++ b/crates/crw-extract/src/lib.rs
@@ -99,6 +99,11 @@ pub mod summary;
 /// Options for the high-level extraction pipeline.
 pub struct ExtractOptions<'a> {
     pub raw_html: &'a str,
+    /// Declared response content type, e.g. `Some("text/plain")`. `None` when
+    /// unknown. Used to decide whether `raw_html` is safe to run through an
+    /// HTML parser / HTML-to-markdown converter at all — see
+    /// `crw_core::is_html_like_content_type`.
+    pub content_type: Option<&'a str>,
     pub source_url: &'a str,
     pub status_code: u16,
     pub rendered_with: Option<String>,
@@ -158,6 +163,7 @@ pub struct ExtractOptions<'a> {
 /// existing borrow-caller keeps compiling; this is purely additive.
 pub struct OwnedExtractInput {
     pub raw_html: String,
+    pub content_type: Option<String>,
     pub source_url: String,
     pub status_code: u16,
     pub rendered_with: Option<String>,
@@ -194,6 +200,7 @@ impl OwnedExtractInput {
     pub fn as_opts(&self) -> ExtractOptions<'_> {
         ExtractOptions {
             raw_html: &self.raw_html,
+            content_type: self.content_type.as_deref(),
             source_url: &self.source_url,
             status_code: self.status_code,
             rendered_with: self.rendered_with.clone(),
@@ -393,6 +400,7 @@ static TRAILING_LIST_ITEM: once_cell::sync::Lazy<regex::Regex> = once_cell::sync
 pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     let ExtractOptions {
         raw_html,
+        content_type,
         source_url,
         status_code,
         rendered_with,
@@ -432,70 +440,95 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         };
     let css_selector = css_selector.or(domain_selector_owned.as_deref());
 
+    // A declared non-HTML content type (text/plain, application/json, ...)
+    // means `raw_html` is NOT markup — it is the literal response body. The
+    // HTTP tier decodes every non-PDF response through this same pipeline
+    // regardless of its declared type, so running html5ever + the HTML-to-
+    // markdown converter over it corrupts the body: htmd escapes any
+    // markdown-metacharacter byte (backticks, `#`, `*`, ...) it finds in a
+    // "text node" and HTML's whitespace-collapse rules merge newlines into
+    // spaces, destroying fenced code blocks and paragraph structure in a way
+    // no response-side repair can undo (crw#530). Skip the HTML pipeline
+    // entirely and treat the body as already-final text for every format.
+    let treat_as_plain = !crw_core::is_html_like_content_type(content_type);
+
     // Step 1: Extract metadata from raw HTML.
     let meta = readability::extract_metadata(raw_html);
 
-    // Step 2: Clean HTML (remove boilerplate, nav, ads, etc.).
-    // `include_tags` narrowing happens inside clean_html; when it matches
-    // nothing, clean_html empties the output and pushes `selector_no_match`.
-    // Capture that here (via the warning delta this call produced) so the rest
-    // of the pipeline can treat it exactly like an unmatched css/xpath selector.
-    let warns_before = warnings.len();
-    let cleaned = clean::clean_html_with_warnings(
-        raw_html,
-        only_main_content,
-        include_tags,
-        exclude_tags,
-        &mut warnings,
-    )
-    .unwrap_or_else(|_| raw_html.to_string());
-    let include_tags_no_match = warnings[warns_before..]
-        .iter()
-        .any(|w| w == "selector_no_match");
-
-    // Step 3: Apply CSS/XPath selector if provided (narrows to a specific element).
-    let selected_html = apply_selector(&cleaned, css_selector, xpath)?;
-    // A user-requested narrowing that matched nothing must NOT fall back to the
-    // whole page (a silent context-bloat footgun: an unmatched `--css`/`--xpath`
-    // or `includeTags` previously returned the entire document). Treat it as an
-    // intentional narrow extraction that yielded empty output. `Some("")` also
-    // short-circuits the alternates ladder below, so the whole page can't sneak
-    // back in via the basic_clean fallback.
-    // Domain-configured default selectors are excluded: a host default that
-    // doesn't apply should still show the page (its no-match sets neither flag).
-    let selected_html = if include_tags_no_match {
-        // include_tags matched nothing, so `cleaned` is already empty. This
-        // takes precedence over any css/xpath applied afterwards: an xpath
-        // scalar like `count(//x)` would otherwise evaluate to "0" against the
-        // empty document and leak a bogus value. clean_html already pushed the
-        // `selector_no_match` warning, so don't push it again.
-        Some(String::new())
-    } else if user_selected && selected_html.is_none() {
-        warnings.push("selector_no_match".to_string());
-        Some(String::new())
+    // Steps 2-4 (clean / selector / readability narrowing) only make sense on
+    // real markup. For a non-HTML body, `raw_html` already IS the content —
+    // none of the markup-aware selection below has anything to select against.
+    let (content_html, cleaned_ref, had_selection, include_tags_no_match) = if treat_as_plain {
+        (raw_html.to_string(), None, false, false)
     } else {
-        selected_html
-    };
-    let after_selection = selected_html.as_deref().unwrap_or(&cleaned);
+        // Step 2: Clean HTML (remove boilerplate, nav, ads, etc.).
+        // `include_tags` narrowing happens inside clean_html; when it matches
+        // nothing, clean_html empties the output and pushes `selector_no_match`.
+        // Capture that here (via the warning delta this call produced) so the rest
+        // of the pipeline can treat it exactly like an unmatched css/xpath selector.
+        let warns_before = warnings.len();
+        let cleaned = clean::clean_html_with_warnings(
+            raw_html,
+            only_main_content,
+            include_tags,
+            exclude_tags,
+            &mut warnings,
+        )
+        .unwrap_or_else(|_| raw_html.to_string());
+        let include_tags_no_match = warnings[warns_before..]
+            .iter()
+            .any(|w| w == "selector_no_match");
 
-    // Step 4: If only_main_content, try to narrow further with readability scoring.
-    let (content_html, cleaned_ref) = if only_main_content && selected_html.is_none() {
-        match readability::extract_main_content_with_provenance(after_selection) {
-            readability::ReadabilityOutcome::Selected { html: main, .. } => {
-                // Re-clean: readability may have selected a broad container
-                // (e.g. <article>) that still contains noise elements
-                // (infobox, navbox, catlinks, etc.).
-                let re_cleaned = clean::clean_html(&main, true, &[], &[]).unwrap_or(main);
-                (re_cleaned, Some(cleaned))
+        // Step 3: Apply CSS/XPath selector if provided (narrows to a specific element).
+        let selected_html = apply_selector(&cleaned, css_selector, xpath)?;
+        // A user-requested narrowing that matched nothing must NOT fall back to the
+        // whole page (a silent context-bloat footgun: an unmatched `--css`/`--xpath`
+        // or `includeTags` previously returned the entire document). Treat it as an
+        // intentional narrow extraction that yielded empty output. `Some("")` also
+        // short-circuits the alternates ladder below, so the whole page can't sneak
+        // back in via the basic_clean fallback.
+        // Domain-configured default selectors are excluded: a host default that
+        // doesn't apply should still show the page (its no-match sets neither flag).
+        let selected_html = if include_tags_no_match {
+            // include_tags matched nothing, so `cleaned` is already empty. This
+            // takes precedence over any css/xpath applied afterwards: an xpath
+            // scalar like `count(//x)` would otherwise evaluate to "0" against the
+            // empty document and leak a bogus value. clean_html already pushed the
+            // `selector_no_match` warning, so don't push it again.
+            Some(String::new())
+        } else if user_selected && selected_html.is_none() {
+            warnings.push("selector_no_match".to_string());
+            Some(String::new())
+        } else {
+            selected_html
+        };
+        let after_selection = selected_html.as_deref().unwrap_or(&cleaned);
+
+        // Step 4: If only_main_content, try to narrow further with readability scoring.
+        let (content_html, cleaned_ref) = if only_main_content && selected_html.is_none() {
+            match readability::extract_main_content_with_provenance(after_selection) {
+                readability::ReadabilityOutcome::Selected { html: main, .. } => {
+                    // Re-clean: readability may have selected a broad container
+                    // (e.g. <article>) that still contains noise elements
+                    // (infobox, navbox, catlinks, etc.).
+                    let re_cleaned = clean::clean_html(&main, true, &[], &[]).unwrap_or(main);
+                    (re_cleaned, Some(cleaned))
+                }
+                readability::ReadabilityOutcome::Rejected { .. } => {
+                    // Listing root or empty body — skip readability and let the
+                    // alternates ladder pick from cleaned / basic-clean.
+                    (cleaned.clone(), Some(cleaned))
+                }
             }
-            readability::ReadabilityOutcome::Rejected { .. } => {
-                // Listing root or empty body — skip readability and let the
-                // alternates ladder pick from cleaned / basic-clean.
-                (cleaned.clone(), Some(cleaned))
-            }
-        }
-    } else {
-        (after_selection.to_string(), None)
+        } else {
+            (after_selection.to_string(), None)
+        };
+        (
+            content_html,
+            cleaned_ref,
+            selected_html.is_some(),
+            include_tags_no_match,
+        )
     };
 
     // Step 5: Produce requested formats. `Summary` also needs markdown
@@ -505,111 +538,117 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
         || formats.contains(&OutputFormat::Json)
         || formats.contains(&OutputFormat::Summary)
     {
-        let primary_md = markdown::html_to_markdown_with(&content_html, normalize_tables);
-        let primary_quality = quality::analyze_md_only(&primary_md);
-
-        // Skip alternates when a selector was explicitly used (short output is
-        // intentional) or when the primary extraction is healthy.
-        // Threshold 0.4 (not 0.6) — readability output that scores 0.4+ is
-        // good enough; running alternates on it tends to swap in basic_clean
-        // (whole-body) which boosts word count but reintroduces nav noise.
-        if selected_html.is_some() || primary_quality.score > 0.4 {
-            Some(primary_md)
+        if treat_as_plain {
+            // Not HTML — `content_html` (== raw_html) is already the final
+            // body. Do not run it through an HTML-to-markdown converter.
+            Some(content_html.clone())
         } else {
-            let mut candidates: Vec<(&'static str, String, quality::Quality)> = Vec::new();
+            let primary_md = markdown::html_to_markdown_with(&content_html, normalize_tables);
+            let primary_quality = quality::analyze_md_only(&primary_md);
 
-            // Alt 1: cleaned HTML (only_main_content path bypasses readability).
-            if only_main_content && let Some(c) = cleaned_ref.as_ref() {
-                let m = markdown::html_to_markdown_with(c, normalize_tables);
-                let q = quality::analyze_md_only(&m);
-                candidates.push(("cleaned", m, q));
-            }
+            // Skip alternates when a selector was explicitly used (short output is
+            // intentional) or when the primary extraction is healthy.
+            // Threshold 0.4 (not 0.6) — readability output that scores 0.4+ is
+            // good enough; running alternates on it tends to swap in basic_clean
+            // (whole-body) which boosts word count but reintroduces nav noise.
+            if had_selection || primary_quality.score > 0.4 {
+                Some(primary_md)
+            } else {
+                let mut candidates: Vec<(&'static str, String, quality::Quality)> = Vec::new();
 
-            // Alt 2: whole-page clean without only_main_content, i.e. the page
-            // with its nav/footer intact. It is the rescue candidate for pages
-            // where readability narrows onto the wrong container.
-            //
-            // Known wart: because the quality score rewards word count, that
-            // boilerplate bulk is also what lets this candidate win on
-            // page-builder sites, which is how a mega menu reaches the markdown
-            // even for onlyMainContent requests. Making it honour
-            // only_main_content fixes those pages but costs recall on the
-            // frozen 1000-URL set (0.3828 -> 0.3651), so it is left alone here.
-            let basic_cleaned = clean::clean_html_with_warnings(
-                raw_html,
-                false,
-                include_tags,
-                exclude_tags,
-                &mut warnings,
-            )
-            .unwrap_or_else(|_| raw_html.to_string());
-            let basic_md = markdown::html_to_markdown_with(&basic_cleaned, normalize_tables);
-            let basic_q = quality::analyze_md_only(&basic_md);
-            candidates.push(("basic_clean", basic_md, basic_q));
-
-            // No structural table/list alternate. It harvested <ul>/<table>
-            // straight out of raw_html, and its only guard was an ancestor tag
-            // check for nav/footer/header — which page builders sail past,
-            // since Elementor and friends render menus as plain <div><ul>. On
-            // an Elementor product page it was the winning candidate and put
-            // 118 nav links into the markdown. Measured contribution across a
-            // labelled corpus: none (identical recall with and without).
-            // Alt 4: XHR/fetch JSON capture — recursively walk every captured
-            // JSON body and gather long text fields. Useful when the article
-            // body lives in an API response loaded after `loadEventFired`
-            // (newsroom feeds, infinite-scroll, paywall-shielded prose).
-            if let Some(xhr_md) = extract_xhr_text(captured_responses) {
-                let q = quality::analyze_md_only(&xhr_md);
-                candidates.push(("xhr_json", xhr_md, q));
-            }
-
-            // Alt 5: plaintext fallback.
-            let plain_md = {
-                let text = plaintext::html_to_plaintext(&content_html);
-                if text.trim().is_empty() {
-                    plaintext::html_to_plaintext(&basic_cleaned)
-                } else {
-                    text
+                // Alt 1: cleaned HTML (only_main_content path bypasses readability).
+                if only_main_content && let Some(c) = cleaned_ref.as_ref() {
+                    let m = markdown::html_to_markdown_with(c, normalize_tables);
+                    let q = quality::analyze_md_only(&m);
+                    candidates.push(("cleaned", m, q));
                 }
-            };
-            let plain_q = quality::analyze_md_only(&plain_md);
-            candidates.push(("plaintext", plain_md, plain_q));
 
-            // Include the primary at the head of the candidate list.
-            candidates.insert(0, ("primary", primary_md, primary_quality));
+                // Alt 2: whole-page clean without only_main_content, i.e. the page
+                // with its nav/footer intact. It is the rescue candidate for pages
+                // where readability narrows onto the wrong container.
+                //
+                // Known wart: because the quality score rewards word count, that
+                // boilerplate bulk is also what lets this candidate win on
+                // page-builder sites, which is how a mega menu reaches the markdown
+                // even for onlyMainContent requests. Making it honour
+                // only_main_content fixes those pages but costs recall on the
+                // frozen 1000-URL set (0.3828 -> 0.3651), so it is left alone here.
+                let basic_cleaned = clean::clean_html_with_warnings(
+                    raw_html,
+                    false,
+                    include_tags,
+                    exclude_tags,
+                    &mut warnings,
+                )
+                .unwrap_or_else(|_| raw_html.to_string());
+                let basic_md = markdown::html_to_markdown_with(&basic_cleaned, normalize_tables);
+                let basic_q = quality::analyze_md_only(&basic_md);
+                candidates.push(("basic_clean", basic_md, basic_q));
 
-            // Primary-biased pick: keep primary unless an alternate beats it by
-            // a clear margin (0.15). Without this margin, basic_clean tends to
-            // win simply by including more nav/footer words, which boosts its
-            // word count but reintroduces noise the readability primary had
-            // correctly excluded.
-            const PRIMARY_MARGIN: f32 = 0.15;
-            let primary_score = candidates[0].2.score;
-            let chosen_idx = candidates
-                .iter()
-                .enumerate()
-                .skip(1)
-                .filter(|(_, c)| c.2.score >= primary_score + PRIMARY_MARGIN)
-                .max_by(|(_, a), (_, b)| {
-                    a.2.score
-                        .partial_cmp(&b.2.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                        .then(a.2.bytes.cmp(&b.2.bytes))
-                })
-                .map(|(i, _)| i)
-                .unwrap_or(0);
+                // No structural table/list alternate. It harvested <ul>/<table>
+                // straight out of raw_html, and its only guard was an ancestor tag
+                // check for nav/footer/header — which page builders sail past,
+                // since Elementor and friends render menus as plain <div><ul>. On
+                // an Elementor product page it was the winning candidate and put
+                // 118 nav links into the markdown. Measured contribution across a
+                // labelled corpus: none (identical recall with and without).
+                // Alt 4: XHR/fetch JSON capture — recursively walk every captured
+                // JSON body and gather long text fields. Useful when the article
+                // body lives in an API response loaded after `loadEventFired`
+                // (newsroom feeds, infinite-scroll, paywall-shielded prose).
+                if let Some(xhr_md) = extract_xhr_text(captured_responses) {
+                    let q = quality::analyze_md_only(&xhr_md);
+                    candidates.push(("xhr_json", xhr_md, q));
+                }
 
-            let names: Vec<&'static str> = candidates.iter().map(|c| c.0).collect();
-            let scores: Vec<f32> = candidates.iter().map(|c| c.2.score).collect();
-            let chosen_name = candidates[chosen_idx].0;
-            tracing::debug!(
-                strategies = ?names,
-                scores = ?scores,
-                chosen = %chosen_name,
-                "quality-selected markdown extraction"
-            );
+                // Alt 5: plaintext fallback.
+                let plain_md = {
+                    let text = plaintext::html_to_plaintext(&content_html);
+                    if text.trim().is_empty() {
+                        plaintext::html_to_plaintext(&basic_cleaned)
+                    } else {
+                        text
+                    }
+                };
+                let plain_q = quality::analyze_md_only(&plain_md);
+                candidates.push(("plaintext", plain_md, plain_q));
 
-            Some(candidates.swap_remove(chosen_idx).1)
+                // Include the primary at the head of the candidate list.
+                candidates.insert(0, ("primary", primary_md, primary_quality));
+
+                // Primary-biased pick: keep primary unless an alternate beats it by
+                // a clear margin (0.15). Without this margin, basic_clean tends to
+                // win simply by including more nav/footer words, which boosts its
+                // word count but reintroduces noise the readability primary had
+                // correctly excluded.
+                const PRIMARY_MARGIN: f32 = 0.15;
+                let primary_score = candidates[0].2.score;
+                let chosen_idx = candidates
+                    .iter()
+                    .enumerate()
+                    .skip(1)
+                    .filter(|(_, c)| c.2.score >= primary_score + PRIMARY_MARGIN)
+                    .max_by(|(_, a), (_, b)| {
+                        a.2.score
+                            .partial_cmp(&b.2.score)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                            .then(a.2.bytes.cmp(&b.2.bytes))
+                    })
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+
+                let names: Vec<&'static str> = candidates.iter().map(|c| c.0).collect();
+                let scores: Vec<f32> = candidates.iter().map(|c| c.2.score).collect();
+                let chosen_name = candidates[chosen_idx].0;
+                tracing::debug!(
+                    strategies = ?names,
+                    scores = ?scores,
+                    chosen = %chosen_name,
+                    "quality-selected markdown extraction"
+                );
+
+                Some(candidates.swap_remove(chosen_idx).1)
+            }
         }
     } else {
         None
@@ -621,6 +660,11 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // Skipped without `onlyMainContent`: there the caller asked for the
     // document as it is.
     let md = md.map(|m| {
+        // Not HTML: there is no nav/menu structure to dedupe, and any
+        // heuristic text match here would mutate the caller's exact bytes.
+        if treat_as_plain {
+            return m;
+        }
         if only_main_content {
             let m = markdown::drop_repeated_nav_lines(&m);
             // `drop_repeated_nav_lines` only catches a menu that a responsive
@@ -651,6 +695,12 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // present in the markdown — otherwise downstream recall scoring loses the
     // most important phrase on the page (the title itself).
     let md = md.map(|m| {
+        // Not HTML: there is no real `<title>`/`og:title` to prepend — any
+        // match `extract_metadata` found is a false positive off a stray
+        // HTML-looking snippet inside the plain-text body itself.
+        if treat_as_plain {
+            return m;
+        }
         // A narrowing that matched nothing is intentionally empty; padding it
         // with the page title would re-leak content the caller narrowed away.
         if user_selected || include_tags_no_match {
@@ -711,6 +761,11 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // is already substantial, the description is short or already present,
     // or it duplicates the page title.
     let md = md.map(|m| {
+        // Not HTML: same false-positive-metadata reasoning as the title
+        // prepend above.
+        if treat_as_plain {
+            return m;
+        }
         if user_selected || include_tags_no_match {
             return m;
         }
@@ -786,10 +841,20 @@ pub fn extract(opts: ExtractOptions<'_>) -> CrwResult<ScrapeData> {
     // Two passes: 1) NBSP → space (lossless: markdown has no NBSP semantics),
     // 2) collapse a blank line that sits between `, : )` punctuation and the
     // next inline link or comma-continuation paragraph.
-    let md = md.map(reflow_inline_lists);
+    let md = md.map(|m| {
+        if treat_as_plain {
+            m
+        } else {
+            reflow_inline_lists(m)
+        }
+    });
 
     let plain = if formats.contains(&OutputFormat::PlainText) {
-        Some(plaintext::html_to_plaintext(&content_html))
+        Some(if treat_as_plain {
+            content_html.clone()
+        } else {
+            plaintext::html_to_plaintext(&content_html)
+        })
     } else {
         None
     };

--- a/crates/crw-extract/tests/extract_tests.rs
+++ b/crates/crw-extract/tests/extract_tests.rs
@@ -6,6 +6,7 @@ fn extract_markdown_format() {
     let html = "<html><head><title>Test</title></head><body><article><h1>Hello</h1><p>World</p></article></body></html>";
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -50,6 +51,7 @@ fn extract_images_format_populates_from_raw_html() {
         <body><article><img src=\"/pic.png\" alt=\"Pic\"></article></body></html>";
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -98,6 +100,7 @@ fn extract_all_formats() {
 
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: Some("http".into()),
@@ -145,6 +148,7 @@ fn extract_metadata_populated() {
 
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -180,6 +184,7 @@ fn extract_metadata_populated() {
 fn extract_empty_html() {
     let data = crw_extract::extract(ExtractOptions {
         raw_html: "",
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -217,6 +222,7 @@ fn extract_with_include_exclude_tags() {
         r#"<html><body><div class="ad">Ad</div><article><p>Content</p></article></body></html>"#;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -261,6 +267,7 @@ fn prepends_metadata_title_when_missing_from_markdown() {
     </body></html>"#;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -303,6 +310,7 @@ fn does_not_duplicate_title_already_in_markdown() {
     </body></html>"#;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -347,6 +355,7 @@ fn strips_site_name_suffix_from_title_when_prepending() {
     </body></html>"#;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -399,6 +408,7 @@ fn preserves_en_dash_inside_title_parentheses() {
     </body></html>"#;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -447,6 +457,7 @@ fn does_not_prepend_title_when_css_selector_provided() {
     </body></html>"#;
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -497,6 +508,7 @@ fn prepends_title_when_only_domain_selector_applies() {
     domain_map.insert("www.raspberrypi.com".to_string(), "main".to_string());
     let data = crw_extract::extract(ExtractOptions {
         raw_html: html,
+        content_type: None,
         source_url: "https://www.raspberrypi.com/news/x/",
         status_code: 200,
         rendered_with: None,
@@ -548,6 +560,7 @@ fn extract_markdown(
 ) -> crw_core::types::ScrapeData {
     crw_extract::extract(ExtractOptions {
         raw_html: NO_MATCH_PAGE,
+        content_type: None,
         source_url: "https://example.com",
         status_code: 200,
         rendered_with: None,
@@ -698,6 +711,7 @@ fn elementor_page_with_duplicated_nav_extracts_cleanly() {
 
     let data = crw_extract::extract(ExtractOptions {
         raw_html: &html,
+        content_type: None,
         source_url: "https://example.com/product/30-rk-panora/",
         status_code: 200,
         rendered_with: None,
@@ -760,5 +774,64 @@ fn elementor_page_with_duplicated_nav_extracts_cleanly() {
     assert!(
         md.contains("[Awards and certifications page]"),
         "nested list link lost: {md}"
+    );
+}
+
+// crw#530: a `text/plain` source (raw.githubusercontent.com and friends) is
+// not HTML. Running it through the HTML-to-markdown converter anyway escaped
+// every backtick (destroying fenced code blocks) and collapsed newlines into
+// spaces (HTML's whitespace-collapse rule, merging paragraphs and code lines
+// together) — corruption no response-side repair could undo. `content_type:
+// Some("text/plain")` must return the body byte-for-byte.
+#[test]
+fn text_plain_source_markdown_is_byte_for_byte_passthrough() {
+    let body = "## One-command install\n\n```bash\ncurl -fsSL https://fastcrw.com/install | sh\n```\n\nRuns local and free, no account needed.\n";
+    let data = crw_extract::extract(ExtractOptions {
+        raw_html: body,
+        content_type: Some("text/plain"),
+        source_url: "https://raw.githubusercontent.com/us/crw/main/README.md",
+        status_code: 200,
+        rendered_with: None,
+        elapsed_ms: 0,
+        render_decision: None,
+        credit_cost: 0,
+        warnings: Vec::new(),
+        formats: &[
+            OutputFormat::Markdown,
+            OutputFormat::PlainText,
+            OutputFormat::Html,
+        ],
+        only_main_content: true,
+        include_tags: &[],
+        exclude_tags: &[],
+        css_selector: None,
+        xpath: None,
+        chunk_strategy: None,
+        query: None,
+        filter_mode: None,
+        top_k: None,
+        domain_selectors: None,
+        captured_responses: &[],
+        llm_fallback: None,
+        debug: false,
+        debug_sink: None,
+        normalize_tables: false,
+    })
+    .unwrap();
+
+    assert_eq!(
+        data.markdown.as_deref(),
+        Some(body),
+        "markdown must be byte-for-byte"
+    );
+    assert_eq!(
+        data.plain_text.as_deref(),
+        Some(body),
+        "plain text must be byte-for-byte"
+    );
+    assert_eq!(
+        data.html.as_deref(),
+        Some(body),
+        "html must be byte-for-byte"
     );
 }

--- a/crates/crw-renderer/src/lib.rs
+++ b/crates/crw-renderer/src/lib.rs
@@ -393,30 +393,14 @@ fn has_recovery_tier(
 
 /// Is this response an HTML document, or an unknown type we must assume is one?
 ///
-/// Two callers, one question. A browser render can only add to an HTML document,
-/// and the HTML structural heuristics in `antibot::classify` are only meaningful
-/// on one (`crw_crawl::single::classify_block`).
-///
-/// The HTTP tier decodes every non-PDF response as HTML regardless of its
-/// declared type, so an empty `application/json` / `text/plain` / `image/*` /
-/// archive response is indistinguishable from an empty HTML shell by body shape
-/// alone. A browser cannot add content to any of those, so escalating them buys
-/// nothing but latency. Absent or unrecognised types stay eligible: a server
-/// that omits `Content-Type` on a bot-wall shell is exactly the case worth
-/// escalating.
-pub fn is_html_like_content_type(content_type: Option<&str>) -> bool {
-    match content_type {
-        None => true,
-        Some(ct) => {
-            let ct = ct.trim().to_ascii_lowercase();
-            ct.is_empty()
-                || ct == "text/html"
-                || ct == "application/xhtml+xml"
-                || ct == "application/xml"
-                || ct == "text/xml"
-        }
-    }
-}
+/// Three callers now, one question. A browser render can only add to an HTML
+/// document, the HTML structural heuristics in `antibot::classify` are only
+/// meaningful on one (`crw_crawl::single::classify_block`), and `crw_extract`
+/// uses it to decide whether running an HTML parser / HTML-to-markdown
+/// converter over the body is even meaningful. Defined in `crw-core` (shared
+/// by extract and renderer, which cannot depend on each other) and
+/// re-exported here for existing callers.
+pub use crw_core::is_html_like_content_type;
 
 fn is_fingerprint_vendor_wall(
     cf_challenge: bool,


### PR DESCRIPTION
## Summary

- `text/plain` (and other non-HTML) response bodies were still run through the HTML clean/readability/HTML-to-markdown pipeline. `htmd` escaped every markdown metacharacter it found and HTML's whitespace-collapse rule merged newlines into spaces, destroying fenced code blocks and paragraph structure for sources like `raw.githubusercontent.com`.
- `ExtractOptions`/`OwnedExtractInput` now carry the response content type. When it isn't HTML-like, `extract()` skips the HTML pipeline entirely and returns the body byte-for-byte for every format (`markdown`, `html`, `plainText`).
- The content-type check is shared with the renderer via a new `crw_core::is_html_like_content_type` (moved out of `crw-renderer`, which cannot depend on `crw-extract`; re-exported there for existing callers).
- Added a regression test (`text_plain_source_markdown_is_byte_for_byte_passthrough`) and verified live against the exact repro in the issue: fixed build's `/v2/scrape` output is byte-for-byte identical to the raw file (9074 chars, 228 newlines, 0 escaped backticks, 20 fences — matching ground truth), where an unpatched build reproduces the reported corruption exactly (7289 chars, 38 newlines, 78/78 escaped, 0 fences).
- Full workspace test suite (cargo test --workspace), clippy, and fmt all pass.

ref #530